### PR TITLE
fix(cli): tab-new navigates to url when provided

### DIFF
--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -32,18 +32,7 @@ const navigate = defineTool({
 
   handle: async (context, params, response) => {
     const tab = await context.ensureTab();
-    let url = params.url;
-    try {
-      new URL(url);
-    } catch (e) {
-      if (url.startsWith('localhost'))
-        url = 'http://' + url;
-      else
-        url = 'https://' + url;
-    }
-
-    context.checkUrlAllowed(url);
-    await tab.navigate(url);
+    const url = await tab.checkUrlAndNavigate(params.url);
 
     response.setIncludeSnapshot();
     response.addCode(`await page.goto('${url}');`);

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -293,6 +293,20 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     await this.page.waitForLoadState(state, options).catch(e => debug('pw:tools:error')(e));
   }
 
+  async checkUrlAndNavigate(url: string): Promise<string> {
+    try {
+      new URL(url);
+    } catch (e) {
+      if (url.startsWith('localhost'))
+        url = 'http://' + url;
+      else
+        url = 'https://' + url;
+    }
+    this.context.checkUrlAllowed(url);
+    await this.navigate(url);
+    return url;
+  }
+
   async navigate(url: string) {
     await this._initializedPromise;
 

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -41,8 +41,11 @@ const browserTabs = defineTool({
       }
       case 'new': {
         const tab = await context.newTab();
-        if (params.url)
-          await tab.page.goto(params.url);
+        if (params.url) {
+          const url = await tab.checkUrlAndNavigate(params.url);
+          response.setIncludeSnapshot();
+          response.addCode(`await page.goto('${url}');`);
+        }
         break;
       }
       case 'close': {

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -28,6 +28,7 @@ const browserTabs = defineTool({
     inputSchema: z.object({
       action: z.enum(['list', 'new', 'close', 'select']).describe('Operation to perform'),
       index: z.number().optional().describe('Tab index, used for close/select. If omitted for close, current tab is closed.'),
+      url: z.string().optional().describe('URL to navigate to in the new tab, used for new.'),
     }),
     type: 'action',
   },
@@ -39,7 +40,9 @@ const browserTabs = defineTool({
         break;
       }
       case 'new': {
-        await context.newTab();
+        const tab = await context.newTab();
+        if (params.url)
+          await tab.page.goto(params.url);
         break;
       }
       case 'close': {

--- a/tests/mcp/cli-navigation.spec.ts
+++ b/tests/mcp/cli-navigation.spec.ts
@@ -40,6 +40,13 @@ test('open without url opens about:blank', async ({ cli }) => {
   expect(output).toContain('- Page URL: about:blank');
 });
 
+test('tab-new with url', async ({ cli, server }) => {
+  await cli('open');
+  const { output } = await cli('tab-new', server.HELLO_WORLD);
+  expect(output).toContain(`- 0: [](about:blank)`);
+  expect(output).toContain(`- 1: (current) [Title](${server.HELLO_WORLD})`);
+});
+
 test('run-code', async ({ cli, server }) => {
   await cli('open', server.HELLO_WORLD);
   const { output } = await cli('run-code', '() => page.title()');

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -78,6 +78,19 @@ test('create new tab', async ({ client }) => {
   });
 });
 
+test('create new tab with url', async ({ client }) => {
+  expect(await client.callTool({
+    name: 'browser_tabs',
+    arguments: {
+      action: 'new',
+      url: `data:text/html,<title>Tab one</title><body>Body one</body>`,
+    },
+  })).toHaveResponse({
+    result: `- 0: [](about:blank)
+- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+  });
+});
+
 test('select tab', async ({ client }) => {
   await createTab(client, 'Tab one', 'Body one');
   await createTab(client, 'Tab two', 'Body two');


### PR DESCRIPTION
## Summary
- `browser_tabs` tool schema was missing the `url` field, so it was never passed through
- The `new` action now navigates to the provided URL after creating the tab