### PR TITLE
chore(cli-daemon): refactor browser install and honor PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -109,11 +109,8 @@ async function ensureConfiguredBrowserInstalled() {
     const config = await configUtils.resolveCLIConfigForCLI(clientInfo.daemonProfilesDir, 'default', {});
     const browserName = config.browser.browserName;
     const channel = config.browser.launchOptions.channel;
-    if (!channel || channel.startsWith('chromium')) {
-      const executable = browserRegistry.findExecutable(channel ?? browserName);
-      if (executable && !fs.existsSync(executable.executablePath()!))
-        await browserRegistry.install([executable]);
-    }
+    if (!channel || channel.startsWith('chromium'))
+      await resolveAndInstall(channel ?? browserName);
   } else {
     const channel = await findOrInstallDefaultBrowser();
     if (channel !== 'chrome')
@@ -127,13 +124,17 @@ async function findOrInstallDefaultBrowser() {
     const executable = browserRegistry.findExecutable(channel);
     if (!executable?.executablePath())
       continue;
+    await resolveAndInstall('ffmpeg');
     console.log(`✅ Found ${channel}, will use it as the default browser.`);
     return channel;
   }
-  const chromiumExecutable = browserRegistry.findExecutable('chromium');
-  if (!fs.existsSync(chromiumExecutable?.executablePath()!))
-    await browserRegistry.install([chromiumExecutable]);
+  await resolveAndInstall('chromium');
   return 'chromium';
+}
+
+async function resolveAndInstall(nameOrChannel: string) {
+  const executables = browserRegistry.resolveBrowsers([nameOrChannel], { shell: 'no' });
+  await browserRegistry.install(executables);
 }
 
 async function createDefaultConfig(channel: string) {

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -27,6 +27,7 @@ import * as configUtils from '../mcp/config';
 import { createClientInfo } from '../cli-client/registry';
 import { program } from '../../utilsBundle';
 import { registry as browserRegistry } from '../../server/registry/index';
+import { getAsBooleanFromENV } from '../../server/utils/env';
 
 program.argument('[session-name]', 'name of the session to create or connect to', 'default')
     .option('--headed', 'run in headed mode (non-headless)')
@@ -103,6 +104,8 @@ async function initWorkspace(initSkills: string | undefined) {
 }
 
 async function ensureConfiguredBrowserInstalled() {
+  if (getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD'))
+    return;
   if (fs.existsSync(defaultConfigFile()) || fs.existsSync(globalConfigFile())) {
     // Config exists, ensure configured browser is installed
     const clientInfo = createClientInfo();


### PR DESCRIPTION
## Summary
- Extract `resolveAndInstall()` helper that uses `resolveBrowsers()` to resolve browsers and their dependencies (e.g. ffmpeg) before installing
- Honor `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` env variable to skip browser installation on daemon startup

Fixes https://github.com/microsoft/playwright-cli/issues/295