### PR TITLE
fix(electron): enable screenshot-on-failure for Electron apps

### DIFF
--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -66,7 +66,11 @@ export class Electron extends ChannelOwner<channels.ElectronChannel> implements 
     };
     const app = ElectronApplication.from((await this._channel.launch(params)).electronApplication);
     this._playwright.selectors._contextsForSelectors.add(app._context);
-    app.once(Events.ElectronApplication.Close, () => this._playwright.selectors._contextsForSelectors.delete(app._context));
+    this._playwright._electronApps.add(app);
+    app.once(Events.ElectronApplication.Close, () => {
+      this._playwright.selectors._contextsForSelectors.delete(app._context);
+      this._playwright._electronApps.delete(app);
+    });
     await app._context._initializeHarFromOptions(options.recordHar);
     app._context.tracing._tracesDir = options.tracesDir;
     return app;

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -23,6 +23,7 @@ import { TimeoutError } from './errors';
 import { APIRequest } from './fetch';
 import { Selectors } from './selectors';
 
+import type { ElectronApplication } from './electron';
 import type * as channels from '@protocol/channels';
 import type { LaunchOptions } from 'playwright-core';
 
@@ -41,6 +42,7 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
   _defaultLaunchOptions?: LaunchOptions;
   _defaultContextTimeout?: number;
   _defaultContextNavigationTimeout?: number;
+  readonly _electronApps = new Set<ElectronApplication>();
 
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
     super(parent, type, guid, initializer);
@@ -75,7 +77,9 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
   }
 
   _allContexts() {
-    return this._browserTypes().flatMap(type => [...type._contexts]);
+    const browserContexts = this._browserTypes().flatMap(type => [...type._contexts]);
+    const electronContexts = [...this._electronApps].map(app => app._context);
+    return [...browserContexts, ...electronContexts];
   }
 
   _allPages() {

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -365,3 +365,30 @@ test('should save downloads to artifactsDir', async ({ launchElectronApp, electr
   // User-provided artifactsDir should not be cleaned up.
   expect(fs.existsSync(artifactsDir)).toBeTruthy();
 });
+
+test('should include electron pages in playwright._allPages()', async ({ playwright, electronApp, newWindow }) => {
+  const window = await newWindow();
+  await window.setContent('<h1>Hello Electron</h1>');
+  const allPages = (playwright as any)._allPages();
+  expect(allPages).toContain(window);
+});
+
+test('should include electron context in playwright._allContexts()', async ({ playwright, electronApp }) => {
+  const allContexts = (playwright as any)._allContexts();
+  expect(allContexts).toContain(electronApp.context());
+});
+
+test('should remove electron context from tracking on close', async ({ playwright, launchElectronApp }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const context = app.context();
+  expect((playwright as any)._allContexts()).toContain(context);
+  await app.close();
+  expect((playwright as any)._allContexts()).not.toContain(context);
+});
+
+test('should take screenshot of electron window', async ({ electronApp, newWindow }) => {
+  const window = await newWindow();
+  await window.setContent('<h1 style="color: red;">Screenshot Test</h1>');
+  const screenshot = await window.screenshot();
+  expect(screenshot.byteLength).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

- Track Electron apps in **`Playwright._electronApps`** so **`_allContexts()`** includes Electron contexts
- Enables **`screenshot: 'only-on-failure'`** to capture Electron windows on test failure

## Update

- Squashed two commits into one
- Removed **`runAfterCreateBrowserContext`** call that caused tracing conflicts with Electron contexts
- Removed `playwright.artifacts.spec.ts` integration test (always skipped in CI due to `ELECTRON_SKIP_BINARY_DOWNLOAD=1`)
- Electron functionality is covered by 4 tests in `tests/electron/electron-app.spec.ts` that run in the electron CI job