### PR TITLE
fix(aria-snapshot): include text children when name is longer than text

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -735,9 +735,6 @@ function textContributesInfo(node: aria.AriaNode, text: string): boolean {
   if (!node.name)
     return true;
 
-  if (node.name.length > text.length)
-    return false;
-
   // Figure out if text adds any value. "longestCommonSubstring" is expensive, so limit strings length.
   const substr = (text.length <= 200 && node.name.length <= 200) ? longestCommonSubstring(text, node.name) : '';
   let filtered = text;

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -909,6 +909,21 @@ test('top-level deep-equal', { annotation: { type: 'issue', description: 'https:
 });
 
 
+test('generated snapshot includes text children when name is longer than text', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40079' } }, async ({ page }) => {
+  await page.setContent(`
+    <section>
+      <div role="progressbar" aria-label="Alpha Beta" aria-valuenow="7" aria-valuemin="0" aria-valuemax="10">
+        <span>Alpha</span>
+        <span>7</span>
+      </div>
+    </section>
+  `);
+  await expect(page.locator('section')).toMatchAriaSnapshot(`
+    - /children: deep-equal
+    - progressbar "Alpha Beta": Alpha 7
+  `);
+});
+
 test('treat bad regex as a string', async ({ page }) => {
   await page.setContent(`<a href="/foo">Log in</a>`);
   const error = await expect(page).toMatchAriaSnapshot(`


### PR DESCRIPTION
## Summary
- `textContributesInfo` had a short-circuit that dropped any text child whose length was less than the accessible name, silently stripping informative text from generated snapshots.
- Removed the bogus early return; the existing longestCommonSubstring heuristic correctly excludes text fully covered by the name.

Fixes https://github.com/microsoft/playwright/issues/40079