### PR TITLE
fix(mcp): skip empty secret values when redacting responses

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -140,8 +140,11 @@ export class Response {
   }
 
   private _redactSecrets(text: string): string {
-    for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {}))
+    for (const [secretName, secretValue] of Object.entries(this._context.config.secrets ?? {})) {
+      if (!secretValue)
+        continue;
       text = text.replaceAll(secretValue, `<secret>${secretName}</secret>`);
+    }
     return text;
   }
 

--- a/tests/mcp/secrets.spec.ts
+++ b/tests/mcp/secrets.spec.ts
@@ -126,3 +126,29 @@ await page.getByRole('textbox', { name: 'Password' }).fill(process.env['X-PASSWO
     inlineSnapshot: expect.stringContaining(`- textbox \"Password\" [active] [ref=e6]: <secret>X-PASSWORD</secret>`),
   });
 });
+
+test('empty secret value is ignored', async ({ startClient, server }) => {
+  const secretsFile = test.info().outputPath('secrets.env');
+  await fs.promises.writeFile(secretsFile, 'EMPTY_SECRET=\nX-PASSWORD=password123');
+
+  const { client } = await startClient({
+    args: ['--secrets', secretsFile],
+  });
+
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <body><p>hello password123</p></body>
+    </html>
+  `, 'text/html');
+
+  const response = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  // Response should not be mangled by empty secret replacement
+  expect(response).toHaveResponse({
+    snapshot: expect.stringContaining(`<secret>X-PASSWORD</secret>`),
+  });
+});


### PR DESCRIPTION
## Summary
- Empty string secrets would corrupt response text via `replaceAll('', ...)`, inserting the replacement between every character
- Skip secrets with empty/falsy values before applying redaction

Closes https://github.com/microsoft/playwright-mcp/issues/1474