### PR TITLE
chore: support macOS 26 Tahoe

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -172,6 +172,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
     'mac15': cftUrl('mac-x64/chrome-mac-x64.zip'),
     'mac15-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
+    'mac26': cftUrl('mac-x64/chrome-mac-x64.zip'),
+    'mac26-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
     'win64': cftUrl('win64/chrome-win64.zip'),
   },
   'chromium-headless-shell': {
@@ -203,6 +205,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
     'mac15': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
     'mac15-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    'mac26': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac26-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
     'win64': cftUrl('win64/chrome-headless-shell-win64.zip'),
   },
   'chromium-tip-of-tree': {
@@ -234,6 +238,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
     'mac15': cftUrl('mac-x64/chrome-mac-x64.zip'),
     'mac15-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
+    'mac26': cftUrl('mac-x64/chrome-mac-x64.zip'),
+    'mac26-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
     'win64': cftUrl('win64/chrome-win64.zip'),
   },
   'chromium-tip-of-tree-headless-shell': {
@@ -265,6 +271,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
     'mac15': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
     'mac15-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    'mac26': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac26-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
     'win64': cftUrl('win64/chrome-headless-shell-win64.zip'),
   },
   'firefox': {
@@ -296,6 +304,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': 'builds/firefox/%s/firefox-mac-arm64.zip',
     'mac15': 'builds/firefox/%s/firefox-mac.zip',
     'mac15-arm64': 'builds/firefox/%s/firefox-mac-arm64.zip',
+    'mac26': 'builds/firefox/%s/firefox-mac.zip',
+    'mac26-arm64': 'builds/firefox/%s/firefox-mac-arm64.zip',
     'win64': 'builds/firefox/%s/firefox-win64.zip',
   },
   'firefox-beta': {
@@ -327,6 +337,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
     'mac15': 'builds/firefox-beta/%s/firefox-beta-mac.zip',
     'mac15-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
+    'mac26': 'builds/firefox-beta/%s/firefox-beta-mac.zip',
+    'mac26-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
     'win64': 'builds/firefox-beta/%s/firefox-beta-win64.zip',
   },
   'webkit': {
@@ -358,6 +370,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': 'builds/webkit/%s/webkit-mac-14-arm64.zip',
     'mac15': 'builds/webkit/%s/webkit-mac-15.zip',
     'mac15-arm64': 'builds/webkit/%s/webkit-mac-15-arm64.zip',
+    'mac26': 'builds/webkit/%s/webkit-mac-15.zip',
+    'mac26-arm64': 'builds/webkit/%s/webkit-mac-15-arm64.zip',
     'win64': 'builds/webkit/%s/webkit-win64.zip',
   },
   'ffmpeg': {
@@ -389,6 +403,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': 'builds/ffmpeg/%s/ffmpeg-mac-arm64.zip',
     'mac15': 'builds/ffmpeg/%s/ffmpeg-mac.zip',
     'mac15-arm64': 'builds/ffmpeg/%s/ffmpeg-mac-arm64.zip',
+    'mac26': 'builds/ffmpeg/%s/ffmpeg-mac.zip',
+    'mac26-arm64': 'builds/ffmpeg/%s/ffmpeg-mac-arm64.zip',
     'win64': 'builds/ffmpeg/%s/ffmpeg-win64.zip',
   },
   'winldd': {
@@ -420,6 +436,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': undefined,
     'mac15': undefined,
     'mac15-arm64': undefined,
+    'mac26': undefined,
+    'mac26-arm64': undefined,
     'win64': 'builds/winldd/%s/winldd-win64.zip',
   },
   'android': {
@@ -451,6 +469,8 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac14-arm64': 'builds/android/%s/android.zip',
     'mac15': 'builds/android/%s/android.zip',
     'mac15-arm64': 'builds/android/%s/android.zip',
+    'mac26': 'builds/android/%s/android.zip',
+    'mac26-arm64': 'builds/android/%s/android.zip',
     'win64': 'builds/android/%s/android.zip',
   },
 };

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -844,8 +844,13 @@ export class WKPage implements PageDelegate {
   }
 
   private _toolbarHeight(): number {
-    if (this._page.browserContext._browser?.options.headful)
-      return hostPlatform === 'mac10.15' ? 55 : 59;
+    if (this._page.browserContext._browser?.options.headful) {
+      if (hostPlatform === 'mac10.15')
+        return 55;
+      if (hostPlatform === 'mac26-arm64' || hostPlatform === 'mac26')
+        return 69;
+      return 59;
+    }
     return 0;
   }
 

