### PR TITLE
fix(vscode): dont include ignored files in listFiles

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -51,10 +51,14 @@ export async function collectProjectsAndTestFiles(testRun: TestRun, doNotRunTest
     allFilesForProject.set(project, files);
   }
 
-  // Filter files based on the file filters, eliminate the empty projects.
+  // Filter files based on the file filters.
   const filesToRunByProject = new Map<FullProjectInternal, string[]>();
   for (const [project, files] of allFilesForProject) {
+    const grepInvertMatcher = project.project.grepInvert ? createTitleMatcher(project.project.grepInvert) : undefined;
     const matchedFiles = files.filter(file => {
+      if (grepInvertMatcher?.(['', project.project.name, file].join(' ')))
+        return false;
+
       if (!config.loadFileFilters.length) {
         // Avoid loading source maps.
         return true;

--- a/tests/playwright-test/test-server.spec.ts
+++ b/tests/playwright-test/test-server.spec.ts
@@ -153,6 +153,34 @@ test('should list tests with testIdAttribute', async ({ startTestServer, writeFi
   expect(onProject.use.testIdAttribute).toBe('testId');
 });
 
+test('listFiles should respect grepInvert', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39981' } }, async ({ startTestServer, writeFiles }) => {
+  await writeFiles({
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('foo', () => {});
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      test('bar', () => {});
+    `,
+    'playwright.config.ts': `
+        module.exports = {
+        projects: [{
+          name: 'chromium',
+          grepInvert: /a.test.ts/,
+        }]
+      };
+      `,
+  });
+
+  const testServerConnection = await startTestServer();
+  const events = await testServerConnection.listFiles({});
+  const project = events.report.find(e => e.method === 'onProject').params.project;
+  expect(project.suites).toEqual([
+    expect.objectContaining({ title: 'b.test.ts' })
+  ]);
+});
+
 test('stdio interception', async ({ startTestServer, writeFiles }) => {
   const testServerConnection = await startTestServer();
   await testServerConnection.initialize({ interceptStdio: true });


### PR DESCRIPTION
See https://github.com/microsoft/playwright/issues/39981. When VS Code calls `listFiles`, for projects with `grepInvert` the list will contain files that `listTests` wouldn't list. This results in useless empty files nodes being shown in the Test Explorer view.

The fix is to apply `grepInvert` as soon as we can. I'm unsure about the right place in the code though, this proposed fix was the smallest possible diff. I also considered putting the change into `createListFilesTask`.