### PR TITLE
fix(test): use separate Playwright instance for inspector tests

### DIFF
--- a/packages/playwright-core/src/inprocess.ts
+++ b/packages/playwright-core/src/inprocess.ts
@@ -23,7 +23,7 @@ import { Connection } from './client/connection';
 import type { Playwright as PlaywrightAPI } from './client/playwright';
 import type { Language } from '@isomorphic/locatorGenerators';
 
-function createInProcessPlaywright(): PlaywrightAPI {
+export function createInProcessPlaywright(): PlaywrightAPI {
   const playwright = createPlaywright({ sdkLanguage: (process.env.PW_LANG_NAME as Language | undefined) || 'javascript' });
   const clientConnection = new Connection(nodePlatform);
   clientConnection.useRawBuffers();

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -47,7 +47,9 @@ const codegenLang2Id: Map<string, string> = new Map([
 const codegenLangId2lang = new Map([...codegenLang2Id.entries()].map(([lang, langId]) => [langId, lang]));
 
 import { inprocess } from '../../../packages/playwright-core/lib/coreBundle';
-const playwrightToAutomateInspector = inprocess.playwright;
+// Use a separate Playwright instance for automating the inspector so that
+// contexts created here do not get tracked by the test runner's tracing.
+const playwrightToAutomateInspector = inprocess.createInProcessPlaywright();
 
 export const test = contextTest.extend<CLITestArgs>({
   recorderPageGetter: async ({ context, toImpl, mode, headless }, run, testInfo) => {


### PR DESCRIPTION
## Summary
- Inspector tests shared the singleton Playwright instance with the test runner. When `PWTEST_TRACE=1` was set, the runner's `ArtifactsRecorder` tracked the recorder UI's chromium context and tried to stop tracing on it after disconnect, causing `ENOENT` / `Target closed` errors.
- Export `createInProcessPlaywright()` from `inprocess.ts` and use a fresh instance in `inspectorTest.ts` so its contexts are invisible to the test runner's instrumentation.

Fixes all `cli-codegen-*` inspector tests failing with `PWTEST_TRACE=1`.

Commit 72310c757 ("chore: export coreBundle") changed how tests/library/inspector/inspectorTest.ts:49-50 gets the Playwright instance used to drive the recorder UI. It went from creating a fresh instance via createInProcessPlaywright(nodePlatform) to using the singleton inprocess.playwright.
