### PR TITLE
test(trace-viewer): add missing @step decorators to TraceViewerPage

### DIFF
--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -119,26 +119,32 @@ class TraceViewerPage {
     await this.page.getByRole('tab', { name }).click();
   }
 
+  @step
   async showErrorsTab() {
     await this.page.getByRole('tab', { name: 'Errors' }).click();
   }
 
+  @step
   async showConsoleTab() {
     await this.page.getByRole('tab', { name: 'Console' }).click();
   }
 
+  @step
   async showSourceTab() {
     await this.page.getByRole('tab', { name: 'Source' }).click();
   }
 
+  @step
   async showNetworkTab() {
     await this.page.getByRole('tab', { name: 'Network' }).click();
   }
 
+  @step
   async showMetadataTab() {
     await this.page.getByRole('tab', { name: 'Metadata' }).click();
   }
 
+  @step
   async showSettings() {
     await this.page.getByRole('button', { name: 'Settings' }).click();
   }


### PR DESCRIPTION
## Motivation
The `TraceViewerPage` POM lacks `@step` decorators on several key methods (e.g., tab switching). When debugging UI tests via Trace Viewer, these actions are hidden in the general timeline instead of being explicitly logged as named steps, degrading test observability.

## Changes
- Added `@step` decorators to tab and settings methods in `tests/config/traceViewerFixtures.ts` (e.g., `showErrorsTab`, `showConsoleTab`, `showSourceTab`, `showNetworkTab`, `showMetadataTab`, `showSettings`).

## Validation
- Actions are now correctly surfaced as discrete steps in the Playwright Trace Viewer timeline.