### PR TITLE
fix(mcp): close browser process on backend disposal

### DIFF
--- a/packages/playwright-core/src/tools/mcp/index.ts
+++ b/packages/playwright-core/src/tools/mcp/index.ts
@@ -40,7 +40,11 @@ export async function createConnection(userConfig: Config = {}, contextGetter?: 
       const context = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
       return new BrowserBackend(config, context, tools);
     },
-    disposed: async () => { }
+    disposed: async backend => {
+      const browserContext = (backend as BrowserBackend).browserContext;
+      await browserContext.close().catch(() => { });
+      await browserContext.browser()?.close().catch(() => { });
+    }
   };
   return createServer('api', packageJSON.version, backendFactory, false);
 }

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -105,7 +105,12 @@ export function decorateMCPCommand(command: Command) {
               const browserContext = browser.contexts()[0];
               return new BrowserBackend(config, browserContext, tools);
             },
-            disposed: async () => { }
+            disposed: async backend => {
+              testDebug('close browser');
+              const browserContext = (backend as BrowserBackend).browserContext;
+              await browserContext.close().catch(() => { });
+              await browserContext.browser()!.close().catch(() => { });
+            }
           };
           await mcpServer.start(serverBackendFactory, config.server);
           return;


### PR DESCRIPTION
## Summary
- API (`createConnection`) and extension backend factories had no-op `disposed` callbacks, leaving browser processes running after `browser_close` or client disconnect
- Added `browserContext.close()` + `browser.close()` to both factories, matching the existing CLI factory behavior

Fixes https://github.com/microsoft/playwright-mcp/issues/1458