### PR TITLE
feat(html): show repeatEachIndex when non-zero

### DIFF
--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -43,6 +43,7 @@ export const TestCaseView: React.FC<{
   const searchParams = useSearchParams();
 
   const visibleTestAnnotations = test.annotations.filter(a => !a.type.startsWith('_')) ?? [];
+  appendRepeatEachIndexAnnotation(visibleTestAnnotations, test.repeatEachIndex);
 
   return <>
     <HeaderView
@@ -78,6 +79,7 @@ export const TestCaseView: React.FC<{
         </div>,
         render: () => {
           const visibleAnnotations = result.annotations.filter(annotation => !annotation.type.startsWith('_'));
+          appendRepeatEachIndexAnnotation(visibleAnnotations, test.repeatEachIndex);
           return <>
             {!!visibleAnnotations.length && <AutoChip header='Annotations' dataTestId='test-case-annotations'>
               {visibleAnnotations.map((annotation, index) => <TestCaseAnnotationView key={index} annotation={annotation} />)}
@@ -96,6 +98,11 @@ function TestCaseAnnotationView({ annotation: { type, description } }: { annotat
       {description && <CopyToClipboardContainer value={description}>: {linkifyText(description)}</CopyToClipboardContainer>}
     </div>
   );
+}
+
+function appendRepeatEachIndexAnnotation(annotations: TestAnnotation[], repeatEachIndex: number | undefined) {
+  if (repeatEachIndex)
+    annotations.push({ type: 'repeatEachIndex', description: String(repeatEachIndex) });
 }
 
 function retryLabel(index: number) {

--- a/packages/html-reporter/src/types.d.ts
+++ b/packages/html-reporter/src/types.d.ts
@@ -84,6 +84,7 @@ export type TestCaseSummary = {
   duration: number;
   ok: boolean;
   results: TestResultSummary[];
+  repeatEachIndex?: number;
 };
 
 export type TestResultSummary = {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -451,6 +451,7 @@ class HtmlBuilder {
         outcome: test.outcome(),
         path,
         results,
+        repeatEachIndex: test.repeatEachIndex || undefined, // Do not include zero.
         ok: test.outcome() === 'expected' || test.outcome() === 'flaky',
       },
       testCaseSummary: {
@@ -464,6 +465,7 @@ class HtmlBuilder {
         outcome: test.outcome(),
         path,
         ok: test.outcome() === 'expected' || test.outcome() === 'flaky',
+        repeatEachIndex: test.repeatEachIndex || undefined, // Do not include zero.
         results: results.map(result => {
           return {
             attachments: result.attachments.map(a => ({ name: a.name, contentType: a.contentType, path: a.path })),

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1317,6 +1317,32 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.getByText('ouch')).toBeHidden();
     });
 
+    test('should show repeatEachIndex annotation when non-zero', async ({ runInlineTest, showReport, page }) => {
+      const result = await runInlineTest({
+        'a.spec.js': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({}, testInfo) => {
+          });
+        `
+      }, { 'reporter': 'dot,html', 'repeat-each': 3 }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(0);
+      await showReport();
+
+      // First repeat (index 0) should not show repeatEachIndex annotation.
+      await page.getByText('sample').first().click();
+      await expect(page.locator('.test-case-annotation')).toBeHidden();
+      await page.goBack();
+
+      // Second repeat (index 1) should show repeatEachIndex annotation.
+      await page.getByText('sample').nth(1).click();
+      await expect(page.locator('.test-case-annotation')).toHaveText('repeatEachIndex: 1');
+      await page.goBack();
+
+      // Third repeat (index 2) should show repeatEachIndex annotation.
+      await page.getByText('sample').nth(2).click();
+      await expect(page.locator('.test-case-annotation')).toHaveText('repeatEachIndex: 2');
+    });
+
     test('should group similar / loop steps', async ({ runInlineTest, showReport, page }) => {
       test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/10098' });
       const result = await runInlineTest({


### PR DESCRIPTION
This helps to differentiate between attempts.

<img width="1001" height="290" alt="Screenshot 2026-04-01 at 3 29 26 PM" src="https://github.com/user-attachments/assets/f8d70abf-6600-4a6e-8090-fe0fa065c026" />
