### PR TITLE
docs: alias bullets for port-specific Object struct names

### DIFF
--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -57,7 +57,8 @@ An object with all the response HTTP headers associated with this response.
 
 ## method: APIResponse.headersArray
 * since: v1.16
-- returns: <[Array]<[Object=Header]>>
+- returns: <[Array]<[Object]>>
+  - alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 

--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -59,6 +59,7 @@ An object with all the response HTTP headers associated with this response.
 * since: v1.16
 - returns: <[Array]<[Object]>>
   - alias-csharp: Header
+  - alias-java: HttpHeader
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -298,7 +298,7 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
 ## async method: Browser.bind
 * since: v1.59
 - returns: <[Object]>
-  - alias-java: Bind
+  - alias: BindResult
   - `endpoint` <[string]>
 
 Binds the browser to a named pipe or web socket, making it available for other clients to connect to.

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -298,6 +298,7 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
 ## async method: Browser.bind
 * since: v1.59
 - returns: <[Object]>
+  - alias-java: Bind
   - `endpoint` <[string]>
 
 Binds the browser to a named pipe or web socket, making it available for other clients to connect to.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -331,6 +331,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
 ### param: BrowserContext.addCookies.cookies
 * since: v1.8
 - `cookies` <[Array]<[Object]>>
+  - alias-java: Cookie
   - `name` <[string]>
   - `value` <[string]>
   - `url` ?<[string]> Either `url` or both `domain` and `path` are required. Optional.
@@ -571,6 +572,7 @@ The default browser context cannot be closed.
 * since: v1.8
 - returns: <[Array]<[Object]>>
   - alias-csharp: BrowserContextCookiesResult
+  - alias-java: Cookie
   - `name` <[string]>
   - `value` <[string]>
   - `domain` <[string]>
@@ -731,6 +733,7 @@ Name of the function on the window object.
 ### param: BrowserContext.exposeBinding.callback
 * since: v1.8
 - `callback` <[function]>
+  - alias-java: BindingCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -930,6 +933,7 @@ Name of the function on the window object.
 ### param: BrowserContext.exposeFunction.callback
 * since: v1.8
 - `callback` <[function]>
+  - alias-java: FunctionCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -1466,6 +1470,7 @@ its geolocation.
 ### param: BrowserContext.setGeolocation.geolocation
 * since: v1.8
 - `geolocation` <[null]|[Object]>
+  - alias-java: Geolocation
   - `latitude` <[float]> Latitude between -90 and 90.
   - `longitude` <[float]> Longitude between -180 and 180.
   - `accuracy` ?<[float]> Non-negative accuracy value. Defaults to `0`.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -569,7 +569,8 @@ The default browser context cannot be closed.
 
 ## async method: BrowserContext.cookies
 * since: v1.8
-- returns: <[Array]<[Object=BrowserContextCookiesResult]>>
+- returns: <[Array]<[Object]>>
+  - alias-csharp: BrowserContextCookiesResult
   - `name` <[string]>
   - `value` <[string]>
   - `domain` <[string]>

--- a/docs/src/api/class-debugger.md
+++ b/docs/src/api/class-debugger.md
@@ -12,8 +12,7 @@ Emitted when the debugger pauses or resumes.
 ## method: Debugger.pausedDetails
 * since: v1.59
 - returns: <[null]|[Object]>
-  - alias-csharp: DebuggerPausedDetails
-  - alias-java: PausedDetails
+  - alias: DebuggerPausedDetails
   - `location` <[Object]>
     - alias-java: Location
     - `file` <[string]>

--- a/docs/src/api/class-debugger.md
+++ b/docs/src/api/class-debugger.md
@@ -11,7 +11,8 @@ Emitted when the debugger pauses or resumes.
 
 ## method: Debugger.pausedDetails
 * since: v1.59
-- returns: <[null]|[Object=DebuggerPausedDetails]>
+- returns: <[null]|[Object]>
+  - alias-csharp: DebuggerPausedDetails
   - `location` <[Object]>
     - `file` <[string]>
     - `line` ?<[int]>

--- a/docs/src/api/class-debugger.md
+++ b/docs/src/api/class-debugger.md
@@ -13,7 +13,9 @@ Emitted when the debugger pauses or resumes.
 * since: v1.59
 - returns: <[null]|[Object]>
   - alias-csharp: DebuggerPausedDetails
+  - alias-java: PausedDetails
   - `location` <[Object]>
