### PR TITLE
docs(mcp): fix persistent profile directory name in docs

### DIFF
--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -173,7 +173,7 @@ Supported values: `chrome`, `firefox`, `webkit`, `msedge`.
 
 Playwright MCP supports three profile modes:
 
--   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-profile` in your platform's cache directory. Override with `--user-data-dir`.
+-   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
 -   **Browser extension**: Connect to your existing browser tabs with the [Playwright MCP Bridge extension](https://github.com/user-attachments/packages/extension). Pass `--extension` to enable.
 


### PR DESCRIPTION
## Summary
- Documentation says persistent profile directory is `mcp-{channel}-profile`, but code generates `mcp-{channel}-{hash}` where `{hash}` is a 7-char SHA-256 of the working directory
- Updated `docs/src/getting-started-mcp.md` to reflect the actual directory naming scheme