### PR TITLE
fix(test-runner): apply --last-failed filter after dependency projects are added

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -202,9 +202,6 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     filterTestsRemoveEmptySuites(rootSuite, test => testsInThisShard.has(test));
   }
 
-  if (config.postShardTestFilters.length)
-    filterTestsRemoveEmptySuites(rootSuite, test => config.postShardTestFilters.every(filter => filter(test)));
-
   const topLevelProjects = [];
   // Now prepend dependency projects without filtration.
   {
@@ -220,6 +217,11 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
         topLevelProjects.push(project);
     }
   }
+
+  // Apply post-shard filters after dependency projects are added so that tests
+  // from dependency projects (e.g. --last-failed) are included in the filter.
+  if (config.postShardTestFilters.length)
+    filterTestsRemoveEmptySuites(rootSuite, test => config.postShardTestFilters.every(filter => filter(test)));
 
   return { rootSuite, topLevelProjects };
 }

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -847,6 +847,39 @@ test('should run last failed tests', async ({ runInlineTest }) => {
   expect(result2.failed).toBe(1);
 });
 
+test('should run last failed tests in dependency projects', async ({ runInlineTest }) => {
+  const workspace = {
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'default', testIgnore: /setup/ },
+          { name: 'sequential', testMatch: /setup/, dependencies: ['default'] },
+        ],
+      });
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+      test('fail', async () => { expect(1).toBe(2); });
+    `,
+    'setup.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('setup', async () => {});
+    `,
+  };
+  const result1 = await runInlineTest(workspace);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.failed).toBe(1);
+
+  const result2 = await runInlineTest(workspace, {}, {}, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.failed).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.output).toContain('fail');
+  expect(result2.output).not.toContain('No tests');
+});
+
 test('should run last failed tests in a shard', async ({ runInlineTest }) => {
   const workspace = {
     'a.spec.js': `


### PR DESCRIPTION
- `--last-failed` silently results in "No tests found" when the config uses project dependencies
- `postShardTestFilters` ran before dependency projects were prepended to `rootSuite`, so failing tests in dependency projects never matched the filter
- moved the filter to after the dependency closure is built so all projects are visible when the filter runs

Fixes https://github.com/microsoft/playwright/issues/39811