### PR TITLE
Bug Fix for playwright-cli drag, drag is failing with Zod validation error

### DIFF
--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -96,10 +96,10 @@ const drag = defineTabTool({
     title: 'Drag mouse',
     description: 'Perform drag and drop between two elements',
     inputSchema: z.object({
-      startElement: z.string().describe('Human-readable source element description used to obtain the permission to interact with the element'),
+      startElement: z.string().optional().describe('Human-readable source element description used to obtain the permission to interact with the element'),
       startRef: z.string().describe('Exact source element reference from the page snapshot'),
       startSelector: z.string().optional().describe('CSS or role selector for the source element, when ref is not available'),
-      endElement: z.string().describe('Human-readable target element description used to obtain the permission to interact with the element'),
+      endElement: z.string().optional().describe('Human-readable target element description used to obtain the permission to interact with the element'),
       endRef: z.string().describe('Exact target element reference from the page snapshot'),
       endSelector: z.string().optional().describe('CSS or role selector for the target element, when ref is not available'),
     }),

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -265,7 +265,7 @@ const drag = declareCommand({
   toolParams: ({ startElement, endElement }) => {
     const start = asRef(startElement);
     const end = asRef(endElement);
-    return { startRef: start.ref, startSelector: start.selector, endRef: end.ref, endSelector: end.selector };
+    return { startElement, startRef: start.ref, startSelector: start.selector, endElement, endRef: end.ref, endSelector: end.selector };
   },
 });
 

--- a/tests/mcp/cli-drag.spec.ts
+++ b/tests/mcp/cli-drag.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './cli-fixtures';
+
+test('drag between elements', async ({ cli, server }) => {
+  server.setContent('/', `
+<!DOCTYPE html>
+<html>
+<body>
+  <div id="source" draggable="true" aria-label="drag source" style="width:60px;height:40px;border:1px solid"></div>
+  <div id="target" aria-label="drop target" style="width:120px;height:80px;border:1px solid;margin-top:20px"></div>
+  <script>
+    document.getElementById('source').addEventListener('dragstart', e => e.dataTransfer.setData('text/plain', 'ok'));
+    document.getElementById('target').addEventListener('dragover', e => e.preventDefault());
+  </script>
+</body>
+</html>`, 'text/html');
+
+  const { snapshot } = await cli('open', server.PREFIX);
+  expect(snapshot).toBeTruthy();
+  expect(snapshot).toContain('drag source');
+  expect(snapshot).toContain('drop target');
+
+  const refForAccessibleName = (name: string) => {
+    const line = snapshot!.split('\n').find(l => l.includes(`"${name}"`) && l.includes('[ref='));
+    return line?.match(/\[ref=(e\d+)\]/)?.[1];
+  };
+  const startRef = refForAccessibleName('drag source');
+  const endRef = refForAccessibleName('drop target');
+  expect(startRef, 'snapshot should list the source element with a ref').toBeTruthy();
+  expect(endRef, 'snapshot should list the target element with a ref').toBeTruthy();
+
+  const { output, error, exitCode } = await cli('drag', startRef!, endRef!);
+  expect(exitCode).toBe(0);
+  expect(error).not.toMatch(/invalid_type|Zod validation error/i);
+  expect(output).toContain('dragTo');
+});


### PR DESCRIPTION
Expected behavior:
Expected: Drag-and-drop is performed between the two elements.

Actual behavior:
Zod validation error

```
[
  {
    "expected": "string",
    "code": "invalid_type",
    "path": ["startElement"],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": ["endElement"],
    "message": "Invalid input: expected string, received undefined"
  }
]
```


Additional context

Root Cause:

The CLI daemon's drag command (playwright-core/lib/tools/cli-daemon/commands.js) converts positional args into startRef/endRef but never passes startElement/endElement to the MCP tool


Test added:

npm run ctest-mcp tests/mcp/cli-drag.spec.ts

Running 1 test using 1 worker

✓  1 [chrome] › tests/mcp/cli-drag.spec.ts:19:5 › drag between elements (3.6s)

1 passed (4.2s)
