### PR TITLE
feat(dashboard): show current workspace sessions first and expanded

### DIFF
--- a/packages/dashboard/src/grid.tsx
+++ b/packages/dashboard/src/grid.tsx
@@ -56,9 +56,10 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
       list.sort((a, b) => a.title.localeCompare(b.title));
 
     // Current workspace first, then alphabetical.
+    const currentWorkspace = clientInfo?.workspaceDir || 'Global';
     const entries = [...groups.entries()];
-    const current = entries.filter(([key]) => key === clientInfo?.workspaceDir);
-    const other = entries.filter(([key]) => key !== clientInfo?.workspaceDir).sort((a, b) => a[0].localeCompare(b[0]));
+    const current = entries.filter(([key]) => key === currentWorkspace);
+    const other = entries.filter(([key]) => key !== currentWorkspace).sort((a, b) => a[0].localeCompare(b[0]));
     return [...current, ...other];
   }, [sessions, clientInfo?.workspaceDir]);
 

--- a/packages/playwright-core/src/tools/dashboard/DEPS.list
+++ b/packages/playwright-core/src/tools/dashboard/DEPS.list
@@ -6,4 +6,5 @@
 ../../server/utils/
 ../../serverRegistry.ts
 ../../utils/
+../cli-client/registry.ts
 ../utils/

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -27,6 +27,7 @@ import { findChromiumChannelBestEffort, registryDirectory } from '../../server/r
 import { CDPConnection, DashboardConnection } from './dashboardController';
 import { serverRegistry } from '../../serverRegistry';
 import { connectToBrowserAcrossVersions } from '../utils/connect';
+import { createClientInfo } from '../cli-client/registry';
 
 import type * as api from '../../..';
 import type { SessionStatus } from '../../../../dashboard/src/sessionModel';
@@ -85,7 +86,8 @@ async function handleApiRequest(httpServer: HttpServer, request: http.IncomingMe
 
   if (apiPath === '/api/sessions/list' && request.method === 'GET') {
     const sessions = await loadBrowserDescriptorSessions(httpServer.wsGuid()!);
-    sendJSON(response, { sessions });
+    const clientInfo = createClientInfo();
+    sendJSON(response, { sessions, clientInfo });
     return;
   }
 

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -29,7 +29,7 @@ import type { CommonFixtures } from '../config/commonFixtures';
 export { expect } from './fixtures';
 export const test = baseTest.extend<{
   cliEnv: Record<string, string>,
-  openDashboard: () => Promise<Page>,
+  openDashboard: (options?: { cwd?: string }) => Promise<Page>,
   cli: (...args: any[]) => Promise<{
     output: string,
     error: string,
@@ -45,9 +45,9 @@ export const test = baseTest.extend<{
   },
   openDashboard: async ({ cli, waitForPort, findFreePort }, use) => {
     const dashboards = [];
-    await use(async () => {
+    await use(async (options?: { cwd?: string }) => {
       const debugPort = await findFreePort();
-      await cli('show', { env: { PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(debugPort) } });
+      await cli('show', { cwd: options?.cwd, env: { PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(debugPort) } });
       await waitForPort(debugPort);
       const browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
       const dashboard = browser.contexts()[0].pages()[0];
@@ -55,11 +55,13 @@ export const test = baseTest.extend<{
       return dashboard;
     });
     for (const { dashboard, browser } of dashboards) {
+      if (!browser.isConnected())
+        continue;
       await Promise.all([
         // Closing the page should close the browser.
         new Promise(r => browser.on('disconnected', r)),
         dashboard.close()
-      ]);
+      ]).catch(e => console.error('Error during dashboard close', e));
     }
   },
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import { test, expect } from './cli-fixtures';
 
 test.beforeEach(({}, testInfo) => {
@@ -40,6 +43,41 @@ test('should show devtools sidebar', async ({ cli, server, openDashboard, mcpBro
   await expect(dashboard.locator('.inspector-frame')).not.toBeVisible();
   await devToolsButton.click();
   await expect(dashboard.locator('.inspector-frame')).toBeVisible();
+});
+
+test('should show current workspace sessions first', async ({ cli, server, openDashboard }) => {
+  const wsA = test.info().outputPath('workspace-a');
+  const wsB = test.info().outputPath('workspace-b');
+
+  await fs.promises.mkdir(path.join(wsA, '.playwright'), { recursive: true });
+  await fs.promises.mkdir(path.join(wsB, '.playwright'), { recursive: true });
+
+  await cli('open', server.EMPTY_PAGE, { cwd: wsA });
+  await cli('open', server.EMPTY_PAGE, { cwd: wsB });
+
+  const checkOrder = async (first: string, second: string) => {
+    const dashboard = await openDashboard({ cwd: first });
+    const workspaceGroups = dashboard.locator('.workspace-group');
+    await expect(workspaceGroups).toHaveCount(2);
+
+    // Current workspace (first) should be first and expanded.
+    await expect(workspaceGroups.nth(0).locator('.workspace-path')).toContainText(first);
+    await expect(workspaceGroups.nth(0).locator('.session-chips')).toBeVisible();
+
+    // Other workspace (second) should be second and collapsed.
+    await expect(workspaceGroups.nth(1).locator('.workspace-path')).toContainText(second);
+    await expect(workspaceGroups.nth(1).locator('.session-chips')).not.toBeVisible();
+
+    await dashboard.close();
+  };
+
+  await test.step('open dashboard in workspace A', async () => {
+    await checkOrder(wsA, wsB);
+  });
+
+  await test.step('open dashboard in workspace B', async () => {
+    await checkOrder(wsB, wsA);
+  });
 });
 
 test('should pick locator from browser', async ({ cli, server, openDashboard }) => {


### PR DESCRIPTION
## Summary
- Dashboard now shows the workspace matching the cwd first and expanded
- When launched from a non-workspace directory, global sessions are shown first
- `openDashboard` fixture accepts optional `cwd` parameter for testing