### PR TITLE
docs(locator): clarify Java List return types

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -72,7 +72,7 @@ texts = page.get_by_role("link").all_inner_texts()
 ```
 
 ```java
-String[] texts = page.getByRole(AriaRole.LINK).allInnerTexts();
+List<String> texts = page.getByRole(AriaRole.LINK).allInnerTexts();
 ```
 
 ```csharp
@@ -104,7 +104,7 @@ texts = page.get_by_role("link").all_text_contents()
 ```
 
 ```java
-String[] texts = page.getByRole(AriaRole.LINK).allTextContents();
+List<String> texts = page.getByRole(AriaRole.LINK).allTextContents();
 ```
 
 ```csharp

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -1104,7 +1104,7 @@ await expect(locator).toContainClass(['inactive', 'active', 'inactive']);
 ```
 
 ```java
-assertThat(page.locator(".list > .component")).containsClass(new String[] {"inactive", "active", "inactive"});
+assertThat(page.locator(".list > .component")).containsClass(Arrays.asList("inactive", "active", "inactive"));
 ```
 
 ```python async


### PR DESCRIPTION
## Summary
- clarify the Java examples for Locator.allInnerTexts() and Locator.allTextContents() to use List<String>

Fixes https://github.com/microsoft/playwright/issues/39899