### PR TITLE
test(electron): add WebContentsView test

### DIFF
--- a/tests/electron/electron-webcontentsview-app.js
+++ b/tests/electron/electron-webcontentsview-app.js
@@ -1,0 +1,16 @@
+const { app, BaseWindow, WebContentsView } = require('electron');
+
+app.on('window-all-closed', e => e.preventDefault());
+
+app.whenReady().then(async () => {
+  const win = new BaseWindow({ width: 800, height: 600 });
+  const viewHeight = 200;
+  for (let i = 0; i < 3; i++) {
+    const view = new WebContentsView();
+    win.contentView.addChildView(view);
+    view.setBounds({ x: 0, y: i * viewHeight, width: 800, height: viewHeight });
+    const colors = ['#e74c3c', '#2ecc71', '#3498db'];
+    const html = `<title>WebContentsView${i + 1}</title><style>body{margin:0;background:${colors[i]};display:flex;align-items:center;justify-content:center;height:100vh;font:bold 32px sans-serif;color:#fff}</style><body>WebContentsView ${i + 1}</body>`;
+    await view.webContents.loadURL('data:text/html,' + encodeURIComponent(html));
+  }
+});

--- a/tests/electron/electron-webcontentsview.spec.ts
+++ b/tests/electron/electron-webcontentsview.spec.ts
@@ -23,6 +23,10 @@ test('should discover WebContentsViews via Playwright electron API', {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39427' });
 
   const app = await launchElectronApp('electron-webcontentsview-app.js');
+
+  const window = await app.firstWindow();
+  expect(await window.title()).toBe('WebContentsView1');
+
   await expect.poll(() => app.windows().length, { timeout: 10000 }).toBe(3);
   const titles = await Promise.all(app.windows().map(w => w.title()));
   expect(titles.sort()).toEqual(['WebContentsView1', 'WebContentsView2', 'WebContentsView3']);

--- a/tests/electron/electron-webcontentsview.spec.ts
+++ b/tests/electron/electron-webcontentsview.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, electronTest as test } from './electronTest';
+
+test('should discover WebContentsViews via Playwright electron API', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39427' },
+}, async ({ launchElectronApp, electronMajorVersion }) => {
+  test.skip(electronMajorVersion < 30, 'WebContentsView was introduced in Electron 30');
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39427' });
+
+  const app = await launchElectronApp('electron-webcontentsview-app.js');
+  await expect.poll(() => app.windows().length, { timeout: 10000 }).toBe(3);
+  const titles = await Promise.all(app.windows().map(w => w.title()));
+  expect(titles.sort()).toEqual(['WebContentsView1', 'WebContentsView2', 'WebContentsView3']);
+});


### PR DESCRIPTION
## Summary
- Add `electron-webcontentsview-app.js` — an Electron app that creates 3 `WebContentsView`s inside a `BaseWindow`, each with distinct colored content
- Add a test covering issue #39427: discovery via `playwright._electron.launch()` + `electronApp.windows()`

Closes https://github.com/microsoft/playwright/issues/39427