### PR TITLE
fix(mcp): skip empty secret values in redactText

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -140,8 +140,10 @@ export class Response {
   }
 
   private _redactSecrets(text: string): string {
-    for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {}))
-      text = text.replaceAll(secretValue, `<secret>${secretName}</secret>`);
+    for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {})) {
+      if (secretValue)
+        text = text.replaceAll(secretValue, `<secret>${secretName}</secret>`);
+    }
     return text;
   }
 

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -464,7 +464,8 @@ export function commaSeparatedList(value: string | undefined): string[] | undefi
 export function dotenvFileLoader(value: string | undefined): Record<string, string> | undefined {
   if (!value)
     return undefined;
-  return dotenv.parse(fs.readFileSync(value, 'utf8'));
+  const parsed = dotenv.parse(fs.readFileSync(value, 'utf8'));
+  return Object.fromEntries(Object.entries(parsed).filter(([, v]) => v));
 }
 
 export function numberParser(value: string | undefined): number | undefined {

--- a/tests/mcp/secrets.spec.ts
+++ b/tests/mcp/secrets.spec.ts
@@ -126,3 +126,28 @@ await page.getByRole('textbox', { name: 'Password' }).fill(process.env['X-PASSWO
     inlineSnapshot: expect.stringContaining(`- textbox \"Password\" [active] [ref=e6]: <secret>X-PASSWORD</secret>`),
   });
 });
+
+
+test('empty secret values should not cause crash', async ({ startClient, server }) => {
+  const secretsFile = test.info().outputPath('secrets.env');
+  await fs.promises.writeFile(secretsFile, 'EMPTY_SECRET=\nREAL_SECRET=password123');
+
+  const { client } = await startClient({
+    args: ['--secrets', secretsFile],
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body>password123</body>
+    </html>
+  `, 'text/html');
+
+  const response = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+  expect(response).toHaveResponse({
+    snapshot: expect.stringContaining('<secret>REAL_SECRET</secret>'),
+  });
+});


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/playwright-mcp/issues/1474

Empty-string secret values parsed from `.env` files (e.g. `KEY=#{VAR}#` where dotenv strips comments) cause `String.replaceAll("", ...)` to insert the replacement tag between every character. This grows the string exponentially across multiple empty secrets, crashing V8 with a `RangeError`.

- Skip empty `secretValue` in `_redactSecrets()` before calling `replaceAll`
- Filter out empty values in `dotenvFileLoader()` at parse time

Fixes https://github.com/microsoft/playwright-mcp/issues/1474