### PR TITLE
fix(mcp): support expressions in browser_evaluate

### DIFF
--- a/packages/playwright-core/src/tools/backend/evaluate.ts
+++ b/packages/playwright-core/src/tools/backend/evaluate.ts
@@ -41,21 +41,35 @@ const evaluate = defineTabTool({
 
   handle: async (tab, params, response) => {
     let locator: Awaited<ReturnType<Tab['refLocator']>> | undefined;
-    if (!/^\s*(async\s+)?(\([^)]*\)\s*=>|[\w$]+\s*=>|function[\s(*])/.test(params.function))
-      params.function = `() => (${params.function})`;
-    if (params.ref) {
+    const expression = params.function;
+    if (params.ref)
       locator = await tab.refLocator({ ref: params.ref, selector: params.selector, element: params.element || 'element' });
-      response.addCode(`await page.${locator.resolved}.evaluate(${escapeWithQuotes(params.function)});`);
-    } else {
-      response.addCode(`await page.evaluate(${escapeWithQuotes(params.function)});`);
-    }
 
     await tab.waitForCompletion(async () => {
-      // eslint-disable-next-line no-restricted-syntax
-      const func = new Function() as any;
-      func.toString = () => params.function;
-      const result = locator?.locator ? await locator?.locator.evaluate(func) : await tab.page.evaluate(func);
-      const text = JSON.stringify(result, null, 2) || 'undefined';
+      let evalResult: { result: unknown, isFunction: boolean };
+      if (locator?.locator) {
+        evalResult = await locator.locator.evaluate(async (element, expr) => {
+          const value = eval(`(${expr})`);
+          const isFunction = typeof value === 'function';
+          const result = await (isFunction ? value(element) : value);
+          return { result, isFunction };
+        }, expression);
+      } else {
+        evalResult = await tab.page.evaluate(async expr => {
+          const value = eval(`(${expr})`);
+          const isFunction = typeof value === 'function';
+          const result = await (isFunction ? value() : value);
+          return { result, isFunction };
+        }, expression);
+      }
+
+      const codeExpression = evalResult.isFunction ? expression : `() => (${expression})`;
+      if (locator)
+        response.addCode(`await page.${locator.resolved}.evaluate(${escapeWithQuotes(codeExpression)});`);
+      else
+        response.addCode(`await page.evaluate(${escapeWithQuotes(codeExpression)});`);
+
+      const text = JSON.stringify(evalResult.result, null, 2) ?? 'undefined';
       await response.addResult('Evaluation result', text, { prefix: 'result', ext: 'json', suggestedFilename: params.filename });
     });
   },

--- a/packages/playwright-core/src/tools/backend/evaluate.ts
+++ b/packages/playwright-core/src/tools/backend/evaluate.ts
@@ -41,7 +41,7 @@ const evaluate = defineTabTool({
 
   handle: async (tab, params, response) => {
     let locator: Awaited<ReturnType<Tab['refLocator']>> | undefined;
-    if (!params.function.includes('=>'))
+    if (!/^\s*(async\s+)?(\([^)]*\)\s*=>|[\w$]+\s*=>|function[\s(*])/.test(params.function))
       params.function = `() => (${params.function})`;
     if (params.ref) {
       locator = await tab.refLocator({ ref: params.ref, selector: params.selector, element: params.element || 'element' });

--- a/tests/mcp/evaluate.spec.ts
+++ b/tests/mcp/evaluate.spec.ts
@@ -76,6 +76,45 @@ test('browser_evaluate object', async ({ client, server }) => {
   });
 });
 
+test('browser_evaluate expression', async ({ client, server }) => {
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    page: expect.stringContaining(`- Page Title: Title`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: '(1+1)',
+    },
+  })).toHaveResponse({
+    result: `2`,
+    code: `await page.evaluate('() => ((1+1))');`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: '[1,2,3].map(x => x*2)',
+    },
+  })).toHaveResponse({
+    result: `[\n  2,\n  4,\n  6\n]`,
+    code: `await page.evaluate('() => ([1,2,3].map(x => x*2))');`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: 'function foo() { return 1; }',
+    },
+  })).toHaveResponse({
+    result: `1`,
+    code: `await page.evaluate('function foo() { return 1; }');`,
+  });
+});
+
 test('browser_evaluate (error)', async ({ client, server }) => {
   expect(await client.callTool({
     name: 'browser_navigate',

--- a/tests/mcp/evaluate.spec.ts
+++ b/tests/mcp/evaluate.spec.ts
@@ -113,6 +113,26 @@ test('browser_evaluate expression', async ({ client, server }) => {
     result: `1`,
     code: `await page.evaluate('function foo() { return 1; }');`,
   });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: 'async () => 42',
+    },
+  })).toHaveResponse({
+    result: `42`,
+    code: `await page.evaluate('async () => 42');`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: 'Promise.resolve(42)',
+    },
+  })).toHaveResponse({
+    result: `42`,
+    code: `await page.evaluate('() => (Promise.resolve(42))');`,
+  });
 });
 
 test('browser_evaluate (error)', async ({ client, server }) => {


### PR DESCRIPTION
## Summary

- Replace `includes('=>')` check with a regex that detects actual function syntax (`() =>`, `x =>`, `function`)
- This fixes expressions containing `=>` (e.g. `[1,2,3].map(x => x*2)`) being incorrectly treated as functions

Fixes https://github.com/microsoft/playwright-cli/issues/296