### PR TITLE
fix: keep html reporter auto-open outside the test server

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -48,6 +48,7 @@ type TestSummary = {
 export type CommonReporterOptions = {
   configDir: string,
   _mode?: 'list' | 'test' | 'merge',
+  _isTestServer?: boolean,
   _commandHash?: string,
 };
 

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -159,10 +159,10 @@ class HtmlReporter implements ReporterV2 {
       return;
     const { ok, singleTestId } = this._buildResult;
     const isCodingAgent = !!process.env.CLAUDECODE || !!process.env.COPILOT_CLI;
-    const shouldOpen = !isCodingAgent && !!process.stdin.isTTY && (this._open === 'always' || (!ok && this._open === 'on-failure'));
+    const shouldOpen = !isCodingAgent && !this._options._isTestServer && (this._open === 'always' || (!ok && this._open === 'on-failure'));
     if (shouldOpen) {
       await showHTMLReport(this._outputFolder, this._host, this._port, singleTestId);
-    } else if (this._options._mode === 'test' && !!process.stdin.isTTY) {
+    } else if (this._options._mode === 'test' && !this._options._isTestServer) {
       const packageManagerCommand = getPackageManagerExecCommand();
       const relativeReportPath = this._outputFolder === standaloneDefaultFolder() ? '' : ' ' + path.relative(process.cwd(), this._outputFolder);
       const hostArg = this._host ? ` --host ${this._host}` : '';

--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -36,7 +36,7 @@ import type { BuiltInReporter, FullConfigInternal } from '../common/config';
 import type { CommonReporterOptions, Screen } from '../reporters/base';
 import type { ReporterV2 } from '../reporters/reporterV2';
 
-export async function createReporters(config: FullConfigInternal, mode: 'list' | 'test' | 'merge', descriptions?: ReporterDescription[]): Promise<ReporterV2[]> {
+export async function createReporters(config: FullConfigInternal, mode: 'list' | 'test' | 'merge', descriptions?: ReporterDescription[], options: { isTestServer?: boolean } = {}): Promise<ReporterV2[]> {
   const defaultReporters: { [key in BuiltInReporter]: new(arg: any) => ReporterV2 } = {
     blob: BlobReporter,
     dot: mode === 'list' ? ListModeReporter : DotReporter,
@@ -52,7 +52,7 @@ export async function createReporters(config: FullConfigInternal, mode: 'list' |
   descriptions ??= config.config.reporter;
   if (config.configCLIOverrides.additionalReporters)
     descriptions = [...descriptions, ...config.configCLIOverrides.additionalReporters];
-  const runOptions = reporterOptions(config, mode);
+  const runOptions = reporterOptions(config, mode, options.isTestServer);
   for (const r of descriptions) {
     const [name, arg] = r;
     const options = { ...runOptions, ...arg };
@@ -103,10 +103,11 @@ export function createErrorCollectingReporter(screen: Screen): ErrorCollectingRe
   };
 }
 
-function reporterOptions(config: FullConfigInternal, mode: 'list' | 'test' | 'merge'): CommonReporterOptions {
+function reporterOptions(config: FullConfigInternal, mode: 'list' | 'test' | 'merge', isTestServer: boolean | undefined): CommonReporterOptions {
   return {
     configDir: config.configDir,
     _mode: mode,
+    _isTestServer: isTestServer,
     _commandHash: computeCommandHash(config),
   };
 }

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -352,7 +352,7 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
       config.preOnlyTestFilters.push(test => testIdSet.has(test.id));
     }
 
-    const configReporters = params.disableConfigReporters ? [] : await createReporters(config, 'test');
+    const configReporters = params.disableConfigReporters ? [] : await createReporters(config, 'test', undefined, { isTestServer: true });
     const reporter = new InternalReporter([...configReporters, userReporter]);
     const stop = new ManualPromise();
     const tasks = [

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -86,6 +86,26 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.getByTestId('metadata-view')).not.toBeVisible();
     });
 
+    test('should open report outside test server even when stdin is not a tty', async ({ interactWithTestRunner }) => {
+      const testProcess = await interactWithTestRunner({
+        'playwright.config.ts': `
+          module.exports = { reporter: 'html' };
+        `,
+        'a.test.js': `
+          import { test } from '@playwright/test';
+          test('passes', async ({}) => {});
+        `,
+      }, {}, { PLAYWRIGHT_HTML_OPEN: 'always' });
+
+      const result = await Promise.race([
+        testProcess.waitForOutput('Serving HTML report at').then(() => 'opened' as const),
+        testProcess.exited.then(() => 'exited' as const),
+      ]);
+      expect(result).toBe('opened');
+
+      await testProcess.kill();
+    });
+
     test('should allow navigating to testId=test.id', async ({ runInlineTest, page, showReport }) => {
       const result = await runInlineTest({
         'a.test.js': `


### PR DESCRIPTION
Fixes #39766.

## Summary
- keep the HTML reporter auto-open path enabled when a regular test run happens outside the test server, even if stdin is not a TTY
- mark reporters created for the test server explicitly so HTML auto-open and the follow-up hint stay suppressed only for that path
- add a regression covering `PLAYWRIGHT_HTML_OPEN=always` under the test runner with non-TTY stdin

## Validation
- `npm run ttest -- reporter-html.spec.ts -g "should open report outside test server even when stdin is not a tty"`
- `npm run eslint -- packages/playwright/src/reporters/html.ts packages/playwright/src/reporters/base.ts packages/playwright/src/runner/reporters.ts packages/playwright/src/runner/testRunner.ts tests/playwright-test/reporter-html.spec.ts`
- `git diff --check`