### PR TITLE
chore: revert api back to nullable video

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4455,7 +4455,7 @@ Optional handler function to route the request.
 
 ## method: Page.video
 * since: v1.8
-- returns: <[Video]>
+- returns: <[null]|[Video]>
 
 Video object associated with this page. Can be used to access the video file when using the `recordVideo` context option.
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -4800,7 +4800,7 @@ export interface Page {
    * Video object associated with this page. Can be used to access the video file when using the `recordVideo` context
    * option.
    */
-  video(): Video;
+  video(): null|Video;
 
   viewportSize(): null|{
     /**

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -281,7 +281,12 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     this._timeoutSettings.setDefaultTimeout(timeout);
   }
 
-  video(): Video {
+  video(): Video | null {
+    // Note: we are creating Video object lazily, because we do not know
+    // BrowserContextOptions when constructing the page - it is assigned
+    // too late during launchPersistentContext.
+    if (!this._browserContext._options.recordVideo)
+      return null;
     return this._video;
   }
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -4800,7 +4800,7 @@ export interface Page {
    * Video object associated with this page. Can be used to access the video file when using the `recordVideo` context
    * option.
    */
-  video(): Video;
+  video(): null|Video;
 
   viewportSize(): null|{
     /**

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -404,7 +404,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures> = ({
         const preserveVideo = captureVideo && (videoMode === 'on' || (testFailed && videoMode === 'retain-on-failure') || (videoMode === 'on-first-retry' && testInfo.retry === 1));
         if (preserveVideo) {
           const { pagesWithVideo: pagesForVideo } = contexts.get(context)!;
-          const videos = pagesForVideo.map(p => p.video());
+          const videos = pagesForVideo.map(p => p.video()).filter(video => !!video);
           await Promise.all(videos.map(async v => {
             try {
               const savedPath = testInfo.outputPath(`video${counter ? '-' + counter : ''}.webm`);

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -164,6 +164,10 @@ it.describe('screencast', () => {
   it.slow();
   it.skip(({ mode }) => mode !== 'default', 'video.path() is not available in remote mode');
 
+  it('should not have video by default', async ({ page }) => {
+    expect(page.video()).toBeNull();
+  });
+
   it('videoSize should require videosPath', async ({ browser }) => {
     const error = await browser.newContext({ videoSize: { width: 100, height: 100 } }).catch(e => e);
     expect(error.message).toContain('"videoSize" option requires "videosPath" to be specified');


### PR DESCRIPTION
As it was before #38991. This way we don't touch the existing public API at all.