### PR TITLE
fix(webkit): fill contenteditable in shadow root

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -876,12 +876,19 @@ export class InjectedScript {
       return 'done';
     }
     (element as HTMLElement | SVGElement).focus();
-    const range = element.ownerDocument.createRange();
-    range.selectNodeContents(element);
-    const selection = element.ownerDocument.defaultView!.getSelection();
-    if (selection) {
-      selection.removeAllRanges();
-      selection.addRange(range);
+    if (this._browserName === 'webkit' && (element as HTMLElement).isContentEditable) {
+      // Use execCommand('selectAll') for contenteditable elements.
+      // This works correctly in shadow DOM on WebKit, where window.getSelection()
+      // does not reflect the selection inside the shadow root.
+      element.ownerDocument.execCommand('selectAll', false);
+    } else {
+      const range = element.ownerDocument.createRange();
+      range.selectNodeContents(element);
+      const selection = element.ownerDocument.defaultView!.getSelection();
+      if (selection) {
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
     }
     return 'done';
   }

--- a/tests/page/page-fill.spec.ts
+++ b/tests/page/page-fill.spec.ts
@@ -426,3 +426,25 @@ it('should fill contenteditable with focus handler that collapses selection', {
   await page.fill('div[contenteditable]', 'some value');
   expect(await page.locator('div[contenteditable]').textContent()).toBe('some value');
 });
+
+it('should fill contenteditable in shadow root', {
+  annotation: {
+    type: 'issue',
+    description: 'https://github.com/microsoft/playwright/issues/39983'
+  }
+}, async ({ page }) => {
+  await page.setContent(`
+    <div id="host"></div>
+    <script>
+      const host = document.getElementById('host')
+      const root = host.attachShadow({ mode: 'open' })
+      const editor = document.createElement('div')
+      editor.contentEditable = 'true'
+      root.appendChild(editor)
+      window.__editor = editor
+    </script>
+  `);
+
+  await page.locator('div[contenteditable]').fill('Hello');
+  await expect(page.locator('div[contenteditable]')).toHaveText('Hello', { timeout: 200 });
+});


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/39983. Very unsure about the implementation, but this was the only thing I could get to work.