### PR TITLE
fix(firefox): commit navigation before init scripts

### DIFF
--- a/browser_patches/firefox/juggler/content/FrameTree.js
+++ b/browser_patches/firefox/juggler/content/FrameTree.js
@@ -273,6 +273,9 @@ export class FrameTree {
     frame._lastCommittedNavigationId = navigationId;
     frame._url = url;
     this.emit(FrameTree.Events.NavigationCommitted, frame);
+    // Run new-document init scripts after the commit so they observe the committed URL
+    // and are reported after Page.navigationCommitted on the protocol.
+    frame._evaluateScriptsToEvaluateOnNewDocument();
     if (frame === this._mainFrame)
       this.forcePageReady();
   }
@@ -555,21 +558,28 @@ class Frame {
       if (name)
         this._createIsolatedContext(name);
       const executionContext = this._worldNameToContext.get(name);
-      // Add bindings before evaluating scripts.
+      // Install bindings eagerly; init scripts run once the document commits.
       for (const [name, script] of world._bindings)
         executionContext.addBinding(name, script);
-      for (const script of world._scriptsToEvaluateOnNewDocument)
-        executionContext.evaluateScriptSafely(script);
     }
 
     const url = this.domWindow().location?.href;
-    if (url === 'about:blank' && !this._url) {
+    if (url === 'about:blank' && !this._url && !this._pendingNavigationId) {
       // Sometimes FrameTree is created too early, before the location has been set.
-      this._url = url;
-      this._frameTree.emit(FrameTree.Events.NavigationCommitted, this);
+      this._frameTree._frameNavigationCommitted(this, url);
     }
 
     this._updateJavaScriptDisabled();
+  }
+
+  _evaluateScriptsToEvaluateOnNewDocument() {
+    for (const [name, world] of this._frameTree._isolatedWorlds) {
+      const executionContext = this._worldNameToContext.get(name);
+      if (!executionContext)
+        continue;
+      for (const script of world._scriptsToEvaluateOnNewDocument)
+        executionContext.evaluateScriptSafely(script);
+    }
   }
 
   _updateJavaScriptDisabled() {
@@ -680,5 +690,3 @@ function channelId(channel) {
   }
   return helper.generateId();
 }
-
-

--- a/tests/mcp/init-script.spec.ts
+++ b/tests/mcp/init-script.spec.ts
@@ -16,51 +16,56 @@
 
 import { test, expect } from './fixtures';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 
 for (const context of ['isolated', 'persistent']) {
-  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server, mcpBrowser }, testInfo) => {
-    // Create a temporary init script
-    const initScriptPath = testInfo.outputPath('init-script1.js');
-    const initScriptContent1 = `window.testInitScriptExecuted = true;`;
-    await fs.promises.writeFile(initScriptPath, initScriptContent1);
+  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server }) => {
+    const initScriptDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-mcp-init-script-'));
+    try {
+      // Create temporary init scripts outside the test output directory.
+      const initScriptPath = path.join(initScriptDir, 'init-script1.js');
+      const initScriptContent1 = `window.testInitScriptExecuted = true;`;
+      await fs.promises.writeFile(initScriptPath, initScriptContent1);
 
-    const initScriptPath2 = testInfo.outputPath('init-script2.js');
-    const initScriptContent2 = `console.log('Init script executed successfully');`;
-    await fs.promises.writeFile(initScriptPath2, initScriptContent2);
+      const initScriptPath2 = path.join(initScriptDir, 'init-script2.js');
+      const initScriptContent2 = `console.log('Init script executed successfully');`;
+      await fs.promises.writeFile(initScriptPath2, initScriptContent2);
 
-    // Start the client with the init script option
-    const { client: client } = await startClient({
-      args: [`--init-script=${initScriptPath}`, `--init-script=${initScriptPath2}`, ...(context === 'isolated' ? ['--isolated'] : [])]
-    });
+      // Start the client with the init script option
+      const { client: client } = await startClient({
+        args: [`--init-script=${initScriptPath}`, `--init-script=${initScriptPath2}`, ...(context === 'isolated' ? ['--isolated'] : [])]
+      });
 
-    // Navigate to a page and verify the init script was executed
-    await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: server.HELLO_WORLD },
-    });
+      // Navigate to a page and verify the init script was executed
+      await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: server.HELLO_WORLD },
+      });
 
-    await client.callTool({
-      name: 'browser_evaluate',
-      arguments: { function: '() => console.log("Custom log")' }
-    });
+      await client.callTool({
+        name: 'browser_evaluate',
+        arguments: { function: '() => console.log("Custom log")' }
+      });
 
-    // Check that the init script variables are available
-    expect(await client.callTool({
-      name: 'browser_evaluate',
-      arguments: { function: '() => window.testInitScriptExecuted' }
-    })).toHaveResponse({
-      result: 'true',
-    });
+      // Check that the init script variables are available
+      expect(await client.callTool({
+        name: 'browser_evaluate',
+        arguments: { function: '() => window.testInitScriptExecuted' }
+      })).toHaveResponse({
+        result: 'true',
+      });
 
-    expect(await client.callTool({
-      name: 'browser_console_messages',
-      // FIXME: in firefox commit event comes after console messages from the init script.
-      // See https://github.com/microsoft/playwright/issues/39624.
-      arguments: { all: mcpBrowser === 'firefox' }
-    })).toHaveResponse({
-      result: expect.stringMatching(/Init script executed successfully.*Custom log/ms),
-    });
+      expect(await client.callTool({
+        name: 'browser_console_messages',
+        arguments: {}
+      })).toHaveResponse({
+        result: expect.stringMatching(/Init script executed successfully.*Custom log/ms),
+      });
+    } finally {
+      await fs.promises.rm(initScriptDir, { recursive: true, force: true });
+    }
   });
 }
 

--- a/tests/page/page-add-init-script.spec.ts
+++ b/tests/page/page-add-init-script.spec.ts
@@ -124,6 +124,6 @@ it('init script should run only once in iframe', async ({ page, server, browserN
   await page.goto(server.PREFIX + '/frames/one-frame.html');
   expect(messages).toEqual([
     'init script: /frames/one-frame.html',
-    'init script: ' + (browserName === 'firefox' && !isBidi ? 'no url yet' : '/frames/frame.html'),
+    'init script: /frames/frame.html',
   ]);
 });


### PR DESCRIPTION
  ## Summary

  This fixes the Firefox/Juggler ordering issue from #39624.

  Before this change, Firefox could create the new document execution context and run init scripts before `Page.navigationCommitted` was reported. Because of that, MCP could observe init script console messages before the navigation commit.

  This change updates the Firefox Juggler frame lifecycle so new-document init scripts run after the navigation commit is reported. It also avoids committing the initial synthetic `about:blank` while a real navigation is still pending.

  The tests were updated to check the new behavior directly:
  - removed the Firefox workaround from the MCP init-script test
  - tightened the Firefox iframe init-script expectation to match the committed frame URL

  ## Testing

  Tested against a patched Firefox app copy with the updated `FrameTree.js` in `omni.ja`.

  - `PLAYWRIGHT_MCP_EXECUTABLE_PATH=/tmp/pwff39624.YQBUwG/Nightly.app/Contents/MacOS/firefox npm run test-mcp -- --project=firefox tests/mcp/init-script.spec.ts`
  - `CI=1 FFPATH=/tmp/pwff39624.YQBUwG/Nightly.app/Contents/MacOS/firefox npm run test -- --project=firefox-page tests/page/page-add-init-script.spec.ts`