+    - alias-java: Location
     - `file` <[string]>
     - `line` ?<[int]>
     - `column` ?<[int]>
@@ -48,6 +50,7 @@ Resumes script execution and pauses when an action originates from the given sou
 ### param: Debugger.runTo.location
 * since: v1.59
 - `location` <[Object]>
+  - alias-java: Location
   - `file` <[string]>
   - `line` ?<[int]>
   - `column` ?<[int]>

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -110,6 +110,7 @@ await locator.ClickAsync();
 * since: v1.8
 - returns: <[null]|[Object]>
   - alias-csharp: ElementHandleBoundingBoxResult
+  - alias-java: BoundingBox
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -108,7 +108,8 @@ await locator.ClickAsync();
 
 ## async method: ElementHandle.boundingBox
 * since: v1.8
-- returns: <[null]|[Object=ElementHandleBoundingBoxResult]>
+- returns: <[null]|[Object]>
+  - alias-csharp: ElementHandleBoundingBoxResult
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-formdata.md
+++ b/docs/src/api/class-formdata.md
@@ -68,7 +68,8 @@ Field name.
 
 ### param: FormData.append.value
 * since: v1.44
-- `value` <[string]|[boolean]|[int]|[Path]|[Object=FilePayload]>
+- `value` <[string]|[boolean]|[int]|[Path]|[Object]>
+  - alias-csharp: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -78,7 +79,8 @@ Field value.
 ### param: FormData.append.value
 * since: v1.44
 * langs: csharp
-- `value` <[string]|[boolean]|[int]|[Object=FilePayload]>
+- `value` <[string]|[boolean]|[int]|[Object]>
+  - alias-csharp: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -135,7 +137,8 @@ Field name.
 
 ### param: FormData.set.value
 * since: v1.18
-- `value` <[string]|[boolean]|[int]|[Path]|[Object=FilePayload]>
+- `value` <[string]|[boolean]|[int]|[Path]|[Object]>
+  - alias-csharp: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -145,7 +148,8 @@ Field value.
 ### param: FormData.set.value
 * since: v1.18
 * langs: csharp
-- `value` <[string]|[boolean]|[int]|[Object=FilePayload]>
+- `value` <[string]|[boolean]|[int]|[Object]>
+  - alias-csharp: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content

--- a/docs/src/api/class-formdata.md
+++ b/docs/src/api/class-formdata.md
@@ -70,6 +70,7 @@ Field name.
 * since: v1.44
 - `value` <[string]|[boolean]|[int]|[Path]|[Object]>
   - alias-csharp: FilePayload
+  - alias-java: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -139,6 +140,7 @@ Field name.
 * since: v1.18
 - `value` <[string]|[boolean]|[int]|[Path]|[Object]>
   - alias-csharp: FilePayload
+  - alias-java: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -242,7 +242,8 @@ Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) 
 
 ## async method: Locator.boundingBox
 * since: v1.14
-- returns: <[null]|[Object=LocatorBoundingBoxResult]>
+- returns: <[null]|[Object]>
+  - alias-csharp: LocatorBoundingBoxResult
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -244,6 +244,7 @@ Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) 
 * since: v1.14
 - returns: <[null]|[Object]>
   - alias-csharp: LocatorBoundingBoxResult
+  - alias-java: BoundingBox
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1829,6 +1829,7 @@ Name of the function on the window object.
 ### param: Page.exposeBinding.callback
 * since: v1.8
 - `callback` <[function]>
+  - alias-java: BindingCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -2030,6 +2031,7 @@ Name of the function on the window object
 ### param: Page.exposeFunction.callback
 * since: v1.8
 - `callback` <[function]>
+  - alias-java: FunctionCallback
 
 Callback function which will be called in Playwright's context.
 
@@ -3005,6 +3007,7 @@ Paper margins, defaults to none.
 * since: v1.8
 * langs: csharp, java
 - `margin` <[Object]>
+  - alias-java: Margin
   - `top` ?<[string]> Top margin, accepts values labeled with units. Defaults to `0`.
   - `right` ?<[string]> Right margin, accepts values labeled with units. Defaults to `0`.
   - `bottom` ?<[string]> Bottom margin, accepts values labeled with units. Defaults to `0`.
@@ -4462,6 +4465,7 @@ Video object associated with this page. Can be used to access the video file whe
 * since: v1.8
 - returns: <[null]|[Object]>
   - alias-csharp: PageViewportSizeResult
