### PR TITLE
fix(test): ensure video frames arrive in flaky video tests

### DIFF
--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -204,6 +204,11 @@ export async function rafraf(target: Page | Frame, count = 1) {
   }
 }
 
+export async function ensureSomeFrames(page: Page) {
+  await rafraf(page, 100);
+  await page.screenshot();
+}
+
 export function roundBox(box: BoundingBox): BoundingBox {
   return {
     x: Math.round(box.x),

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import WebSocket from 'ws';
 import { expect, playwrightTest } from '../config/browserTest';
-import { parseTraceRaw, suppressCertificateWarning, rafraf } from '../config/utils';
+import { ensureSomeFrames, parseTraceRaw, suppressCertificateWarning } from '../config/utils';
 import formidable from 'formidable';
 import type { Browser, ConnectOptions } from 'playwright-core';
 
@@ -500,7 +500,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       });
       const page = await context.newPage();
       await page.evaluate(() => document.body.style.backgroundColor = 'red');
-      await rafraf(page, 100);
+      await ensureSomeFrames(page);
       await context.close();
 
       test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36685' });
@@ -521,7 +521,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       });
       const page = await context.newPage();
       await page.evaluate(() => document.body.style.backgroundColor = 'red');
-      await rafraf(page, 100);
+      await ensureSomeFrames(page);
       await context.close();
 
       const savedAsPath = testInfo.outputPath('my-video.webm');
@@ -541,7 +541,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       });
       const page = await context.newPage();
       await page.evaluate(() => document.body.style.backgroundColor = 'red');
-      await rafraf(page, 100);
+      await ensureSomeFrames(page);
       await context.close();
 
       expect(fs.existsSync(path.join(artifactsDir, (page as any)._guid + '.webm'))).toBeTruthy();

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import { expect, browserTest as test } from '../config/browserTest';
-import { rafraf } from '../config/utils';
+import { ensureSomeFrames } from '../config/utils';
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { VideoPlayer } from './videoPlayer';
 
