### PR TITLE
chore: enforce dispatcher API convention for server types

### DIFF
--- a/packages/playwright-core/src/server/dialog.ts
+++ b/packages/playwright-core/src/server/dialog.ts
@@ -20,6 +20,7 @@ import { SdkObject } from './instrumentation';
 
 import type { Instrumentation } from './instrumentation';
 import type { Page } from './page';
+import type { Progress } from '@protocol/progress';
 
 type OnHandle = (accept: boolean, promptText?: string) => Promise<void>;
 
@@ -42,6 +43,14 @@ export class Dialog extends SdkObject {
     this._defaultValue = defaultValue || '';
   }
 
+  async accept(progress: Progress, promptText?: string) {
+    await progress.race(this._accept(promptText));
+  }
+
+  async dismiss(progress: Progress) {
+    await progress.race(this._dismiss());
+  }
+
   page() {
     return this._page;
   }
@@ -58,14 +67,14 @@ export class Dialog extends SdkObject {
     return this._defaultValue;
   }
 
-  async accept(promptText?: string) {
+  async _accept(promptText?: string) {
     assert(!this._handled, 'Cannot accept dialog which is already handled!');
     this._handled = true;
     this._page.browserContext.dialogManager._dialogWillClose(this);
     await this._onHandle(true, promptText);
   }
 
-  async dismiss() {
+  async _dismiss() {
     assert(!this._handled, 'Cannot dismiss dialog which is already handled!');
     this._handled = true;
     this._page.browserContext.dialogManager._dialogWillClose(this);
@@ -74,9 +83,9 @@ export class Dialog extends SdkObject {
 
   async _close() {
     if (this._type === 'beforeunload')
-      await this.accept();
+      await this._accept();
     else
-      await this.dismiss();
+      await this._dismiss();
   }
 }
 
@@ -128,7 +137,7 @@ export class DialogManager {
   async closeBeforeUnloadDialogs() {
     await Promise.all([...this._openedDialogs].map(async dialog => {
       if (dialog.type() === 'beforeunload')
-        await dialog.dismiss();
+        await dialog._dismiss();
     }));
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
@@ -37,10 +37,10 @@ export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogChannel,
   }
 
   async accept(params: channels.DialogAcceptParams, progress: Progress): Promise<void> {
-    await progress.race(this._object.accept(params.promptText));
+    await this._object.accept(progress, params.promptText);
   }
 
   async dismiss(params: channels.DialogDismissParams, progress: Progress): Promise<void> {
-    await progress.race(this._object.dismiss());
+    await this._object.dismiss(progress);
   }
 }

--- a/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/electronDispatcher.ts
@@ -77,12 +77,12 @@ export class ElectronApplicationDispatcher extends Dispatcher<ElectronApplicatio
 
   async evaluateExpression(params: channels.ElectronApplicationEvaluateExpressionParams, progress: Progress): Promise<channels.ElectronApplicationEvaluateExpressionResult> {
     const handle = await progress.race(this._object._nodeElectronHandlePromise);
-    return { value: serializeResult(await progress.race(handle.evaluateExpression(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg)))) };
+    return { value: serializeResult(await handle.evaluateExpression(progress, params.expression, { isFunction: params.isFunction }, parseArgument(params.arg))) };
   }
 
   async evaluateExpressionHandle(params: channels.ElectronApplicationEvaluateExpressionHandleParams, progress: Progress): Promise<channels.ElectronApplicationEvaluateExpressionHandleResult> {
     const handle = await progress.race(this._object._nodeElectronHandlePromise);
-    const result = await progress.race(handle.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg)));
+    const result = await handle.evaluateExpressionHandle(progress, params.expression, { isFunction: params.isFunction }, parseArgument(params.arg));
     return { handle: JSHandleDispatcher.fromJSHandle(this, result) };
   }
 

