### PR TITLE
fix(clock): handle
  NS_ERROR_NOT_INITIALIZED in Firefox embedder timers

### DIFF
--- a/packages/injected/src/clock.ts
+++ b/packages/injected/src/clock.ts
@@ -766,12 +766,24 @@ export function createClock(globalObject: WindowOrWorkerGlobalScope, config: Ins
     dateNow: () => originals.raw.Date.now(),
     performanceNow: () => Math.ceil(originals.raw.performance!.now()) as EmbedderTicks,
     setTimeout: (task: () => void, timeout?: number) => {
-      const timerId = originals.bound.setTimeout(task, timeout);
-      return () => originals.bound.clearTimeout(timerId);
+      try {
+        const timerId = originals.bound.setTimeout(task, timeout);
+        return () => originals.bound.clearTimeout(timerId);
+      } catch {
+        // Firefox may throw NS_ERROR_NOT_INITIALIZED if the timer service
+        // is not available (e.g. during page teardown or frame lifecycle changes).
+        return () => {};
+      }
     },
     setInterval: (task: () => void, delay: number) => {
-      const intervalId = originals.bound.setInterval(task, delay);
-      return () => originals.bound.clearInterval(intervalId);
+      try {
+        const intervalId = originals.bound.setInterval(task, delay);
+        return () => originals.bound.clearInterval(intervalId);
+      } catch {
+        // Firefox may throw NS_ERROR_NOT_INITIALIZED if the timer service
+        // is not available (e.g. during page teardown or frame lifecycle changes).
+        return () => {};
+      }
     },
   };
 


### PR DESCRIPTION
## Summary
  - Firefox throws `NS_ERROR_NOT_INITIALIZED` when calling native `setTimeout`/`setInterval` on a window whose JS context is no longer available
  - The clock embedder in `createClock()` uses saved native timer references for the real-time sync loop, which can throw when the window context
  becomes unavailable
  - Wraps the embedder `setTimeout`/`setInterval` calls in try/catch so the clock skips one sync tick and recovers

  Fixes https://github.com/microsoft/playwright/issues/40011