### PR TITLE
fix(trace-viewer): show 'Canceled' for canceled network requests

### DIFF
--- a/packages/trace-viewer/src/sw/traceLoaderBackends.ts
+++ b/packages/trace-viewer/src/sw/traceLoaderBackends.ts
@@ -66,9 +66,9 @@ export class ZipTraceLoaderBackend implements TraceLoaderBackend {
     const entry = entries.get(entryName);
     if (!entry)
       return;
-    const writer = new zipjs.TextWriter();
+    const writer = new zipjs.Uint8ArrayWriter();
     await entry.getData?.(writer);
-    return writer.getData();
+    return new TextDecoder().decode(writer.getData());
   }
 
   async readBlob(entryName: string): Promise<Blob | undefined> {
@@ -76,9 +76,9 @@ export class ZipTraceLoaderBackend implements TraceLoaderBackend {
     const entry = entries.get(entryName);
     if (!entry)
       return;
-    const writer = new zipjs.BlobWriter() as zip.BlobWriter;
+    const writer = new zipjs.Uint8ArrayWriter();
     await entry.getData!(writer);
-    return writer.getData();
+    return new Blob([writer.getData()]);
   }
 }
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -195,8 +195,9 @@ const renderCell = (entry: RenderedEntry, column: ColumnName): RenderedGridCell 
   if (column === 'method')
     return { body: entry.method };
   if (column === 'status') {
+    const statusBody = entry.status.code > 0 ? entry.status.code : (entry.status.code === -1 ? 'Canceled' : '');
     return {
-      body: entry.status.code > 0 ? entry.status.code : '',
+      body: statusBody,
       title: entry.status.text
     };
   }


### PR DESCRIPTION
When network requests are canceled (status -1), the trace viewer network tab was showing a blank status cell. This PR displays 'Canceled' instead for better visibility.

Fixes #39887