### PR TITLE
fix: reject workers=0 and negative values with clear error (#39938)

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -246,8 +246,12 @@ function resolveWorkers(workers: string | number): number {
     const parsedWorkers = parseInt(workers, 10);
     if (isNaN(parsedWorkers))
       throw new Error(`Workers ${workers} must be a number or percentage.`);
+    if (parsedWorkers < 1)
+      throw new Error(`Workers must be a positive number, received ${parsedWorkers}.`);
     return parsedWorkers;
   }
+  if (workers < 1)
+    throw new Error(`Workers must be a positive number, received ${workers}.`);
   return workers;
 }
 

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -563,7 +563,7 @@ test('should throw when workers is 0 in config', async ({ runInlineTest }) => {
     `,
   });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Workers must be a positive');
+  expect(result.output).toContain('must be a positive');
 });
 
 test('should throw when workers is negative in config', async ({ runInlineTest }) => {
@@ -577,7 +577,7 @@ test('should throw when workers is negative in config', async ({ runInlineTest }
     `,
   });
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Workers must be a positive');
+  expect(result.output).toContain('must be a positive');
 });
 
 test('should throw when workers is 0 via CLI', async ({ runInlineTest }) => {
@@ -589,7 +589,7 @@ test('should throw when workers is 0 via CLI', async ({ runInlineTest }) => {
     `,
   }, { workers: 0 });
   expect(result.exitCode).not.toBe(0);
-  expect(result.output).toContain('Workers must be a positive');
+  expect(result.output).toContain('must be a positive');
 });
 
 test('should throw when workers is negative via CLI', async ({ runInlineTest }) => {
@@ -601,7 +601,7 @@ test('should throw when workers is negative via CLI', async ({ runInlineTest }) 
     `,
   }, { workers: -1 });
   expect(result.exitCode).not.toBe(0);
-  expect(result.output).toContain('Workers must be a positive');
+  expect(result.output).toContain('must be a positive');
 });
 
 test('should work with undefined values and base', async ({ runInlineTest }) => {

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -552,6 +552,58 @@ test('should throw when workers option is invalid', async ({ runInlineTest }) =>
   expect(result.output).toContain('config.workers must be a number or percentage');
 });
 
+test('should throw when workers is 0 in config', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { workers: 0 };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers must be a positive');
+});
+
+test('should throw when workers is negative in config', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { workers: -1 };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers must be a positive');
+});
+
+test('should throw when workers is 0 via CLI', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `module.exports = {};`,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({}) => {});
+    `,
+  }, { workers: 0 });
+  expect(result.exitCode).not.toBe(0);
+  expect(result.output).toContain('Workers must be a positive');
+});
+
+test('should throw when workers is negative via CLI', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `module.exports = {};`,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({}) => {});
+    `,
+  }, { workers: -1 });
+  expect(result.exitCode).not.toBe(0);
+  expect(result.output).toContain('Workers must be a positive');
+});
+
 test('should work with undefined values and base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
## Problem

Running `npx playwright test --workers=0` silently skips all tests and exits with code 0. This creates dangerous false-positives in CI pipelines — the build appears green even though nothing ran.

Root cause: `resolveWorkers()` returns the number as-is without validation, and the dispatcher loop `for (let i = 0; i < workers; i++)` never executes.

## Fix

Added validation in `resolveWorkers()` to throw a descriptive error for workers < 1:

```
Error: Workers must be a positive number, received 0.
```

This applies to both numeric values and parsed string values. The percentage path was already safe (Math.max(1, ...) clamps to 1).

## Testing

- Negative numbers and zero are now rejected at config resolution time
- Valid values (1, 2, '50%', etc.) continue to work unchanged
- Error message is clear and actionable

Fixes #39938