### PR TITLE
docs(mcp): fix broken link to Playwright MCP Bridge extension

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -283,7 +283,7 @@ Connect to your existing browser tabs instead of launching a new browser:
 playwright-cli attach --extension
 ```
 
-This requires the [Playwright MCP Bridge browser extension](https://github.com/user-attachments/packages/extension) to be installed.
+This requires the [Playwright MCP Bridge browser extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md) to be installed.
 
 ## Quick Reference
 

--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -175,7 +175,7 @@ Playwright MCP supports three profile modes:
 
 -   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
--   **Browser extension**: Connect to your existing browser tabs with the [Playwright MCP Bridge extension](https://github.com/user-attachments/packages/extension). Pass `--extension` to enable.
+-   **Browser extension**: Connect to your existing browser tabs with the [Playwright MCP Bridge extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). Pass `--extension` to enable.
 
 ### Configuration file
 


### PR DESCRIPTION
## Summary
- Point the MCP Bridge extension link to the canonical README in microsoft/playwright-mcp instead of the broken `user-attachments` URL.

Fixes https://github.com/microsoft/playwright/issues/40099