### PR TITLE
fix(har): match stored regex URLs during replay

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1253,7 +1253,7 @@ If specified, updates the given HAR with the actual network information instead 
 * since: v1.23
 - `url` <[string]|[RegExp]>
 
-A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used together with [`option: BrowserContext.routeFromHAR.update`] and a regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed requests.
 
 ### option: BrowserContext.routeFromHAR.updateMode
 * since: v1.32

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -3770,7 +3770,7 @@ If specified, updates the given HAR with the actual network information instead 
 * since: v1.23
 - `url` <[string]|[RegExp]>
 
-A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used together with [`option: Page.routeFromHAR.update`] and a regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed requests.
 
 ### option: Page.routeFromHAR.updateMode
 * since: v1.32

--- a/docs/src/mock.md
+++ b/docs/src/mock.md
@@ -414,7 +414,7 @@ In the trace of our test we can see that the route was fulfilled from the HAR fi
 If we inspect the response we can see our new fruit was added to the JSON, which was done by manually updating the hashed `.txt` file inside the `hars` folder.
 <img src="https://github.com/microsoft/playwright/assets/13063165/db3117fc-7b02-4973-9a51-29e213261a6a" alt="trace showing response from HAR file" width="2946" height="1902" />
 
-HAR replay matches URL and HTTP method strictly. For POST requests, it also matches POST payloads strictly. If multiple recordings match a request, the one with the most matching headers is picked. An entry resulting in a redirect will be followed automatically.
+HAR replay matches URL and HTTP method strictly by default. For POST requests, it also matches POST payloads strictly. If an entry was recorded with [`method: Page.routeFromHAR`] or [`method: BrowserContext.routeFromHAR`] using [`option: Page.routeFromHAR.update`] / [`option: BrowserContext.routeFromHAR.update`] and a regular-expression [`option: Page.routeFromHAR.url`] / [`option: BrowserContext.routeFromHAR.url`], Playwright stores that regex in the HAR entry and uses it during replay. If multiple recordings match a request, the one with the most matching headers is picked. An entry resulting in a redirect will be followed automatically.
 
 Similar to when recording, if given HAR file name ends with `.zip`, it is considered an archive containing the HAR file along with network payloads stored as separate entries. You can also extract this archive, edit payloads or HAR log manually and point to the extracted har file. All the payloads will be resolved relative to the extracted har file on the file system.
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -4151,7 +4151,10 @@ export interface Page {
 
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the
-     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used
+     * together with [`update`](https://playwright.dev/docs/api/class-page#page-route-from-har-option-update) and a
+     * regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed
+     * requests.
      */
     url?: string|RegExp;
   }): Promise<void>;
