### PR TITLE
fix(dashboard): light mode styles

### DIFF
--- a/packages/dashboard/src/dashboard.css
+++ b/packages/dashboard/src/dashboard.css
@@ -38,11 +38,6 @@
   background: var(--color-canvas-overlay);
 }
 
-.dashboard-view.interactive .tab.active {
-  background: rgb(var(--interactive-orange));
-  color: var(--color-fg-on-emphasis);
-}
-
 .dashboard-view.interactive .toolbar::after {
   content: '';
   position: absolute;
@@ -72,7 +67,7 @@
   transform: translate(-50%, -50%) scale(0.35);
   box-shadow: 0 0 0 0 rgb(var(--interactive-orange) / 0.52);
   z-index: -1;
-  animation: interactive-track-radial 420ms cubic-bezier(0.12, 0.72, 0.22, 1);
+  animation: interactive-track-radial 420ms cubic-bezier(0.12, 0.72, 0.22, 1) forwards;
 }
 
 .dashboard-view.interactive .segmented-control.interactive::after {
@@ -186,6 +181,11 @@
 }
 :root.light-mode .tab.active {
   background: var(--color-canvas-subtle);
+}
+
+.dashboard-view.interactive .tab.active {
+  background: rgb(var(--interactive-orange));
+  color: var(--color-fg-on-emphasis);
 }
 
 .tab-label {


### PR DESCRIPTION
Fixes tab colour and "Interactive" button animation end state in light mode:
 
Before:
<img width="741" height="135" alt="Screenshot 2026-03-31 at 13 51 39" src="https://github.com/user-attachments/assets/87fd35cb-7a51-49c9-8b00-8a1f5ec33f67" />
After:
<img width="731" height="129" alt="Screenshot 2026-03-31 at 13 51 25" src="https://github.com/user-attachments/assets/986c0b51-5793-496b-8db0-0705cf0bb7d0" />
