### PR TITLE
chore(chromium): reenable RenderDocument again

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -40,8 +40,6 @@ const disabledFeatures = (assistantMode?: boolean) => [
   'Translate',
   // See https://issues.chromium.org/u/1/issues/435410220
   'AutoDeElevate',
-  // See https://github.com/microsoft/playwright/issues/37714
-  'RenderDocument',
   // Prevents downloading optimization hints on startup.
   'OptimizationHints',
   assistantMode ? 'AutomationControlled' : '',


### PR DESCRIPTION
Chromium 147+ includes the fixes. Closes #37714.