+  - alias-java: ViewportSize
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4460,7 +4460,8 @@ Video object associated with this page. Can be used to access the video file whe
 
 ## method: Page.viewportSize
 * since: v1.8
-- returns: <[null]|[Object=PageViewportSizeResult]>
+- returns: <[null]|[Object]>
+  - alias-csharp: PageViewportSizeResult
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 

--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -113,7 +113,8 @@ You can use [`method: Request.allHeaders`] for complete list of headers that inc
 
 ## async method: Request.headersArray
 * since: v1.15
-- returns: <[Array]<[Object=Header]>>
+- returns: <[Array]<[Object]>>
+  - alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -310,7 +311,8 @@ Requests originated in a Service Worker do not have a [`method: Request.frame`] 
 
 ## async method: Request.sizes
 * since: v1.15
-- returns: <[Object=RequestSizesResult]>
+- returns: <[Object]>
+  - alias-csharp: RequestSizesResult
   - `requestBodySize` <[int]> Size of the request body (POST data payload) in bytes. Set to 0 if there was no body.
   - `requestHeadersSize` <[int]> Total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body.
   - `responseBodySize` <[int]> Size of the received response body (encoded) in bytes.
@@ -320,7 +322,8 @@ Returns resource size information for given request.
 
 ## method: Request.timing
 * since: v1.8
-- returns: <[Object=RequestTimingResult]>
+- returns: <[Object]>
+  - alias-csharp: RequestTimingResult
   - `startTime` <[float]> Request start time in milliseconds elapsed since January 1, 1970 00:00:00 UTC
   - `domainLookupStart` <[float]> Time immediately before the browser starts the domain name lookup for the
     resource. The value is given in milliseconds relative to `startTime`, -1 if not available.

--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -115,6 +115,7 @@ You can use [`method: Request.allHeaders`] for complete list of headers that inc
 * since: v1.15
 - returns: <[Array]<[Object]>>
   - alias-csharp: Header
+  - alias-java: HttpHeader
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -313,6 +314,7 @@ Requests originated in a Service Worker do not have a [`method: Request.frame`] 
 * since: v1.15
 - returns: <[Object]>
   - alias-csharp: RequestSizesResult
+  - alias-java: Sizes
   - `requestBodySize` <[int]> Size of the request body (POST data payload) in bytes. Set to 0 if there was no body.
   - `requestHeadersSize` <[int]> Total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body.
   - `responseBodySize` <[int]> Size of the received response body (encoded) in bytes.
@@ -324,6 +326,7 @@ Returns resource size information for given request.
 * since: v1.8
 - returns: <[Object]>
   - alias-csharp: RequestTimingResult
+  - alias-java: Timing
   - `startTime` <[float]> Request start time in milliseconds elapsed since January 1, 1970 00:00:00 UTC
   - `domainLookupStart` <[float]> Time immediately before the browser starts the domain name lookup for the
     resource. The value is given in milliseconds relative to `startTime`, -1 if not available.

--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -48,7 +48,8 @@ You can use [`method: Response.allHeaders`] for complete list of headers that in
 
 ## async method: Response.headersArray
 * since: v1.15
-- returns: <[Array]<[Object=Header]>>
+- returns: <[Array]<[Object]>>
+  - alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -118,7 +119,8 @@ Returns the matching [Request] object.
 
 ## async method: Response.securityDetails
 * since: v1.13
-- returns: <[null]|[Object=ResponseSecurityDetailsResult]>
+- returns: <[null]|[Object]>
+  - alias-csharp: ResponseSecurityDetailsResult
   - `issuer` ?<[string]> Common Name component of the Issuer field.
     from the certificate. This should only be used for informational purposes. Optional.
   - `protocol` ?<[string]> The specific TLS protocol used. (e.g. `TLS 1.3`). Optional.
@@ -133,7 +135,8 @@ Returns SSL and other security information.
 
 ## async method: Response.serverAddr
 * since: v1.13
-- returns: <[null]|[Object=ResponseServerAddrResult]>
+- returns: <[null]|[Object]>
+  - alias-csharp: ResponseServerAddrResult
   - `ipAddress` <[string]> IPv4 or IPV6 address of the server.
   - `port` <[int]>
 

--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -50,6 +50,7 @@ You can use [`method: Response.allHeaders`] for complete list of headers that in
 * since: v1.15
 - returns: <[Array]<[Object]>>
   - alias-csharp: Header
