### PR TITLE
fix(mcp): enable heartbeat for stdio transport to detect client disconnect

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -191,7 +191,7 @@ function addServerListener(server: Server, event: 'close' | 'initialized', liste
 
 export async function start(serverBackendFactory: ServerBackendFactory, options: { host?: string; port?: number, allowedHosts?: string[], socketPath?: string } = {}) {
   if (options.port === undefined) {
-    await connect(serverBackendFactory, new mcpBundle.StdioServerTransport(), false);
+    await connect(serverBackendFactory, new mcpBundle.StdioServerTransport(), true);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Stdio transport had heartbeat disabled, so when a client like Claude Code disconnects through `npm exec`, the MCP server process never detects the disconnect and runs indefinitely
- Enable the existing heartbeat mechanism (ping every 3s, 5s timeout) for stdio, matching HTTP/SSE behavior

**Root cause:** The watchdog relies on `stdin.on('close')` but when `npm exec` sits between client and server, stdin close doesn't propagate. Observed 5 orphaned MCP server processes running 13+ hours on a real machine.

Fixes https://github.com/microsoft/playwright-mcp/issues/1458