### PR TITLE
fix(web): pass default colors to ansi2html in error message component

### DIFF
--- a/packages/web/src/components/errorMessage.tsx
+++ b/packages/web/src/components/errorMessage.tsx
@@ -21,6 +21,11 @@ import './errorMessage.css';
 export const ErrorMessage: React.FC<{
   error: string;
 }> = ({ error }) => {
-  const html = React.useMemo(() => ansi2html(error), [error]);
+  const html = React.useMemo(() => {
+    return ansi2html(error, {
+      bg: 'var(--vscode-editor-background)',
+      fg: 'var(--vscode-editor-foreground)',
+    });
+  }, [error]);
   return <div className='error-message' dangerouslySetInnerHTML={{ __html: html || '' }}></div>;
 };


### PR DESCRIPTION
The `ErrorMessage` component used by UI mode and trace viewer calls `ansi2html()` without `defaultColors`. When ANSI reverse video (code 7) is active — used by expect matchers to highlight changed characters in assertion diffs — the foreground color is left undefined and inherits the page's dark text color, producing dark text on a dark red/green background.

The HTML reporter's `testErrorView.tsx` already passes `defaultColors` to `ansi2html()`, so this aligns the shared `ErrorMessage` component with the same pattern.

Fixes https://github.com/microsoft/playwright/issues/39484