### PR TITLE
fix(api): remove deprecated timeout option from isVisible and isHidden

### DIFF
--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -1318,7 +1318,7 @@ Returns whether the element is hidden, the opposite of [visible](../actionabilit
 ### option: Frame.isHidden.timeout
 * since: v1.8
 * deprecated: This option is ignored. [`method: Frame.isHidden`] does not wait for the element to become hidden and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## async method: Frame.isVisible
 * since: v1.8
@@ -1336,7 +1336,7 @@ Returns whether the element is [visible](../actionability.md#visible). [`param: 
 ### option: Frame.isVisible.timeout
 * since: v1.8
 * deprecated: This option is ignored. [`method: Frame.isVisible`] does not wait for the element to become visible and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## method: Frame.locator
 * since: v1.14

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1735,7 +1735,7 @@ Boolean hidden = await page.GetByRole(AriaRole.Button).IsHiddenAsync();
 ### option: Locator.isHidden.timeout
 * since: v1.14
 * deprecated: This option is ignored. [`method: Locator.isHidden`] does not wait for the element to become hidden and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## async method: Locator.isVisible
 * since: v1.14
@@ -1772,7 +1772,7 @@ Boolean visible = await page.GetByRole(AriaRole.Button).IsVisibleAsync();
 ### option: Locator.isVisible.timeout
 * since: v1.14
 * deprecated: This option is ignored. [`method: Locator.isVisible`] does not wait for the element to become visible and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## method: Locator.last
 * since: v1.14

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2657,7 +2657,7 @@ Returns whether the element is hidden, the opposite of [visible](../actionabilit
 * since: v1.8
 * deprecated: This option is ignored. [`method: Page.isHidden`] does not wait for the
   element to become hidden and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## async method: Page.isVisible
 * since: v1.8
@@ -2676,7 +2676,7 @@ Returns whether the element is [visible](../actionability.md#visible). [`param: 
 * since: v1.8
 * deprecated: This option is ignored. [`method: Page.isVisible`] does not wait
   for the element to become visible and returns immediately.
-- `timeout` <[float]>
+- `timeout` <[never]>
 
 ## property: Page.keyboard
 * since: v1.8

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -3586,7 +3586,7 @@ export interface Page {
      * [page.isHidden(selector[, options])](https://playwright.dev/docs/api/class-page#page-is-hidden) does not wait for
      * the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -3612,7 +3612,7 @@ export interface Page {
      * [page.isVisible(selector[, options])](https://playwright.dev/docs/api/class-page#page-is-visible) does not wait for
      * the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -7341,7 +7341,7 @@ export interface Frame {
      * [frame.isHidden(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-is-hidden) does not wait
      * for the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -7367,7 +7367,7 @@ export interface Frame {
      * [frame.isVisible(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-is-visible) does not wait
      * for the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -14134,7 +14134,7 @@ export interface Locator {
      * [locator.isHidden([options])](https://playwright.dev/docs/api/class-locator#locator-is-hidden) does not wait for
      * the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -14158,7 +14158,7 @@ export interface Locator {
      * [locator.isVisible([options])](https://playwright.dev/docs/api/class-locator#locator-is-visible) does not wait for
      * the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3586,7 +3586,7 @@ export interface Page {
      * [page.isHidden(selector[, options])](https://playwright.dev/docs/api/class-page#page-is-hidden) does not wait for
      * the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -3612,7 +3612,7 @@ export interface Page {
      * [page.isVisible(selector[, options])](https://playwright.dev/docs/api/class-page#page-is-visible) does not wait for
      * the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -7341,7 +7341,7 @@ export interface Frame {
      * [frame.isHidden(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-is-hidden) does not wait
      * for the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -7367,7 +7367,7 @@ export interface Frame {
      * [frame.isVisible(selector[, options])](https://playwright.dev/docs/api/class-frame#frame-is-visible) does not wait
      * for the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -14134,7 +14134,7 @@ export interface Locator {
      * [locator.isHidden([options])](https://playwright.dev/docs/api/class-locator#locator-is-hidden) does not wait for
      * the element to become hidden and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**
@@ -14158,7 +14158,7 @@ export interface Locator {
      * [locator.isVisible([options])](https://playwright.dev/docs/api/class-locator#locator-is-visible) does not wait for
      * the element to become visible and returns immediately.
      */
-    timeout?: number;
+    timeout?: never;
   }): Promise<boolean>;
 
   /**


### PR DESCRIPTION
## Summary
- Remove the deprecated `timeout` option from `isVisible` and `isHidden` on Locator, Page, and Frame
- These are one-shot operations that return immediately — the timeout was never used
- TypeScript users now get a compile error instead of silently passing a no-op option

Fixes https://github.com/microsoft/playwright/issues/33017