### PR TITLE
fix(html): dont show empty project label

### DIFF
--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -46,8 +46,8 @@ export const ProjectAndTagLabelsView: React.FC<{
   // We can have an empty project name if we have no projects specified in the config
   const hasProjectNames = projectNames.length > 0 && !!activeProjectName;
 
-  return (hasProjectNames || otherLabels.length > 0) && <span className='label-row' style={style ?? {}}>
-    <ProjectLink projectNames={projectNames} projectName={activeProjectName} />
+  return (hasProjectNames || otherLabels.length > 0) && <span className='label-row' style={style}>
+    {hasProjectNames && <ProjectLink projectNames={projectNames} projectName={activeProjectName} />}
     <LabelsClickView labels={otherLabels} />
   </span>;
 };

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1768,7 +1768,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         const result = await runInlineTest({
           'a.test.js': `
             const { expect, test } = require('@playwright/test');
-            test('pass', async ({}) => {
+            test('pass', { tag: '@smoke' }, async ({}) => {
               expect(1).toBe(1);
             });
           `,
@@ -1779,8 +1779,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
 
         await showReport();
 
-        await expect(page.locator('.test-file-test .label')).toHaveCount(0);
-        await expect(page.locator('.label-row')).not.toBeVisible();
+        await expect(page.locator('.test-file-test .label')).toHaveCount(1);
       });
 
       test('testCaseView - after click test label and go back, testCaseView should be visible', async ({ runInlineTest, showReport, page }) => {


### PR DESCRIPTION
We're showing an empty label (the blue underscore) when the project name is `""`:

<img width="436" height="258" alt="Screenshot 2026-03-31 at 16 11 41" src="https://github.com/user-attachments/assets/17dac3ff-296b-4334-895b-9ab5c5cf5c6d" />
