### PR TITLE
fix(cli): fix list command not showing sessions when workspaceDir is undefined

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -295,21 +295,22 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
   let count = 0;
   const runningSessions = new Set<string>();
   const entries = registry.entryMap();
-  for (const [workspace, list] of entries) {
-    if (!all && workspace !== clientInfo.workspaceDir)
+  const clientKey = clientInfo.workspaceDir || clientInfo.workspaceDirHash;
+  for (const [workspaceKey, list] of entries) {
+    if (!all && workspaceKey !== clientKey)
       continue;
-    count += await gcAndPrintSessions(clientInfo, list.map(entry => new Session(entry)), all ? `${path.relative(process.cwd(), workspace) || '/'}:` : undefined, runningSessions);
+    count += await gcAndPrintSessions(clientInfo, list.map(entry => new Session(entry)), all ? `${path.relative(process.cwd(), workspaceKey) || '/'}:` : undefined, runningSessions);
   }
 
   // Filter out server entries that already have an attached session.
   const serverEntries = await serverRegistry.list();
   const filteredServerEntries = new Map<string, BrowserStatus[]>();
-  for (const [workspace, list] of serverEntries) {
-    if (!all && workspace !== clientInfo.workspaceDir)
+  for (const [workspaceKey, list] of serverEntries) {
+    if (!all && workspaceKey !== clientKey)
       continue;
     const unattached = list.filter(d => !runningSessions.has(d.title));
     if (unattached.length)
-      filteredServerEntries.set(workspace, unattached);
+      filteredServerEntries.set(workspaceKey, unattached);
   }
 
   if (filteredServerEntries.size) {
@@ -317,8 +318,8 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
       console.log('');
     console.log('### Browser servers available for attach');
   }
-  for (const [workspace, list] of filteredServerEntries)
-    count += await gcAndPrintBrowserSessions(workspace, list);
+  for (const [workspaceKey, list] of filteredServerEntries)
+    count += await gcAndPrintBrowserSessions(workspaceKey, list);
 
   if (!count)
     console.log('  (no browsers)');

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -22,7 +22,7 @@ import { execSync, spawn } from 'child_process';
 import crypto from 'crypto';
 import os from 'os';
 import path from 'path';
-import { createClientInfo, explicitSessionName, Registry, resolveSessionName } from './registry';
+import { clientKey, createClientInfo, explicitSessionName, Registry, resolveSessionName } from './registry';
 import { Session, renderResolvedConfig } from './session';
 import { serverRegistry } from '../../serverRegistry';
 import { minimist } from './minimist';
@@ -295,9 +295,9 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
   let count = 0;
   const runningSessions = new Set<string>();
   const entries = registry.entryMap();
-  const clientKey = clientInfo.workspaceDir || clientInfo.workspaceDirHash;
+  const key = clientKey(clientInfo);
   for (const [workspaceKey, list] of entries) {
-    if (!all && workspaceKey !== clientKey)
+    if (!all && workspaceKey !== key)
       continue;
     count += await gcAndPrintSessions(clientInfo, list.map(entry => new Session(entry)), all ? `${path.relative(process.cwd(), workspaceKey) || '/'}:` : undefined, runningSessions);
   }
@@ -306,7 +306,7 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
   const serverEntries = await serverRegistry.list();
   const filteredServerEntries = new Map<string, BrowserStatus[]>();
   for (const [workspaceKey, list] of serverEntries) {
-    if (!all && workspaceKey !== clientKey)
+    if (!all && workspaceKey !== key)
       continue;
     const unattached = list.filter(d => !runningSessions.has(d.title));
     if (unattached.length)

--- a/packages/playwright-core/src/tools/cli-client/registry.ts
+++ b/packages/playwright-core/src/tools/cli-client/registry.ts
@@ -28,6 +28,10 @@ export type ClientInfo = {
   workspaceDir: string | undefined;
 };
 
+export function clientKey(clientInfo: ClientInfo): string {
+  return clientInfo.workspaceDir || clientInfo.workspaceDirHash;
+}
+
 export type SessionConfig = {
   name: string;
   version: string;
@@ -58,14 +62,13 @@ export class Registry {
   }
 
   entry(clientInfo: ClientInfo, sessionName: string): SessionFile | undefined {
-    const key = clientInfo.workspaceDir || clientInfo.workspaceDirHash;
+    const key = clientKey(clientInfo);
     const entries = this._files.get(key) || [];
     return entries.find(entry => entry.config.name === sessionName);
   }
 
   entries(clientInfo: ClientInfo): SessionFile[] {
-    const key = clientInfo.workspaceDir || clientInfo.workspaceDirHash;
-    return this._files.get(key) || [];
+    return this._files.get(clientKey(clientInfo)) || [];
   }
 
   entryMap(): Map<string, SessionFile[]> {
@@ -77,7 +80,7 @@ export class Registry {
     if (!entry)
       throw new Error(`Could not start the session "${sessionName}"`);
 
-    const key = clientInfo.workspaceDir || clientInfo.workspaceDirHash;
+    const key = clientKey(clientInfo);
     let list = this._files.get(key);
     if (!list) {
       list = [];

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -34,8 +34,8 @@ test('list', async ({ cli, server }) => {
 });
 
 test('list shows sessions when cwd has no .playwright directory', async ({ cli, server }) => {
-  // Use a temp dir outside testInfo.outputPath() so findWorkspaceDir returns undefined,
-  // meaning the registry key is workspaceDirHash instead of workspaceDir.
+  // Temp dir must have no .playwright ancestor so findWorkspaceDir returns undefined
+  // and the registry key falls back to workspaceDirHash.
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-no-workspace-'));
   try {
     await cli('open', server.HELLO_WORLD, { cwd: tmpDir });

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { test, expect, daemonFolder } from './cli-fixtures';
 import { killProcessGroup } from '../config/commonFixtures';
@@ -30,6 +31,21 @@ test('list', async ({ cli, server }) => {
   const { output: listOutput } = await cli('list');
   expect(listOutput).toContain('### Browsers');
   expect(listOutput).toContain('- default:');
+});
+
+test('list shows sessions when cwd has no .playwright directory', async ({ cli, server }) => {
+  // Use a temp dir outside testInfo.outputPath() so findWorkspaceDir returns undefined,
+  // meaning the registry key is workspaceDirHash instead of workspaceDir.
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-no-workspace-'));
+  try {
+    await cli('open', server.HELLO_WORLD, { cwd: tmpDir });
+
+    const { output } = await cli('list', { cwd: tmpDir });
+    expect(output).toContain('### Browsers');
+    expect(output).toContain('- default:');
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
 });
 
 test('close', async ({ cli, server }) => {


### PR DESCRIPTION
## Summary
- When the cwd has no `.playwright` directory, `workspaceDir` is undefined and the registry stores sessions under `workspaceDirHash` as the key
- The `list` command was comparing workspace keys against `clientInfo.workspaceDir` only, so `workspaceDirHash !== undefined` was always `true` and all sessions were skipped
- Fix uses `clientInfo.workspaceDir || clientInfo.workspaceDirHash` (same pattern as `Registry.entries()`) for the comparison