### PR TITLE
chore(bidi): ignore "unable to set cookie" errors

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -295,7 +295,7 @@ export class BidiBrowserContext extends BrowserContext {
 
   async addCookies(cookies: channels.SetNetworkCookie[]) {
     cookies = network.rewriteCookies(cookies);
-    const promises = cookies.map((c: channels.SetNetworkCookie) => {
+    const promises = cookies.map(async (c: channels.SetNetworkCookie) => {
       const cookie: bidi.Storage.PartialCookie = {
         name: c.name,
         value: { type: 'string', value: c.value },
@@ -306,8 +306,13 @@ export class BidiBrowserContext extends BrowserContext {
         sameSite: c.sameSite && toBidiSameSite(c.sameSite),
         expiry: (c.expires === -1 || c.expires === undefined) ? undefined : Math.round(c.expires),
       };
-      return this._browser._browserSession.send('storage.setCookie',
-          { cookie, partition: { type: 'storageKey', userContext: this._browserContextId, sourceOrigin: c.partitionKey } });
+      try {
+        return await this._browser._browserSession.send('storage.setCookie',
+            { cookie, partition: { type: 'storageKey', userContext: this._browserContextId, sourceOrigin: c.partitionKey } });
+      } catch (e) {
+        if (!e.message.startsWith('Protocol error (storage.setCookie): unable to set cookie'))
+          throw e;
+      }
     });
     await Promise.all(promises);
   }

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -1,5 +1,4 @@
 library/agent-perform.spec.ts › retrieve a secret [timeout]
-library/browsercontext-add-cookies.spec.ts › should set cookies with SameSite attribute and no secure attribute [fail]
 library/browsercontext-basic.spec.ts › fetch with keepalive should throw when offline [fail]
 library/browsercontext-basic.spec.ts › should disable javascript [fail]
 library/browsercontext-basic.spec.ts › should emulate media in cross-process iframe [fail]

--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -65,7 +65,7 @@ it('should add cookies with empty value', async ({ context, page, server }) => {
   expect(await page.evaluate(() => document.cookie)).toEqual('marker=');
 });
 
-it('should set cookies with SameSite attribute and no secure attribute', async ({ context, browserName, isWindows, isLinux, defaultSameSiteCookieValue, channel }) => {
+it('should set cookies with SameSite attribute and no secure attribute', async ({ context, browserName, isWindows, isLinux, defaultSameSiteCookieValue, channel, isBidi }) => {
   // Use domain instead of URL to ensure that the `secure` attribute is not set.
   await context.addCookies([{
     domain: 'foo.com',
@@ -101,7 +101,7 @@ it('should set cookies with SameSite attribute and no secure attribute', async (
     httpOnly: false,
     secure: false,
     sameSite: defaultSameSiteCookieValue,
-  }, ...(browserName === 'chromium' || (browserName === 'webkit' && (isLinux || channel === 'webkit-wsl')) ? [] : [{
+  }, ...(browserName === 'chromium' || (browserName === 'webkit' && (isLinux || channel === 'webkit-wsl')) || isBidi ? [] : [{
     name: 'same-site-none',
     value: '1',
     domain: 'foo.com',


### PR DESCRIPTION
The `storage.setCookie` Bidi command returns an error if the cookie can't be set (e.g. if it has `SameSite=None` but no `Secure` attribute) but `BrowserContext.addCookies()` isn't expected to throw in this case.
Fixes "should set cookies with SameSite attribute and no secure attribute" in `library/browsercontext-add-cookies.spec.ts`.
