### PR TITLE
chore(cli): clarify --skills option description

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -924,7 +924,7 @@ const install = declareCommand({
   category: 'install',
   args: z.object({}),
   options: z.object({
-    skills: z.string().optional().describe('Install skills to ".claude" (default) or ".agents" dir'),
+    skills: z.string().optional().describe('Install skills, possible values: claude (default), agents.'),
   }),
   toolName: '',
   toolParams: () => ({}),


### PR DESCRIPTION
## Summary
- Clarify that `--skills` accepts `claude` (default) or `agents` as values, consistent with how other options with predefined values are described (e.g. `--browser`)

Fixes https://github.com/microsoft/playwright-cli/issues/294