### PR TITLE
docs: add FixSense to third-party reporter list

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -467,3 +467,4 @@ Here's a short list of open source reporter implementations that you can take a 
 * [Mail Reporter](https://github.com/estruyf/playwright-mail-reporter)
 * [ReportPortal](https://github.com/reportportal/agent-js-playwright)
 * [Monocart](https://github.com/cenfun/monocart-reporter)
+* [FixSense](https://github.com/CopilotMe/playwright-fixsense-reporter)


### PR DESCRIPTION
Adds [FixSense](https://github.com/CopilotMe/playwright-fixsense-reporter) to the list of open source reporter implementations in the test reporters docs.

**npm:** [`playwright-fixsense-reporter`](https://www.npmjs.com/package/playwright-fixsense-reporter)

FixSense is a Playwright reporter that sends test failure results to the FixSense platform for AI-powered root cause analysis and optional auto-fix PR generation.