@@ -9257,7 +9260,11 @@ export interface BrowserContext {
 
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the
-     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used
+     * together with
+     * [`update`](https://playwright.dev/docs/api/class-browsercontext#browser-context-route-from-har-option-update) and a
+     * regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed
+     * requests.
      */
     url?: string|RegExp;
   }): Promise<void>;

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -609,6 +609,7 @@ export class HarTracer {
 }
 
 function createHarEntry(pageRef: string | undefined, method: string, url: URL, frameref: string | undefined, options: HarTracerOptions): har.Entry {
+  const urlFilter = options.urlFilter instanceof RegExp ? options.urlFilter : undefined;
   const harEntry: har.Entry = {
     pageref: pageRef,
     startedDateTime: new Date().toISOString(),
@@ -622,6 +623,8 @@ function createHarEntry(pageRef: string | undefined, method: string, url: URL, f
       queryString: [...url.searchParams].map(e => ({ name: e[0], value: e[1] })),
       headersSize: -1,
       bodySize: -1,
+      _urlRegexSource: urlFilter?.source,
+      _urlRegexFlags: urlFilter?.flags || undefined,
     },
     response: {
       status: -1,

--- a/packages/playwright-core/src/server/harBackend.ts
+++ b/packages/playwright-core/src/server/harBackend.ts
@@ -46,21 +46,21 @@ export class HarBackend {
     headers?: HeadersArray,
     body?: Buffer
   }> {
-    let entry;
+    let result;
     try {
-      entry = await this._harFindResponse(url, method, headers, postData);
+      result = await this._harFindResponse(url, method, headers, postData);
     } catch (e) {
       return { action: 'error', message: 'HAR error: ' + e.message };
     }
 
-    if (!entry)
+    if (!result)
       return { action: 'noentry' };
 
     // If navigation is being redirected, restart it with the final url to ensure the document's url changes.
-    if (entry.request.url !== url && isNavigationRequest)
-      return { action: 'redirect', redirectURL: entry.request.url };
+    if (result.followedRedirect && isNavigationRequest)
+      return { action: 'redirect', redirectURL: result.entry.request.url };
 
-    const response = entry.response;
+    const response = result.entry.response;
     try {
       const buffer = await this._loadContent(response.content);
       return {
@@ -88,13 +88,15 @@ export class HarBackend {
     return buffer;
   }
 
-  private async _harFindResponse(url: string, method: string, headers: HeadersArray, postData: Buffer | undefined): Promise<har.Entry | undefined> {
+  private async _harFindResponse(url: string, method: string, headers: HeadersArray, postData: Buffer | undefined): Promise<{ entry: har.Entry, followedRedirect: boolean } | undefined> {
     const harLog = this._harFile.log;
     const visited = new Set<har.Entry>();
+    let followedRedirect = false;
     while (true) {
-      const entries: har.Entry[] = [];
+      const entries: { candidate: har.Entry, exactUrlMatch: boolean }[] = [];
       for (const candidate of harLog.entries) {
-        if (candidate.request.url !== url || candidate.request.method !== method)
+        const urlMatch = urlMatchesHarRequest(candidate.request, url);
+        if (!urlMatch || candidate.request.method !== method)
           continue;
         if (method === 'POST' && postData && candidate.request.postData) {
           const buffer = await this._loadContent(candidate.request.postData);
@@ -110,22 +112,22 @@ export class HarBackend {
               continue;
           }
         }
-        entries.push(candidate);
+        entries.push({ candidate, exactUrlMatch: urlMatch === 'exact' });
       }
 
       if (!entries.length)
         return;
 
-      let entry = entries[0];
+      let entry = entries[0].candidate;
 
       // Disambiguate using headers - then one with most matching headers wins.
       if (entries.length > 1) {
-        const list: { candidate: har.Entry, matchingHeaders: number }[] = [];
-        for (const candidate of entries) {
+        const list: { candidate: har.Entry, exactUrlMatch: boolean, matchingHeaders: number }[] = [];
+        for (const { candidate, exactUrlMatch } of entries) {
           const matchingHeaders = countMatchingHeaders(candidate.request.headers, headers);
-          list.push({ candidate, matchingHeaders });
+          list.push({ candidate, exactUrlMatch, matchingHeaders });
         }
-        list.sort((a, b) => b.matchingHeaders - a.matchingHeaders);
+        list.sort((a, b) => +b.exactUrlMatch - +a.exactUrlMatch || b.matchingHeaders - a.matchingHeaders);
         entry = list[0].candidate;
       }
 
@@ -137,6 +139,7 @@ export class HarBackend {
       // Follow redirects.
       const locationHeader = entry.response.headers.find(h => h.name.toLowerCase() === 'location');
       if (redirectStatus.includes(entry.response.status) && locationHeader) {
+        followedRedirect = true;
         const locationURL = new URL(locationHeader.value, url);
         url = locationURL.toString();
         if ((entry.response.status === 301 || entry.response.status === 302) && method === 'POST' ||
@@ -147,7 +150,7 @@ export class HarBackend {
         continue;
       }
 
-      return entry;
+      return { entry, followedRedirect };
     }
   }
 
@@ -164,6 +167,14 @@ function countMatchingHeaders(harHeaders: har.Header[], headers: HeadersArray): 
       ++matches;
   }
   return matches;
+}
+
+function urlMatchesHarRequest(request: har.Request, url: string): 'exact' | 'regex' | undefined {
+  if (request.url === url)
+    return 'exact';
+  if (!request._urlRegexSource)
+    return undefined;
+  return new RegExp(request._urlRegexSource, request._urlRegexFlags).test(url) ? 'regex' : undefined;
 }
 
 function multipartBoundary(headers: HeadersArray) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -4151,7 +4151,10 @@ export interface Page {
 
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the
-     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used
+     * together with [`update`](https://playwright.dev/docs/api/class-page#page-route-from-har-option-update) and a
+     * regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed
+     * requests.
      */
     url?: string|RegExp;
   }): Promise<void>;
@@ -9257,7 +9260,11 @@ export interface BrowserContext {
 
     /**
      * A glob pattern, regular expression or predicate to match the request URL. Only requests with URL matching the
-     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file.
+     * pattern will be served from the HAR file. If not specified, all requests are served from the HAR file. When used
+     * together with
+     * [`update`](https://playwright.dev/docs/api/class-browsercontext#browser-context-route-from-har-option-update) and a
+     * regular expression, Playwright stores that regular expression in the HAR and uses it later when matching replayed
+     * requests.
      */
     url?: string|RegExp;
   }): Promise<void>;

--- a/packages/trace/src/har.ts
+++ b/packages/trace/src/har.ts
@@ -85,6 +85,8 @@ export type Request = {
   headersSize: number;
   bodySize: number;
   comment?: string;
+  _urlRegexSource?: string;
+  _urlRegexFlags?: string;
 };
 
 export type Response = {

--- a/tests/library/browsercontext-har.spec.ts
+++ b/tests/library/browsercontext-har.spec.ts
@@ -324,6 +324,30 @@ it('should round-trip har with postData', async ({ contextFactory, server }, tes
   expect(await page2.evaluate(fetchFunction, '4').catch(e => e)).toBeTruthy();
 });
 
+it('should round-trip har with regex url matching', async ({ contextFactory, server }, testInfo) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27430' });
+  server.setRoute('/echo?foo=one', (req, res) => res.end('one'));
+
+  const harPath = testInfo.outputPath('regex.har');
+  const context1 = await contextFactory();
+  await context1.routeFromHAR(harPath, { update: true, url: /\/echo\?foo=.*/ });
+  const page1 = await context1.newPage();
+  await page1.goto(server.EMPTY_PAGE);
+  const fetchFunction = async (requestURL: string) => {
+    const response = await fetch(requestURL);
+    return await response.text();
+  };
+  expect(await page1.evaluate(fetchFunction, `${server.PREFIX}/echo?foo=one`)).toBe('one');
+  await context1.close();
+
+  server.reset();
+  const context2 = await contextFactory();
+  await context2.routeFromHAR(harPath, { notFound: 'fallback' });
+  const page2 = await context2.newPage();
+  await page2.goto(server.EMPTY_PAGE);
+  expect(await page2.evaluate(fetchFunction, `${server.PREFIX}/echo?foo=two`)).toBe('one');
+});
+
 it('should record overridden requests to har', async ({ contextFactory, server }, testInfo) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/29190' });
   server.setRoute('/echo', async (req, res) => {


### PR DESCRIPTION
## Summary
- persist regex URL filters into recorded HAR entries when `routeFromHAR(..., { update: true, url: /.../ })` is used
- replay requests against stored regex metadata while preserving exact-match precedence and redirect handling
- document the replay behavior and cover it with a HAR round-trip regression test

Fixes https://github.com/microsoft/playwright/issues/27430

## Validation
- `npm run ctest tests/library/browsercontext-har.spec.ts -- --grep "round-trip har with regex url matching"`
- `npm run ctest tests/library/browsercontext-har.spec.ts`
- `npm run flint` is blocked locally in `npm run doc` because WebKit exits immediately on this Windows host (`libsharpyuv.dll` / `Playwright.exe` startup issue) even after `npx playwright install`

cc @pavelfeldman