### PR TITLE
fix(config): refactor config resolution into separate MCP and CLI paths

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -24,11 +24,9 @@ import { startCliDaemonServer } from './daemon';
 import { setupExitWatchdog } from '../mcp/watchdog';
 import { createBrowserWithInfo } from '../mcp/browserFactory';
 import * as configUtils from '../mcp/config';
-import { ClientInfo, createClientInfo } from '../cli-client/registry';
+import { createClientInfo } from '../cli-client/registry';
 import { program } from '../../utilsBundle';
 import { registry as browserRegistry } from '../../server/registry/index';
-
-import type { FullConfig } from '../mcp/config';
 
 program.argument('[session-name]', 'name of the session to create or connect to', 'default')
     .option('--headed', 'run in headed mode (non-headless)')
@@ -49,7 +47,7 @@ program.argument('[session-name]', 'name of the session to create or connect to'
 
       setupExitWatchdog();
       const clientInfo = createClientInfo();
-      const mcpConfig = await resolveCLIConfig(clientInfo, sessionName, options);
+      const mcpConfig = await configUtils.resolveCLIConfigForCLI(clientInfo.daemonProfilesDir, sessionName, options);
       const clientInfoEx = {
         cwd: process.cwd(),
         sessionName,
@@ -82,63 +80,6 @@ function globalConfigFile(): string {
   return path.join(process.env['PWTEST_CLI_GLOBAL_CONFIG'] ?? os.homedir(), '.playwright', 'cli.config.json');
 }
 
-export async function resolveCLIConfig(clientInfo: ClientInfo, sessionName: string, options: any): Promise<FullConfig> {
-  const config = options.config ? path.resolve(options.config) : undefined;
-  try {
-    if (!config && fs.existsSync(defaultConfigFile()))
-      options.config = defaultConfigFile();
-  } catch {
-  }
-
-  const daemonOverrides = configUtils.configFromCLIOptions({
-    config: options.config,
-    browser: options.browser,
-    headless: options.headed ? false : undefined,
-    extension: options.extension,
-    userDataDir: options.profile,
-    snapshotMode: 'full',
-  });
-  daemonOverrides.browser!.remoteEndpoint = options.attach;
-
-  const envOverrides = configUtils.configFromEnv();
-  const configFile = envOverrides.configFile ?? daemonOverrides.configFile;
-  const configInFile = await configUtils.loadConfig(configFile);
-  const globalConfigPath = fs.existsSync(globalConfigFile()) ? globalConfigFile() : undefined;
-  const globalConfigInFile = await configUtils.loadConfig(globalConfigPath);
-
-  let result = configUtils.mergeConfig(configUtils.defaultConfig, {
-    browser: {
-      launchOptions: {
-        headless: true,
-      }
-    }
-  });
-
-  result = configUtils.mergeConfig(result, globalConfigInFile);
-  result = configUtils.mergeConfig(result, configInFile);
-  result = configUtils.mergeConfig(result, daemonOverrides);
-  result = configUtils.mergeConfig(result, envOverrides);
-
-  if (result.browser.isolated === undefined)
-    result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.extension;
-
-  if (!result.extension && !result.browser.isolated && !result.browser.userDataDir && !result.browser.remoteEndpoint) {
-    // No custom value provided, use the daemon data dir.
-    const browserToken = result.browser.launchOptions?.channel ?? result.browser?.browserName;
-    const userDataDir = path.resolve(clientInfo.daemonProfilesDir, `ud-${sessionName}-${browserToken}`);
-    result.browser.userDataDir = userDataDir;
-  }
-
-  result.configFile = configFile;
-  result.skillMode = true;
-  if (result.browser.launchOptions.headless !== false)
-    result.browser.contextOptions.viewport ??= { width: 1280, height: 720 };
-
-  await configUtils.validateConfig(result);
-
-  return result;
-}
-
 async function initWorkspace(initSkills: string | undefined) {
   const cwd = process.cwd();
   const playwrightDir = path.join(cwd, '.playwright');
@@ -165,7 +106,7 @@ async function ensureConfiguredBrowserInstalled() {
   if (fs.existsSync(defaultConfigFile()) || fs.existsSync(globalConfigFile())) {
     // Config exists, ensure configured browser is installed
     const clientInfo = createClientInfo();
-    const config = await resolveCLIConfig(clientInfo, 'default', {});
+    const config = await configUtils.resolveCLIConfigForCLI(clientInfo.daemonProfilesDir, 'default', {});
     const browserName = config.browser.browserName;
     const channel = config.browser.launchOptions.channel;
     if (!channel || channel.startsWith('chromium')) {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 import os from 'os';
 
 import { devices } from '../../..';
@@ -74,18 +75,11 @@ export type CLIOptions = {
   viewportSize?: ViewportSize;
 };
 
-export const defaultConfig: FullConfig = {
+const defaultConfig: MergedConfig = {
   browser: {
-    browserName: 'chromium',
-    launchOptions: {
-      channel: 'chrome',
-      headless: os.platform() === 'linux' && !process.env.DISPLAY,
-    },
-    contextOptions: {
-      viewport: null,
-    },
+    launchOptions: {},
+    contextOptions: {},
   },
-  server: {},
   timeouts: {
     action: 5000,
     navigation: 60000,
@@ -95,22 +89,28 @@ export const defaultConfig: FullConfig = {
 
 type BrowserUserConfig = NonNullable<Config['browser']>;
 
-export type FullConfig = Config & {
-  browser: Omit<BrowserUserConfig, 'browserName' | 'launchOptions' | 'contextOptions'> & {
-    browserName: 'chromium' | 'firefox' | 'webkit';
+export type MergedConfig = Config & {
+  browser: BrowserUserConfig & {
     launchOptions: NonNullable<BrowserUserConfig['launchOptions']>;
     contextOptions: NonNullable<BrowserUserConfig['contextOptions']>;
+  }
+};
+
+export type FullConfig = MergedConfig & {
+  browser: MergedConfig['browser'] & {
+    browserName: 'chromium' | 'firefox' | 'webkit';
   },
-  server?: Config['server'],
   skillMode?: boolean;
   configFile?: string;
 };
 
 export async function resolveConfig(config: Config): Promise<FullConfig> {
-  return mergeConfig(defaultConfig, config);
+  const merged = mergeConfig(defaultConfig, config);
+  const browser = await validateBrowserConfig(merged.browser);
+  return { ...merged, browser };
 }
 
-export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConfig> {
+export async function resolveCLIConfigForMCP(cliOptions: CLIOptions): Promise<FullConfig> {
   const envOverrides = configFromEnv();
   const cliOverrides = configFromCLIOptions(cliOptions);
   const configFile = cliOverrides.configFile ?? envOverrides.configFile;
@@ -120,37 +120,103 @@ export async function resolveCLIConfig(cliOptions: CLIOptions): Promise<FullConf
   result = mergeConfig(result, configInFile);
   result = mergeConfig(result, envOverrides);
   result = mergeConfig(result, cliOverrides);
-  result.configFile = configFile;
-  await validateConfig(result);
-  return result;
+
+  const browser = await validateBrowserConfig(result.browser);
+  if (browser.launchOptions.headless === undefined)
+    browser.launchOptions.headless = os.platform() === 'linux' && !process.env.DISPLAY;
+
+  return { ...result, browser, configFile };
 }
 
-export async function validateConfig(config: FullConfig): Promise<void> {
-  if (config.browser.browserName === 'chromium' && config.browser.launchOptions.chromiumSandbox === undefined) {
-    if (process.platform === 'linux')
-      config.browser.launchOptions.chromiumSandbox = config.browser.launchOptions.channel !== 'chromium' && config.browser.launchOptions.channel !== 'chrome-for-testing';
-    else
-      config.browser.launchOptions.chromiumSandbox = true;
+export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionName: string, options: any): Promise<FullConfig> {
+  const config = options.config ? path.resolve(options.config) : undefined;
+  try {
+    const defaultConfigFile = path.resolve('.playwright', 'cli.config.json');
+    if (!config && fs.existsSync(defaultConfigFile))
+      options.config = defaultConfigFile;
+  } catch {
   }
 
-  if (config.browser.isolated && config.browser.userDataDir)
+  const daemonOverrides = configFromCLIOptions({
+    config: options.config,
+    browser: options.browser,
+    headless: options.headed ? false : undefined,
+    extension: options.extension,
+    userDataDir: options.profile,
+    snapshotMode: 'full',
+  });
+  daemonOverrides.browser!.remoteEndpoint = options.attach;
+
+  const envOverrides = configFromEnv();
+  const configFile = envOverrides.configFile ?? daemonOverrides.configFile;
+  const configInFile = await loadConfig(configFile);
+  const globalConfigPath = path.join(process.env['PWTEST_CLI_GLOBAL_CONFIG'] ?? os.homedir(), '.playwright', 'cli.config.json');
+  const globalConfigInFile = await loadConfig(fs.existsSync(globalConfigPath) ? globalConfigPath : undefined);
+
+  let result = defaultConfig;
+  result = mergeConfig(result, globalConfigInFile);
+  result = mergeConfig(result, configInFile);
+  result = mergeConfig(result, daemonOverrides);
+  result = mergeConfig(result, envOverrides);
+
+  if (result.browser.isolated === undefined)
+    result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.extension;
+
+  if (!result.extension && !result.browser.isolated && !result.browser.userDataDir && !result.browser.remoteEndpoint) {
+    // No custom value provided, use the daemon data dir.
+    const browserToken = result.browser.launchOptions?.channel ?? result.browser?.browserName;
+    const userDataDir = path.resolve(daemonProfilesDir, `ud-${sessionName}-${browserToken}`);
+    result.browser.userDataDir = userDataDir;
+  }
+
+  if (result.browser.launchOptions.headless === undefined)
+    result.browser.launchOptions.headless = true;
+
+  const browser = await validateBrowserConfig(result.browser);
+  return { ...result, browser, configFile, skillMode: true };
+}
+
+async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<FullConfig['browser']> {
+  let browserName = browser.browserName;
+  if (!browserName) {
+    browserName = 'chromium';
+    // Assign channel only if the browserName is not provided, otherwise assume full control to the user.
+    if (browser.launchOptions.channel === undefined)
+      browser.launchOptions.channel = 'chrome';
+  }
+
+  if (browser.browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
+    if (process.platform === 'linux')
+      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
+    else
+      browser.launchOptions.chromiumSandbox = true;
+  }
+
+  if (browser.isolated && browser.userDataDir)
     throw new Error('Browser userDataDir is not supported in isolated mode.');
 
-  if (config.browser.initScript) {
-    for (const script of config.browser.initScript) {
+  if (browser.initScript) {
+    for (const script of browser.initScript) {
       if (!await fileExistsAsync(script))
         throw new Error(`Init script file does not exist: ${script}`);
     }
   }
-  if (config.browser.initPage) {
-    for (const page of config.browser.initPage) {
+  if (browser.initPage) {
+    for (const page of browser.initPage) {
       if (!await fileExistsAsync(page))
         throw new Error(`Init page file does not exist: ${page}`);
     }
   }
+  if (browser.contextOptions.viewport === undefined) {
+    if (browser.launchOptions.headless)
+      browser.contextOptions.viewport = { width: 1280, height: 720 };
+    else
+      browser.contextOptions.viewport = null;
+  }
+  return { ...browser, browserName };
 }
 
-export function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: string } {
+function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: string } {
   let browserName: 'chromium' | 'firefox' | 'webkit' | undefined;
   let channel: string | undefined;
   switch (cliOptions.browser) {
@@ -334,11 +400,11 @@ function pickDefined<T extends object>(obj: T | undefined): Partial<T> {
   ) as Partial<T>;
 }
 
-export function mergeConfig(base: FullConfig, overrides: Config): FullConfig {
-  const browser: FullConfig['browser'] = {
+function mergeConfig(base: MergedConfig, overrides: Config): MergedConfig {
+  const browser: Config['browser'] = {
     ...pickDefined(base.browser),
     ...pickDefined(overrides.browser),
-    browserName: overrides.browser?.browserName ?? base.browser?.browserName ?? 'chromium',
+    browserName: overrides.browser?.browserName ?? base.browser?.browserName,
     isolated: overrides.browser?.isolated ?? base.browser?.isolated,
     launchOptions: {
       ...pickDefined(base.browser?.launchOptions),

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -17,7 +17,7 @@
 import { ProgramOption } from '../../utilsBundle';
 
 import * as mcpServer from '../utils/mcp/server';
-import { commaSeparatedList, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfig, semicolonSeparatedList } from './config';
+import { commaSeparatedList, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
 import { setupExitWatchdog } from './watchdog';
 import { createBrowser } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
@@ -91,7 +91,7 @@ export function decorateMCPCommand(command: Command) {
         if (options.caps?.includes('tracing'))
           options.caps.push('devtools');
 
-        const config = await resolveCLIConfig(options);
+        const config = await resolveCLIConfigForMCP(options);
         const tools = filteredTools(config);
         if (config.extension) {
           const serverBackendFactory: mcpServer.ServerBackendFactory = {

--- a/tests/mcp/cli-config-resolve.spec.ts
+++ b/tests/mcp/cli-config-resolve.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { test, expect } from '@playwright/test';
+
+import { resolveCLIConfigForCLI } from '../../packages/playwright-core/lib/tools/mcp/config';
+
+import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
+
+test.describe('resolveCLIConfigForCLI - browserName and channel', () => {
+  test('no browser option defaults to chromium / chrome', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome');
+  });
+
+  test('--browser=chrome sets chromium with chrome channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'chrome' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome');
+  });
+
+  test('--browser=chromium sets chromium with chrome-for-testing channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'chromium' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+  });
+
+  test('--browser=firefox sets firefox without channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'firefox' });
+    expect(config.browser.browserName).toBe('firefox');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('--browser=webkit sets webkit without channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'webkit' });
+    expect(config.browser.browserName).toBe('webkit');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('--browser=msedge sets chromium with msedge channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'msedge' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('msedge');
+  });
+
+  test('config file browserName chromium does not auto-set channel', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'chromium' } }));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('config file browserName + channel are both preserved', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { browserName: 'chromium', launchOptions: { channel: 'msedge' } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('msedge');
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - headless and viewport', () => {
+  test('headless by default', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.browser.launchOptions.headless).toBe(true);
+  });
+
+  test('--headed sets headless=false', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { headed: true });
+    expect(config.browser.launchOptions.headless).toBe(false);
+  });
+
+  test('headless viewport defaults to 1280x720', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 1280, height: 720 });
+  });
+
+  test('headed viewport defaults to null', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { headed: true });
+    expect(config.browser.contextOptions.viewport).toBeNull();
+  });
+
+  test('config file viewport is preserved', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { contextOptions: { viewport: { width: 640, height: 480 } } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 640, height: 480 });
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - isolated and userDataDir', () => {
+  test('defaults to isolated when no profile, persistent, userDataDir, or remoteEndpoint', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.browser.isolated).toBe(true);
+  });
+
+  test('not isolated when --profile is set', async ({}, testInfo) => {
+    const profileDir = testInfo.outputPath('my-profile');
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { profile: profileDir });
+    expect(config.browser.isolated).toBe(false);
+    expect(config.browser.userDataDir).toBe(profileDir);
+  });
+
+  test('not isolated when --persistent is set', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { persistent: true });
+    expect(config.browser.isolated).toBe(false);
+  });
+
+  test('not isolated when --attach is set', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { attach: 'ws://localhost:1234' });
+    expect(config.browser.isolated).toBe(false);
+  });
+
+  test('not isolated when config file sets userDataDir', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const userDataDir = testInfo.outputPath('custom-data');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { userDataDir } }));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.browser.isolated).toBe(false);
+    expect(config.browser.userDataDir).toBe(userDataDir);
+  });
+
+  test('auto userDataDir uses daemonProfilesDir with session and browser token', async ({}, testInfo) => {
+    const profilesDir = testInfo.outputPath('profiles');
+    const config = await resolveCLIConfigForCLI(profilesDir, 'mysession', { persistent: true, browser: 'chrome' });
+    expect(config.browser.userDataDir).toBe(path.resolve(profilesDir, 'ud-mysession-chrome'));
+  });
+
+  test('auto userDataDir uses browserName when no channel', async ({}, testInfo) => {
+    const profilesDir = testInfo.outputPath('profiles');
+    const config = await resolveCLIConfigForCLI(profilesDir, 'default', { persistent: true, browser: 'firefox' });
+    expect(config.browser.userDataDir).toBe(path.resolve(profilesDir, 'ud-default-firefox'));
+  });
+
+  test('auto userDataDir uses undefined token when no browser specified', async ({}, testInfo) => {
+    const profilesDir = testInfo.outputPath('profiles');
+    const config = await resolveCLIConfigForCLI(profilesDir, 'default', { persistent: true });
+    expect(config.browser.userDataDir).toBe(path.resolve(profilesDir, 'ud-default-undefined'));
+  });
+
+  test('no auto userDataDir when isolated', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.browser.isolated).toBe(true);
+    expect(config.browser.userDataDir).toBeUndefined();
+  });
+
+  test('no auto userDataDir when --profile is set', async ({}, testInfo) => {
+    const profileDir = testInfo.outputPath('my-profile');
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { profile: profileDir });
+    expect(config.browser.userDataDir).toBe(profileDir);
+  });
+
+  test('no auto userDataDir when remoteEndpoint is set', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { attach: 'ws://localhost:1234' });
+    expect(config.browser.userDataDir).toBeUndefined();
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - timeouts', () => {
+  test('default timeouts', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.timeouts.action).toBe(5000);
+    expect(config.timeouts.navigation).toBe(60000);
+    expect(config.timeouts.expect).toBe(5000);
+  });
+
+  test('config file timeouts override defaults', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ timeouts: { action: 7000 } }));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.timeouts.action).toBe(7000);
+    expect(config.timeouts.navigation).toBe(60000);
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - sandbox', () => {
+  test('chromium sandbox enabled for chrome channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'chrome' });
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('chromium sandbox for chrome-for-testing channel', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'chromium' });
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    if (process.platform === 'linux')
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+    else
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('sandbox not set for non-chromium browsers', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { browser: 'firefox' });
+    expect(config.browser.launchOptions.chromiumSandbox).toBeUndefined();
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - skillMode and snapshotMode', () => {
+  test('skillMode is always set', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {});
+    expect(config.skillMode).toBe(true);
+  });
+
+  test('snapshot mode is full', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', {}) as any;
+    expect(config.snapshot?.mode).toBe('full');
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - config file discovery', () => {
+  test('explicit config file is used', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ timeouts: { action: 3000 } }));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile });
+    expect(config.timeouts.action).toBe(3000);
+    expect(config.configFile).toBe(configFile);
+  });
+
+  test('merge order: config file < daemon overrides', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { browserName: 'firefox' },
+      timeouts: { action: 1000 },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    // --browser cli option overrides config file browserName.
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile, browser: 'webkit' });
+    expect(config.browser.browserName).toBe('webkit');
+    // Timeouts from file are preserved.
+    expect(config.timeouts.action).toBe(1000);
+  });
+
+  test('config file values preserved when cli does not override', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      network: { allowedOrigins: ['https://example.com'] },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { config: configFile }) as any;
+    expect(config.network?.allowedOrigins).toEqual(['https://example.com']);
+  });
+});
+
+test.describe('resolveCLIConfigForCLI - extension', () => {
+  test('--extension disables isolated', async ({}, testInfo) => {
+    const config = await resolveCLIConfigForCLI(testInfo.outputPath('profiles'), 'default', { extension: true }) as any;
+    expect(config.extension).toBe(true);
+    expect(config.browser.isolated).toBe(false);
+  });
+});

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -17,7 +17,7 @@
 import fs from 'node:fs';
 
 import { test, expect, parseResponse } from './fixtures';
