### PR TITLE
fix: pin 5 unpinned action(s), extract 1 unsafe expression to env var

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -39,7 +39,7 @@ jobs:
         HTML_REPORT_URL: 'https://mspwblobreport.z1.web.core.windows.net/run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}/index.html'
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
       with:
         client-id: ${{ secrets.AZURE_BLOB_REPORTS_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_BLOB_REPORTS_TENANT_ID }}

--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -35,7 +35,7 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git add .
             git commit -m "chore: update generated files after dependency update"
-            git push origin HEAD:${{ github.head_ref }}
+            git push origin HEAD:"${HEAD_REF}"
             # Pushing with GITHUB_TOKEN does not retrigger workflow runs, see:
             # https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs
             # Close and reopen the PR to fire a pull_request reopened event, which
@@ -49,3 +49,4 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -54,7 +54,7 @@ jobs:
       run: utils/publish_all_packages.sh --release
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
       with:
         client-id: ${{ secrets.AZURE_PW_CDN_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_PW_CDN_TENANT_ID }}

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -24,13 +24,13 @@ jobs:
         node-version: 20
         registry-url: 'https://registry.npmjs.org'
     - name: Set up Docker QEMU for arm64 docker builds
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
       with:
         platforms: arm64
     - run: npm ci
     - run: npm run build
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
       with:
         client-id: ${{ secrets.AZURE_DOCKER_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_DOCKER_TENANT_ID }}

--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Azure Login
       if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
       with:
         client-id: ${{ secrets.AZURE_BLOB_REPORTS_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_BLOB_REPORTS_TENANT_ID }}


### PR DESCRIPTION
Re-submission of #39878. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins GitHub Actions to immutable commit SHAs and extracts an unsafe expression from a `run:` block into an `env:` mapping.

- Pin 5 unpinned actions to full 40-character SHAs
- Extract 1 critical `github.head_ref` injection from run block to env var

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- **Expression extraction**: `${{ github.head_ref }}` in `run:` moves to `env:` block, referenced as `"${HEAD_REF}"` in the script
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)