### PR TITLE
fix: do not inline package.json into coreBundle

### DIFF
--- a/packages/playwright-core/src/package.ts
+++ b/packages/playwright-core/src/package.ts
@@ -16,8 +16,10 @@
 
 import path from 'path';
 
-export const packageJSON = require('../package.json');
-export const packageRoot = path.dirname(require.resolve('../package.json'));
+// Use a dynamic path so esbuild does not statically resolve and inline
+// package.json into coreBundle.js.
+export const packageRoot = path.join(__dirname, '..');
+export const packageJSON = require(path.join(packageRoot, 'package.json'));
 export const binPath = path.join(packageRoot, 'bin');
 
 export function libPath(...parts: string[]): string {


### PR DESCRIPTION
## Summary

`packages/playwright-core/src/package.ts` does `require('../package.json')`. esbuild statically resolves this when bundling `coreBundle.ts` and inlines the JSON contents (with the source `1.x.0-next` version) into `lib/coreBundle.js`. After release tagging the on-disk `package.json` carries the published version, but the bundle still reports `1.x.0-next`.

This breaks playwright-cli's daemon protocol. The daemon (which loads `coreBundle.js`) writes session files with `version: "1.x.0-next"`, while the client (which loads the standalone `lib/package.js`) reports the published version like `1.60.0-alpha-2026-04-07`. The semver compatibility check in [`tools/cli-client/session.ts`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/tools/cli-client/session.ts) then rejects every command with:

```
Error: Client is v1.60.0-alpha-2026-04-07, session 'default' is v1.60.0-next.
```

The bug was introduced in #40074, which was the first change to ship a pre-built `coreBundle.js` to npm.

## Fix

Use a runtime-computed path so esbuild cannot statically analyze the require, matching the pattern already used for `api.json` and `help.json` elsewhere in the codebase (`require(libPath(...))`, `require(path.join(packageRoot, ...))`).