--- a/packages/utils/hostPlatform.ts
+++ b/packages/utils/hostPlatform.ts
@@ -27,6 +27,7 @@ export type HostPlatform = 'win64' |
                            'mac13' | 'mac13-arm64' |
                            'mac14' | 'mac14-arm64' |
                            'mac15' | 'mac15-arm64' |
+                           'mac26' | 'mac26-arm64' |
                            'ubuntu18.04-x64' | 'ubuntu18.04-arm64' |
                            'ubuntu20.04-x64' | 'ubuntu20.04-arm64' |
                            'ubuntu22.04-x64' | 'ubuntu22.04-arm64' |
@@ -54,12 +55,17 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
       macVersion = 'mac10.14';
     } else if (ver[0] === 19) {
       macVersion = 'mac10.15';
-    } else {
-      // ver[0] >= 20
-      const LAST_STABLE_MACOS_MAJOR_VERSION = 15;
-      // Best-effort support for MacOS beta versions.
-      macVersion = 'mac' + Math.min(ver[0] - 9, LAST_STABLE_MACOS_MAJOR_VERSION);
+    } else if (ver[0] < 25) {
+      // Darwin 20..24 → macOS 11..15 (BigSur..Sequoia).
+      macVersion = 'mac' + (ver[0] - 9);
       // BigSur is the first version that might run on Apple Silicon.
+      if (os.cpus().some(cpu => cpu.model.includes('Apple')))
+        macVersion += '-arm64';
+    } else {
+      // Apple jumped from macOS 15 (Sequoia) to macOS 26 (Tahoe), so Darwin 25 = macOS 26.
+      // Best-effort support for MacOS beta versions.
+      const LAST_STABLE_MACOS_MAJOR_VERSION = 26;
+      macVersion = 'mac' + Math.min(ver[0] + 1, LAST_STABLE_MACOS_MAJOR_VERSION);
       if (os.cpus().some(cpu => cpu.model.includes('Apple')))
         macVersion += '-arm64';
     }

--- a/tests/config/platformFixtures.ts
+++ b/tests/config/platformFixtures.ts
@@ -38,7 +38,11 @@ function platform(): 'win32' | 'darwin' | 'linux' {
 function macVersion() {
   if (process.platform !== 'darwin')
     return 0;
-  return +os.release().split('.')[0] - 9;
+  const darwinMajor = +os.release().split('.')[0];
+  // Apple jumped from macOS 15 (Sequoia) to macOS 26 (Tahoe), so Darwin 25 = macOS 26.
+  if (darwinMajor >= 25)
+    return darwinMajor + 1;
+  return darwinMajor - 9;
 }
 
 export const platformTest = test.extend<{}, PlatformWorkerFixtures>({

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -458,12 +458,12 @@ for (const params of [
 
     // Check all frame sizes.
     for (const frame of frames) {
-      expect(frame.width).toBe(params.width);
-      expect(frame.height).toBe(params.height);
+      expect.soft(frame.width).toBe(params.width);
+      expect.soft(frame.height).toBe(params.height);
       const buffer = resources.get('resources/' + frame.sha1);
       const image = jpegjs.decode(buffer);
-      expect(image.width).toBe(previewWidth);
-      expect(image.height).toBe(previewHeight);
+      expect.soft(image.width).toBe(previewWidth);
+      expect.soft(image.height).toBe(previewHeight);
     }
 
     const frame = frames[frames.length - 1]; // pick last frame.


### PR DESCRIPTION
## Summary
- Add `mac26`/`mac26-arm64` to `HostPlatform` and detect Darwin 25 → macOS 26 (Apple jumped from macOS 15 Sequoia straight to macOS 26 Tahoe).
- List `mac26`/`mac26-arm64` explicitly in the download registry for all browsers and tools.
- Bump the WebKit headed toolbar height for macOS 26 (the toolbar got taller in Tahoe) and relax per-frame size assertions in the screencast tracing tests to soft expects.
- Update the `macVersion()` test fixture so it returns `26` on Tahoe instead of `16`.

Fixes the following tests in headed mode on macOS 26:
- `tests/library/screencast.spec.ts` › `screencast.start delivers frames via onFrame callback`
- `tests/library/tracing.spec.ts` › `should produce screencast frames {fit,crop,scale}`
- `tests/library/video.spec.ts` › `screencast` › `should capture static page`
- `tests/library/video.spec.ts` › `screencast` › `should continue recording main page after popup closes`
- `tests/library/video.spec.ts` › `screencast` › `should work for popups`
- `tests/library/video.spec.ts` › `screencast` › `should capture full viewport`
- `tests/library/video.spec.ts` › `screencast` › `should capture full viewport on hidpi`