### PR TITLE
lint: modernize __proto__ with getPrototypeOf

### DIFF
--- a/packages/injected/src/clock.ts
+++ b/packages/injected/src/clock.ts
@@ -724,8 +724,7 @@ function fakePerformance(clock: ClockController, performance: Builtins['performa
     now: () => clock.performanceNow(),
   };
   result.__defineGetter__('timeOrigin', () => clock._now.origin || 0);
-  // eslint-disable-next-line no-proto
-  for (const key of Object.keys((performance as any).__proto__)) {
+  for (const key of Object.keys(Object.getPrototypeOf(performance) as object)) {
     if (key === 'now' || key === 'timeOrigin')
       continue;
     if (key === 'getEntries' || key === 'getEntriesByName' || key === 'getEntriesByType')

--- a/tests/assets/reading-list/vue_2.6.14.js
+++ b/tests/assets/reading-list/vue_2.6.14.js
@@ -524,7 +524,7 @@
   /*  */
 
   // can we use __proto__?
-  var hasProto = '__proto__' in {};
+  var hasProto = !!Object.setPrototypeOf;
 
   // Browser environment sniffing
   var inBrowser = typeof window !== 'undefined';
@@ -961,12 +961,10 @@
 
   /**
    * Augment a target Object or Array by intercepting
-   * the prototype chain using __proto__
+   * the prototype chain using Object.setPrototypeOf
    */
   function protoAugment (target, src) {
-    /* eslint-disable no-proto */
-    target.__proto__ = src;
-    /* eslint-enable no-proto */
+    Object.setPrototypeOf(target, src);
   }
 
   /**

--- a/tests/library/events/method-names.spec.ts
+++ b/tests/library/events/method-names.spec.ts
@@ -25,8 +25,7 @@ import { test, expect } from '@playwright/test';
 
 test('EventEmitter prototype test', () => {
   const ee = new EventEmitter();
-  // eslint-disable-next-line no-proto
-  expect((ee as any).__proto__.constructor.name).toEqual('EventEmitter');
+  expect(Object.getPrototypeOf(ee).constructor.name).toEqual('EventEmitter');
   expect(ee.on).toEqual(ee.addListener);  // Same method.
   expect(ee.off).toEqual(ee.removeListener);  // Same method.
 


### PR DESCRIPTION
There's an eslint setting against this, but apparently some people don't get it.
For context, see https://github.com/microsoft/playwright/pull/17386.