--- a/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
@@ -43,24 +43,24 @@ export class JSHandleDispatcher<ParentScope extends JSHandleDispatcherParentScop
   }
 
   async evaluateExpression(params: channels.JSHandleEvaluateExpressionParams, progress: Progress): Promise<channels.JSHandleEvaluateExpressionResult> {
-    const jsHandle = await progress.race(this._object.evaluateExpression(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg)));
+    const jsHandle = await this._object.evaluateExpression(progress, params.expression, { isFunction: params.isFunction }, parseArgument(params.arg));
     return { value: serializeResult(jsHandle) };
   }
 
   async evaluateExpressionHandle(params: channels.JSHandleEvaluateExpressionHandleParams, progress: Progress): Promise<channels.JSHandleEvaluateExpressionHandleResult> {
-    const jsHandle = await progress.race(this._object.evaluateExpressionHandle(params.expression, { isFunction: params.isFunction }, parseArgument(params.arg)));
+    const jsHandle = await this._object.evaluateExpressionHandle(progress, params.expression, { isFunction: params.isFunction }, parseArgument(params.arg));
     // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
     return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this.parentScope() as FrameDispatcher, jsHandle) };
   }
 
   async getProperty(params: channels.JSHandleGetPropertyParams, progress: Progress): Promise<channels.JSHandleGetPropertyResult> {
-    const jsHandle = await progress.race(this._object.getProperty(params.name));
+    const jsHandle = await this._object.getProperty(progress, params.name);
     // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
     return { handle: ElementHandleDispatcher.fromJSOrElementHandle(this.parentScope() as FrameDispatcher, jsHandle) };
   }
 
   async getPropertyList(params: channels.JSHandleGetPropertyListParams, progress: Progress): Promise<channels.JSHandleGetPropertyListResult> {
-    const map = await progress.race(this._object.getProperties());
+    const map = await this._object.getProperties(progress);
     const properties = [];
     for (const [name, value] of map) {
       // If "jsHandle" is an ElementHandle, it belongs to the same frame as "this".
@@ -70,7 +70,7 @@ export class JSHandleDispatcher<ParentScope extends JSHandleDispatcherParentScop
   }
 
   async jsonValue(params: channels.JSHandleJsonValueParams, progress: Progress): Promise<channels.JSHandleJsonValueResult> {
-    return { value: serializeResult(await progress.race(this._object.jsonValue())) };
+    return { value: serializeResult(await this._object.jsonValue(progress)) };
   }
 
   async dispose(_: any, progress: Progress) {

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -67,11 +67,11 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
   }
 
   async rawRequestHeaders(params: channels.RequestRawRequestHeadersParams, progress: Progress): Promise<channels.RequestRawRequestHeadersResult> {
-    return { headers: await progress.race(this._object.rawRequestHeaders()) };
+    return { headers: await this._object.rawRequestHeaders(progress) };
   }
 
   async response(params: channels.RequestResponseParams, progress: Progress): Promise<channels.RequestResponseResult> {
-    return { response: ResponseDispatcher.fromNullable(this._browserContextDispatcher, await progress.race(this._object.response())) };
+    return { response: ResponseDispatcher.fromNullable(this._browserContextDispatcher, await this._object.response(progress)) };
   }
 }
 