+  - alias-java: HttpHeader
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -121,6 +122,7 @@ Returns the matching [Request] object.
 * since: v1.13
 - returns: <[null]|[Object]>
   - alias-csharp: ResponseSecurityDetailsResult
+  - alias-java: SecurityDetails
   - `issuer` ?<[string]> Common Name component of the Issuer field.
     from the certificate. This should only be used for informational purposes. Optional.
   - `protocol` ?<[string]> The specific TLS protocol used. (e.g. `TLS 1.3`). Optional.
@@ -137,6 +139,7 @@ Returns SSL and other security information.
 * since: v1.13
 - returns: <[null]|[Object]>
   - alias-csharp: ResponseServerAddrResult
+  - alias-java: ServerAddr
   - `ipAddress` <[string]> IPv4 or IPV6 address of the server.
   - `port` <[int]>
 

--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -31,7 +31,8 @@ await page.screencast.stop();
 
 ### option: Screencast.start.onFrame
 * since: v1.59
-- `onFrame` <[function]\([Object=ScreencastFrame]\): [Promise]>
+- `onFrame` <[function]\([Object]\): [Promise]>
+  - alias-csharp: ScreencastFrame
   - `data` <[Buffer]> JPEG-encoded frame data.
 
 Callback that receives JPEG-encoded frame data.
@@ -51,7 +52,8 @@ The quality of the image, between 0-100.
 ### option: Screencast.start.size
 * since: v1.59
 * langs: js
-- `size` ?<[Object=ScreencastSize]>
+- `size` ?<[Object]>
+  - alias-csharp: ScreencastSize
   - `width` <[int]> Max frame width in pixels.
   - `height` <[int]> Max frame height in pixels.
 

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -367,6 +367,7 @@ Group name shown in the trace viewer.
 ### option: Tracing.group.location
 * since: v1.49
 - `location` ?<[Object]>
+  - alias-java: Location
   - `file` <[string]>
   - `line` ?<[int]>
   - `column` ?<[int]>

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -126,7 +126,8 @@ and Linux and to "Meta" on macOS.
 Defaults to `left`.
 
 ## input-files
-- `files` <[path]|[Array]<[path]>|[Object=FilePayload]|[Array]<[Object=FilePayload]>>
+- `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
+  - alias-csharp: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -805,12 +806,14 @@ When set to `minimal`, only record information necessary for routing from HAR. T
 * langs: js
 - `recordVideo` <[Object]>
   - `dir` ?<[path]> Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see [`method: BrowserType.launch`] options).
-  - `size` ?<[Object=RecordVideoSize]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
+  - `size` ?<[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
     scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
     Actual picture of each page will be scaled down if necessary to fit the specified size.
+    - alias-csharp: RecordVideoSize
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
-  - `showActions` ?<[Object=ShowActionsOptions]> If specified, enables visual annotations on interacted elements during video recording.
+  - `showActions` ?<[Object]> If specified, enables visual annotations on interacted elements during video recording.
+    - alias-csharp: ShowActionsOptions
     - `duration` ?<[float]> How long each annotation is displayed in milliseconds. Defaults to `500`.
     - `position` ?<[AnnotatePosition]<"top-left"|"top"|"top-right"|"bottom-left"|"bottom"|"bottom-right">> Position of the action title overlay. Defaults to `"top-right"`.
     - `fontSize` ?<[int]> Font size of the action title in pixels. Defaults to `24`.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -97,6 +97,7 @@ A selector to search for an element to drop onto. If there are multiple elements
 
 ## input-position
 - `position` <[Object]>
+  - alias-java: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -128,6 +129,7 @@ Defaults to `left`.
 ## input-files
 - `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
   - alias-csharp: FilePayload
+  - alias-java: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -154,6 +156,7 @@ When set, this method only performs the [actionability](../actionability.md) che
 
 ## input-source-position
 - `sourcePosition` <[Object]>
+  - alias-java: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -161,6 +164,7 @@ Clicks on the source element at this point relative to the top-left corner of th
 
 ## input-target-position
 - `targetPosition` <[Object]>
+  - alias-java: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -236,6 +240,7 @@ Dangerous option; use with care. Defaults to `false`.
 
 ## browser-option-proxy
 - `proxy` <[Object]>
