### PR TITLE
fix(cli): fix drag command Zod validation error on startElement/endElement

### DIFF
--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -96,10 +96,10 @@ const drag = defineTabTool({
     title: 'Drag mouse',
     description: 'Perform drag and drop between two elements',
     inputSchema: z.object({
-      startElement: z.string().describe('Human-readable source element description used to obtain the permission to interact with the element'),
+      startElement: z.string().optional().describe('Human-readable source element description used to obtain the permission to interact with the element'),
       startRef: z.string().describe('Exact source element reference from the page snapshot'),
       startSelector: z.string().optional().describe('CSS or role selector for the source element, when ref is not available'),
-      endElement: z.string().describe('Human-readable target element description used to obtain the permission to interact with the element'),
+      endElement: z.string().optional().describe('Human-readable target element description used to obtain the permission to interact with the element'),
       endRef: z.string().describe('Exact target element reference from the page snapshot'),
       endSelector: z.string().optional().describe('CSS or role selector for the target element, when ref is not available'),
     }),

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -265,7 +265,7 @@ const drag = declareCommand({
   toolParams: ({ startElement, endElement }) => {
     const start = asRef(startElement);
     const end = asRef(endElement);
-    return { startRef: start.ref, startSelector: start.selector, endRef: end.ref, endSelector: end.selector };
+    return { startElement, startRef: start.ref, startSelector: start.selector, endElement, endRef: end.ref, endSelector: end.selector };
   },
 });
 


### PR DESCRIPTION
Bug

  playwright-cli drag <startRef> <endRef> always fails with a Zod validation error:

  Invalid input: expected string, received undefined — path: ["startElement"]
  Invalid input: expected string, received undefined — path: ["endElement"]

  This makes the drag CLI command completely unusable.

  Root cause

  Two issues in playwright-core:

  1. browser_drag schema requires startElement/endElement as mandatory (snapshot.ts)

  Every other snapshot tool uses element: z.string().optional() via elementSchema. The drag tool is the only one that
  makes the human-readable description mandatory — z.string() instead of z.string().optional().

  2. CLI toolParams doesn't forward startElement/endElement (commands.ts)

  The CLI command parses its args as startElement/endElement, extracts ref/selector via asRef(), but only returns {
  startRef, startSelector, endRef, endSelector } — dropping the original startElement/endElement values. Even if the
  schema were lenient, MCP clients that do provide these fields would lose them.

  Fix

  - Make startElement/endElement optional in the browser_drag input schema (consistent with all other tools)
  - Pass startElement/endElement through in the CLI command's toolParams