### PR TITLE
Update Claude Sonnet version in agents to 4.6

### DIFF
--- a/examples/todomvc/.github/agents/playwright-test-generator.agent.md
+++ b/examples/todomvc/.github/agents/playwright-test-generator.agent.md
@@ -22,7 +22,7 @@ tools:
   - playwright-test/generator_read_log
   - playwright-test/generator_setup_page
   - playwright-test/generator_write_test
-model: Claude Sonnet 4
+model: Claude Sonnet 4.6
 mcp-servers:
   playwright-test:
     type: stdio

--- a/examples/todomvc/.github/agents/playwright-test-healer.agent.md
+++ b/examples/todomvc/.github/agents/playwright-test-healer.agent.md
@@ -12,7 +12,7 @@ tools:
   - playwright-test/test_debug
   - playwright-test/test_list
   - playwright-test/test_run
-model: Claude Sonnet 4
+model: Claude Sonnet 4.6
 mcp-servers:
   playwright-test:
     type: stdio

--- a/examples/todomvc/.github/agents/playwright-test-planner.agent.md
+++ b/examples/todomvc/.github/agents/playwright-test-planner.agent.md
@@ -23,7 +23,7 @@ tools:
   - playwright-test/browser_wait_for
   - playwright-test/planner_setup_page
   - playwright-test/planner_save_plan
-model: Claude Sonnet 4
+model: Claude Sonnet 4.6
 mcp-servers:
   playwright-test:
     type: stdio

--- a/packages/playwright/src/agents/generateAgents.ts
+++ b/packages/playwright/src/agents/generateAgents.ts
@@ -202,7 +202,7 @@ export class CopilotGenerator {
       'name': agent.name,
       'description': agent.description + examples,
       'tools': agent.tools,
-      'model': 'Claude Sonnet 4',
+      'model': 'Claude Sonnet 4.6',
       'mcp-servers': CopilotGenerator.mcpServers,
     };
     lines.push(`---`);


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/N-M/playwright/sessions/8e40e8d2-d7c6-4394-9b9e-790c60e49b5b
Title: chore(copilot): update default model to claude-sonnet-4-6

Update the model field from claude-sonnet-4-20250514 to claude-sonnet-4-6 in the Playwright agent configuration files (playwright-test-generator.agent.md, playwright-test-healer.agent.md, playwright-test-planner.agent.md) and in the CopilotGenerator class in generateAgents.ts.