@@ -35,7 +35,7 @@ test('screencast.start delivers frames via onFrame callback', async ({ browser, 
   await page.screencast.start({ onFrame: ({ data }) => frames.push(data), size });
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.screencast.stop();
 
   expect(frames.length).toBeGreaterThan(0);
@@ -86,7 +86,7 @@ test('start returns a disposable that stops screencast', async ({ browser, serve
   await page.screencast.start({ onFrame: ({ data }) => frames.push(data), size: { width: 500, height: 400 } });
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.screencast.stop();
 
   const frameCountAfterDispose = frames.length;
@@ -94,7 +94,7 @@ test('start returns a disposable that stops screencast', async ({ browser, serve
 
   // No more frames should arrive after dispose.
   await page.evaluate(() => document.body.style.backgroundColor = 'blue');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   expect(frames.length).toBe(frameCountAfterDispose);
 
   await context.close();
@@ -110,12 +110,12 @@ test('start/stop twice without path creates two files in artifactsDir', async ({
 
   await page.screencast.start({ path: testInfo.outputPath('video1.webm'), size });
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.screencast.stop();
 
   await page.screencast.start({ path: testInfo.outputPath('video2.webm'), size });
   await page.evaluate(() => document.body.style.backgroundColor = 'blue');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.screencast.stop();
 
   const videoFiles = fs.readdirSync(artifactsDir).filter(f => f.endsWith('.webm'));
@@ -138,7 +138,7 @@ test('start should work when recordVideo is set', async ({ browser }, testInfo) 
 
   await page.screencast.start({ path: path.join(manualDir, 'video.webm') });
   await page.evaluate(() => document.body.style.backgroundColor = 'blue');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.screencast.stop();
   const videoFiles1 = fs.readdirSync(manualDir).filter(f => f.endsWith('.webm'));
   expect(videoFiles1).toHaveLength(1);
@@ -169,7 +169,7 @@ test('start should finish when page is closed', async ({ browser }, testInfo) =>
   const videoPath = testInfo.outputPath('video.webm');
   await page.screencast.start({ path: videoPath, size: { width: 800, height: 800 } });
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await page.close();
   const error = await page.screencast.stop().catch(e => e);
   expect(error.message).toContain(kTargetClosedErrorMessage);
@@ -196,7 +196,7 @@ test('start dispose stops recording', async ({ browser }, testInfo) => {
   const videoPath = testInfo.outputPath('dispose-video.webm');
   const disposable = await page.screencast.start({ path: videoPath, size });
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await disposable.dispose();
   expectRedFrames(videoPath, size);
   await context.close();

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { jpegjs } from 'playwright-core/lib/utilsBundle';
 import { expect, browserTest as it } from '../config/browserTest';
-import { parseTraceRaw, rafraf } from '../config/utils';
+import { ensureSomeFrames, parseTraceRaw } from '../config/utils';
 import { VideoPlayer } from './videoPlayer';
 
 type Pixel = { r: number, g: number, b: number, alpha: number };
@@ -128,7 +128,7 @@ it.describe('screencast', () => {
     const page = await context.newPage();
 
     await page.evaluate(() => document.body.style.backgroundColor = 'red');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -158,7 +158,7 @@ it.describe('screencast', () => {
       document.body.textContent = ''; // remove link
       document.body.style.backgroundColor = 'red';
     });
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -196,7 +196,7 @@ it.describe('screencast', () => {
     const page = await context.newPage();
     const deletePromise = page.video().delete();
     await page.evaluate(() => document.body.style.backgroundColor = 'red');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoPath = await page.video().path();
@@ -287,9 +287,9 @@ it.describe('screencast', () => {
     const page = await context.newPage();
 
     await page.goto(server.PREFIX + '/background-color.html#rgb(0,0,0)');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await page.goto(server.CROSS_PROCESS_PREFIX + '/background-color.html#rgb(100,100,100)');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -325,7 +325,7 @@ it.describe('screencast', () => {
     const page = await context.newPage();
 
     await page.goto(server.PREFIX + '/rotate-z.html');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -359,8 +359,8 @@ it.describe('screencast', () => {
     ]);
     await popup.evaluate(() => document.body.style.backgroundColor = 'red');
     await Promise.all([
-      rafraf(page, 100),
-      rafraf(popup, 100),
+      ensureSomeFrames(page),
+      ensureSomeFrames(popup),
     ]);
     await context.close();
 
@@ -392,11 +392,11 @@ it.describe('screencast', () => {
     await page.$eval('.container', container => {
       container.firstElementChild.classList.remove('red');
     });
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await page.$eval('.container', container => {
       container.firstElementChild.classList.add('red');
     });
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -432,7 +432,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -449,7 +449,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -469,7 +469,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -490,7 +490,7 @@ it.describe('screencast', () => {
     });
 
     await page.evaluate(() => document.body.style.backgroundColor = 'red');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -519,7 +519,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.close();
 
     const videoFile = await page.video().path();
@@ -540,7 +540,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await browser.close();
 
     const file = testInfo.outputPath('saved-video-');
@@ -561,7 +561,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await (browser as any)._channel.killForTests();
 
     const file = testInfo.outputPath('saved-video-');
@@ -583,7 +583,7 @@ it.describe('screencast', () => {
     });
 
     const page = await context.newPage();
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await page.close();
     await context.close();
     await browser.close();
@@ -638,7 +638,7 @@ it.describe('screencast', () => {
 
     const page = await context.newPage();
     await page.goto(server.EMPTY_PAGE);
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
 
     const cookies = await context.cookies();
     expect(cookies.length).toBe(1);
@@ -667,7 +667,7 @@ it.describe('screencast', () => {
 
     const page = await context.newPage();
     await page.setContent(`<div style='margin: 0; background: red; position: fixed; right:0; bottom:0; width: 30; height: 30;'></div>`);
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await page.close();
     await context.close();
     await browser.close();
@@ -704,7 +704,7 @@ it.describe('screencast', () => {
 
     const page = await context.newPage();
     await page.setContent(`<div style='margin: 0; background: red; position: fixed; right:0; bottom:0; width: 30; height: 30;'></div>`);
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await page.close();
     await context.close();
     await browser.close();
@@ -740,7 +740,7 @@ it.describe('screencast', () => {
     const page = await context.newPage();
 
     await page.evaluate(() => document.body.style.backgroundColor = 'red');
-    await rafraf(page, 100);
+    await ensureSomeFrames(page);
     await context.tracing.stop({ path: traceFile });
     await context.close();
 
@@ -779,7 +779,7 @@ it('should saveAs video', async ({ browser }, testInfo) => {
   });
   const page = await context.newPage();
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
-  await rafraf(page, 100);
+  await ensureSomeFrames(page);
   await context.close();
 
   const saveAsPath = testInfo.outputPath('my-video.webm');


### PR DESCRIPTION
## Summary
- Add `ensureSomeFrames()` helper that calls `rafraf(page, 100)` + `page.screenshot()` to reliably force video frames
- Replace bare `rafraf(page, 100)` calls in video, screencast, and browsertype-connect tests