### PR TITLE
fix(trace-viewer): block meta refresh and sandbox snapshot iframes

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -371,8 +371,13 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
         }
         if (removeNoScript && nodeName === 'NOSCRIPT')
           return;
-        if (nodeName === 'META' && (node as HTMLMetaElement).httpEquiv.toLowerCase() === 'content-security-policy')
-          return;
+        if (nodeName === 'META') {
+          const httpEquiv = (node as HTMLMetaElement).httpEquiv.toLowerCase();
+          // Drop META directives that can navigate, set cookies, or otherwise
+          // affect the trace viewer when the recorded snapshot is rendered.
+          if (httpEquiv === 'content-security-policy' || httpEquiv === 'refresh' || httpEquiv === 'set-cookie')
+            return;
+        }
         // Skip iframes which are inside document's head as they are not visible.
         // See https://github.com/microsoft/playwright/issues/12005.
         if ((nodeName === 'IFRAME' || nodeName === 'FRAME') && headNesting)

--- a/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/playwright-core/src/utils/isomorphic/trace/snapshotRenderer.ts
@@ -109,8 +109,13 @@ export class SnapshotRenderer {
         const isFrame = nodeName === 'IFRAME' || nodeName === 'FRAME';
         const isAnchor = nodeName === 'A';
         const isImg = nodeName === 'IMG';
+        const isMeta = nodeName === 'META';
         const isImgWithCurrentSrc = isImg && attrs.some(a => a[0] === kCurrentSrcAttribute);
         const isSourceInsidePictureWithCurrentSrc = nodeName === 'SOURCE' && parentTag === 'PICTURE' && parentAttrs?.some(a => a[0] === kCurrentSrcAttribute);
+        // For META, only allow a small whitelist of http-equiv directives so a malicious snapshot
+        // cannot navigate the snapshot iframe via e.g. <meta http-equiv="refresh"> or otherwise
+        // affect the trace viewer.
+        const hasUnsafeHttpEquiv = isMeta && attrs.some(a => a[0].toLowerCase() === 'http-equiv' && !kAllowedMetaHttpEquivs.has(a[1].trim().toLowerCase()));
         for (const [attr, value] of attrs) {
           let attrName = attr;
           if (isFrame && attr.toLowerCase() === 'src') {
@@ -126,6 +131,10 @@ export class SnapshotRenderer {
             // Disable actual <img src>, <img srcset>, <source src> and <source srcset> if
             // we will be using the currentSrc instead.
             attrName = '_' + attrName;
+          }
+          if (hasUnsafeHttpEquiv && (attr.toLowerCase() === 'http-equiv' || attr.toLowerCase() === 'content')) {
+            // Neutralize the META directive by renaming the attribute so the browser ignores it.
+            attrName = '_' + attr;
           }
           let attrValue = value;
           if (!isAnchor && (attr.toLowerCase() === 'href' || attr.toLowerCase() === 'src' || attr === kCurrentSrcAttribute))
@@ -219,6 +228,10 @@ export class SnapshotRenderer {
 }
 
 const autoClosing = new Set(['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'MENUITEM', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR']);
+
+// Whitelist of META http-equiv directives that are safe to render in the trace viewer.
+// Notably excludes 'refresh' (auto-navigation), 'set-cookie' and 'content-security-policy'.
+const kAllowedMetaHttpEquivs = new Set(['content-type', 'content-language', 'default-style', 'x-ua-compatible']);
 
 function snapshotNodes(snapshot: FrameSnapshot): NodeSnapshot[] {
   if (!(snapshot as any)._nodes) {

--- a/packages/trace-viewer/snapshot.html
+++ b/packages/trace-viewer/snapshot.html
@@ -16,7 +16,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <body>
-    <iframe src="about:blank" style="position:absolute;top:0;left:0;right:0;bottom:0;width:100%;height:100%;border:none;"></iframe>
+    <iframe src="about:blank" sandbox="allow-same-origin allow-scripts" style="position:absolute;top:0;left:0;right:0;bottom:0;width:100%;height:100%;border:none;"></iframe>
     <script>
       (async () => {
         if (!navigator.serviceWorker)

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -188,8 +188,8 @@ export const SnapshotView: React.FunctionComponent<{
       iteration={loadingRef.current.iteration} />
     <SnapshotWrapper snapshotInfo={snapshotInfo}>
       <div className='snapshot-switcher'>
-        <iframe ref={iframeRef0} name='snapshot' title='DOM Snapshot' className={clsx(loadingRef.current.visibleIframe === 0 && 'snapshot-visible')}></iframe>
-        <iframe ref={iframeRef1} name='snapshot' title='DOM Snapshot' className={clsx(loadingRef.current.visibleIframe === 1 && 'snapshot-visible')}></iframe>
+        <iframe ref={iframeRef0} name='snapshot' title='DOM Snapshot' sandbox='allow-same-origin allow-scripts' className={clsx(loadingRef.current.visibleIframe === 0 && 'snapshot-visible')}></iframe>
+        <iframe ref={iframeRef1} name='snapshot' title='DOM Snapshot' sandbox='allow-same-origin allow-scripts' className={clsx(loadingRef.current.visibleIframe === 1 && 'snapshot-visible')}></iframe>
       </div>
     </SnapshotWrapper>
   </div>;

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -2272,6 +2272,63 @@ test('should replace meta content attr that specifies charset', async ({ runAndT
   await expect.poll(() => frame.locator('body').evaluate(() => document.querySelector('meta')?.outerHTML.toLowerCase())).toBe('<meta http-equiv="content-type" content="text/html; charset=utf-8">');
 });
 
+test('should drop meta http-equiv refresh during recording', async ({ runAndTrace, page, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    // Use a very large delay so the recorded page does not actually navigate before the snapshot is taken.
+    await page.setContent(`
+      <head>
+        <meta http-equiv="refresh" content="999999; url=https://example.com/evil">
+      </head>
+      <body><div>safe</div></body>
+    `);
+  });
+  const frame = await traceViewer.snapshotFrame('Set content');
+  await expect(frame.locator('div')).toHaveText('safe');
+  // Refresh META must be stripped from the snapshot, so the iframe is not navigated.
+  await expect.poll(() => frame.locator('head').evaluate(head => head.querySelector('meta[http-equiv]')?.outerHTML.toLowerCase() ?? '')).toBe('');
+  // The trace viewer top-level title and body must remain untouched.
+  await expect(traceViewer.page).toHaveTitle(/Playwright Trace Viewer/);
+  await expect(traceViewer.page.locator('body')).not.toHaveAttribute('data-pwned', /.*/);
+});
+
+test('should neutralize meta http-equiv refresh during rendering', async ({ runAndTrace, page, server }) => {
+  // Inject a META refresh directly via DOM manipulation that bypasses the
+  // recording-time strip (so this test specifically validates the renderer-side defense).
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.evaluate(() => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('http-equiv', 'refresh');
+      meta.setAttribute('content', '999999; url=https://example.com/evil');
+      document.head.appendChild(meta);
+      const div = document.createElement('div');
+      div.textContent = 'safe';
+      document.body.appendChild(div);
+    });
+  });
+  const frame = await traceViewer.snapshotFrame('Evaluate');
+  await expect(frame.locator('div')).toHaveText('safe');
+  // Even if a META refresh is in the recorded snapshot, the renderer must
+  // neutralize the http-equiv and content attributes so it has no effect.
+  await expect.poll(() => frame.locator('head').evaluate(head => !!head.querySelector('meta[http-equiv="refresh"]'))).toBe(false);
+  await expect(traceViewer.page).toHaveTitle(/Playwright Trace Viewer/);
+});
+
+test('snapshot iframes should be sandboxed', async ({ runAndTrace, page, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.setContent('<div>hello</div>');
+  });
+  await traceViewer.snapshotFrame('Set content');
+  const sandboxValues = await traceViewer.page.locator('iframe[name=snapshot]').evaluateAll(frames => frames.map(f => f.getAttribute('sandbox')));
+  for (const value of sandboxValues) {
+    expect(value).toBeTruthy();
+    expect(value).toContain('allow-same-origin');
+    expect(value).toContain('allow-scripts');
+  }
+});
+
 test('should capture iframe with srcdoc', async ({ page, server, runAndTrace }) => {
   await page.route('**/empty.html', route => {
     void route.fulfill({


### PR DESCRIPTION
A crafted trace could embed a META http-equiv=refresh directive that navigated the snapshot iframe to attacker-controlled HTML served from the trace viewer origin, executing script in the trusted viewer context.

Defense in depth:
- Strip http-equiv=refresh META directives during snapshot recording
- During snapshot rendering, allow only a small whitelist of META http-equiv directives
- Sandbox the trace viewer snapshot iframes with "allow-same-origin allow-scripts" to block top navigation, popups, downloads, forms, and other capabilities that legitimate snapshots do not need.