### PR TITLE
chore(test-runner): bake child-process entry per bundle

### DIFF
--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -56,47 +56,48 @@ export class ProcessRunner {
 let gracefullyCloseCalled = false;
 let forceExitInitiated = false;
 
-sendMessageToParent({ method: 'ready' });
-
-process.on('disconnect', () => gracefullyCloseAndExit(true));
-process.on('SIGINT', () => {});
-process.on('SIGTERM', () => {});
-
 let processRunner: ProcessRunner | undefined;
 let processName: string | undefined;
 const startingEnv = { ...process.env };
 
-process.on('message', async (message: any) => {
-  if (message.method === '__init__') {
-    const { processParams, runnerParams, runnerScript } = message.params as { processParams: ProcessInitParams, runnerParams: any, runnerScript: string };
-    void serverUtils.startProfiling();
-    iso.setTimeOrigin(processParams.timeOrigin);
-    const { create } = require(runnerScript);
-    processRunner = create(runnerParams) as ProcessRunner;
-    processName = processParams.processName;
-    return;
-  }
-  if (message.method === '__stop__') {
-    const keys = new Set([...Object.keys(process.env), ...Object.keys(startingEnv)]);
-    const producedEnv: EnvProducedPayload = [...keys].filter(key => startingEnv[key] !== process.env[key]).map(key => [key, process.env[key] ?? null]);
-    sendMessageToParent({ method: '__env_produced__', params: producedEnv });
-    await gracefullyCloseAndExit(false);
-    return;
-  }
-  if (message.method === '__dispatch__') {
-    const { id, method, params } = message.params as ProtocolRequest;
-    try {
-      const result = await (processRunner as any)[method](params);
-      const response: ProtocolResponse = { id, result };
-      sendMessageToParent({ method: '__dispatch__', params: response });
-    } catch (e) {
-      const response: ProtocolResponse = { id, error: serializeError(e) };
-      sendMessageToParent({ method: '__dispatch__', params: response });
+export function startProcessRunner(create: (params: any) => ProcessRunner) {
+  sendMessageToParent({ method: 'ready' });
+
+  process.on('disconnect', () => gracefullyCloseAndExit(true));
+  process.on('SIGINT', () => {});
+  process.on('SIGTERM', () => {});
+
+  process.on('message', async (message: any) => {
+    if (message.method === '__init__') {
+      const { processParams, runnerParams } = message.params as { processParams: ProcessInitParams, runnerParams: any };
+      void serverUtils.startProfiling();
+      iso.setTimeOrigin(processParams.timeOrigin);
+      processRunner = create(runnerParams);
+      processName = processParams.processName;
+      return;
     }
-  }
-  if (message.method === '__response__')
-    handleResponseFromParent(message.params as ProtocolResponse);
-});
+    if (message.method === '__stop__') {
+      const keys = new Set([...Object.keys(process.env), ...Object.keys(startingEnv)]);
+      const producedEnv: EnvProducedPayload = [...keys].filter(key => startingEnv[key] !== process.env[key]).map(key => [key, process.env[key] ?? null]);
+      sendMessageToParent({ method: '__env_produced__', params: producedEnv });
+      await gracefullyCloseAndExit(false);
+      return;
+    }
+    if (message.method === '__dispatch__') {
+      const { id, method, params } = message.params as ProtocolRequest;
+      try {
+        const result = await (processRunner as any)[method](params);
+        const response: ProtocolResponse = { id, result };
+        sendMessageToParent({ method: '__dispatch__', params: response });
+      } catch (e) {
+        const response: ProtocolResponse = { id, error: serializeError(e) };
+        sendMessageToParent({ method: '__dispatch__', params: response });
+      }
+    }
+    if (message.method === '__response__')
+      handleResponseFromParent(message.params as ProtocolResponse);
+  });
+}
 
 const kForceExitTimeout = +(process.env.PWTEST_FORCE_EXIT_TIMEOUT || 30000);
 

--- a/packages/playwright/src/loader/loaderProcessEntry.ts
+++ b/packages/playwright/src/loader/loaderProcessEntry.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { startProcessRunner } from '../common/process';
+import { create } from './loaderMain';
+
+startProcessRunner(create);

--- a/packages/playwright/src/runner/loaderHost.ts
+++ b/packages/playwright/src/runner/loaderHost.ts
@@ -56,7 +56,7 @@ export class OutOfProcessLoaderHost {
 
   constructor(config: FullConfigInternal) {
     this._config = config;
-    this._processHost = new ProcessHost(require.resolve('../loader/loaderMain.js'), 'loader', {});
+    this._processHost = new ProcessHost(require.resolve('../loader/loaderProcessEntry.js'), 'loader', {});
   }
 
   async start(errors: TestError[]) {

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -34,7 +34,7 @@ export class ProcessHost extends EventEmitter {
   private _didSendStop = false;
   private _processDidExit = false;
   private _didExitAndRanOnExit = false;
-  private _runnerScript: string;
+  private _entryScript: string;
   private _lastMessageId = 0;
   private _callbacks = new Map<number, { resolve: (result: any) => void, reject: (error: Error) => void }>();
   private _processName: string;
@@ -42,16 +42,16 @@ export class ProcessHost extends EventEmitter {
   private _extraEnv: Record<string, string | undefined>;
   private _requestHandlers = new Map<string, (params: any) => Promise<any>>();
 
-  constructor(runnerScript: string, processName: string, env: Record<string, string | undefined>) {
+  constructor(entryScript: string, processName: string, env: Record<string, string | undefined>) {
     super();
-    this._runnerScript = runnerScript;
+    this._entryScript = entryScript;
     this._processName = processName;
     this._extraEnv = env;
   }
 
   async startRunner(runnerParams: any, options: { onStdOut?: (chunk: Buffer | string) => void, onStdErr?: (chunk: Buffer | string) => void } = {}): Promise<ProcessExitData | undefined> {
     iso.assert(!this.process, 'Internal error: starting the same process twice');
-    this.process = child_process.fork(require.resolve('../common/process'), {
+    this.process = child_process.fork(this._entryScript, {
       // Note: we pass detached:false, so that workers are in the same process group.
       // This way Ctrl+C or a kill command can shutdown all workers in case they misbehave.
       // Otherwise user can end up with a bunch of workers stuck in a busy loop without self-destructing.
@@ -133,7 +133,6 @@ export class ProcessHost extends EventEmitter {
     this.send({
       method: '__init__', params: {
         processParams,
-        runnerScript: this._runnerScript,
         runnerParams
       }
     });

--- a/packages/playwright/src/runner/workerHost.ts
+++ b/packages/playwright/src/runner/workerHost.ts
@@ -47,7 +47,7 @@ export class WorkerHost extends ProcessHost {
 
   constructor(testGroup: TestGroup, options: WorkerHostOptions) {
     const workerIndex = lastWorkerIndex++;
-    super(require.resolve('../worker/workerMain.js'), `worker-${workerIndex}`, {
+    super(require.resolve('../worker/workerProcessEntry.js'), `worker-${workerIndex}`, {
       ...options.extraEnv,
       FORCE_COLOR: '1',
       DEBUG_COLORS: process.env.DEBUG_COLORS === undefined ? '1' : process.env.DEBUG_COLORS,

--- a/packages/playwright/src/worker/workerProcessEntry.ts
+++ b/packages/playwright/src/worker/workerProcessEntry.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { startProcessRunner } from '../common/process';
+import { create } from './workerMain';
+
+startProcessRunner(create);


### PR DESCRIPTION
## Summary

- Refactor `common/process.ts` so its IPC plumbing is exported as `startProcessRunner(create)` instead of running at module load time.
- Each child process now has a dedicated entry shim (`worker/workerProcessEntry.ts`, `loader/loaderProcessEntry.ts`) that imports its `create()` factory statically and calls `startProcessRunner`.
- `ProcessHost` forks the entry shim directly and no longer dispatches through a `__init__.runnerScript` indirection.