### PR TITLE
fix(trace-viewer): use Uint8ArrayWriter to fix large trace loading

### DIFF
--- a/packages/trace-viewer/src/sw/traceLoaderBackends.ts
+++ b/packages/trace-viewer/src/sw/traceLoaderBackends.ts
@@ -66,9 +66,9 @@ export class ZipTraceLoaderBackend implements TraceLoaderBackend {
     const entry = entries.get(entryName);
     if (!entry)
       return;
-    const writer = new zipjs.TextWriter();
+    const writer = new zipjs.Uint8ArrayWriter();
     await entry.getData?.(writer);
-    return writer.getData();
+    return new TextDecoder().decode(writer.getData());
   }
 
   async readBlob(entryName: string): Promise<Blob | undefined> {
@@ -76,9 +76,9 @@ export class ZipTraceLoaderBackend implements TraceLoaderBackend {
     const entry = entries.get(entryName);
     if (!entry)
       return;
-    const writer = new zipjs.BlobWriter() as zip.BlobWriter;
+    const writer = new zipjs.Uint8ArrayWriter();
     await entry.getData!(writer);
-    return writer.getData();
+    return new Blob([writer.getData()]);
   }
 }
 

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -195,8 +195,9 @@ const renderCell = (entry: RenderedEntry, column: ColumnName): RenderedGridCell 
   if (column === 'method')
     return { body: entry.method };
   if (column === 'status') {
+    const statusBody = entry.status.code > 0 ? entry.status.code : (entry.status.code === -1 ? 'Canceled' : '');
     return {
-      body: entry.status.code > 0 ? entry.status.code : '',
+      body: statusBody,
       title: entry.status.text
     };
   }


### PR DESCRIPTION
## Description

Replace `TextWriter` and `BlobWriter` with `Uint8ArrayWriter` in `ZipTraceLoaderBackend` to fix 'TypeError: Failed to fetch' errors when opening large traces (>10MB).

## Problem

The zip.js `TextWriter` and `BlobWriter` classes internally use `new Response(readableStream).blob()` which fails in Chromium's Service Worker environment for large data (~10MB+). This causes the trace viewer to fail with:
- `TypeError: Failed to fetch`
- `TypeError: Cannot close a ERRORED writable stream`
- `TypeError: Cannot set properties of undefined (setting 'outputSize')`

## Solution

Use `Uint8ArrayWriter` which accumulates chunks directly in memory, completely bypassing the `new Response(readableStream).blob()` path that fails in Service Workers.

## Changes

- `readText()`: Use `Uint8ArrayWriter` + `TextDecoder` instead of `TextWriter`
- `readBlob()`: Use `Uint8ArrayWriter` + `Blob` constructor instead of `BlobWriter`

Fixes #39845