### PR TITLE
fix(mcp): merge user ignoreDefaultArgs with persistent mode defaults

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -145,15 +145,19 @@ async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInf
     throw new Error(`Browser is already in use for ${userDataDir}, use --isolated to run multiple instances of the same browser`);
 
   const browserType = playwright[config.browser.browserName];
+  const configIgnoreDefaultArgs = config.browser.launchOptions?.ignoreDefaultArgs;
   const launchOptions: playwright.LaunchOptions & playwright.BrowserContextOptions = {
     tracesDir,
     ...config.browser.launchOptions,
     ...config.browser.contextOptions,
     handleSIGINT: false,
     handleSIGTERM: false,
-    ignoreDefaultArgs: [
-      '--disable-extensions',
-    ],
+    ignoreDefaultArgs: configIgnoreDefaultArgs === true
+      ? true
+      : [
+        '--disable-extensions',
+        ...Array.isArray(configIgnoreDefaultArgs) ? configIgnoreDefaultArgs : [],
+      ],
   };
   try {
     const browserContext = await browserType.launchPersistentContext(userDataDir, launchOptions);

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -104,6 +104,37 @@ test.describe(() => {
   });
 });
 
+test('config ignoreDefaultArgs merged with persistent mode defaults', async ({ startClient, mcpBrowser }, testInfo) => {
+  test.skip(!['chrome', 'chromium', 'msedge'].includes(mcpBrowser!), 'chrome://version is Chromium-specific');
+  const config: Config = {
+    browser: {
+      userDataDir: testInfo.outputPath('user-data-dir'),
+      launchOptions: {
+        ignoreDefaultArgs: ['--password-store=basic'],
+      },
+    },
+  };
+  const { client } = await startClient({ config });
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'chrome://version' },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: { function: '() => document.getElementById("command_line").innerText' },
+  });
+  const commandLine = result.content[0].text;
+
+  // User-specified arg should be removed.
+  expect(commandLine).not.toContain('--password-store=basic');
+  // Persistent mode's built-in --disable-extensions should also be removed.
+  expect(commandLine).not.toContain('--disable-extensions');
+  // Other default args should still be present.
+  expect(commandLine).toContain('--use-mock-keychain');
+});
+
 test('browser_get_config returns merged config from file, env and cli', async ({ startClient }) => {
   const { client } = await startClient({
     config: {


### PR DESCRIPTION
## Summary

In `createPersistentBrowser`, the hardcoded `ignoreDefaultArgs: ['--disable-extensions']` was placed after `...config.browser.launchOptions` in the object literal, silently overwriting any user-provided `ignoreDefaultArgs` from the config file. This meant users could not remove specific Chromium default arguments (e.g., `--force-color-profile=srgb`, `--password-store=basic`) when using persistent browser mode.

The fix merges the persistent mode's built-in `['--disable-extensions']` with the user's configured list (deduplicated via `Set`), and passes through `ignoreDefaultArgs: true` unchanged.

## Details

**Root cause:** In `browserFactory.ts`, `createPersistentBrowser` constructs `launchOptions` as:

```js
const launchOptions = {
  ...config.browser.launchOptions,   // user's ignoreDefaultArgs lands here
  ignoreDefaultArgs: ['--disable-extensions'],  // then gets overwritten here
};
```

**Fix:** Extract `userIgnoreDefaultArgs` before the spread, then merge:

- `true` → passthrough (ignore all default args)
- `string[]` → merge with `['--disable-extensions']` via `Set` (dedup)
- `undefined` / unset → default behavior (`['--disable-extensions']` only)

**Isolated mode is unaffected** — `createIsolatedBrowser` doesn't override `ignoreDefaultArgs`.

**Test:** End-to-end test in persistent mode: sets `ignoreDefaultArgs: ['--password-store=basic']` via config, navigates to `chrome://version`, reads the command line, and verifies:
- `--password-store=basic` is removed (user config honored)
- `--disable-extensions` is removed (persistent mode built-in honored)
- `--use-mock-keychain` is still present (other defaults preserved)