@@ -102,27 +102,27 @@ export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseCh
   }
 
   async body(params: channels.ResponseBodyParams, progress: Progress): Promise<channels.ResponseBodyResult> {
-    return { binary: await progress.race(this._object.body()) };
+    return { binary: await this._object.body(progress) };
   }
 
   async securityDetails(params: channels.ResponseSecurityDetailsParams, progress: Progress): Promise<channels.ResponseSecurityDetailsResult> {
-    return { value: await progress.race(this._object.securityDetails()) || undefined };
+    return { value: await this._object.securityDetails(progress) || undefined };
   }
 
   async serverAddr(params: channels.ResponseServerAddrParams, progress: Progress): Promise<channels.ResponseServerAddrResult> {
-    return { value: await progress.race(this._object.serverAddr()) || undefined };
+    return { value: await this._object.serverAddr(progress) || undefined };
   }
 
   async rawResponseHeaders(params: channels.ResponseRawResponseHeadersParams, progress: Progress): Promise<channels.ResponseRawResponseHeadersResult> {
-    return { headers: await progress.race(this._object.rawResponseHeaders()) };
+    return { headers: await this._object.rawResponseHeaders(progress) };
   }
 
   async httpVersion(params: channels.ResponseHttpVersionParams, progress: Progress): Promise<channels.ResponseHttpVersionResult> {
-    return { value: await progress.race(this._object.httpVersion()) };
+    return { value: await this._object.httpVersion(progress) };
   }
 
   async sizes(params: channels.ResponseSizesParams, progress: Progress): Promise<channels.ResponseSizesResult> {
-    return { sizes: await progress.race(this._object.sizes()) };
+    return { sizes: await this._object.sizes(progress) };
   }
 }
 
@@ -223,28 +223,19 @@ export class APIRequestContextDispatcher extends Dispatcher<APIRequestContext, c
   }
 
   async fetch(params: channels.APIRequestContextFetchParams, progress: Progress): Promise<channels.APIRequestContextFetchResult> {
-    const fetchResponse = await this._object.fetch(progress, params);
-    return {
-      response: {
-        url: fetchResponse.url,
-        status: fetchResponse.status,
-        statusText: fetchResponse.statusText,
-        headers: fetchResponse.headers,
-        fetchUid: fetchResponse.fetchUid
-      }
-    };
+    const response = await this._object.fetch(progress, params);
+    return { response };
   }
 
   async fetchResponseBody(params: channels.APIRequestContextFetchResponseBodyParams, progress: Progress): Promise<channels.APIRequestContextFetchResponseBodyResult> {
-    return { binary: this._object.fetchResponses.get(params.fetchUid) };
+    return { binary: this._object.fetchResponseBody(progress, params.fetchUid) };
   }
 
   async fetchLog(params: channels.APIRequestContextFetchLogParams, progress: Progress): Promise<channels.APIRequestContextFetchLogResult> {
-    const log = this._object.fetchLog.get(params.fetchUid) || [];
-    return { log };
+    return { log: this._object.fetchLogForUid(progress, params.fetchUid) };
   }
 
   async disposeAPIResponse(params: channels.APIRequestContextDisposeAPIResponseParams, progress: Progress): Promise<void> {
-    this._object.disposeResponse(params.fetchUid);
+    this._object.disposeResponse(progress, params.fetchUid);
   }
 }

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -116,16 +116,18 @@ export abstract class APIRequestContext extends SdkObject {
     APIRequestContext.allInstances.add(this);
   }
 
