### PR TITLE
fix(config): throw on workers=0 or negative value

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -246,8 +246,12 @@ function resolveWorkers(workers: string | number): number {
     const parsedWorkers = parseInt(workers, 10);
     if (isNaN(parsedWorkers))
       throw new Error(`Workers ${workers} must be a number or percentage.`);
+    if (parsedWorkers <= 0)
+      throw new Error(`Workers ${workers} must be a positive number.`);
     return parsedWorkers;
   }
+  if (workers <= 0)
+    throw new Error(`Workers ${workers} must be a positive number.`);
   return workers;
 }
 

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -552,6 +552,28 @@ test('should throw when workers option is invalid', async ({ runInlineTest }) =>
   expect(result.output).toContain('config.workers must be a number or percentage');
 });
 
+test('should throw when workers option is zero via CLI', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+    `
+  }, { workers: 0 });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers 0 must be a positive number');
+});
+
+test('should throw when workers option is negative via CLI', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+    `
+  }, { workers: -1 });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers -1 must be a positive number');
+});
+
 test('should work with undefined values and base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
- \`--workers=0\` and \`--workers=-1\` via CLI bypassed validation and resolved silently, causing an empty test run that exits 0
- \`resolveWorkers\` only guarded against NaN, not <= 0
- config-file path already throws (configLoader.ts:325) but CLI override path did not

Fixes https://github.com/microsoft/playwright/issues/39938