+  - alias-java: Proxy
   - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example
     `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
     proxy.
@@ -332,6 +337,7 @@ When using [`method: Page.goto`], [`method: Page.route`], [`method: Page.waitFor
 * langs: js, java
   - alias-java: viewportSize
 - `viewport` <[null]|[Object]>
+  - alias-java: ViewportSize
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
@@ -365,6 +371,7 @@ It makes the execution of the tests non-deterministic.
   - alias-java: screenSize
   - alias-csharp: screenSize
 - `screen` <[Object]>
+  - alias-java: ScreenSize
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
@@ -595,6 +602,7 @@ Does not enforce fixed viewport, allows resizing window in the headed mode.
 
 ## context-option-clientCertificates
 - `clientCertificates` <[Array]<[Object]>>
+  - alias-java: ClientCertificate
   - `origin` <[string]> Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
   - `certPath` ?<[path]> Path to the file with the certificate in PEM format.
   - `cert` ?<[Buffer]> Direct value of the certificate in PEM format.
@@ -649,6 +657,7 @@ for a list of supported timezone IDs. Defaults to the system timezone.
 
 ## context-option-geolocation
 - `geolocation` <[Object]>
+  - alias-java: Geolocation
   - `latitude` <[float]> Latitude between -90 and 90.
   - `longitude` <[float]> Longitude between -180 and 180.
   - `accuracy` ?<[float]> Non-negative accuracy value. Defaults to `0`.
@@ -676,6 +685,7 @@ Whether to emulate network being offline. Defaults to `false`. Learn more about 
 
 ## context-option-httpcredentials
 - `httpCredentials` <[Object]>