-  protected _disposeImpl() {
-    APIRequestContext.allInstances.delete(this);
-    this.fetchResponses.clear();
-    this.fetchLog.clear();
-    this.emit(APIRequestContext.Events.Dispose);
+  abstract storageState(progress: Progress, indexedDB?: boolean): Promise<channels.APIRequestContextStorageStateResult>;
+
+  fetchResponseBody(progress: Progress, fetchUid: string): Buffer | undefined {
+    return this.fetchResponses.get(fetchUid);
   }
 
-  disposeResponse(fetchUid: string) {
-    this.fetchResponses.delete(fetchUid);
-    this.fetchLog.delete(fetchUid);
+  fetchLogForUid(progress: Progress, fetchUid: string): string[] {
+    return this.fetchLog.get(fetchUid) || [];
+  }
+
+  disposeResponse(progress: Progress, fetchUid: string) {
+    this._disposeResponse(fetchUid);
   }
 
   abstract tracing(): Tracing;
@@ -135,7 +137,18 @@ export abstract class APIRequestContext extends SdkObject {
   abstract _defaultOptions(): FetchRequestOptions;
   abstract _addCookies(cookies: channels.NetworkCookie[]): Promise<void>;
   abstract _cookies(url: URL): Promise<channels.NetworkCookie[]>;
-  abstract storageState(progress: Progress, indexedDB?: boolean): Promise<channels.APIRequestContextStorageStateResult>;
+
+  protected _disposeImpl() {
+    APIRequestContext.allInstances.delete(this);
+    this.fetchResponses.clear();
+    this.fetchLog.clear();
+    this.emit(APIRequestContext.Events.Dispose);
+  }
+
+  _disposeResponse(fetchUid: string) {
+    this.fetchResponses.delete(fetchUid);
+    this.fetchLog.delete(fetchUid);
+  }
 
   private _storeResponseBody(body: Buffer): string {
     const uid = createGuid();

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -101,7 +101,7 @@ export class FrameSelectors {
       return elements;
     }, { info: resolved.info, scope: resolved.scope });
 
-    const properties = await arrayHandle.getProperties();
+    const properties = await arrayHandle.internalGetProperties();
     arrayHandle.dispose();
 
     // Note: adopting elements one by one may be slow. If we encounter the issue here,

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -685,7 +685,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       await helper.waitForEvent(progress, this, Frame.Events.AddLifecycle, (e: types.LifecycleEvent) => e === waitUntil).promise;
 
     const request = event.newDocument ? event.newDocument.request : undefined;
-    const response = request ? progress.race(request._finalRequest().response()) : null;
+    const response = request ? progress.race(request._finalRequest().internalResponse()) : null;
     return response;
   }
 
@@ -709,7 +709,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       await helper.waitForEvent(progress, this, Frame.Events.AddLifecycle, (e: types.LifecycleEvent) => e === waitUntil).promise;
 
     const request = navigationEvent.newDocument ? navigationEvent.newDocument.request : undefined;
-    return request ? progress.race(request._finalRequest().response()) : null;
+    return request ? progress.race(request._finalRequest().internalResponse()) : null;
   }
 
   async waitForLoadState(progress: Progress, state: types.LifecycleEvent): Promise<void> {
@@ -834,14 +834,14 @@ export class Frame extends SdkObject<FrameEventMap> {
     const handle = await this.selectors.query(selector, { strict }, scope);
     if (!handle)
       throw new Error(`Failed to find element matching selector "${selector}"`);
-    const result = await handle.evaluateExpression(expression, { isFunction }, arg);
+    const result = await handle.internalEvaluateExpression(expression, { isFunction }, arg);
     handle.dispose();
     return result;
   }
 
   async evalOnSelectorAll(selector: string, expression: string, isFunction: boolean | undefined, arg: any, scope?: dom.ElementHandle): Promise<any> {
     const arrayHandle = await this.selectors.queryArrayInMainWorld(selector, scope);
-    const result = await arrayHandle.evaluateExpression(expression, { isFunction }, arg);
+    const result = await arrayHandle.internalEvaluateExpression(expression, { isFunction }, arg);
     arrayHandle.dispose();
     return result;
   }

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -309,7 +309,7 @@ export class HarTracer {
     // In WebKit security details and server ip are reported in Network.loadingFinished, so we populate
     // it here to not hang in case of long chunked responses, see https://github.com/microsoft/playwright/issues/21182.
     if (!this._options.omitServerIP) {
-      this._addBarrier(page || request.serviceWorker(), response.serverAddr().then(server => {
+      this._addBarrier(page || request.serviceWorker(), response.internalServerAddr().then(server => {
         if (server?.ipAddress)
           harEntry.serverIPAddress = server.ipAddress;
         if (server?.port)
@@ -317,7 +317,7 @@ export class HarTracer {
       }));
     }
     if (!this._options.omitSecurityDetails) {
-      this._addBarrier(page || request.serviceWorker(), response.securityDetails().then(details => {
+      this._addBarrier(page || request.serviceWorker(), response.internalSecurityDetails().then(details => {
         if (details)
           harEntry._securityDetails = details;
       }));
@@ -345,7 +345,7 @@ export class HarTracer {
     if (compressionCalculationBarrier)
       this._addBarrier(page || request.serviceWorker(), compressionCalculationBarrier.barrier);
 
-    const promise = response.body().then(buffer => {
+    const promise = response.internalBody().then(buffer => {
       if (this._options.omitScripts && request.resourceType() === 'script') {
         compressionCalculationBarrier?.setDecodedBodySize(0);
         return;
@@ -362,7 +362,7 @@ export class HarTracer {
     });
     this._addBarrier(page || request.serviceWorker(), promise);
 
-    this._addBarrier(page || request.serviceWorker(), response.httpVersion().then(httpVersion => {
+    this._addBarrier(page || request.serviceWorker(), response.internalHttpVersion().then(httpVersion => {
       harEntry.request.httpVersion = httpVersion;
       harEntry.response.httpVersion = httpVersion;
     }));
@@ -373,7 +373,7 @@ export class HarTracer {
     this._computeHarEntryTotalTime(harEntry);
 
     if (!this._options.omitSizes) {
-      this._addBarrier(page || request.serviceWorker(), response.sizes().then(sizes => {
+      this._addBarrier(page || request.serviceWorker(), response.internalSizes().then(sizes => {
         harEntry.response.bodySize = sizes.responseBodySize;
         harEntry.response.headersSize = sizes.responseHeadersSize;
         harEntry.response._transferSize = sizes.transferSize;
@@ -490,13 +490,13 @@ export class HarTracer {
     }
 
     this._recordRequestOverrides(harEntry, request);
-    this._addBarrier(page || request.serviceWorker(), request.rawRequestHeaders().then(headers => {
+    this._addBarrier(page || request.serviceWorker(), request.internalRawRequestHeaders().then(headers => {
       this._recordRequestHeadersAndCookies(harEntry, headers);
     }));
     // Record available headers including redirect location in case the tracing is stopped before
     // response extra info is received (in Chromium).
     this._recordResponseHeaders(harEntry, response.headers());
-    this._addBarrier(page || request.serviceWorker(), response.rawResponseHeaders().then(headers => {
+    this._addBarrier(page || request.serviceWorker(), response.internalRawResponseHeaders().then(headers => {
       this._recordResponseHeaders(harEntry, headers);
     }));
   }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -21,6 +21,7 @@ import { serializeAsCallArgument } from '../utils/isomorphic/utilityScriptSerial
 import { LongStandingScope } from '../utils/isomorphic/manualPromise';
 
 import type * as dom from './dom';
+import type { Progress } from '@protocol/progress';
 import type { UtilityScript } from '@injected/utilityScript';
 
 interface TaggedAsJSHandle<T> {
@@ -137,6 +138,26 @@ export class JSHandle<T = any> extends SdkObject {
       (globalThis as any).leakedJSHandles.set(this, new Error('Leaked JSHandle'));
   }
 
+  async evaluateExpression(progress: Progress, expression: string, options: { isFunction?: boolean }, arg: any) {
+    return await progress.race(this.internalEvaluateExpression(expression, options, arg));
+  }
+
+  async evaluateExpressionHandle(progress: Progress, expression: string, options: { isFunction?: boolean }, arg: any): Promise<JSHandle<any>> {
+    return await progress.race(this.internalEvaluateExpressionHandle(expression, options, arg));
+  }
+
+  async getProperty(progress: Progress, propertyName: string): Promise<JSHandle> {
+    return await progress.race(this.internalGetProperty(propertyName));
+  }
+
+  async getProperties(progress: Progress): Promise<Map<string, JSHandle>> {
+    return await progress.race(this.internalGetProperties());
+  }
+
+  async jsonValue(progress: Progress): Promise<T> {
+    return await progress.race(this.internalJsonValue());
+  }
+
   async evaluate<R, Arg>(pageFunction: FuncOn<T, Arg, R>, arg?: Arg): Promise<R> {
     return evaluate(this._context, true /* returnByValue */, pageFunction, this, arg);
   }
@@ -145,27 +166,27 @@ export class JSHandle<T = any> extends SdkObject {
     return evaluate(this._context, false /* returnByValue */, pageFunction, this, arg);
   }
 
-  async evaluateExpression(expression: string, options: { isFunction?: boolean }, arg: any) {
+  async internalEvaluateExpression(expression: string, options: { isFunction?: boolean }, arg: any) {
     return await evaluateExpression(this._context, expression, { ...options, returnByValue: true }, this, arg);
   }
 
-  async evaluateExpressionHandle(expression: string, options: { isFunction?: boolean }, arg: any): Promise<JSHandle<any>> {
+  async internalEvaluateExpressionHandle(expression: string, options: { isFunction?: boolean }, arg: any): Promise<JSHandle<any>> {
     return await evaluateExpression(this._context, expression, { ...options, returnByValue: false }, this, arg);
   }
 
-  async getProperty(propertyName: string): Promise<JSHandle> {
+  async internalGetProperty(propertyName: string): Promise<JSHandle> {
     const objectHandle = await this.evaluateHandle((object: any, propertyName) => {
       const result: any = { __proto__: null };
       result[propertyName] = object[propertyName];
       return result;
     }, propertyName);
-    const properties = await objectHandle.getProperties();
+    const properties = await objectHandle.internalGetProperties();
     const result = properties.get(propertyName)!;
     objectHandle.dispose();
     return result;
   }
 
-  async getProperties(): Promise<Map<string, JSHandle>> {
+  async internalGetProperties(): Promise<Map<string, JSHandle>> {
     if (!this._objectId)
       return new Map();
     return this._context.getProperties(this);
@@ -175,7 +196,7 @@ export class JSHandle<T = any> extends SdkObject {
     return this._value;
   }
 
-  async jsonValue(): Promise<T> {
+  async internalJsonValue(): Promise<T> {
     if (!this._objectId)
       return this._value;
     const script = `(utilityScript, ...args) => utilityScript.jsonValue(...args)`;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -27,6 +27,7 @@ import type * as types from './types';
 import type { NormalizedContinueOverrides } from './types';
 import type { HeadersArray, NameValue } from '../utils/isomorphic/types';
 import type * as channels from '@protocol/channels';
+import type { Progress } from '@protocol/progress';
 
 
 export function filterCookies(cookies: channels.NetworkCookie[], urls: string[]): channels.NetworkCookie[] {
@@ -213,6 +214,14 @@ export class Request extends SdkObject {
     this._isFavicon = url.endsWith('/favicon.ico') || !!redirectedFrom?._isFavicon;
   }
 
+  async rawRequestHeaders(progress: Progress): Promise<HeadersArray> {
+    return await progress.race(this.internalRawRequestHeaders());
+  }
+
+  async response(progress: Progress): Promise<Response | null> {
+    return await progress.race(this.internalResponse());
+  }
+
   _setFailureText(failureText: string) {
     this._failureText = failureText;
     this._waitForResponsePromise.resolve(null);
@@ -258,11 +267,11 @@ export class Request extends SdkObject {
       this._rawRequestHeadersPromise.resolve(headers || this._headers);
   }
 
-  async rawRequestHeaders(): Promise<HeadersArray> {
+  async internalRawRequestHeaders(): Promise<HeadersArray> {
     return this._overrides?.headers || this._rawRequestHeadersPromise;
   }
 
-  response(): Promise<Response | null> {
+  internalResponse(): Promise<Response | null> {
     return this._waitForResponsePromise;
   }
 
@@ -318,7 +327,7 @@ export class Request extends SdkObject {
     headersSize += this.method().length;
     headersSize += (new URL(this.url())).pathname.length;
     headersSize += 8; // httpVersion
-    const headers = await this.rawRequestHeaders();
+    const headers = await this.internalRawRequestHeaders();
     for (const header of headers)
       headersSize += header.name.length + header.value.length + 4; // 4 = ': ' + '\r\n'
     return headersSize;
@@ -417,7 +426,7 @@ export class Route extends SdkObject {
     headers.push({ name: 'vary', value: 'Origin' });
   }
 
-  async continue(overrides: types.NormalizedContinueOverrides) {
+  async continue(overrides: channels.RouteContinueParams) {
     if (overrides.url) {
       const newUrl = new URL(overrides.url);
       const oldUrl = new URL(this._request.url());
@@ -529,6 +538,30 @@ export class Response extends SdkObject {
     this._fromServiceWorker = fromServiceWorker;
   }
 
+  async body(progress: Progress): Promise<Buffer> {
+    return await progress.race(this.internalBody());
+  }
+
+  async securityDetails(progress: Progress): Promise<SecurityDetails | null> {
+    return await progress.race(this.internalSecurityDetails());
+  }
+
+  async serverAddr(progress: Progress): Promise<RemoteAddr | null> {
+    return await progress.race(this.internalServerAddr());
+  }
+
+  async rawResponseHeaders(progress: Progress): Promise<NameValue[]> {
+    return await progress.race(this.internalRawResponseHeaders());
+  }
+
+  async httpVersion(progress: Progress): Promise<string> {
+    return await progress.race(this.internalHttpVersion());
+  }
+
+  async sizes(progress: Progress): Promise<ResourceSizes> {
+    return await progress.race(this.internalSizes());
+  }
+
   _serverAddrFinished(addr?: RemoteAddr) {
     this._serverAddrPromise.resolve(addr);
   }
@@ -569,7 +602,7 @@ export class Response extends SdkObject {
     return this._headersMap.get(name);
   }
 
-  async rawResponseHeaders(): Promise<NameValue[]> {
+  async internalRawResponseHeaders(): Promise<NameValue[]> {
     return this._rawResponseHeadersPromise;
   }
 
@@ -595,15 +628,15 @@ export class Response extends SdkObject {
     return this._timing;
   }
 
-  async serverAddr(): Promise<RemoteAddr|null> {
+  async internalServerAddr(): Promise<RemoteAddr|null> {
     return await this._serverAddrPromise || null;
   }
 
-  async securityDetails(): Promise<SecurityDetails|null> {
+  async internalSecurityDetails(): Promise<SecurityDetails|null> {
     return await this._securityDetailsPromise || null;
   }
 
-  body(): Promise<Buffer> {
+  internalBody(): Promise<Buffer> {
     if (!this._contentPromise) {
       this._contentPromise = this._finishedPromise.then(async () => {
         if (this._status >= 300 && this._status <= 399)
@@ -630,7 +663,7 @@ export class Response extends SdkObject {
     return this._request.frame();
   }
 
-  async httpVersion(): Promise<string> {
+  async internalHttpVersion(): Promise<string> {
     const httpVersion = await this._httpVersionPromise || null;
     if (!httpVersion)
       return 'HTTP/1.1';
@@ -662,7 +695,7 @@ export class Response extends SdkObject {
     return headersSize;
   }
 
-  async sizes(): Promise<ResourceSizes> {
+  async internalSizes(): Promise<ResourceSizes> {
     const requestHeadersSize = await this._request._requestHeadersSize();
     const responseHeadersSize = await this.responseHeadersSize();
 


### PR DESCRIPTION
## Summary
- Dispatcher-facing methods on Request, Response, and APIRequestContext now accept `progress: Progress` as first arg
- Internal callers use `internal*` variants (e.g. `internalBody()`, `internalRawRequestHeaders()`)
- Dispatcher API methods grouped at top of each class with comment separator