### PR TITLE
fix: prevent LastRunReporter in --list mode

### DIFF
--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -467,11 +467,19 @@ export async function runAllTestsWithConfig(config: FullConfigInternal): Promise
   webServerPluginsForConfig(config).forEach(p => config.plugins.push({ factory: p }));
 
   const reporters = await createReporters(config, listOnly ? 'list' : 'test');
-  const lastRun = new LastRunReporter(config);
-  if (config.cliLastFailed)
-    await lastRun.filterLastFailed();
+  //change done here
+  let reporter;
 
-  const reporter = new InternalReporter([...reporters, lastRun]);
+  if (listOnly) {
+    // In --list mode → do NOT use LastRunReporter
+    reporter = new InternalReporter([...reporters]);
+  } else {
+    const lastRun = new LastRunReporter(config);
+    if (config.cliLastFailed)
+      await lastRun.filterLastFailed();
+
+    reporter = new InternalReporter([...reporters, lastRun]);
+  }
   const tasks = listOnly ? [
     createLoadTask('in-process', { failOnLoadErrors: true, filterOnly: false }),
     createReportBeginTask(),


### PR DESCRIPTION
Fixes an issue where LastRunReporter was initialized even in --list mode.
Although writing to .last-run.json was skipped internally, the reporter was still being created and attached, which is unnecessary for list-only execution.
This change ensures that LastRunReporter is only used during actual test runs and not during --list mode, making list execution fully side-effect free.
This aligns with expected behavior of --list being a read-only operation.