-import { resolveCLIConfig } from '../../packages/playwright-core/lib/tools/mcp/config';
+import { resolveCLIConfigForMCP } from '../../packages/playwright-core/lib/tools/mcp/config';
 import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
 
 test('config user data dir', async ({ startClient, server }, testInfo) => {
@@ -106,7 +106,7 @@ test.describe(() => {
 });
 
 async function sandboxOption(cli: any) {
-  const config: any = await resolveCLIConfig(cli);
+  const config: any = await resolveCLIConfigForMCP(cli);
   return config.browser.launchOptions.chromiumSandbox;
 }
 
@@ -131,7 +131,7 @@ test('file browser.cdpHeaders preserved when PLAYWRIGHT_MCP_CDP_HEADERS unset', 
     const configPath = testInfo.outputPath('config.json');
     await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2));
 
-    const resolved = await resolveCLIConfig({ config: configPath });
+    const resolved = await resolveCLIConfigForMCP({ config: configPath });
     expect(resolved.browser.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
   } finally {
     if (prev !== undefined)

--- a/tests/mcp/mcp-config-resolve.spec.ts
+++ b/tests/mcp/mcp-config-resolve.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+
+import { test, expect } from '@playwright/test';
+
+import { resolveCLIConfigForMCP } from '../../packages/playwright-core/lib/tools/mcp/config';
+
+import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
+
+test.describe('resolveCLIConfigForMCP - browserName and channel', () => {
+  test('no config defaults to chromium with chrome channel', async () => {
+    const config = await resolveCLIConfigForMCP({});
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome');
+  });
+
+  test('--browser=chrome resolves to chromium with chrome channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chrome' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome');
+  });
+
+  test('--browser=chromium resolves to chromium with chrome-for-testing channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chromium' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+  });
+
+  test('--browser=firefox resolves to firefox without channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'firefox' });
+    expect(config.browser.browserName).toBe('firefox');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('--browser=webkit resolves to webkit without channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'webkit' });
+    expect(config.browser.browserName).toBe('webkit');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('--browser=msedge resolves to chromium with msedge channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'msedge' });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('msedge');
+  });
+
+  test('config file browserName chromium does not set chrome channel', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'chromium' } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('config file browserName firefox does not set channel', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'firefox' } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile });
+    expect(config.browser.browserName).toBe('firefox');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+  });
+
+  test('config file browserName + explicit channel are both preserved', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { browserName: 'chromium', launchOptions: { channel: 'msedge' } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile });
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('msedge');
+  });
+
+  test('cli --browser overrides config file browserName', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'firefox' } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile, browser: 'webkit' });
+    expect(config.browser.browserName).toBe('webkit');
+  });
+});
+
+test.describe('resolveCLIConfigForMCP - headless and viewport', () => {
+  test('headless defaults based on platform', async () => {
+    const config = await resolveCLIConfigForMCP({});
+    expect(config.browser.launchOptions.headless).toBeDefined();
+  });
+
+  test('explicit headless=true is preserved', async () => {
+    const config = await resolveCLIConfigForMCP({ headless: true });
+    expect(config.browser.launchOptions.headless).toBe(true);
+  });
+
+  test('explicit headless=false is preserved', async () => {
+    const config = await resolveCLIConfigForMCP({ headless: false });
+    expect(config.browser.launchOptions.headless).toBe(false);
+  });
+
+  test('headless sets default viewport 1280x720', async () => {
+    const config = await resolveCLIConfigForMCP({ headless: true });
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 1280, height: 720 });
+  });
+
+  test('headed sets viewport to null', async () => {
+    const config = await resolveCLIConfigForMCP({ headless: false });
+    expect(config.browser.contextOptions.viewport).toBeNull();
+  });
+
+  test('explicit viewport is preserved when headless', async () => {
+    const config = await resolveCLIConfigForMCP({ headless: true, viewportSize: { width: 800, height: 600 } });
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 800, height: 600 });
+  });
+
+  test('config file viewport is preserved when headless', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { contextOptions: { viewport: { width: 640, height: 480 } } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile, headless: true });
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 640, height: 480 });
+  });
+});
+
+test.describe('resolveCLIConfigForMCP - timeouts', () => {
+  test('default timeouts', async () => {
+    const config = await resolveCLIConfigForMCP({});
+    expect(config.timeouts.action).toBe(5000);
+    expect(config.timeouts.navigation).toBe(60000);
+    expect(config.timeouts.expect).toBe(5000);
+  });
+
+  test('cli timeout overrides defaults', async () => {
+    const config = await resolveCLIConfigForMCP({ timeoutAction: 10000, timeoutNavigation: 30000 });
+    expect(config.timeouts.action).toBe(10000);
+    expect(config.timeouts.navigation).toBe(30000);
+    expect(config.timeouts.expect).toBe(5000);
+  });
+
+  test('config file timeouts are used', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ timeouts: { action: 7000 } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile });
+    expect(config.timeouts.action).toBe(7000);
+    expect(config.timeouts.navigation).toBe(60000);
+  });
+
+  test('cli timeout overrides config file timeout', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ timeouts: { action: 1000 } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile, timeoutAction: 9999 });
+    expect(config.timeouts.action).toBe(9999);
+  });
+});
+
+test.describe('resolveCLIConfigForMCP - sandbox', () => {
+  test('chromium sandbox enabled for chrome channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chrome' });
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('chromium sandbox for chrome-for-testing channel', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chromium' });
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    // On Linux, chrome-for-testing disables sandbox; on other platforms sandbox is always true.
+    if (process.platform === 'linux')
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+    else
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('sandbox not set for non-chromium browsers', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'firefox' });
+    expect(config.browser.launchOptions.chromiumSandbox).toBeUndefined();
+  });
+
+  test('explicit --sandbox overrides default', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chromium', sandbox: true });
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('explicit --no-sandbox overrides default', async () => {
+    const config = await resolveCLIConfigForMCP({ browser: 'chrome', sandbox: false });
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+  });
+});
+
+test.describe('resolveCLIConfigForMCP - validation', () => {
+  test('isolated + userDataDir throws', async () => {
+    await expect(resolveCLIConfigForMCP({ isolated: true, userDataDir: '/tmp/data' }))
+        .rejects.toThrow('Browser userDataDir is not supported in isolated mode.');
+  });
+});
+
+test.describe('resolveCLIConfigForMCP - merge order', () => {
+  test('cli overrides config file', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      timeouts: { action: 1000 },
+      browser: { contextOptions: { viewport: { width: 640, height: 480 } } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile, timeoutAction: 9999 });
+    expect(config.timeouts.action).toBe(9999);
+    expect(config.browser.contextOptions.viewport).toEqual({ width: 640, height: 480 });
+  });
+
+  test('config file values preserved when cli does not override', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      network: { allowedOrigins: ['https://example.com'] },
+      browser: { isolated: true },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile }) as any;
+    expect(config.network?.allowedOrigins).toEqual(['https://example.com']);
+    expect(config.browser.isolated).toBe(true);
+  });
+});

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -320,7 +320,7 @@ test('browser_take_screenshot size cap', async ({ startClient, server, mcpBrowse
   });
 
   const expectations = [
-    { title: '2000x500', pageWidth: 2000, pageHeight: 500, expectedWidth: 1568, expectedHeight: 500 * 1568 / 2000 | 0 },
+    { title: '2000x500', pageWidth: 2000, pageHeight: 500, expectedWidth: 1568, expectedHeight: 720 * 1568 / 2000 | 0 },
     { title: '2000x2000', pageWidth: 2000, pageHeight: 2000, expectedWidth: 1098, expectedHeight: 1098 },
     { title: '1280x800', pageWidth: 1280, pageHeight: 800, expectedWidth: 1280, expectedHeight: 800 },
   ];


### PR DESCRIPTION
## Summary
- Move browserName/channel defaults from `mergeConfig` into `validateConfig` so explicitly setting `browserName: 'chromium'` in config doesn't auto-set `channel: 'chrome'`
- Split config resolution into `resolveCLIConfigForMCP` (platform-based headless) and `resolveCLIConfigForCLI` (headless by default)
- Move viewport defaulting into `validateConfig` (1280x720 when headless, null when headed)
- Add unit tests for both config resolution paths

Fixes https://github.com/microsoft/playwright-cli/issues/320