### PR TITLE
chore(test): use expect(page).toMatchAriaSnapshot in ui-mode and reporter tests

### DIFF
--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -710,7 +710,7 @@ test('generate html with attachment urls', async ({ runInlineTest, mergeReports,
   // Check that trace loads.
   await page.locator('.test-file-test').filter({ hasText: /failing 1/ }).getByRole('link', { name: 'View Trace' }).click();
   await expect(page).toHaveTitle('Playwright Trace Viewer');
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /Expect "toBe" \\d+[hmsp]+/ [selected]
   `);
@@ -2290,7 +2290,7 @@ test('shard chart', async ({ runInlineTest, writeFiles, showReport, page, mergeR
 
   await page.getByRole('link', { name: 'Speedboard' }).click();
 
-  await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - button "Timeline"
     - region:
       - img:

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3098,7 +3098,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
       const reportPath = path.join(test.info().outputPath(), 'playwright-report', 'index.html');
       await page.goto(url.pathToFileURL(reportPath).toString());
-      await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+      await expect(page).toMatchAriaSnapshot(`
         - button "tests/a/test.spec.ts"
         - button "tests/b/test.spec.ts"
       `);
@@ -3203,7 +3203,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       expect(result.exitCode).toBe(0);
       await showReport();
       await page.getByRole('link', { name: 'sample' }).click();
-      await expect(page.locator('body')).toMatchAriaSnapshot(`
+      await expect(page).toMatchAriaSnapshot(`
         - treeitem "Click Click me"
       `);
     });
@@ -3405,7 +3405,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await page.getByRole('link', { name: 'Speedboard' }).click();
         await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
-        await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+        await expect(page).toMatchAriaSnapshot(`
           - button "Slowest Tests"
           - region:
             - list:
@@ -3429,7 +3429,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
                 - text: /bar/
         `);
         await page.getByText('foo').first().click();
-        await expect(page.getByRole('main')).toMatchAriaSnapshot(`
+        await expect(page).toMatchAriaSnapshot(`
           - button "Slowest Tests"
         `);
 
@@ -3503,7 +3503,7 @@ test('should support merge files option', async ({ runInlineTest, showReport, pa
   await page.getByRole('button', { name: 'Settings' }).click();
   await page.getByRole('checkbox', { name: 'Merge files' }).click();
 
-  await expect(page.locator('body')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - button "<anonymous>" [expanded]
     - region:
       - list:

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -61,7 +61,7 @@ test('should run visible', async ({ runUITest }) => {
         ⊘ skipped
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -121,7 +121,7 @@ test('should run on hover', async ({ runUITest }) => {
         ◯ fails
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -150,7 +150,7 @@ test('should run on double click', async ({ runUITest }) => {
         ◯ fails
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -180,7 +180,7 @@ test('should run on Enter', async ({ runUITest }) => {
         ❌ fails <=
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -221,7 +221,7 @@ test('should run by project', async ({ runUITest }) => {
         ⊘ skipped
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -259,7 +259,7 @@ test('should run by project', async ({ runUITest }) => {
       ► ◯ skipped
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -292,7 +292,7 @@ test('should run by project', async ({ runUITest }) => {
       ► ❌ fails
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -326,7 +326,7 @@ test('should run by project', async ({ runUITest }) => {
       ► ⊘ skipped
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -377,7 +377,7 @@ test('should stop', async ({ runUITest }) => {
         🕦 test 3
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-loading] a.test.ts" [expanded]:
         - group:
@@ -400,7 +400,7 @@ test('should stop', async ({ runUITest }) => {
         ◯ test 3
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -438,7 +438,7 @@ test('should run folder', async ({ runUITest }) => {
         ◯ passes
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] folder-b" [expanded] [selected]:
         - group:
@@ -471,7 +471,7 @@ test('should show time', async ({ runUITest }) => {
         ⊘ skipped
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-error] a.test.ts" [expanded]:
         - group:
@@ -515,7 +515,7 @@ test('should show test.fail as passing', async ({ runUITest }) => {
         ✅ should fail XXms
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -551,7 +551,7 @@ test('should ignore repeatEach', async ({ runUITest }) => {
         ✅ should pass
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -586,7 +586,7 @@ test('should remove output folder before test run', async ({ runUITest }) => {
         ✅ should pass
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -601,7 +601,7 @@ test('should remove output folder before test run', async ({ runUITest }) => {
         ✅ should pass
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -649,7 +649,7 @@ test('should show proper total when using deps', async ({ runUITest }) => {
         ◯ run @chromium
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -669,7 +669,7 @@ test('should show proper total when using deps', async ({ runUITest }) => {
         ✅ run @chromium <=
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -739,7 +739,7 @@ test('should respect --tsconfig option', {
         ✅ test
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:
@@ -768,7 +768,7 @@ test('should respect --ignore-snapshots option', {
         ✅ snapshot
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] a.test.ts" [expanded]:
         - group:

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -154,7 +154,7 @@ test('should run setup and teardown projects (1)', async ({ runUITest }) => {
         ✅ test
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] setup.ts" [expanded]:
         - group:
@@ -203,7 +203,7 @@ test('should run setup and teardown projects (2)', async ({ runUITest }) => {
         ✅ test
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] teardown.ts" [expanded]:
         - group:
@@ -247,7 +247,7 @@ test('should run setup and teardown projects (3)', async ({ runUITest }) => {
         ✅ test
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] test.ts" [expanded]:
         - group:
@@ -293,7 +293,7 @@ test('should run part of the setup only', async ({ runUITest }) => {
         ◯ test
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-check] setup.ts" [expanded] [selected]:
         - button "Run"

--- a/tests/playwright-test/ui-mode-test-shortcut.spec.ts
+++ b/tests/playwright-test/ui-mode-test-shortcut.spec.ts
@@ -49,7 +49,7 @@ test('should run tests', async ({ runUITest }) => {
         ✅ test 3
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -76,7 +76,7 @@ test('should stop tests', async ({ runUITest }) => {
         🕦 test 3
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-loading] a.test.ts" [expanded]:
         - group:

--- a/tests/playwright-test/ui-mode-test-source.spec.ts
+++ b/tests/playwright-test/ui-mode-test-source.spec.ts
@@ -40,7 +40,7 @@ test('should show selected test in sources', async ({ runUITest }) => {
         ◯ third
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -103,7 +103,7 @@ test('should show top-level errors in file', async ({ runUITest }) => {
         ◯ third
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts"
       - treeitem "[icon-circle-outline] b.test.ts" [expanded]:
@@ -138,7 +138,7 @@ test('should show syntax errors in file', async ({ runUITest }) => {
       ◯ a.test.ts
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts"
   `);

--- a/tests/playwright-test/ui-mode-test-tree.spec.ts
+++ b/tests/playwright-test/ui-mode-test-tree.spec.ts
@@ -47,7 +47,7 @@ test('should list tests', async ({ runUITest }) => {
         ◯ fails
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -114,7 +114,7 @@ test('should list all tests from projects with clashing names', async ({ runUITe
           ◯ two
   `);
 
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] bar" [expanded]:
         - group:
@@ -140,7 +140,7 @@ test('should traverse up/down', async ({ runUITest }) => {
         ◯ fails
       ► ◯ suite
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded] [selected]:
         - group:
@@ -156,7 +156,7 @@ test('should traverse up/down', async ({ runUITest }) => {
         ◯ fails
       ► ◯ suite
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -164,7 +164,7 @@ test('should traverse up/down', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] fails"
           - treeitem "[icon-circle-outline] suite" [expanded=false]
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot();
+  await expect(page).toMatchAriaSnapshot();
 
   await page.keyboard.press('ArrowDown');
   await expect.poll(dumpTestTree(page)).toContain(`
@@ -173,7 +173,7 @@ test('should traverse up/down', async ({ runUITest }) => {
         ◯ fails <=
       ► ◯ suite
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -181,7 +181,7 @@ test('should traverse up/down', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] fails" [selected]
           - treeitem "[icon-circle-outline] suite" [expanded=false]
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot();
+  await expect(page).toMatchAriaSnapshot();
 
   await page.keyboard.press('ArrowUp');
   await expect.poll(dumpTestTree(page)).toContain(`
@@ -190,7 +190,7 @@ test('should traverse up/down', async ({ runUITest }) => {
         ◯ fails
       ► ◯ suite
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -198,7 +198,7 @@ test('should traverse up/down', async ({ runUITest }) => {
           - treeitem "[icon-circle-outline] fails"
           - treeitem "[icon-circle-outline] suite" [expanded=false]
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot();
+  await expect(page).toMatchAriaSnapshot();
 });
 
 test('should expand / collapse groups', async ({ runUITest }) => {
@@ -214,7 +214,7 @@ test('should expand / collapse groups', async ({ runUITest }) => {
           ◯ inner passes
           ◯ inner fails
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -233,7 +233,7 @@ test('should expand / collapse groups', async ({ runUITest }) => {
         ◯ fails
       ► ◯ suite <=
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -249,7 +249,7 @@ test('should expand / collapse groups', async ({ runUITest }) => {
         ◯ passes
         ◯ fails
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded] [selected]:
         - group:
@@ -261,7 +261,7 @@ test('should expand / collapse groups', async ({ runUITest }) => {
   await expect.poll(dumpTestTree(page)).toContain(`
     ► ◯ a.test.ts <=
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [selected] [expanded=false]
   `);
@@ -290,7 +290,7 @@ test('should merge folder trees', async ({ runUITest }) => {
     ▼ ◯ in-a.test.ts
         ◯ passes
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] b" [expanded]:
         - group:
@@ -326,7 +326,7 @@ test('should list parametrized tests', async ({ runUITest }) => {
           ◯ test DE
           ◯ test LT
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -362,7 +362,7 @@ test('should update parametrized tests', async ({ runUITest, writeFiles }) => {
           ◯ test DE
           ◯ test LT
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -393,7 +393,7 @@ test('should update parametrized tests', async ({ runUITest, writeFiles }) => {
           ◯ test FR
           ◯ test LT
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -417,7 +417,7 @@ test('should collapse all', async ({ runUITest }) => {
           ◯ inner passes
           ◯ inner fails
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -433,7 +433,7 @@ test('should collapse all', async ({ runUITest }) => {
   await expect.poll(dumpTestTree(page)).toContain(`
     ► ◯ a.test.ts
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded=false]
   `);
@@ -463,7 +463,7 @@ test('should expand all', {
         ◯ passes
         ◯ fails
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -566,7 +566,7 @@ test('should resolve title conflicts', async ({ runUITest }) => {
           ◯ bar
           ◯ bar 2
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] a.test.ts" [expanded]:
         - group:
@@ -617,7 +617,7 @@ test('should merge files', async ({ runUITest }) => {
         ◯ second
         ◯ fifth
   `);
-  await expect(page.getByTestId('test-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem "[icon-circle-outline] <anonymous>" [expanded]:
         - group:

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -70,7 +70,7 @@ test('should work with non-existing rootDir and testDir outside of it', {
   });
 
   await page.getByText('example test').dblclick();
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /Before Hooks/
     - treeitem /Set content/ [selected]
     - treeitem /After Hooks/
@@ -207,7 +207,7 @@ test('should show snapshots for steps', {
 
   await page.getByText('steps test').dblclick();
 
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /Before Hooks/
       - treeitem /first/
@@ -448,7 +448,7 @@ test('should work behind reverse proxy', { annotation: { type: 'issue', descript
 
   await page.getByText('trace test').dblclick();
 
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /Before Hooks/
       - treeitem /Set content/
@@ -557,7 +557,7 @@ test('should hide boxed fixtures and contents, reveal upon show all actions sett
   });
 
   await page.getByText('example').dblclick();
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /Before Hooks/
       - treeitem /Expect "toBeVisible"/
@@ -573,7 +573,7 @@ test('should hide boxed fixtures and contents, reveal upon show all actions sett
   await page.getByTestId('actions-tree').getByRole('treeitem', { name: 'Before Hooks' }).locator('.codicon-chevron-right').click();
   await page.getByTestId('actions-tree').getByRole('treeitem', { name: 'Fixture "fixture"' }).locator('.codicon-chevron-right').click();
 
-  await expect(page.getByTestId('actions-tree')).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /Before Hooks/:
         - group:
@@ -619,7 +619,7 @@ test('attachments tab shows all but top-level .push attachments', async ({ runUI
   const actionsTree = page.getByTestId('actions-tree');
   await actionsTree.getByRole('treeitem', { name: 'step' }).click();
   await page.keyboard.press('ArrowRight');
-  await expect(actionsTree, 'attach() and top-level attachments.push calls are shown as actions').toMatchAriaSnapshot(`
+  await expect(page, 'attach() and top-level attachments.push calls are shown as actions').toMatchAriaSnapshot(`
     - tree:
       - treeitem /step/:
         - group:
@@ -655,7 +655,7 @@ test('skipped steps should have an indicator', async ({ runUITest }) => {
   const actionsTree = page.getByTestId('actions-tree');
   await actionsTree.getByRole('treeitem', { name: 'outer' }).click();
   await page.keyboard.press('ArrowRight');
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - tree:
       - treeitem /outer/ [expanded]:
         - group:
@@ -783,7 +783,7 @@ test('should partition action tree state by test', async ({ runUITest }) => {
   await actionsTree.getByRole('treeitem', { name: 'After Hooks' }).click();
   await page.keyboard.press('ArrowRight');
 
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /After Hooks/ [expanded] [selected]:
       - group:
         - treeitem /Fixture \"page\"/
@@ -792,7 +792,7 @@ test('should partition action tree state by test', async ({ runUITest }) => {
 
   await page.getByTestId('test-tree').getByText('test2').click();
 
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /Evaluate/ [selected]
     - treeitem /After Hooks/ [expanded=false]:
       - /children: equal
@@ -800,7 +800,7 @@ test('should partition action tree state by test', async ({ runUITest }) => {
 
   await page.getByTestId('test-tree').getByText('test1').click();
 
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /Evaluate/ [selected=false]
     - treeitem /After Hooks/ [expanded] [selected]:
       - group:
@@ -818,12 +818,10 @@ test('should update state on subsequent run', async ({ runUITest, writeFiles }) 
       });
     `,
   });
-  const actionsTree = page.getByTestId('actions-tree');
-
   await page.getByTestId('test-tree').getByText('test1').click();
   await page.keyboard.press('Enter');
 
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /Evaluate/ [selected]
   `);
 
@@ -839,7 +837,7 @@ test('should update state on subsequent run', async ({ runUITest, writeFiles }) 
 
   await page.keyboard.press('Enter');
 
-  await expect(actionsTree).toMatchAriaSnapshot(`
+  await expect(page).toMatchAriaSnapshot(`
     - treeitem /Expect \"toBe\"/
   `);
 });


### PR DESCRIPTION
## Summary
- Replace `expect(locator).toMatchAriaSnapshot()` with `expect(page).toMatchAriaSnapshot()` for test-tree, actions-tree, body, and main role assertions across ui-mode and reporter tests
- 70 assertions updated across 8 test files