+  - alias-java: HttpCredentials
   - `username` <[string]>
   - `password` <[string]>
   - `origin` ?<[string]> Restrain sending http credentials on specific origin (scheme://host:port).
@@ -833,6 +843,7 @@ not recorded. Make sure to call [`method: BrowserContext.close`] for videos to b
 * langs: csharp, java, python
   - alias-python: record_video_size
 - `recordVideoSize` <[Object]>
+  - alias-java: RecordVideoSize
   - `width` <[int]> Video frame width.
   - `height` <[int]> Video frame height.
 
@@ -842,6 +853,7 @@ Actual picture of each page will be scaled down if necessary to fit the specifie
 
 ## context-option-proxy
 - `proxy` <[Object]>
+  - alias-java: Proxy
   - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example
     `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
   - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
@@ -889,6 +901,7 @@ Specifies whether to wait for already running handlers and what to do if they th
 ## select-options-values
 * langs: java, js, csharp
 - `values` <[null]|[string]|[ElementHandle]|[Array]<[string]>|[Object]|[Array]<[ElementHandle]>|[Array]<[Object]>>
+  - alias-java: SelectOption
   - `value` ?<[string]> Matches by `option.value`. Optional.
   - `label` ?<[string]> Matches by `option.label`. Optional.
   - `index` ?<[int]> Matches by the index. Optional.
@@ -1293,6 +1306,7 @@ When true, takes a screenshot of the full scrollable page, instead of the curren
 
 ## screenshot-option-clip
 - `clip` <[Object]>
+  - alias-java: Clip
   - `x` <[float]> x-coordinate of top-left corner of clip area
   - `y` <[float]> y-coordinate of top-left corner of clip area
   - `width` <[float]> width of clipping area

--- a/utils/doclint/api_parser.js
+++ b/utils/doclint/api_parser.js
@@ -230,13 +230,21 @@ class ApiParser {
   parseType(spec, since) {
     const arg = parseVariable(spec.text);
     const properties = [];
+    /** @type {Object<string, string>} */
+    const langAliases = {};
     for (const child of /** @type {MarkdownLiNode[]} */ (spec.children) || []) {
-      const { name, text } = parseVariable(/** @type {string} */(child.text));
+      const childText = /** @type {string} */(child.text);
+      const aliasMatch = childText.match(/^alias(?:-(\w+))?\s*:\s*(.*)$/);
+      if (aliasMatch) {
+        langAliases[aliasMatch[1] || 'default'] = aliasMatch[2].trim();
+        continue;
+      }
+      const { name, text } = parseVariable(childText);
       const comments = /** @type {MarkdownNode[]} */ ([{ type: 'text', text }]);
       const childType = this.parseType(child, since);
       properties.push(docs.Member.createProperty({ langs: {}, since, deprecated: undefined, discouraged: undefined }, name, childType.type, comments, !childType.optional));
     }
-    const type = docs.Type.parse(arg.type, properties);
+    const type = docs.Type.parse(arg.type, properties, langAliases);
     return { type, optional: arg.optional };
   }
 }

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -497,18 +497,22 @@ class Type {
       return type;
     const types = [];
     type._collectAllTypes(types);
-    let success = false;
+    let assignedToObject = false;
     for (const t of types) {
       if (t.name === 'Object') {
         if (properties.length)
           t.properties = properties;
         if (hasAliases)
           t.langAliases = { ...langAliases };
-        success = true;
+        assignedToObject = true;
       }
     }
-    if (!success)
-      throw new Error('Nested properties or aliases given, but there are no objects in type expression: ' + expression);
+    if (!assignedToObject) {
+      if (properties.length)
+        throw new Error('Nested properties given, but there are no objects in type expression: ' + expression);
+      if (hasAliases)
+        type.langAliases = { ...langAliases };
+    }
     return type;
   }
 

--- a/utils/doclint/documentation.js
+++ b/utils/doclint/documentation.js
@@ -483,27 +483,32 @@ class Type {
   /**
    * @param {string} expression
    * @param {!Array<!Member>=} properties
+   * @param {!Object<string, string>=} langAliases
    * @return {Type}
    */
-  static parse(expression, properties = []) {
+  static parse(expression, properties = [], langAliases = {}) {
     expression = expression.replace(/\\\(/g, '(').replace(/\\\)/g, ')');
     const type = Type.fromParsedType(parseTypeExpression(expression));
     type.expression = expression;
     if (type.name === 'number')
       throw new Error('Number types should be either int or float, not number in: ' + expression);
-    if (!properties.length)
+    const hasAliases = Object.keys(langAliases).length > 0;
+    if (!properties.length && !hasAliases)
       return type;
     const types = [];
     type._collectAllTypes(types);
     let success = false;
     for (const t of types) {
       if (t.name === 'Object') {
-        t.properties = properties;
+        if (properties.length)
+          t.properties = properties;
+        if (hasAliases)
+          t.langAliases = { ...langAliases };
         success = true;
       }
     }
     if (!success)
-      throw new Error('Nested properties given, but there are no objects in type expression: ' + expression);
+      throw new Error('Nested properties or aliases given, but there are no objects in type expression: ' + expression);
     return type;
   }
 
@@ -545,13 +550,6 @@ class Type {
       return type;
     }
 
-    const stripped = parsedType.name.replace(/^\[/, '').replace(/\]$/, '');
-    const eqIndex = stripped.indexOf('=');
-    if (eqIndex !== -1) {
-      const type = new Type(stripped.substring(0, eqIndex));
-      type.structName = stripped.substring(eqIndex + 1);
-      return type;
-    }
     return new Type(parsedType.name);
   }
 
@@ -573,8 +571,8 @@ class Type {
     this.templates = undefined;
     /** @type {string | undefined} */
     this.expression = undefined;
-    /** @type {string | undefined} */
-    this.structName = undefined;
+    /** @type {Object<string, string> | undefined} */
+    this.langAliases = undefined;
   }
 
   visit(visitor) {
@@ -597,7 +595,8 @@ class Type {
     if (this.templates)
       type.templates = this.templates.map(type => type.clone());
     type.expression = this.expression;
-    type.structName = this.structName;
+    if (this.langAliases)
+      type.langAliases = { ...this.langAliases };
     return type;
   }
 

--- a/utils/doclint/generateDotnetApi.js
+++ b/utils/doclint/generateDotnetApi.js
@@ -389,9 +389,10 @@ function getPropertyOverloads(type, member, name, parent) {
  * @param {*} parent
  */
 function generateNameDefault(member, name, t, parent) {
-  if (t.structName) {
-    registerModelType(t.structName, t);
-    return t.structName;
+  const structName = t.langAliases?.csharp || t.langAliases?.default;
+  if (structName) {
+    registerModelType(structName, t);
+    return structName;
   }
 
   if (!t.properties


### PR DESCRIPTION
## Summary
- Replace `[Object=Name]` with `- alias:` / `- alias-LANG:` child bullets so language ports can override the struct name independently.
- Add `alias-java` entries for every top-level Object/function type the Java port currently customizes via its hardcoded `customTypeNames` map and `toTitle(parent.jsonName)` inference, so the Java generator can be simplified after the next roll.

C# generator output is byte-identical to baseline.