### PR TITLE
fix(html-reporter): align screenshot slider size labels

### DIFF
--- a/packages/web/src/shared/imageDiffView.tsx
+++ b/packages/web/src/shared/imageDiffView.tsx
@@ -149,7 +149,7 @@ export const ImageDiffSlider: React.FC<{
   const sameSize = expectedImage.naturalWidth === actualImage.naturalWidth && expectedImage.naturalHeight === actualImage.naturalHeight;
 
   return <div style={{ flex: 'none', display: 'flex', alignItems: 'center', flexDirection: 'column', userSelect: 'none' }}>
-    {!hideSize && <div data-testid='test-result-image-mismatch-slider-size' style={{ margin: 5 }}>
+    {!hideSize && <div style={{ margin: 5 }}>
       {!sameSize && <span style={{ flex: 'none', margin: '0 5px' }}>Actual </span>}
       {!sameSize && <span>{actualImage.naturalWidth}</span>}
       {!sameSize && <span style={{ flex: 'none', margin: '0 5px' }}>x</span>}

--- a/packages/web/src/shared/imageDiffView.tsx
+++ b/packages/web/src/shared/imageDiffView.tsx
@@ -149,15 +149,15 @@ export const ImageDiffSlider: React.FC<{
   const sameSize = expectedImage.naturalWidth === actualImage.naturalWidth && expectedImage.naturalHeight === actualImage.naturalHeight;
 
   return <div style={{ flex: 'none', display: 'flex', alignItems: 'center', flexDirection: 'column', userSelect: 'none' }}>
-    {!hideSize && <div style={{ margin: 5 }}>
-      {!sameSize && <span style={{ flex: 'none', margin: '0 5px' }}>Expected </span>}
-      <span>{expectedImage.naturalWidth}</span>
-      <span style={{ flex: 'none', margin: '0 5px' }}>x</span>
-      <span>{expectedImage.naturalHeight}</span>
-      {!sameSize && <span style={{ flex: 'none', margin: '0 5px 0 15px' }}>Actual </span>}
+    {!hideSize && <div data-testid='test-result-image-mismatch-slider-size' style={{ margin: 5 }}>
+      {!sameSize && <span style={{ flex: 'none', margin: '0 5px' }}>Actual </span>}
       {!sameSize && <span>{actualImage.naturalWidth}</span>}
       {!sameSize && <span style={{ flex: 'none', margin: '0 5px' }}>x</span>}
       {!sameSize && <span>{actualImage.naturalHeight}</span>}
+      {!sameSize && <span style={{ flex: 'none', margin: '0 5px 0 15px' }}>{expectedTitle} </span>}
+      <span>{expectedImage.naturalWidth}</span>
+      <span style={{ flex: 'none', margin: '0 5px' }}>x</span>
+      <span>{expectedImage.naturalHeight}</span>
     </div>}
     <div style={{ position: 'relative', width: canvasWidth, height: canvasHeight, margin: 15, ...checkerboardStyle }}>
       <ResizeView

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -226,6 +226,40 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       }
     });
 
+    test('should show slider dimensions in visual order', async ({ runInlineTest, page, showReport }) => {
+      const expected = createImage(201, 200, 255, 0, 0);
+      const actual = createImage(200, 200, 0, 255, 0);
+      const result = await runInlineTest({
+        'playwright.config.ts': `
+          module.exports = { use: { viewport: { width: 200, height: 200 }} };
+        `,
+        'a.test.js-snapshots/expected-linux.png': expected,
+        'a.test.js-snapshots/expected-darwin.png': expected,
+        'a.test.js-snapshots/expected-win32.png': expected,
+        'actual.png': actual,
+        'a.test.js': `
+          import fs from 'fs';
+          import { test, expect } from '@playwright/test';
+          test('fails', async () => {
+            const screenshot = fs.readFileSync('actual.png');
+            await expect(screenshot).toMatchSnapshot('expected.png');
+          });
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(1);
+      expect(result.failed).toBe(1);
+
+      await showReport();
+      await page.getByRole('link', { name: 'fails' }).click();
+      const imageDiff = page.getByTestId('test-results-image-diff').getByTestId('test-result-image-mismatch');
+      await imageDiff.getByText('Slider', { exact: true }).click();
+      await expect(imageDiff.getByTestId('test-result-image-mismatch-slider-size')).toHaveText(
+          /Actual\s*200\s*x\s*200\s*Expected\s*201\s*x\s*200/
+      );
+      await expect(imageDiff.locator('img').first()).toHaveAttribute('alt', 'Expected');
+      await expect(imageDiff.locator('img').last()).toHaveAttribute('alt', 'Actual');
+    });
+
     test('should include multiple image diffs', async ({ runInlineTest, page, showReport }) => {
       const IMG_WIDTH = 200;
       const IMG_HEIGHT = 200;

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -226,40 +226,6 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       }
     });
 
-    test('should show slider dimensions in visual order', async ({ runInlineTest, page, showReport }) => {
-      const expected = createImage(201, 200, 255, 0, 0);
-      const actual = createImage(200, 200, 0, 255, 0);
-      const result = await runInlineTest({
-        'playwright.config.ts': `
-          module.exports = { use: { viewport: { width: 200, height: 200 }} };
-        `,
-        'a.test.js-snapshots/expected-linux.png': expected,
-        'a.test.js-snapshots/expected-darwin.png': expected,
-        'a.test.js-snapshots/expected-win32.png': expected,
-        'actual.png': actual,
-        'a.test.js': `
-          import fs from 'fs';
-          import { test, expect } from '@playwright/test';
-          test('fails', async () => {
-            const screenshot = fs.readFileSync('actual.png');
-            await expect(screenshot).toMatchSnapshot('expected.png');
-          });
-        `,
-      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
-      expect(result.exitCode).toBe(1);
-      expect(result.failed).toBe(1);
-
-      await showReport();
-      await page.getByRole('link', { name: 'fails' }).click();
-      const imageDiff = page.getByTestId('test-results-image-diff').getByTestId('test-result-image-mismatch');
-      await imageDiff.getByText('Slider', { exact: true }).click();
-      await expect(imageDiff.getByTestId('test-result-image-mismatch-slider-size')).toHaveText(
-          /Actual\s*200\s*x\s*200\s*Expected\s*201\s*x\s*200/
-      );
-      await expect(imageDiff.locator('img').first()).toHaveAttribute('alt', 'Expected');
-      await expect(imageDiff.locator('img').last()).toHaveAttribute('alt', 'Actual');
-    });
-
     test('should include multiple image diffs', async ({ runInlineTest, page, showReport }) => {
       const IMG_WIDTH = 200;
       const IMG_HEIGHT = 200;


### PR DESCRIPTION
This fixes the order of the Expected/Actual size labels that appear above the Slider view in the Image mismatch section of a failed test report, when the Expected and Actual image sizes don't match.

The problem with the existing label order was that the slider shows the expected image on the right and the actual image on the left (which is already counterintuitive, but that's a separate topic), while the labels were reversed: the `Expected W x H` appeared on the left and the `Actual W x H` appeared on the right. Together, this made the Slider UI pretty confusing.

This PR only changes the label order; it doesn't change the slider behavior.

Before:

<img width="600" alt="old" src="https://github.com/user-attachments/assets/dbaf7d7c-679e-4bd9-99d7-31a2fc9db008" />

After:

<img width="600" alt="new" src="https://github.com/user-attachments/assets/dc4c138b-7127-4bfb-81af-128a21aef2bd" />
