### PR TITLE
Add better error message for CBOR-related errors

### DIFF
--- a/packages/playwright-core/src/server/chromium/crExecutionContext.ts
+++ b/packages/playwright-core/src/server/chromium/crExecutionContext.ts
@@ -100,9 +100,10 @@ function rewriteError(error: Error): Protocol.Runtime.evaluateReturnValue {
     throw new Error('Cannot serialize result: object reference chain is too long.');
   if (error.message.includes('Object couldn\'t be returned by value'))
     return { result: { type: 'undefined' } };
-
+  if (error.message.includes('Failed to convert response to JSON'))
+    throw rewriteErrorMessage(error, error.message + '. The serialized object may be too large.');
   if (error instanceof TypeError && error.message.startsWith('Converting circular structure to JSON'))
-    rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');
+    throw rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');
   if (!js.isJavaScriptErrorInEvaluate(error) && !isSessionClosedError(error))
     throw new Error('Execution context was destroyed, most likely because of a navigation.');
   throw error;

--- a/packages/playwright-core/src/server/firefox/ffExecutionContext.ts
+++ b/packages/playwright-core/src/server/firefox/ffExecutionContext.ts
@@ -105,7 +105,7 @@ function rewriteError(error: Error): (Protocol.Runtime.evaluateReturnValue | Pro
   if (error.message.includes('cyclic object value') || error.message.includes('Object is not serializable'))
     return { result: { type: 'undefined', value: undefined } };
   if (error instanceof TypeError && error.message.startsWith('Converting circular structure to JSON'))
-    rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');
+    throw rewriteErrorMessage(error, error.message + ' Are you passing a nested JSHandle?');
   if (!js.isJavaScriptErrorInEvaluate(error) && !isSessionClosedError(error))
     throw new Error('Execution context was destroyed, most likely because of a navigation.');
   throw error;


### PR DESCRIPTION
# Summary

This PR adjusts the `rewriteError` function for Chromium to output the full error message if the message contains the phrase `Failed to convert response to JSON`. It also fixes a couple of cases where the result of `rewriteErrorMessage` wasn't being used because a generic error message is thrown instead.

# Problem

In our app, we were accidentally retrieving a very large object from a `JSHandle` using `jsonValue` (whereas we actually only needed to check whether it was null). This failed in Chromium, but with the unhelpful error message `Execution context was destroyed, most likely because of a navigation.`

The real error message (found by adding `console.log`s to `rewriteError`) was:

```
ProtocolError: Protocol error (Runtime.callFunctionOn): Failed to convert response to JSON: CBOR: stack limit exceeded at position 147857
```

# Solution

I've added a check for this error message in `rewriteError`, so that it instead outputs:

```
Error: jsHandle.jsonValue: Protocol error (Runtime.callFunctionOn): Failed to convert response to JSON: CBOR: stack limit exceeded at position 147857. The serialized object may be too large.
```

This error message (particularly `The serialized object may be too large.`) would have made it easier for me to locate and fix the actual cause of the problem much sooner.

# Testing

I haven't added test a test for this change, mainly because I'm not sure what exactly about the object we're passing causes the `stack limit exceeded` error. I can see that Playwright already has tests for objects that are too deep, but this appears to be unrelated. I also don't think it's related to circular object structures, since this is covered under an existing error message.

I have, however, verified that this change produces the correct error message in our application.