### PR TITLE
Escape inline HTML report script sentinels

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -209,6 +209,10 @@ function parseBooleanEnvVar(name: string): boolean | undefined {
   return undefined;
 }
 
+function escapeClosingScriptTag(text: string): string {
+  return text.replace(/<\/script/gi, '<\\/script');
+}
+
 function standaloneDefaultFolder(): string {
   return reportFolderFromEnv() ?? resolveReporterOutputPath('playwright-report', process.cwd(), undefined);
 }
@@ -386,7 +390,7 @@ class HtmlBuilder {
         fs.promises.readFile(path.join(appFolder, 'report.js'), 'utf-8'),
         fs.promises.readFile(path.join(appFolder, 'report.css'), 'utf-8'),
       ]);
-      html = html.replace(/<script type="module"[^>]*><\/script>/, () => `<script type="module">${js}</script>`);
+      html = html.replace(/<script type="module"[^>]*><\/script>/, () => `<script type="module">${escapeClosingScriptTag(js)}</script>`);
       html = html.replace(/<link rel="stylesheet"[^>]*>/, () => `<style type='text/css'>${css}</style>`);
       await fs.promises.writeFile(reportIndexFile, html);
     }

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3251,6 +3251,25 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.getByText('example.spec.ts')).toBeVisible();
     });
 
+    test('should escape closing script tags when inlining assets', async ({ runInlineTest, showReport, page }, testInfo) => {
+      const result = await runInlineTest({
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('passes', async ({}) => {});
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(0);
+
+      const reportFolder = testInfo.outputPath('playwright-report');
+      const html = fs.readFileSync(path.join(reportFolder, 'index.html'), 'utf-8');
+      expect(html).toContain('s.innerHTML="<script><\\/script>"');
+      expect(html).not.toContain('s.innerHTML="<script></script>"');
+
+      await showReport();
+      await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
+      await expect(page.getByRole('link', { name: 'passes' })).toBeVisible();
+    });
+
     test('worker test list', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'playwright.config.ts': `


### PR DESCRIPTION
Fixes microsoft/playwright#40134

Escape any closing script-tag sentinels before inlining the HTML reporter's report.js bundle into index.html.

This prevents the browser from terminating the inline <script type="module"> element early when the bundle contains \u003c/script sequences.

Regression test: adds a reporter-html test that inspects the generated index.html and verifies the sentinel is escaped before serving the report.

Verification note: I could not run the full Playwright test target in this checkout because the stable test runner dependencies are not installed here.