### PR TITLE
feat(trace): add 'trace close' command

### DIFF
--- a/packages/playwright-core/src/tools/trace/SKILL.md
+++ b/packages/playwright-core/src/tools/trace/SKILL.md
@@ -15,6 +15,7 @@ Inspect `.zip` trace files produced by Playwright tests without opening a browse
 3. Use `trace action <action-id>` to drill into a specific action — see parameters, logs, source location, and available snapshots.
 4. Use `trace requests`, `trace console`, or `trace errors` for cross-cutting views.
 5. Use `trace snapshot <action-id>` to get the DOM snapshot, or run a browser command against it.
+6. Use `trace close` to remove the extracted trace data when done.
 
 All commands after `open` operate on the currently opened trace — no need to pass the trace file again. Opening a new trace replaces the previous one.
 
@@ -25,6 +26,13 @@ All commands after `open` operate on the currently opened trace — no need to p
 ```bash
 # Extract trace and show metadata: browser, viewport, duration, action/error counts
 npx playwright trace open <trace.zip>
+```
+
+### Close a trace
+
+```bash
+# Remove extracted trace data
+npx playwright trace close
 ```
 
 ### Actions

--- a/packages/playwright-core/src/tools/trace/traceCli.ts
+++ b/packages/playwright-core/src/tools/trace/traceCli.ts
@@ -30,6 +30,14 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       });
 
   traceCommand
+      .command('close')
+      .description('remove extracted trace data')
+      .action(async () => {
+        const { closeTrace } = await import('./traceUtils');
+        closeTrace().catch(logErrorAndExit);
+      });
+
+  traceCommand
       .command('actions')
       .description('list actions in the trace')
       .option('--grep <pattern>', 'filter actions by title pattern')

--- a/packages/playwright-core/src/tools/trace/traceUtils.ts
+++ b/packages/playwright-core/src/tools/trace/traceUtils.ts
@@ -57,12 +57,16 @@ function ensureTraceOpen(): string {
   return traceDir;
 }
 
+export async function closeTrace() {
+  if (fs.existsSync(traceDir))
+    await fs.promises.rm(traceDir, { recursive: true });
+}
+
 export async function openTrace(traceFile: string) {
   const filePath = path.resolve(traceFile);
   if (!fs.existsSync(filePath))
     throw new Error(`Trace file not found: ${filePath}`);
-  if (fs.existsSync(traceDir))
-    await fs.promises.rm(traceDir, { recursive: true });
+  await closeTrace();
   await fs.promises.mkdir(traceDir, { recursive: true });
   await extractTrace(filePath, traceDir);
 }

--- a/tests/mcp/trace-cli.spec.ts
+++ b/tests/mcp/trace-cli.spec.ts
@@ -170,6 +170,20 @@ test('trace screenshot saves image file', async ({ runTraceCli }, testInfo) => {
   }
 });
 
+test('trace close removes extracted trace', async ({ traceFile, runTraceCli }) => {
+  const { exitCode } = await runTraceCli(['close']);
+  expect(exitCode).toBe(0);
+
+  // Subsequent commands should fail because trace is closed.
+  const { stderr, exitCode: exitCode2 } = await runTraceCli(['actions']);
+  expect(exitCode2).toBe(1);
+  expect(stderr).toContain('No trace opened');
+
+  // Re-open for remaining tests.
+  const { exitCode: exitCode3 } = await runTraceCli(['open', traceFile]);
+  expect(exitCode3).toBe(0);
+});
+
 test('trace attachments lists attachments', async ({ runTraceCli }) => {
   const { stdout, exitCode } = await runTraceCli(['attachments']);
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- Add `trace close` command that removes the extracted trace directory
- Reuse cleanup logic in `openTrace` via shared `closeTrace()` function
- Update SKILL.md with new command documentation