### PR TITLE
chore(bidi): use the browser-supplied text for console.timeLog/timeEnd messages

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -294,7 +294,8 @@ export class BidiPage implements PageDelegate {
     const callFrame = params.stackTrace?.callFrames[0];
     const location = callFrame ?? { url: '', lineNumber: 1, columnNumber: 1 };
     const type = entry.method === 'warn' ? 'warning' : entry.method;
-    this._page.addConsoleMessage(null, type, entry.args.map(arg => createHandle(context, arg)), location, undefined, params.timestamp);
+    const text = (entry.method === 'timeLog' || entry.method === 'timeEnd') && entry.text ? entry.text : undefined;
+    this._page.addConsoleMessage(null, type, entry.args.map(arg => createHandle(context, arg)), location, text, params.timestamp);
   }
 
   private async _onFileDialogOpened(params: bidi.Input.FileDialogInfo) {

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -91,8 +91,8 @@ it('should work for different console API calls', async ({ page }) => {
   ]);
 });
 
-it('should format the message correctly with time/timeLog/timeEnd', async ({ page, browserName }) => {
-  it.fixme(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/10580');
+it('should format the message correctly with time/timeLog/timeEnd', async ({ page, browserName, isBidi }) => {
+  it.fixme(browserName === 'firefox' && !isBidi, 'https://github.com/microsoft/playwright/issues/10580');
   const messages = [];
   page.on('console', msg => messages.push(msg));
   await page.evaluate(async () => {
@@ -107,6 +107,8 @@ it('should format the message correctly with time/timeLog/timeEnd', async ({ pag
     expect(messages[0].type()).toBe('timeEnd');
   else if (browserName === 'chromium')
     expect(messages[0].type()).toBe('log');
+  else if (browserName === 'firefox')
+    expect(messages[0].type()).toBe('timeLog');
   expect(messages[1].type()).toBe('timeEnd');
 
   // WebKit has a space before the unit: https://bugs.webkit.org/show_bug.cgi?id=233556


### PR DESCRIPTION
For `console.timeLog()` and `console.timeEnd()` the Bidi console event doesn't include the corresponding timer's value, so Playwright can't add it to its rendering of the console message.
With this PR Playwright uses the browser's rendering of the console message for these events. Once the `time` parameter has been added to them ([spec issue](https://github.com/w3c/webdriver-bidi/issues/1111)) we could extend Playwright's message rendering to include it.
Fixes "should format the message correctly with time/timeLog/timeEnd" in `page/page-event-console.spec.ts`.
