### PR TITLE
feat(locator): warn when deprecated timeout is passed to isVisible/isHidden

### DIFF
--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -296,10 +296,14 @@ export class Locator implements api.Locator {
   }
 
   async isHidden(options?: TimeoutOptions): Promise<boolean> {
+    if (options?.timeout !== undefined)
+      console.warn('locator.isHidden: "timeout" option is deprecated and has no effect. locator.isHidden() does not wait for the element and returns immediately.');
     return await this._frame.isHidden(this._selector, { strict: true, ...options });
   }
 
   async isVisible(options?: TimeoutOptions): Promise<boolean> {
+    if (options?.timeout !== undefined)
+      console.warn('locator.isVisible: "timeout" option is deprecated and has no effect. locator.isVisible() does not wait for the element and returns immediately.');
     return await this._frame.isVisible(this._selector, { strict: true, ...options });
   }
 

--- a/tests/page/locator-is-visible.spec.ts
+++ b/tests/page/locator-is-visible.spec.ts
@@ -103,3 +103,37 @@ it('isVisible with invalid selector should throw', async ({ page }) => {
   const error = await page.locator('hey=what').isVisible().catch(e => e);
   expect(error.message).toContain('Unknown engine "hey" while parsing selector hey=what');
 });
+
+it('isVisible should warn when deprecated timeout option is used', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33017' });
+  await page.setContent(`<div>Hi</div>`);
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (msg: string) => warnings.push(msg);
+  try {
+    const visible = await page.locator('div').isVisible({ timeout: 5000 });
+    expect(visible).toBe(true);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('timeout');
+    expect(warnings[0]).toContain('deprecated');
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+it('isHidden should warn when deprecated timeout option is used', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33017' });
+  await page.setContent(`<div>Hi</div>`);
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (msg: string) => warnings.push(msg);
+  try {
+    const hidden = await page.locator('div').isHidden({ timeout: 5000 });
+    expect(hidden).toBe(false);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('timeout');
+    expect(warnings[0]).toContain('deprecated');
+  } finally {
+    console.warn = origWarn;
+  }
+});


### PR DESCRIPTION
## Description

Add a console warning when the deprecated `timeout` option is passed to `locator.isVisible()` or `locator.isHidden()`. The timeout option has been deprecated and silently ignored for years, causing confusion among users who rely on it for waiting behavior.

### Changes
- `packages/playwright-core/src/client/locator.ts`: Added `console.warn()` when `timeout` option is provided to `isVisible()` and `isHidden()`
- `tests/page/locator-is-visible.spec.ts`: Added 2 test cases to verify the deprecation warning is emitted

### Motivation
As described in #33017, the `timeout` argument to `Locator.isVisible` and `Locator.isHidden` has been deprecated for years but is silently ignored. This leads to incorrect code where users think their visibility check waits for the timeout period, when it actually returns immediately.

This PR adds a visible `console.warn` message so users are aware the option has no effect and can update their code accordingly.

Fixes #33017