### PR TITLE
chore: bulk-annotate private methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ npm run watch       # Watch mode (recommended during development)
 
 Assume watch is running and code is up to date. Generated files (types, channels, validators) are produced by watch automatically.
 
-## Lint
+## Lint and type check
 
 ```bash
 npm run flint
@@ -93,6 +93,15 @@ Import boundaries are enforced via `DEPS.list` files (52+ across the repo), chec
 
 **Key rule**: Client code NEVER imports server code. Server code NEVER imports client code. Communication is only through the protocol.
 When creating or moving files, update the relevant `DEPS.list` to declare allowed imports. Files marked `"strict"` can only import what is explicitly listed.
+
+## Coding Convention
+
+For exported classes:
+- `private _method()` — only used within the class itself
+- `_method()` (no `private`) — used by other code in the same file, but not outside the file
+- `method()` (public) — used in other files
+
+Non-exported classes have no naming convention; they are internal implementation details.
 
 ## Commit Convention
 

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -353,7 +353,7 @@ export class AndroidDevice extends SdkObject {
 
       const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, androidBrowser, browserOptions));
       const defaultContext = browser._defaultContext!;
-      await defaultContext._loadDefaultContextAsIs(progress);
+      await defaultContext.loadDefaultContextAsIs(progress);
       return defaultContext;
     } catch (error) {
       socket.close();

--- a/packages/playwright-core/src/server/artifact.ts
+++ b/packages/playwright-core/src/server/artifact.ts
@@ -41,10 +41,6 @@ export class Artifact extends SdkObject {
     this._cancelCallback = cancelCallback;
   }
 
-  finishedPromise() {
-    return this._finishedPromise;
-  }
-
   localPath() {
     return this._localPath;
   }

--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -85,7 +85,7 @@ export class BidiBrowser extends Browser {
     if (options.persistent) {
       const context = new BidiBrowserContext(browser, undefined, options.persistent);
       browser._defaultContext = context;
-      await context._initialize();
+      await context.initialize();
       // Create default page as we cannot get access to the existing one.
       const page = await browser._defaultContext.doCreateNewPage();
       await page.waitForInitializedOrError();
@@ -104,7 +104,7 @@ export class BidiBrowser extends Browser {
   }
 
   _onDisconnect() {
-    this._didClose();
+    this.didClose();
   }
 
   async doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
@@ -114,7 +114,7 @@ export class BidiBrowser extends Browser {
       proxy: getProxyConfiguration(proxy),
     });
     const context = new BidiBrowserContext(this, userContext, options);
-    await context._initialize();
+    await context.initialize();
     this._contexts.set(userContext, context);
     return context;
   }
@@ -215,16 +215,16 @@ export class BidiBrowserContext extends BrowserContext {
 
   constructor(browser: BidiBrowser, browserContextId: string | undefined, options: types.BrowserContextOptions) {
     super(browser, options, browserContextId);
-    this._authenticateProxyViaHeader();
+    this.authenticateProxyViaHeader();
   }
 
   private _bidiPages() {
     return [...this._browser._bidiPages.values()].filter(bidiPage => bidiPage._browserContext === this);
   }
 
-  override async _initialize() {
+  override async initialize() {
     const promises: Promise<any>[] = [
-      super._initialize(),
+      super.initialize(),
     ];
     const downloadBehavior: bidi.Browser.DownloadBehavior = this._options.acceptDownloads === 'accept' ?
       { type: 'allowed', destinationFolder: this._browser.options.downloadsPath } :

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -118,7 +118,7 @@ export class BidiPage implements PageDelegate {
       if (context.frame === frame) {
         this._contextIdToContext.delete(contextId);
         if (notifyFrame)
-          frame._contextDestroyed(context);
+          frame.contextDestroyed(context);
       }
     }
   }
@@ -151,7 +151,7 @@ export class BidiPage implements PageDelegate {
     }
     const delegate = new BidiExecutionContext(this._session, realmInfo);
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
-    frame._contextCreated(worldName, context);
+    frame.contextCreated(worldName, context);
     this._contextIdToContext.set(realmInfo.realm, context);
   }
 
@@ -175,7 +175,7 @@ export class BidiPage implements PageDelegate {
     const context = this._contextIdToContext.get(params.realm);
     if (context) {
       this._contextIdToContext.delete(params.realm);
-      context.frame._contextDestroyed(context);
+      context.frame.contextDestroyed(context);
       return true;
     }
     const existed = this._realmToWorkerContext.delete(params.realm);
@@ -254,13 +254,13 @@ export class BidiPage implements PageDelegate {
     if (!originPage)
       return;
 
-    this._browserContext._browser._downloadCreated(originPage, event.navigation, event.url, event.suggestedFilename, event.suggestedFilename);
+    this._browserContext._browser.downloadCreated(originPage, event.navigation, event.url, event.suggestedFilename, event.suggestedFilename);
   }
 
   private _onDownloadEnded(event: bidi.BrowsingContext.DownloadEndParams) {
     if (!event.navigation)
       return;
-    this._browserContext._browser._downloadFinished(event.navigation, event.status === 'canceled' ? 'canceled' : undefined);
+    this._browserContext._browser.downloadFinished(event.navigation, event.status === 'canceled' ? 'canceled' : undefined);
   }
 
   private _onLogEntryAdded(params: bidi.Log.Entry) {
@@ -302,7 +302,7 @@ export class BidiPage implements PageDelegate {
     const frame = this._page.frameManager.frame(params.context);
     if (!frame)
       return;
-    const executionContext = await frame._mainContext();
+    const executionContext = await frame.mainContext();
     try {
       const handle = await toBidiExecutionContext(executionContext).remoteObjectForNodeId(executionContext, { sharedId: params.element.sharedId });
       await this._page._onFileChooserOpened(handle as dom.ElementHandle);
@@ -631,7 +631,7 @@ export class BidiPage implements PageDelegate {
     const node = await this._getFrameNode(frame);
     if (!node?.sharedId)
       throw new Error('Frame has been detached.');
-    const parentFrameExecutionContext = await parent._mainContext();
+    const parentFrameExecutionContext = await parent.mainContext();
     return await toBidiExecutionContext(parentFrameExecutionContext).remoteObjectForNodeId(parentFrameExecutionContext, { sharedId: node.sharedId });
   }
 

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -139,19 +139,19 @@ export abstract class Browser extends SdkObject {
     return this._contextForReuse?.context;
   }
 
-  _downloadCreated(page: Page, uuid: string, url: string, suggestedFilename?: string, downloadFilename?: string) {
+  downloadCreated(page: Page, uuid: string, url: string, suggestedFilename?: string, downloadFilename?: string) {
     const download = new Download(page, this.options.downloadsPath || '', uuid, url, suggestedFilename, downloadFilename);
     this._downloads.set(uuid, download);
   }
 
-  _downloadFilenameSuggested(uuid: string, suggestedFilename: string) {
+  downloadFilenameSuggested(uuid: string, suggestedFilename: string) {
     const download = this._downloads.get(uuid);
     if (!download)
       return;
-    download._filenameSuggested(suggestedFilename);
+    download.filenameSuggested(suggestedFilename);
   }
 
-  _downloadFinished(uuid: string, error?: string) {
+  downloadFinished(uuid: string, error?: string) {
     const download = this._downloads.get(uuid);
     if (!download)
       return;
@@ -167,11 +167,11 @@ export abstract class Browser extends SdkObject {
     await this._server.stop();
   }
 
-  _didClose() {
+  protected didClose() {
     for (const context of this.contexts())
-      context._browserClosed();
+      context.browserClosed();
     if (this._defaultContext)
-      this._defaultContext._browserClosed();
+      this._defaultContext.browserClosed();
     this.stopServer().catch(() => {});
     this.emit(Browser.Events.Disconnected);
     this.instrumentation.onBrowserClose(this);

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -141,7 +141,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     return this._selectors;
   }
 
-  async _initialize() {
+  async initialize() {
     if (this.attribution.playwright.options.isInternalPlaywright)
       return;
     // Debugger will pause execution upon page.pause in headed mode.
@@ -244,7 +244,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     await page?.resetForReuse(progress);
   }
 
-  _browserClosed() {
+  browserClosed() {
     for (const page of this.pages())
       page._didClose();
     this._didCloseInternal();
@@ -419,7 +419,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     }
   }
 
-  async _loadDefaultContextAsIs(progress: Progress): Promise<Page | undefined> {
+  async loadDefaultContextAsIs(progress: Progress): Promise<Page | undefined> {
     if (!this.possiblyUninitializedPages().length) {
       const waitForEvent = helper.waitForEvent(progress, this, BrowserContext.Events.Page);
       // Race against BrowserContext.close
@@ -435,8 +435,8 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     return page;
   }
 
-  async _loadDefaultContext(progress: Progress) {
-    const defaultPage = await this._loadDefaultContextAsIs(progress);
+  async loadDefaultContext(progress: Progress) {
+    const defaultPage = await this.loadDefaultContextAsIs(progress);
     if (!defaultPage)
       return;
     const browserName = this._browser.options.name;
@@ -449,7 +449,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     }
   }
 
-  protected _authenticateProxyViaHeader() {
+  protected authenticateProxyViaHeader() {
     const proxy = this._options.proxy || this._browser.options.proxy || { username: undefined, password: undefined };
     const { username, password } = proxy;
     if (username) {
@@ -462,7 +462,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     }
   }
 
-  protected _authenticateProxyViaCredentials() {
+  protected authenticateProxyViaCredentials() {
     const proxy = this._options.proxy || this._browser.options.proxy;
     if (!proxy)
       return;

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -67,7 +67,7 @@ export abstract class BrowserType extends SdkObject {
     options = this._validateLaunchOptions(options);
     const seleniumHubUrl = (options as any).__testHookSeleniumRemoteURL || process.env.SELENIUM_REMOTE_URL;
     if (seleniumHubUrl)
-      return this._launchWithSeleniumHub(progress, seleniumHubUrl, options);
+      return this.launchWithSeleniumHub(progress, seleniumHubUrl, options);
     return this._innerLaunchWithRetries(progress, options, undefined, helper.debugProtocolLogger(protocolLogger)).catch(e => { throw this._rewriteStartupLog(e); });
   }
 
@@ -138,7 +138,7 @@ export abstract class BrowserType extends SdkObject {
       (browser as any)._userDataDirForTest = userDataDir;
       // We assume no control when using custom arguments, and do not prepare the default context in that case.
       if (persistent && !options.ignoreAllDefaultArgs)
-        await browser._defaultContext!._loadDefaultContext(progress);
+        await browser._defaultContext!.loadDefaultContext(progress);
       return browser;
     } catch (error) {
       await browserProcess.close().catch(() => {});
@@ -293,7 +293,7 @@ export abstract class BrowserType extends SdkObject {
     throw new Error('CDP connections are only supported by Chromium');
   }
 
-  async _launchWithSeleniumHub(progress: Progress, hubUrl: string, options: types.LaunchOptions): Promise<Browser> {
+  async launchWithSeleniumHub(progress: Progress, hubUrl: string, options: types.LaunchOptions): Promise<Browser> {
     throw new Error('Connecting to SELENIUM_REMOTE_URL is only supported by Chromium');
   }
 

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -190,7 +190,7 @@ export class Chromium extends BrowserType {
     transport.send(message);
   }
 
-  override async _launchWithSeleniumHub(progress: Progress, hubUrl: string, options: types.LaunchOptions): Promise<CRBrowser> {
+  override async launchWithSeleniumHub(progress: Progress, hubUrl: string, options: types.LaunchOptions): Promise<CRBrowser> {
     if (!hubUrl.endsWith('/'))
       hubUrl = hubUrl + '/';
 

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -91,7 +91,7 @@ export class CRBrowser extends Browser {
         // This can be removed after https://chromium-review.googlesource.com/c/chromium/src/+/2885888 lands in stable.
         await session.send('Target.getTargetInfo');
       }),
-      (browser._defaultContext as CRBrowserContext)._initialize(),
+      browser._defaultContext.initialize(),
     ]);
     await browser._waitForAllPagesToBeInitialized();
     return browser;
@@ -124,7 +124,7 @@ export class CRBrowser extends Browser {
       proxyBypassList,
     });
     const context = new CRBrowserContext(this, browserContextId, options);
-    await context._initialize();
+    await context.initialize();
     this._contexts.set(browserContextId, context);
     return context;
   }
@@ -233,7 +233,7 @@ export class CRBrowser extends Browser {
     for (const serviceWorker of this._serviceWorkers.values())
       serviceWorker.didClose();
     this._serviceWorkers.clear();
-    this._didClose();
+    this.didClose();
   }
 
   private _findOwningPage(frameId: string) {
@@ -261,14 +261,14 @@ export class CRBrowser extends Browser {
       originPage = page._opener._page.initializedOrUndefined();
     if (!originPage)
       return;
-    this._downloadCreated(originPage, payload.guid, payload.url, payload.suggestedFilename);
+    this.downloadCreated(originPage, payload.guid, payload.url, payload.suggestedFilename);
   }
 
   _onDownloadProgress(payload: any) {
     if (payload.state === 'completed')
-      this._downloadFinished(payload.guid, '');
+      this.downloadFinished(payload.guid, '');
     if (payload.state === 'canceled')
-      this._downloadFinished(payload.guid, this._closeReason || 'canceled');
+      this.downloadFinished(payload.guid, this._closeReason || 'canceled');
   }
 
   async _closePage(crPage: CRPage) {
@@ -344,12 +344,12 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
 
   constructor(browser: CRBrowser, browserContextId: string | undefined, options: types.BrowserContextOptions) {
     super(browser, options, browserContextId);
-    this._authenticateProxyViaCredentials();
+    this.authenticateProxyViaCredentials();
   }
 
-  override async _initialize() {
+  override async initialize() {
     assert(!Array.from(this._browser._crPages.values()).some(page => page._browserContext === this));
-    const promises: Promise<any>[] = [super._initialize()];
+    const promises: Promise<any>[] = [super.initialize()];
     if (this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
       promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
         behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -354,7 +354,7 @@ export class CRPage implements PageDelegate {
     parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    return parentSession._adoptBackendNodeId(backendNodeId, await parent._mainContext());
+    return parentSession._adoptBackendNodeId(backendNodeId, await parent.mainContext());
   }
 
   shouldToggleStyleSheetToSyncAnimations(): boolean {
@@ -668,7 +668,7 @@ class FrameSession {
       worldName = 'utility';
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     if (worldName)
-      frame._contextCreated(worldName, context);
+      frame.contextCreated(worldName, context);
     this._contextIdToContext.set(contextPayload.id, context);
   }
 
@@ -677,7 +677,7 @@ class FrameSession {
     if (!context)
       return;
     this._contextIdToContext.delete(executionContextId);
-    context.frame._contextDestroyed(context);
+    context.frame.contextDestroyed(context);
   }
 
   _onExecutionContextsCleared() {
@@ -863,7 +863,7 @@ class FrameSession {
       return;
     let handle;
     try {
-      const utilityContext = await frame._utilityContext();
+      const utilityContext = await frame.utilityContext();
       handle = await this._adoptBackendNodeId(event.backendNodeId, utilityContext);
     } catch (e) {
       // During async processing, frame/context may go away. We should not throw.

--- a/packages/playwright-core/src/server/cookieStore.ts
+++ b/packages/playwright-core/src/server/cookieStore.ts
@@ -24,7 +24,7 @@ export class Cookie {
     this._raw = data;
   }
 
-  name(): string {
+  _name(): string {
     return this._raw.name;
   }
 
@@ -39,21 +39,21 @@ export class Cookie {
     return true;
   }
 
-  equals(other: Cookie) {
+  _equals(other: Cookie) {
     return this._raw.name === other._raw.name &&
       this._raw.domain === other._raw.domain &&
       this._raw.path === other._raw.path;
   }
 
-  networkCookie(): channels.NetworkCookie {
+  _networkCookie(): channels.NetworkCookie {
     return this._raw;
   }
 
-  updateExpiresFrom(other: Cookie) {
+  _updateExpiresFrom(other: Cookie) {
     this._raw.expires = other._raw.expires;
   }
 
-  expired() {
+  _expired() {
     if (this._raw.expires === -1)
       return false;
     return this._raw.expires * 1000 < Date.now();
@@ -72,7 +72,7 @@ export class CookieStore {
     const result = [];
     for (const cookie of this._cookiesIterator()) {
       if (cookie.matches(url))
-        result.push(cookie.networkCookie());
+        result.push(cookie._networkCookie());
     }
     return result;
   }
@@ -80,19 +80,19 @@ export class CookieStore {
   allCookies(): channels.NetworkCookie[] {
     const result = [];
     for (const cookie of this._cookiesIterator())
-      result.push(cookie.networkCookie());
+      result.push(cookie._networkCookie());
     return result;
   }
 
   private _addCookie(cookie: Cookie) {
-    let set = this._nameToCookies.get(cookie.name());
+    let set = this._nameToCookies.get(cookie._name());
     if (!set) {
       set = new Set();
-      this._nameToCookies.set(cookie.name(), set);
+      this._nameToCookies.set(cookie._name(), set);
     }
     // https://datatracker.ietf.org/doc/html/rfc6265#section-5.3
     for (const other of set) {
-      if (other.equals(cookie))
+      if (other._equals(cookie))
         set.delete(other);
     }
     set.add(cookie);
@@ -111,7 +111,7 @@ export class CookieStore {
 
   private static pruneExpired(cookies: Set<Cookie>) {
     for (const cookie of cookies) {
-      if (cookie.expired())
+      if (cookie._expired())
         cookies.delete(cookie);
     }
   }

--- a/packages/playwright-core/src/server/dialog.ts
+++ b/packages/playwright-core/src/server/dialog.ts
@@ -61,18 +61,18 @@ export class Dialog extends SdkObject {
   async accept(promptText?: string) {
     assert(!this._handled, 'Cannot accept dialog which is already handled!');
     this._handled = true;
-    this._page.browserContext.dialogManager.dialogWillClose(this);
+    this._page.browserContext.dialogManager._dialogWillClose(this);
     await this._onHandle(true, promptText);
   }
 
   async dismiss() {
     assert(!this._handled, 'Cannot dismiss dialog which is already handled!');
     this._handled = true;
-    this._page.browserContext.dialogManager.dialogWillClose(this);
+    this._page.browserContext.dialogManager._dialogWillClose(this);
     await this._onHandle(false);
   }
 
-  async close() {
+  async _close() {
     if (this._type === 'beforeunload')
       await this.accept();
     else
@@ -92,7 +92,7 @@ export class DialogManager {
   dialogDidOpen(dialog: Dialog) {
     // Any ongoing evaluations will be stalled until the dialog is closed.
     for (const frame of dialog.page().frameManager.frames())
-      frame._invalidateNonStallingEvaluations('JavaScript dialog interrupted evaluation');
+      frame.invalidateNonStallingEvaluations('JavaScript dialog interrupted evaluation');
     this._openedDialogs.add(dialog);
     this._instrumentation.onDialog(dialog);
 
@@ -102,10 +102,10 @@ export class DialogManager {
         hasHandlers = true;
     }
     if (!hasHandlers)
-      dialog.close().then(() => {});
+      dialog._close().then(() => {});
   }
 
-  dialogWillClose(dialog: Dialog) {
+  _dialogWillClose(dialog: Dialog) {
     this._openedDialogs.delete(dialog);
   }
 
@@ -117,7 +117,7 @@ export class DialogManager {
     this._dialogHandlers.delete(handler);
     if (!this._dialogHandlers.size) {
       for (const dialog of this._openedDialogs)
-        dialog.close().catch(() => {});
+        dialog._close().catch(() => {});
     }
   }
 

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -136,7 +136,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async evaluateInUtility<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<R | 'error:notconnected'> {
     try {
-      const utility = await this._frame._utilityContext();
+      const utility = await this._frame.utilityContext();
       return await utility.evaluate(pageFunction, [await utility.injectedScript(), this, arg]);
     } catch (e) {
       if (this._frame.isNonRetriableError(e))
@@ -145,9 +145,9 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     }
   }
 
-  async evaluateHandleInUtility<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<js.JSHandle<R> | 'error:notconnected'> {
+  private async _evaluateHandleInUtility<R, Arg>(pageFunction: js.Func1<[js.JSHandle<InjectedScript>, ElementHandle<T>, Arg], R>, arg: Arg): Promise<js.JSHandle<R> | 'error:notconnected'> {
     try {
-      const utility = await this._frame._utilityContext();
+      const utility = await this._frame.utilityContext();
       return await utility.evaluateHandle(pageFunction, [await utility.injectedScript(), this, arg]);
     } catch (e) {
       if (this._frame.isNonRetriableError(e))
@@ -171,12 +171,12 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     return null;
   }
 
-  async isIframeElement(): Promise<boolean | 'error:notconnected'> {
+  private async _isIframeElement(): Promise<boolean | 'error:notconnected'> {
     return this.evaluateInUtility(([injected, node]) => node && (node.nodeName === 'IFRAME' || node.nodeName === 'FRAME'), {});
   }
 
   async contentFrame(): Promise<frames.Frame | null> {
-    const isFrameElement = throwRetargetableDOMError(await this.isIframeElement());
+    const isFrameElement = throwRetargetableDOMError(await this._isIframeElement());
     if (!isFrameElement)
       return null;
     return this._page.delegate.getContentFrame(this);
@@ -249,7 +249,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
     const [quads, metrics] = await Promise.all([
       this._page.delegate.getContentQuads(this),
-      this._page.mainFrame()._utilityContext().then(utility => utility.evaluate(() => ({ width: innerWidth, height: innerHeight }))),
+      this._page.mainFrame().utilityContext().then(utility => utility.evaluate(() => ({ width: innerWidth, height: innerHeight }))),
     ] as const);
     if (quads === 'error:notconnected')
       return quads;
@@ -453,7 +453,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
         return frameCheckResult;
       const hitPoint = frameCheckResult.framePoint;
       const actionType = actionName === 'move and up' ? 'drag' : ((actionName === 'hover' || actionName === 'tap') ? actionName : 'mouse');
-      const handle = await progress.race(this.evaluateHandleInUtility(([injected, node, { actionType, hitPoint, trial }]) => injected.setupHitTargetInterceptor(node, actionType, hitPoint, trial), { actionType, hitPoint, trial: !!options.trial } as const));
+      const handle = await progress.race(this._evaluateHandleInUtility(([injected, node, { actionType, hitPoint, trial }]) => injected.setupHitTargetInterceptor(node, actionType, hitPoint, trial), { actionType, hitPoint, trial: !!options.trial } as const));
       if (handle === 'error:notconnected')
         return handle;
       if (!handle._objectId) {
@@ -616,7 +616,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       }, { value, force: options.force }));
       if (result === 'needsinput') {
         if (value)
-          await this._page.keyboard._insertText(progress, value);
+          await this._page.keyboard.insertText(progress, value);
         else
           await this._page.keyboard.press(progress, 'Delete');
         return 'done';
@@ -652,7 +652,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async _setInputFiles(progress: Progress, items: InputFilesItems): Promise<'error:notconnected' | 'done'> {
     const { filePayloads, localPaths, localDirectory } = items;
     const multiple = filePayloads && filePayloads.length > 1 || localPaths && localPaths.length > 1;
-    const result = await progress.race(this.evaluateHandleInUtility(([injected, node, { multiple, directoryUpload }]): Element | undefined => {
+    const result = await progress.race(this._evaluateHandleInUtility(([injected, node, { multiple, directoryUpload }]): Element | undefined => {
       const element = injected.retarget(node, 'follow-label');
       if (!element)
         return;

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -40,11 +40,7 @@ export class Download {
       this._fireDownloadEvent();
   }
 
-  page(): Page {
-    return this._page;
-  }
-
-  _filenameSuggested(suggestedFilename: string) {
+  filenameSuggested(suggestedFilename: string) {
     assert(this._suggestedFilename === undefined);
     this._suggestedFilename = suggestedFilename;
     this._fireDownloadEvent();

--- a/packages/playwright-core/src/server/fileChooser.ts
+++ b/packages/playwright-core/src/server/fileChooser.ts
@@ -15,15 +15,12 @@
  */
 
 import type { ElementHandle } from './dom';
-import type { Page } from './page';
 
 export class FileChooser {
-  private _page: Page;
   private _elementHandle: ElementHandle;
   private _isMultiple: boolean;
 
-  constructor(page: Page, elementHandle: ElementHandle, isMultiple: boolean) {
-    this._page = page;
+  constructor(elementHandle: ElementHandle, isMultiple: boolean) {
     this._elementHandle = elementHandle;
     this._isMultiple = isMultiple;
   }
@@ -34,9 +31,5 @@ export class FileChooser {
 
   isMultiple(): boolean {
     return this._isMultiple;
-  }
-
-  page(): Page {
-    return this._page;
   }
 }

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -57,7 +57,7 @@ export class FFBrowser extends Browser {
     ];
     if (options.persistent) {
       browser._defaultContext = new FFBrowserContext(browser, undefined, options.persistent);
-      promises.push((browser._defaultContext as FFBrowserContext)._initialize());
+      promises.push(browser._defaultContext.initialize());
     }
     const proxy = options.originalLaunchOptions.proxyOverride || options.proxy;
     if (proxy)
@@ -94,7 +94,7 @@ export class FFBrowser extends Browser {
       throw new Error('options.isMobile is not supported in Firefox');
     const { browserContextId } = await this.session.send('Browser.createBrowserContext', { removeOnDetach: true });
     const context = new FFBrowserContext(this, browserContextId, options);
-    await context._initialize();
+    await context.initialize();
     this._contexts.set(browserContextId, context);
     return context;
   }
@@ -147,19 +147,19 @@ export class FFBrowser extends Browser {
     }
     if (!originPage)
       return;
-    this._downloadCreated(originPage, payload.uuid, payload.url, payload.suggestedFileName);
+    this.downloadCreated(originPage, payload.uuid, payload.url, payload.suggestedFileName);
   }
 
   _onDownloadFinished(payload: Protocol.Browser.downloadFinishedPayload) {
     const error = payload.canceled ? 'canceled' : payload.error;
-    this._downloadFinished(payload.uuid, error);
+    this.downloadFinished(payload.uuid, error);
   }
 
   _onDisconnect() {
     for (const ffPage of this._ffPages.values())
       ffPage.didClose();
     this._ffPages.clear();
-    this._didClose();
+    this.didClose();
   }
 }
 
@@ -170,11 +170,11 @@ export class FFBrowserContext extends BrowserContext {
     super(browser, options, browserContextId);
   }
 
-  override async _initialize() {
+  override async initialize() {
     assert(!this._ffPages().length);
     const browserContextId = this._browserContextId;
     const promises: Promise<any>[] = [
-      super._initialize(),
+      super.initialize(),
       this._updateInitScripts(),
     ];
     if (this._options.acceptDownloads !== 'internal-browser-default') {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -149,7 +149,7 @@ export class FFPage implements PageDelegate {
       worldName = 'main';
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     if (worldName)
-      frame._contextCreated(worldName, context);
+      frame.contextCreated(worldName, context);
     this._contextIdToContext.set(executionContextId, context);
   }
 
@@ -159,7 +159,7 @@ export class FFPage implements PageDelegate {
     if (!context)
       return;
     this._contextIdToContext.delete(executionContextId);
-    context.frame._contextDestroyed(context);
+    context.frame.contextDestroyed(context);
   }
 
   _onExecutionContextsCleared() {
@@ -544,7 +544,7 @@ export class FFPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const context = await parent._mainContext();
+    const context = await parent.mainContext();
     const result = await this._session.send('Page.adoptNode', {
       frameId: frame._id,
       executionContextId: (context.delegate as FFExecutionContext)._executionContextId

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -62,7 +62,7 @@ export class FrameSelectors {
       handle.dispose();
       return null;
     }
-    return adoptIfNeeded(elementHandle, await resolved.frame._mainContext());
+    return adoptIfNeeded(elementHandle, await resolved.frame.mainContext());
   }
 
   async queryArrayInMainWorld(selector: string, scope?: ElementHandle): Promise<JSHandle<Element[]>> {
@@ -106,7 +106,7 @@ export class FrameSelectors {
 
     // Note: adopting elements one by one may be slow. If we encounter the issue here,
     // we might introduce 'useMainContext' option or similar to speed things up.
-    const targetContext = await resolved.frame._mainContext();
+    const targetContext = await resolved.frame.mainContext();
     const result: Promise<ElementHandle<Element>>[] = [];
     for (const property of properties.values()) {
       const elementHandle = property.asElement() as ElementHandle<Element>;
@@ -148,7 +148,7 @@ export class FrameSelectors {
     for (let i = 0; i < frameChunks.length - 1; ++i) {
       const info = this._parseSelector(frameChunks[i], options);
       frame = this._jumpToAriaRefFrameIfNeeded(selector, info, frame);
-      const context = await frame._context(info.world);
+      const context = await frame.context(info.world);
       const injectedScript = await context.injectedScript();
       const handle = await injectedScript.evaluateHandle((injected, { info, scope, selectorString }) => {
         const element = injected.querySelector(info.parsed, scope || document, info.strict);
@@ -178,7 +178,7 @@ export class FrameSelectors {
     // Be careful, |this.frame| can be different from |resolved.frame|.
     if (!resolved)
       return;
-    const context = await resolved.frame._context(options?.mainWorld ? 'main' : resolved.info.world);
+    const context = await resolved.frame.context(options?.mainWorld ? 'main' : resolved.info.world);
     const injected = await context.injectedScript();
     return { injected, info: resolved.info, frame: resolved.frame, scope: resolved.scope };
   }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -108,7 +108,7 @@ export class FrameManager {
     this._mainFrame = undefined as any as Frame;
   }
 
-  nextFrameSeq() {
+  _allocateFrameSeq() {
     return this._nextFrameSeq++;
   }
 
@@ -120,7 +120,7 @@ export class FrameManager {
   dispose() {
     for (const frame of this._frames.values()) {
       frame._stopNetworkIdleTimer();
-      frame._invalidateNonStallingEvaluations('Target crashed');
+      frame.invalidateNonStallingEvaluations('Target crashed');
     }
   }
 
@@ -135,7 +135,7 @@ export class FrameManager {
 
     function collect(frame: Frame) {
       frames.push(frame);
-      for (const subframe of frame.childFrames())
+      for (const subframe of frame._getChildFrames())
         collect(subframe);
     }
   }
@@ -205,13 +205,13 @@ export class FrameManager {
     }
 
     const request = documentId ? Array.from(frame._inflightRequests).find(request => request._documentId === documentId) : undefined;
-    frame.setPendingDocument({ documentId, request });
+    frame._setPendingDocument({ documentId, request });
   }
 
   frameCommittedNewDocumentNavigation(frameId: string, url: string, name: string, documentId: string, initial: boolean) {
     const frame = this._frames.get(frameId)!;
     this.removeChildFramesRecursively(frame);
-    this.clearWebSockets(frame);
+    this._clearWebSockets(frame);
     frame._url = url;
     frame._name = name;
 
@@ -234,7 +234,7 @@ export class FrameManager {
         keepPending = pendingDocument;
         frame._currentDocument = { documentId, request: undefined };
       }
-      frame.setPendingDocument(undefined);
+      frame._setPendingDocument(undefined);
     } else {
       // No pending - just commit a new document.
       frame._currentDocument = { documentId, request: undefined };
@@ -248,7 +248,7 @@ export class FrameManager {
       this._page.frameNavigatedToNewDocument(frame);
     }
     // Restore pending if any - see comments above about keepPending.
-    frame.setPendingDocument(keepPending);
+    frame._setPendingDocument(keepPending);
   }
 
   frameCommittedSameDocumentNavigation(frameId: string, url: string) {
@@ -258,7 +258,7 @@ export class FrameManager {
     const pending = frame.pendingDocument();
     if (pending && pending.documentId === undefined && pending.request === undefined) {
       // WebKit has notified about the same-document navigation being requested, so clear it.
-      frame.setPendingDocument(undefined);
+      frame._setPendingDocument(undefined);
     }
     frame._url = url;
     const navigationEvent: NavigationEvent = { url, name: frame._name, isPublic: true };
@@ -279,7 +279,7 @@ export class FrameManager {
       error: new NavigationAbortedError(documentId, errorText),
       isPublic: !(documentId && frame._redirectedNavigations.has(documentId)),
     };
-    frame.setPendingDocument(undefined);
+    frame._setPendingDocument(undefined);
     this._fireInternalFrameNavigation(frame, navigationEvent);
   }
 
@@ -294,14 +294,14 @@ export class FrameManager {
   frameLifecycleEvent(frameId: string, event: RegularLifecycleEvent) {
     const frame = this._frames.get(frameId);
     if (frame)
-      frame._onLifecycleEvent(event);
+      frame.onLifecycleEvent(event);
   }
 
   requestStarted(request: network.Request, route?: network.RouteDelegate) {
     const frame = request.frame()!;
     this._inflightRequestStarted(request);
     if (request._documentId)
-      frame.setPendingDocument({ documentId: request._documentId, request });
+      frame._setPendingDocument({ documentId: request._documentId, request });
     if (request._isFavicon) {
       // Abort favicon requests to avoid network access in case of interception.
       route?.abort('aborted').catch(() => {});
@@ -341,7 +341,7 @@ export class FrameManager {
   }
 
   removeChildFramesRecursively(frame: Frame) {
-    for (const child of frame.childFrames())
+    for (const child of frame._getChildFrames())
       this._removeFramesRecursively(child);
   }
 
@@ -385,7 +385,7 @@ export class FrameManager {
     return true;
   }
 
-  clearWebSockets(frame: Frame) {
+  private _clearWebSockets(frame: Frame) {
     // TODO: attribute sockets to frames.
     if (frame.parentFrame())
       return;
@@ -479,7 +479,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   constructor(page: Page, id: string, parentFrame: Frame | null) {
     super(page, 'frame');
     this.attribution.frame = this;
-    this.seq = page.frameManager.nextFrameSeq();
+    this.seq = page.frameManager._allocateFrameSeq();
     this._id = id;
     this._page = page;
     this._parentFrame = parentFrame;
@@ -499,11 +499,11 @@ export class Frame extends SdkObject<FrameEventMap> {
       this._startNetworkIdleTimer();
   }
 
-  isDetached(): boolean {
+  private _isDetached(): boolean {
     return this._detachedScope.isClosed();
   }
 
-  _onLifecycleEvent(event: RegularLifecycleEvent) {
+  onLifecycleEvent(event: RegularLifecycleEvent) {
     if (this._firedLifecycleEvents.has(event))
       return;
     this._firedLifecycleEvents.add(event);
@@ -523,20 +523,20 @@ export class Frame extends SdkObject<FrameEventMap> {
     if (this._inflightRequests.size === 0)
       this._startNetworkIdleTimer();
     this._page.mainFrame()._recalculateNetworkIdle(this);
-    this._onLifecycleEvent('commit');
+    this.onLifecycleEvent('commit');
   }
 
-  setPendingDocument(documentInfo: DocumentInfo | undefined) {
+  _setPendingDocument(documentInfo: DocumentInfo | undefined) {
     this._pendingDocument = documentInfo;
     if (documentInfo)
-      this._invalidateNonStallingEvaluations('Navigation interrupted the evaluation');
+      this.invalidateNonStallingEvaluations('Navigation interrupted the evaluation');
   }
 
   pendingDocument(): DocumentInfo | undefined {
     return this._pendingDocument;
   }
 
-  _invalidateNonStallingEvaluations(message: string) {
+  invalidateNonStallingEvaluations(message: string) {
     if (!this._raceAgainstEvaluationStallingEventsPromises.size)
       return;
     const error = new Error(message);
@@ -689,7 +689,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     return response;
   }
 
-  async _waitForNavigation(progress: Progress, requiresNewDocument: boolean, options: types.NavigateOptions): Promise<network.Response | null> {
+  async waitForNavigation(progress: Progress, requiresNewDocument: boolean, options: types.NavigateOptions): Promise<network.Response | null> {
     const waitUntil = verifyLifecycle('waitUntil', options.waitUntil === undefined ? 'load' : options.waitUntil);
     progress.log(`waiting for navigation until "${waitUntil}"`);
 
@@ -722,7 +722,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     return this._page.delegate.getFrameElement(this);
   }
 
-  _context(world: types.World): Promise<dom.FrameExecutionContext> {
+  context(world: types.World): Promise<dom.FrameExecutionContext> {
     return this._contextData.get(world)!.contextPromise.then(contextOrDestroyedReason => {
       if (contextOrDestroyedReason instanceof js.ExecutionContext)
         return contextOrDestroyedReason;
@@ -730,26 +730,26 @@ export class Frame extends SdkObject<FrameEventMap> {
     });
   }
 
-  _mainContext(): Promise<dom.FrameExecutionContext> {
-    return this._context('main');
+  mainContext(): Promise<dom.FrameExecutionContext> {
+    return this.context('main');
   }
 
   private _existingMainContext(): dom.FrameExecutionContext | null {
     return this._contextData.get('main')?.context || null;
   }
 
-  _utilityContext(): Promise<dom.FrameExecutionContext> {
-    return this._context('utility');
+  utilityContext(): Promise<dom.FrameExecutionContext> {
+    return this.context('utility');
   }
 
   async evaluateExpression(expression: string, options: { isFunction?: boolean, world?: types.World } = {}, arg?: any): Promise<any> {
-    const context = await this._context(options.world ?? 'main');
+    const context = await this.context(options.world ?? 'main');
     const value = await context.evaluateExpression(expression, options, arg);
     return value;
   }
 
   async evaluateExpressionHandle(expression: string, options: { isFunction?: boolean, world?: types.World } = {}, arg?: any): Promise<js.JSHandle<any>> {
-    const context = await this._context(options.world ?? 'main');
+    const context = await this.context(options.world ?? 'main');
     const value = await context.evaluateExpressionHandle(expression, options, arg);
     return value;
   }
@@ -815,13 +815,13 @@ export class Frame extends SdkObject<FrameEventMap> {
       if ((options as any).__testHookBeforeAdoptNode)
         await progress.race((options as any).__testHookBeforeAdoptNode());
       try {
-        const mainContext = await progress.race(resolved.frame._mainContext());
+        const mainContext = await progress.race(resolved.frame.mainContext());
         return await progress.race(element._adoptTo(mainContext));
       } catch (e) {
         return continuePolling;
       }
     });
-    return scope ? scope._context._raceAgainstContextDestroyed(promise) : promise;
+    return scope ? scope._context.raceAgainstContextDestroyed(promise) : promise;
   }
 
   async dispatchEvent(progress: Progress, selector: string, type: string, eventInit: Object = {}, options: types.QueryOnSelectorOptions, scope?: dom.ElementHandle): Promise<void> {
@@ -847,7 +847,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async maskSelectors(selectors: ParsedSelector[], color: string): Promise<void> {
-    const context = await this._utilityContext();
+    const context = await this.utilityContext();
     const injectedScript = await context.injectedScript();
     await injectedScript.evaluate((injected, { parsed, color }) => {
       injected.maskSelectors(parsed, color);
@@ -870,7 +870,7 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   async content(): Promise<string> {
     try {
-      const context = await this._utilityContext();
+      const context = await this.utilityContext();
       return await context.evaluate(() => {
         let retVal = '';
         if (document.doctype)
@@ -891,7 +891,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     await this.raceNavigationAction(progress, async () => {
       const waitUntil = options.waitUntil === undefined ? 'load' : options.waitUntil;
       progress.log(`setting frame content, waiting until "${waitUntil}"`);
-      const context = await progress.race(this._utilityContext());
+      const context = await progress.race(this.utilityContext());
       const tagPromise = new ManualPromise<void>();
       this._page.frameManager._consoleMessageTags.set(tag, () => {
         // Clear lifecycle right after document.open() - see 'tag' below.
@@ -930,7 +930,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     return this._parentFrame;
   }
 
-  childFrames(): Frame[] {
+  _getChildFrames(): Frame[] {
     return Array.from(this._childFrames);
   }
 
@@ -947,7 +947,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     if (!url && !content)
       throw new Error('Provide an object with a `url`, `path` or `content` property');
 
-    const context = await this._mainContext();
+    const context = await this.mainContext();
     return this._raceWithCSPError(async () => {
       if (url !== null)
         return (await context.evaluateHandle(addScriptUrl, { url, type })).asElement()!;
@@ -994,7 +994,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     if (!url && !content)
       throw new Error('Provide an object with a `url`, `path` or `content` property');
 
-    const context = await this._mainContext();
+    const context = await this.mainContext();
     return this._raceWithCSPError(async () => {
       if (url !== null)
         return (await context.evaluateHandle(addStyleUrl, url)).asElement()!;
@@ -1091,7 +1091,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     if (dom.isNonRecoverableDOMError(e) || isInvalidSelectorError(e))
       return true;
     // If the call is made on the detached frame - throw.
-    if (this.isDetached())
+    if (this._isDetached())
       return true;
     // Retry upon all other errors.
     return false;
@@ -1284,7 +1284,7 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   async hideHighlight() {
     return this.raceAgainstEvaluationStallingEvents(async () => {
-      const context = await this._utilityContext();
+      const context = await this.utilityContext();
       const injectedScript = await context.injectedScript();
       return await injectedScript.evaluate(injected => {
         return injected.hideHighlight();
@@ -1445,7 +1445,7 @@ export class Frame extends SdkObject<FrameEventMap> {
 
     const { frame, info } = selectorInFrame || { frame: this, info: undefined };
     const world = options.expression === 'to.have.property' ? 'main' : (info?.world ?? 'utility');
-    const context = await race(frame._context(world));
+    const context = await race(frame.context(world));
     const injected = await race(context.injectedScript());
 
     const { log, matches, received, missingReceived } = await race(injected.evaluate(async (injected, { info, options, callId }) => {
@@ -1487,7 +1487,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       assert(options.pollingInterval > 0, 'Cannot poll with non-positive interval: ' + options.pollingInterval);
     expression = js.normalizeEvaluationExpression(expression, isFunction);
     return this.retryWithProgressAndTimeouts(progress, [100], async () => {
-      const context = world === 'main' ? await progress.race(this._mainContext()) : await progress.race(this._utilityContext());
+      const context = world === 'main' ? await progress.race(this.mainContext()) : await progress.race(this.utilityContext());
       const injectedScript = await progress.race(context.injectedScript());
       const handle = await progress.race(injectedScript.evaluateHandle((injected, { expression, isFunction, polling, arg }) => {
         let evaledExpression: any;
@@ -1564,7 +1564,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   async title(): Promise<string> {
     try {
       return await this.raceAgainstEvaluationStallingEvents(async () => {
-        const context = await this._utilityContext();
+        const context = await this.utilityContext();
         return await context.evaluate(() => document.title);
       });
     } catch {
@@ -1578,7 +1578,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   async rafrafTimeout(progress: Progress, timeout: number): Promise<void> {
     if (timeout === 0)
       return;
-    const context = await progress.race(this._utilityContext());
+    const context = await progress.race(this.utilityContext());
     await Promise.all([
       // wait for double raf
       progress.race(context.evaluate(() => new Promise(x => {
@@ -1626,7 +1626,7 @@ export class Frame extends SdkObject<FrameEventMap> {
         return continuePolling;
       return value!;
     });
-    return scope ? scope._context._raceAgainstContextDestroyed(promise) : promise;
+    return scope ? scope._context.raceAgainstContextDestroyed(promise) : promise;
   }
 
   private _setContext(world: types.World, context: dom.FrameExecutionContext | null) {
@@ -1638,7 +1638,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       data.contextPromise = new ManualPromise();
   }
 
-  _contextCreated(world: types.World, context: dom.FrameExecutionContext) {
+  contextCreated(world: types.World, context: dom.FrameExecutionContext) {
     const data = this._contextData.get(world)!;
     // In case of multiple sessions to the same target, there's a race between
     // connections so we might end up creating multiple isolated worlds.
@@ -1650,7 +1650,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     this._setContext(world, context);
   }
 
-  _contextDestroyed(context: dom.FrameExecutionContext) {
+  contextDestroyed(context: dom.FrameExecutionContext) {
     // Sometimes we get this after detach, in which case we should not reset
     // our already destroyed contexts to something that will never resolve.
     if (this._detachedScope.isClosed())
@@ -1683,7 +1683,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async extendInjectedScript(source: string, arg?: any) {
-    const context = await this._context('main');
+    const context = await this.context('main');
     const injectedScriptHandle = await context.injectedScript();
     await injectedScriptHandle.evaluate((injectedScript, { source, arg }) => {
       injectedScript.extend(source, arg);

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -96,10 +96,10 @@ export class Keyboard {
 
   async apiInsertText(progress: Progress, text: string) {
     await this._page.instrumentation.onBeforeInputAction(this._page, progress.metadata);
-    await this._insertText(progress, text);
+    await this.insertText(progress, text);
   }
 
-  async _insertText(progress: Progress, text: string) {
+  async insertText(progress: Progress, text: string) {
     await this._raw.sendText(progress, text);
   }
 
@@ -116,7 +116,7 @@ export class Keyboard {
       } else {
         if (delay)
           await progress.wait(delay);
-        await this._insertText(progress, char);
+        await this.insertText(progress, char);
       }
     }
   }
@@ -209,7 +209,7 @@ export class Mouse {
     this._keyboard = this._page.keyboard;
   }
 
-  currentPoint() {
+  private _currentPoint() {
     return { x: this._x, y: this._y };
   }
 
@@ -233,7 +233,7 @@ export class Mouse {
   }
 
   async apiDown(progress: Progress, options: { button?: types.MouseButton, clickCount?: number } = {}) {
-    progress.metadata.point = this.currentPoint();
+    progress.metadata.point = this._currentPoint();
     await this._page.instrumentation.onBeforeInputAction(this._page, progress.metadata);
     await this.down(progress, options);
   }
@@ -246,7 +246,7 @@ export class Mouse {
   }
 
   async apiUp(progress: Progress, options: { button?: types.MouseButton, clickCount?: number } = {}) {
-    progress.metadata.point = this.currentPoint();
+    progress.metadata.point = this._currentPoint();
     await this._page.instrumentation.onBeforeInputAction(this._page, progress.metadata);
     await this.up(progress, options);
   }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -69,28 +69,28 @@ export class ExecutionContext extends SdkObject {
     this._contextDestroyedScope.close(new Error(reason));
   }
 
-  async _raceAgainstContextDestroyed<T>(promise: Promise<T>): Promise<T> {
+  async raceAgainstContextDestroyed<T>(promise: Promise<T>): Promise<T> {
     return this._contextDestroyedScope.race(promise);
   }
 
   rawEvaluateJSON(expression: string): Promise<any> {
-    return this._raceAgainstContextDestroyed(this.delegate.rawEvaluateJSON(expression));
+    return this.raceAgainstContextDestroyed(this.delegate.rawEvaluateJSON(expression));
   }
 
   rawEvaluateHandle(expression: string): Promise<JSHandle> {
-    return this._raceAgainstContextDestroyed(this.delegate.rawEvaluateHandle(this, expression));
+    return this.raceAgainstContextDestroyed(this.delegate.rawEvaluateHandle(this, expression));
   }
 
-  async evaluateWithArguments(expression: string, returnByValue: boolean, values: any[], handles: JSHandle[]): Promise<any> {
-    const utilityScript = await this.utilityScript();
-    return this._raceAgainstContextDestroyed(this.delegate.evaluateWithArguments(expression, returnByValue, utilityScript, values, handles));
+  async _evaluateWithArguments(expression: string, returnByValue: boolean, values: any[], handles: JSHandle[]): Promise<any> {
+    const utilityScript = await this._utilityScript();
+    return this.raceAgainstContextDestroyed(this.delegate.evaluateWithArguments(expression, returnByValue, utilityScript, values, handles));
   }
 
   getProperties(object: JSHandle): Promise<Map<string, JSHandle>> {
-    return this._raceAgainstContextDestroyed(this.delegate.getProperties(object));
+    return this.raceAgainstContextDestroyed(this.delegate.getProperties(object));
   }
 
-  releaseHandle(handle: JSHandle): Promise<void> {
+  _releaseHandle(handle: JSHandle): Promise<void> {
     return this.delegate.releaseHandle(handle);
   }
 
@@ -98,7 +98,7 @@ export class ExecutionContext extends SdkObject {
     return null;
   }
 
-  utilityScript(): Promise<JSHandle<UtilityScript>> {
+  private _utilityScript(): Promise<JSHandle<UtilityScript>> {
     if (!this._utilityScriptPromise) {
       const source = `
       (() => {
@@ -106,17 +106,13 @@ export class ExecutionContext extends SdkObject {
         ${rawUtilityScriptSource.source}
         return new (module.exports.UtilityScript())(globalThis, ${isUnderTest()});
       })();`;
-      this._utilityScriptPromise = this._raceAgainstContextDestroyed(this.delegate.rawEvaluateHandle(this, source))
+      this._utilityScriptPromise = this.raceAgainstContextDestroyed(this.delegate.rawEvaluateHandle(this, source))
           .then(handle => {
             handle._setPreview('UtilityScript');
             return handle;
           });
     }
     return this._utilityScriptPromise;
-  }
-
-  async doSlowMo() {
-    // overridden in FrameExecutionContext
   }
 }
 
@@ -150,15 +146,11 @@ export class JSHandle<T = any> extends SdkObject {
   }
 
   async evaluateExpression(expression: string, options: { isFunction?: boolean }, arg: any) {
-    const value = await evaluateExpression(this._context, expression, { ...options, returnByValue: true }, this, arg);
-    await this._context.doSlowMo();
-    return value;
+    return await evaluateExpression(this._context, expression, { ...options, returnByValue: true }, this, arg);
   }
 
   async evaluateExpressionHandle(expression: string, options: { isFunction?: boolean }, arg: any): Promise<JSHandle<any>> {
-    const value = await evaluateExpression(this._context, expression, { ...options, returnByValue: false }, this, arg);
-    await this._context.doSlowMo();
-    return value;
+    return await evaluateExpression(this._context, expression, { ...options, returnByValue: false }, this, arg);
   }
 
   async getProperty(propertyName: string): Promise<JSHandle> {
@@ -187,7 +179,7 @@ export class JSHandle<T = any> extends SdkObject {
     if (!this._objectId)
       return this._value;
     const script = `(utilityScript, ...args) => utilityScript.jsonValue(...args)`;
-    return this._context.evaluateWithArguments(script, true, [true], [this]);
+    return this._context._evaluateWithArguments(script, true, [true], [this]);
   }
 
   asElement(): dom.ElementHandle | null {
@@ -199,7 +191,7 @@ export class JSHandle<T = any> extends SdkObject {
       return;
     this._disposed = true;
     if (this._objectId) {
-      this._context.releaseHandle(this).catch(e => {});
+      this._context._releaseHandle(this).catch(e => {});
       if ((globalThis as any).leakedJSHandles)
         (globalThis as any).leakedJSHandles.delete(this);
     }
@@ -268,7 +260,7 @@ export async function evaluateExpression(context: ExecutionContext, expression: 
 
   const script = `(utilityScript, ...args) => utilityScript.evaluate(...args)`;
   try {
-    return await context.evaluateWithArguments(script, options.returnByValue || false, utilityScriptValues, utilityScriptObjects);
+    return await context._evaluateWithArguments(script, options.returnByValue || false, utilityScriptValues, utilityScriptObjects);
   } finally {
     toDispose.map(handlePromise => handlePromise.then(handle => handle.dispose()));
   }

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -313,7 +313,7 @@ export class Request extends SdkObject {
     return this._bodySize || this.postDataBuffer()?.length || 0;
   }
 
-  async requestHeadersSize(): Promise<number> {
+  async _requestHeadersSize(): Promise<number> {
     let headersSize = 4; // 4 = 2 spaces + 2 line breaks (GET /path \r\n)
     headersSize += this.method().length;
     headersSize += (new URL(this.url())).pathname.length;
@@ -663,7 +663,7 @@ export class Response extends SdkObject {
   }
 
   async sizes(): Promise<ResourceSizes> {
-    const requestHeadersSize = await this._request.requestHeadersSize();
+    const requestHeadersSize = await this._request._requestHeadersSize();
     const responseHeadersSize = await this.responseHeadersSize();
 
     let encodedBodySize = await this._encodedBodySizePromise;

--- a/packages/playwright-core/src/server/overlay.ts
+++ b/packages/playwright-core/src/server/overlay.ts
@@ -47,7 +47,7 @@ export class Overlay {
   }
 
   private async _doAdd(id: string, html: string) {
-    const utility = await this._page.mainFrame()._utilityContext();
+    const utility = await this._page.mainFrame().utilityContext();
     await utility.evaluate(({ injected, html, id }) => {
       return injected.addUserOverlay(id, html);
     }, { injected: await utility.injectedScript(), html, id });
@@ -55,7 +55,7 @@ export class Overlay {
 
   async remove(id: string): Promise<void> {
     this._overlays.delete(id);
-    const utility = await this._page.mainFrame()._utilityContext();
+    const utility = await this._page.mainFrame().utilityContext();
     await utility.evaluate(({ injected, id }) => {
       injected.removeUserOverlay(id);
     }, { injected: await utility.injectedScript(), id }).catch(e => debugLogger.log('error', e));
@@ -116,7 +116,7 @@ export class Overlay {
     const id = await this.show(html);
     await new Promise(f => setTimeout(f, duration));
     // Trigger fade-out, then remove after animation completes.
-    const utility = await this._page.mainFrame()._utilityContext();
+    const utility = await this._page.mainFrame().utilityContext();
     await utility.evaluate(({ injected, id, fadeDuration }) => {
       const overlay = injected.getUserOverlay(id);
       const bg = overlay?.querySelector('#background');
@@ -130,7 +130,7 @@ export class Overlay {
   async setVisible(visible: boolean): Promise<void> {
     if (!this._overlays.size)
       return;
-    const utility = await this._page.mainFrame()._utilityContext();
+    const utility = await this._page.mainFrame().utilityContext();
     await utility.evaluate(({ injected, visible }) => {
       injected.setUserOverlaysVisible(visible);
     }, { injected: await utility.injectedScript(), visible }).catch(e => debugLogger.log('error', e));

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -315,7 +315,7 @@ export class Page extends SdkObject<PageEventMap> {
       handle.dispose();
       return;
     }
-    const fileChooser = new FileChooser(this, handle, multiple);
+    const fileChooser = new FileChooser(handle, multiple);
     this.emit(Page.Events.FileChooser, fileChooser);
   }
 
@@ -447,7 +447,7 @@ export class Page extends SdkObject<PageEventMap> {
       // so we should await it immediately.
       const [response] = await Promise.all([
         // Reload must be a new document, and should not be confused with a stray pushState.
-        this.mainFrame()._waitForNavigation(progress, true /* requiresNewDocument */, options),
+        this.mainFrame().waitForNavigation(progress, true /* requiresNewDocument */, options),
         progress.race(this.delegate.reload()),
       ]);
       return response;
@@ -459,7 +459,7 @@ export class Page extends SdkObject<PageEventMap> {
       // Note: waitForNavigation may fail before we get response to goBack,
       // so we should catch it immediately.
       let error: Error | undefined;
-      const waitPromise = this.mainFrame()._waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
+      const waitPromise = this.mainFrame().waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
         error = e;
         return null;
       });
@@ -480,7 +480,7 @@ export class Page extends SdkObject<PageEventMap> {
       // Note: waitForNavigation may fail before we get response to goForward,
       // so we should catch it immediately.
       let error: Error | undefined;
-      const waitPromise = this.mainFrame()._waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
+      const waitPromise = this.mainFrame().waitForNavigation(progress, false /* requiresNewDocument */, options).catch(e => {
         error = e;
         return null;
       });
@@ -1041,7 +1041,7 @@ export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Fra
   // Only await the topmost navigations, inner frames will be empty when racing.
   const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async continuePolling => {
     try {
-      const context = await progress.race(frame._utilityContext());
+      const context = await progress.race(frame.utilityContext());
       const injectedScript = await progress.race(context.injectedScript());
       const snapshotOrRetry = await progress.race(injectedScript.evaluate((injected, options) => {
         if (options.info) {

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -50,10 +50,6 @@ export class ProgressController {
     });
   }
 
-  static runInternalTask(task: (progress: Progress) => Promise<void>, timeout?: number) {
-    const progress = new ProgressController();
-    return progress.run(task, timeout);
-  }
 
   async abort(error: Error) {
     if (this._state === 'running') {

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -248,7 +248,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       this.onBeforeCall(pausedDetails.sdkObject, pausedDetails.metadata);
     this.emit(RecorderEvent.PausedStateChanged, this._debugger.isPaused());
     this._updateUserSources();
-    this.updateCallLog([...this._currentCallsMetadata.keys()]);
+    this._updateCallLog([...this._currentCallsMetadata.keys()]);
   }
 
   mode() {
@@ -406,7 +406,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       return;
     this._currentCallsMetadata.set(metadata, sdkObject);
     this._updateUserSources();
-    this.updateCallLog([metadata]);
+    this._updateCallLog([metadata]);
     if (isScreenshotCommand(metadata))
       this.hideHighlightedSelector();
     else if (metadata.params && metadata.params.selector)
@@ -419,7 +419,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     if (!metadata.error)
       this._currentCallsMetadata.delete(metadata);
     this._updateUserSources();
-    this.updateCallLog([metadata]);
+    this._updateCallLog([metadata]);
   }
 
   private _updateUserSources() {
@@ -449,10 +449,10 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async onCallLog(sdkObject: SdkObject, metadata: CallMetadata, logName: string, message: string): Promise<void> {
-    this.updateCallLog([metadata]);
+    this._updateCallLog([metadata]);
   }
 
-  updateCallLog(metadatas: CallMetadata[]) {
+  private _updateCallLog(metadatas: CallMetadata[]) {
     if (this._isRecording())
       return;
     const logs: CallLog[] = [];

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -221,7 +221,7 @@ export class RecorderApp {
     });
     const controller = new ProgressController();
     await controller.run(async progress => {
-      await appContext._browser._defaultContext!._loadDefaultContextAsIs(progress);
+      await appContext._browser._defaultContext!.loadDefaultContextAsIs(progress);
     });
 
     const appParams = {

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -134,7 +134,7 @@ async function generateFrameSelectorInParent(parent: Frame, frame: Frame): Promi
       const frameElement = await frame.frameElement();
       if (!frameElement || !parent)
         return;
-      const utility = await parent._utilityContext();
+      const utility = await parent.utilityContext();
       const injected = await utility.injectedScript();
       const selector = await injected.evaluate((injected, element) => {
         return injected.generateSelectorSimple(element as Element);

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -87,10 +87,6 @@ export class Screencast implements InstrumentationListener {
       this._stopScreencast();
   }
 
-  size(): types.Size | undefined {
-    return this._size;
-  }
-
   private _startScreencast(size: types.Size | undefined, quality: number | undefined) {
     this._size = size;
     if (!this._size) {
@@ -152,7 +148,7 @@ export class Screencast implements InstrumentationListener {
       return;
 
     const actionTitle = renderTitleForCall(metadata);
-    const utility = await page.mainFrame()._utilityContext();
+    const utility = await page.mainFrame().utilityContext();
 
     // Run this outside of the progress timer.
     await utility.evaluate(async options => {

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -202,7 +202,7 @@ export class Screenshotter {
 
   async screenshotPage(progress: Progress, options: ScreenshotOptions): Promise<Buffer> {
     const format = validateScreenshotOptions(options);
-    return this._queue.postTask(async () => {
+    return this._queue._postTask(async () => {
       progress.log('taking page screenshot');
       const viewportSize = await this._originalViewportSize(progress);
       await this._preparePageForScreenshot(progress, this._page.mainFrame(), options.style, options.caret !== 'initial', options.animations === 'disabled');
@@ -225,7 +225,7 @@ export class Screenshotter {
 
   async screenshotElement(progress: Progress, handle: dom.ElementHandle, options: ScreenshotOptions): Promise<Buffer> {
     const format = validateScreenshotOptions(options);
-    return this._queue.postTask(async () => {
+    return this._queue._postTask(async () => {
       progress.log('taking element screenshot');
       const viewportSize = await this._originalViewportSize(progress);
 
@@ -250,7 +250,7 @@ export class Screenshotter {
     });
   }
 
-  async _preparePageForScreenshot(progress: Progress, frame: Frame, screenshotStyle: string | undefined, hideCaret: boolean, disableAnimations: boolean) {
+  private async _preparePageForScreenshot(progress: Progress, frame: Frame, screenshotStyle: string | undefined, hideCaret: boolean, disableAnimations: boolean) {
     if (disableAnimations)
       progress.log('  disabled all CSS animations');
     const syncAnimations = this._page.delegate.shouldToggleStyleSheetToSyncAnimations();
@@ -267,11 +267,11 @@ export class Screenshotter {
     }
   }
 
-  async _restorePageAfterScreenshot() {
+  private async _restorePageAfterScreenshot() {
     await this._page.safeNonStallingEvaluateInAllFrames('window.__pwCleanupScreenshot && window.__pwCleanupScreenshot()', 'utility');
   }
 
-  async _maskElements(progress: Progress, options: ScreenshotOptions): Promise<() => Promise<void>> {
+  private async _maskElements(progress: Progress, options: ScreenshotOptions): Promise<() => Promise<void>> {
     if (!options.mask || !options.mask.length)
       return () => Promise.resolve();
 
@@ -332,7 +332,7 @@ class TaskQueue {
     this._chain = Promise.resolve();
   }
 
-  postTask(task: () => any): Promise<any> {
+  _postTask(task: () => any): Promise<any> {
     const result = this._chain.then(task);
     this._chain = result.catch(() => {});
     return result;

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -128,7 +128,7 @@ class SocksProxyConnection {
   }
 
   async connect() {
-    const proxyAgent = this.socksProxy.getProxyAgent(this.host, this.port);
+    const proxyAgent = this.socksProxy._getProxyAgent(this.host, this.port);
     if (proxyAgent)
       this._serverEncrypted = await proxyAgent.connect(new EventEmitter() as any, { host: rewriteToLocalhostIfNeeded(this.host), port: this.port, secureEndpoint: false });
     else
@@ -147,14 +147,14 @@ class SocksProxyConnection {
     });
   }
 
-  public onClose() {
+  onClose() {
     // Close the other end and cleanup TLS resources.
     this._serverEncrypted.destroy();
     this._browserEncrypted.destroy();
     this._closed = true;
   }
 
-  public onData(data: Buffer) {
+  onData(data: Buffer) {
     // HTTP / TLS are client-hello based protocols. This allows us to detect
     // the protocol on the first package and attach appropriate listeners.
     if (!this._firstPackageReceived) {
@@ -309,7 +309,7 @@ export class ClientCertificatesProxy {
     loadDummyServerCertsIfNeeded();
   }
 
-  getProxyAgent(host: string, port: number) {
+  _getProxyAgent(host: string, port: number) {
     const proxyFromOptions = createProxyAgent(this._proxy);
     if (proxyFromOptions)
       return proxyFromOptions;

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -167,7 +167,7 @@ export class Snapshotter {
       const parent = frame.parentFrame();
       if (!parent)
         return;
-      const context = await parent._mainContext();
+      const context = await parent.mainContext();
       await context?.evaluate(({ snapshotStreamer, frameElement, frameId }) => {
         (window as any)[snapshotStreamer].markIframe(frameElement, frameId);
       }, { snapshotStreamer: this._snapshotStreamer, frameElement, frameId: frame.guid });

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -184,7 +184,7 @@ export async function openTraceViewerApp(url: string, browserName: string, optio
 
   const controller = new ProgressController();
   await controller.run(async progress => {
-    await context._browser._defaultContext!._loadDefaultContextAsIs(progress);
+    await context._browser._defaultContext!.loadDefaultContextAsIs(progress);
 
     if (process.env.PWTEST_PRINT_WS_ENDPOINT) {
       // eslint-disable-next-line no-restricted-properties

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -72,7 +72,7 @@ export class VideoRecorder {
     this._videoRecorder = undefined;
 
     this._screencast.removeClient(client);
-    await videoRecorder.stop();
+    await videoRecorder._stop();
     await artifact.reportFinished();
   }
 }
@@ -225,7 +225,7 @@ class FfmpegVideoRecorder {
     });
   }
 
-  async stop() {
+  async _stop() {
     // Only report the error on stop. This allows to make the constructor synchronous.
     const error = await this._launchPromise;
     if (error)

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -51,7 +51,7 @@ export class WKBrowser extends Browser {
     if (options.persistent) {
       options.persistent.userAgent ||= DEFAULT_USER_AGENT;
       browser._defaultContext = new WKBrowserContext(browser, undefined, options.persistent);
-      promises.push((browser._defaultContext as WKBrowserContext)._initialize());
+      promises.push(browser._defaultContext.initialize());
     }
     await Promise.all(promises);
     return browser;
@@ -75,7 +75,7 @@ export class WKBrowser extends Browser {
     for (const wkPage of this._wkPages.values())
       wkPage.didClose();
     this._wkPages.clear();
-    this._didClose();
+    this.didClose();
   }
 
   async doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
@@ -89,7 +89,7 @@ export class WKBrowser extends Browser {
     const { browserContextId } = await this._browserSession.send('Playwright.createContext', createOptions);
     options.userAgent = options.userAgent || DEFAULT_USER_AGENT;
     const context = new WKBrowserContext(this, browserContextId, options);
-    await context._initialize();
+    await context.initialize();
     this._contexts.set(browserContextId, context);
     return context;
   }
@@ -136,15 +136,15 @@ export class WKBrowser extends Browser {
     }
     if (!originPage)
       return;
-    this._downloadCreated(originPage, payload.uuid, payload.url);
+    this.downloadCreated(originPage, payload.uuid, payload.url);
   }
 
   _onDownloadFilenameSuggested(payload: Protocol.Playwright.downloadFilenameSuggestedPayload) {
-    this._downloadFilenameSuggested(payload.uuid, payload.suggestedFilename);
+    this.downloadFilenameSuggested(payload.uuid, payload.suggestedFilename);
   }
 
   _onDownloadFinished(payload: Protocol.Playwright.downloadFinishedPayload) {
-    this._downloadFinished(payload.uuid, payload.error);
+    this.downloadFinished(payload.uuid, payload.error);
   }
 
   _onPageProxyCreated(event: Protocol.Playwright.pageProxyCreatedPayload) {
@@ -210,13 +210,13 @@ export class WKBrowserContext extends BrowserContext {
   constructor(browser: WKBrowser, browserContextId: string | undefined, options: types.BrowserContextOptions) {
     super(browser, options, browserContextId);
     this._validateEmulatedViewport(options.viewport);
-    this._authenticateProxyViaHeader();
+    this.authenticateProxyViaHeader();
   }
 
-  override async _initialize() {
+  override async initialize() {
     assert(!this._wkPages().length);
     const browserContextId = this._browserContextId;
-    const promises: Promise<any>[] = [super._initialize()];
+    const promises: Promise<any>[] = [super.initialize()];
     promises.push(this._browser._browserSession.send('Playwright.setDownloadBehavior', {
       behavior: this._options.acceptDownloads === 'accept' ? 'allow' : 'deny',
       downloadPath: this._browser.options.channel === 'webkit-wsl' ? await translatePathToWSL(this._browser.options.downloadsPath) : this._browser.options.downloadsPath,

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -487,7 +487,7 @@ export class WKPage implements PageDelegate {
       if (context.frame === frame) {
         this._contextIdToContext.delete(contextId);
         if (notifyFrame)
-          frame._contextDestroyed(context);
+          frame.contextDestroyed(context);
       }
     }
   }
@@ -506,7 +506,7 @@ export class WKPage implements PageDelegate {
       worldName = 'utility';
     const context = new dom.FrameExecutionContext(delegate, frame, worldName);
     if (worldName)
-      frame._contextCreated(worldName, context);
+      frame.contextCreated(worldName, context);
     this._contextIdToContext.set(contextPayload.id, context);
   }
 
@@ -619,7 +619,7 @@ export class WKPage implements PageDelegate {
   private async _onFileChooserOpened(event: {frameId: Protocol.Network.FrameId, element: Protocol.Runtime.RemoteObject}) {
     let handle;
     try {
-      const context = await this._page.frameManager.frame(event.frameId)!._mainContext();
+      const context = await this._page.frameManager.frame(event.frameId)!.mainContext();
       handle =  createHandle(context, event.element).asElement()!;
     } catch (e) {
       // During async processing, frame/context may go away. We should not throw.
@@ -1005,7 +1005,7 @@ export class WKPage implements PageDelegate {
     const parent = frame.parentFrame();
     if (!parent)
       throw new Error('Frame has been detached.');
-    const context = await parent._mainContext();
+    const context = await parent.mainContext();
     const result = await this._session.send('DOM.resolveNode', {
       frameId: frame._id,
       executionContextId: (context.delegate as WKExecutionContext)._contextId

--- a/tests/page/page-leaks.spec.ts
+++ b/tests/page/page-leaks.spec.ts
@@ -43,7 +43,7 @@ function leakedJSHandles(): string {
 
 async function weakRefObjects(pageImpl: any, selector: string) {
   for (const world of ['main', 'utility']) {
-    const context = await pageImpl.mainFrame()._context(world);
+    const context = await pageImpl.mainFrame().context(world);
     await context.evaluate(selector => {
       const elements = document.querySelectorAll(selector);
       globalThis.weakRefs = globalThis.weakRefs || [];
@@ -57,7 +57,7 @@ async function weakRefCount(pageImpl): Promise<{ main: number, utility: number }
   const result = { main: 0, utility: 0 };
   for (const world of ['main', 'utility']) {
     await pageImpl.requestGC();
-    const context = await pageImpl.mainFrame()._context(world);
+    const context = await pageImpl.mainFrame().context(world);
     result[world] = await context.evaluate(() => globalThis.weakRefs.filter(r => !!r.deref()).length);
   }
   return result;


### PR DESCRIPTION

For exported classes:
- `private _method()` — only used within the class itself
- `_method()` (no `private`) — used by other code in the same file, but not outside the file
- `method()` (public) — used in other files

Non-exported classes have no naming convention; they are internal implementation details.