### PR TITLE
fix(connectOverCDP): preserve browser-default downloads in the default context

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -112,7 +112,17 @@ export class Chromium extends BrowserType {
 
     try {
       const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
-      const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
+      const persistent: types.BrowserContextOptions = {
+        noDefaultViewport: true,
+        // When attaching to an externally-launched browser via CDP, the user
+        // (not Playwright) owns the browser. Do not send
+        // Browser.setDownloadBehavior, which would hijack the real browser's
+        // download folder globally — including for tabs the user opened
+        // manually outside of automation. Callers that need automation-owned
+        // downloads can still opt in by passing acceptDownloads explicitly
+        // on a new BrowserContext.
+        acceptDownloads: 'internal-browser-default',
+      };
       const browserOptions: BrowserOptions = {
         slowMo: options.slowMo,
         name: 'chromium',

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -89,7 +89,11 @@ test('should cleanup artifacts dir after connectOverCDP disconnects due to ws cl
   expect(exists2).toBe(false);
 });
 
-test('should connectOverCDP and manage downloads in default context', async ({ browserType, mode, server }, testInfo) => {
+test('should connectOverCDP and manage downloads in an opted-in context', async ({ browserType, mode, server }, testInfo) => {
+  // Downloads from Playwright-created contexts still work normally when the caller opts
+  // in via `newContext({ acceptDownloads: true })`. The default context (shared with the
+  // attached browser) no longer intercepts downloads by default, to preserve the real
+  // user's download behavior — see test below for that guarantee.
   server.setRoute('/downloadWithFilename', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
@@ -105,7 +109,8 @@ test('should connectOverCDP and manage downloads in default context', async ({ b
     const browser = await browserType.connectOverCDP({
       endpointURL: `http://127.0.0.1:${port}/`,
     });
-    const page = await browser.contexts()[0].newPage();
+    const context = await browser.newContext({ acceptDownloads: true });
+    const page = await context.newPage();
     await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
 
     const [download] = await Promise.all([
@@ -120,6 +125,47 @@ test('should connectOverCDP and manage downloads in default context', async ({ b
     await download.saveAs(userPath);
     expect(fs.existsSync(userPath)).toBeTruthy();
     expect(fs.readFileSync(userPath).toString()).toBe('Hello world');
+    await context.close();
+  } finally {
+    await browserServer.close();
+  }
+});
+
+test('should not override browser-default download behavior on the default context', async ({ browserType, mode, server }, testInfo) => {
+  // Regression guard: connectOverCDP must NOT send Browser.setDownloadBehavior for the
+  // default context it inherits from the attached browser. Previously it did, which
+  // globally hijacked the real user's download folder (downloads landed in a Playwright
+  // temp dir with UUID filenames — see chromium.ts comment in _connectOverCDPImpl).
+  server.setRoute('/downloadWithFilename', (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
+    res.end(`Hello world`);
+  });
+
+  const port = 9339 + testInfo.workerIndex;
+  const browserServer = await browserType.launch({
+    args: ['--remote-debugging-port=' + port]
+  });
+
+  try {
+    const browser = await browserType.connectOverCDP({
+      endpointURL: `http://127.0.0.1:${port}/`,
+    });
+    const defaultContext = browser.contexts()[0];
+    const page = await defaultContext.newPage();
+    await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
+
+    // Playwright must NOT emit a 'download' event on the default context after the fix,
+    // because the default context's acceptDownloads is 'internal-browser-default' and
+    // Browser.setDownloadBehavior is never sent with eventsEnabled=true for it.
+    let sawDownloadEvent = false;
+    page.on('download', () => { sawDownloadEvent = true; });
+
+    await page.click('a');
+    // Give Chrome and Playwright a moment to deliver the event if it were going to fire.
+    await page.waitForTimeout(500);
+
+    expect(sawDownloadEvent).toBe(false);
   } finally {
     await browserServer.close();
   }


### PR DESCRIPTION
# fix(connectOverCDP): preserve browser-default downloads in the default context

## What this does

When `browserType.connectOverCDP()` attaches to an externally-launched browser, the default context it inherits is **the user's real browser context** — not an isolated automation context. This PR stops Playwright from overriding that context's download behavior by default. Downloads in the default context are now handled by the browser natively (real filename from `Content-Disposition`, user's own download folder) instead of being hijacked into Playwright's temp artifacts folder with a UUID filename.

**Old default:**  `acceptDownloads: 'accept'` → Playwright sends `Browser.setDownloadBehavior` with `behavior: 'allowAndName'` and `downloadPath: artifactsDir`. Every download in the entire browser (including tabs the user opened manually, long after automation finished) lands in `/tmp/playwright-artifacts-XXXX/<uuid>` with no extension and no real name.

**New default:** `acceptDownloads: 'internal-browser-default'` → Playwright does not send `Browser.setDownloadBehavior` at all. The browser's own settings apply. This matches what [`launchApp.ts:62`](../blob/main/packages/playwright-core/src/server/launchApp.ts#L62) already does for Playwright's own dev tools (`codegen`, `open`, etc.) when not under test.

## Why this matters (real-world impact)

I discovered this while debugging a missing Chrome download. A Read.ai transcript downloaded to "Done" in the Chrome popup but was nowhere in `~/Downloads`. Tracing Chrome's SQLite download history DB showed **every download over the past week** had been silently rerouted:

```
('/var/folders/.../T/playwright-artifacts-GKCPC0/a1957412-...',    15332, '2026-04-10 12:14:54')  ← the one I noticed
('/var/folders/.../T/playwright-artifacts-GKCPC0/2d420415-...',    64140, '2026-04-08 19:37:47')  ← FoxData CSV
('/var/folders/.../T/playwright-artifacts-GKCPC0/d7e05cb8-...',    64140, '2026-04-08 19:37:32')  ← (dup)
('/var/folders/.../T/playwright-artifacts-GKCPC0/db927849-...', 1409325857, '2026-04-08 14:08:16')  ← 1.4 GB video
('/var/folders/.../T/playwright-artifacts-GKCPC0/838b1bde-...', 1409325857, '2026-04-08 14:02:30')  ← SAME 1.4 GB video, duplicated
```

**2.6 GB of orphan downloads** in a temp folder the user never knew existed — including a 1.4 GB video file saved twice because I'd downloaded it twice. All because a browser agent running on my machine was calling `connectOverCDP()` against my daily Chrome.

The user experience for anyone running a browser-agent MCP server (Claude-in-Chrome, Playwright-MCP, Selenoid, etc.) is currently: *"I installed an AI agent and now my browser downloads are silently broken."* That's the bug this PR fixes.

## How the bug chain works (before this PR)

`packages/playwright-core/src/server/chromium/chromium.ts:113-129` — `_connectOverCDPImpl`:

```typescript
try {
  const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
  const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
  const browserOptions: BrowserOptions = {
    // ...
    artifactsDir,
    downloadsPath: options.downloadsPath || artifactsDir,   // ← defaults to temp dir
    // ...
  };
  validateBrowserContextOptions(persistent, browserOptions);
```

`packages/playwright-core/src/server/browserContext.ts:745-746` — `validateBrowserContextOptions`:

```typescript
if (options.acceptDownloads === undefined && browserOptions.name !== 'electron')
  options.acceptDownloads = 'accept';   // ← defaults to 'accept'
```

`packages/playwright-core/src/server/chromium/crBrowser.ts:353-359` — `CRBrowserContext.initialize()`:

```typescript
if (this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
  promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
    behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',
    browserContextId: this._browserContextId,
    downloadPath: this._browser.options.downloadsPath,   // ← artifactsDir
    eventsEnabled: true,
  }));
}
```

Chain: attach via CDP → default context has `acceptDownloads === 'accept'` → `Browser.setDownloadBehavior` sent with `allowAndName` + Playwright's temp `artifactsDir` → Chrome now routes every subsequent download in that browser context to the temp folder with a UUID filename. The CDP command affects the whole browser context, including pages the user opens manually.

## The fix

Set `acceptDownloads: 'internal-browser-default'` on the `persistent` context options passed into `_connectOverCDPImpl`. This is a 7-line change (+ a comment explaining why). It piggybacks on the existing `'internal-browser-default'` escape hatch that `CRBrowserContext.initialize()` already checks for and on the existing usage pattern in `launchApp.ts`.

```diff
 try {
   const browserProcess: BrowserProcess = { close: doClose, kill: doClose };
-  const persistent: types.BrowserContextOptions = { noDefaultViewport: true };
+  const persistent: types.BrowserContextOptions = {
+    noDefaultViewport: true,
+    // When attaching to an externally-launched browser via CDP, the user
+    // (not Playwright) owns the browser. Do not send
+    // Browser.setDownloadBehavior, which would hijack the real browser's
+    // download folder globally — including for tabs the user opened
+    // manually outside of automation. Callers that need automation-owned
+    // downloads can still opt in by passing acceptDownloads explicitly
+    // on a new BrowserContext.
+    acceptDownloads: 'internal-browser-default',
+  };
```

## API contract after this PR

| Scenario | Before | After |
|---|---|---|
| `browserType.launch()` + downloads | ✅ Works (unchanged) | ✅ Works (unchanged) |
| `browserType.launchPersistentContext()` + downloads | ✅ Works (unchanged) | ✅ Works (unchanged) |
| `connectOverCDP()` + `browser.newContext({ acceptDownloads: true })` + downloads | ✅ Works | ✅ Works (unchanged) |
| `connectOverCDP()` + `browser.contexts()[0]` + `page.waitForEvent('download')` | ⚠️ "Worked" by hijacking the user's real browser download folder globally | 🟡 **Behavior change:** default context no longer intercepts downloads. Users must create a new context to receive Playwright `download` events. |

This is technically a behavior change for the last row, but that row was the bug. The intent of `connectOverCDP()` is to let Playwright *observe* an existing browser, not silently reconfigure its download folder. Tests verify both the new guarantee and that the opt-in path still works.

## Tests

Two changes in `tests/library/chromium/connect-over-cdp.spec.ts`:

1. **Updated `should connectOverCDP and manage downloads in an opted-in context`** (renamed from "... in default context"). Demonstrates the new idiomatic way: create a new context with `browser.newContext({ acceptDownloads: true })` before expecting the Playwright download API to fire. This is the recommended pattern for anyone who needs automation-managed downloads via CDP connect.

2. **New `should not override browser-default download behavior on the default context`**. Regression guard: creates a page in `browser.contexts()[0]`, clicks a download link, asserts that Playwright does NOT emit a `download` event. The observable absence of the event is the signal that `Browser.setDownloadBehavior` was not sent.

## Test results

```
tests/library/chromium/connect-over-cdp.spec.ts  —  28 passed, 1 skipped (no regressions, both new/updated tests pass)
tests/library/download.spec.ts                   —  38 passed (full download suite, zero regressions)
npm run tsc                                      —  clean
npm run build                                    —  clean
```

I also ran the full `connect-over-cdp.spec.ts` suite to make sure no other CDP tests regress. All good.

## Addressing the prior maintainer position

Issues #10700, #12543, #34542, and microsoft/playwright-python#2105 were all closed as "not planned" with variations of:
> "Only the launcher of the browser has control over the download folder for security reasons."

**I fully agree with that principle — and it is precisely why this PR is correct.** In `connectOverCDP()`, Playwright is *not* the launcher. The user is. This PR is the exact application of the "only the launcher controls downloads" rule to a code path where Playwright was violating it.

The existing `'internal-browser-default'` code path and the `launchApp.ts:62` default both demonstrate that the maintainers already agree with this philosophy for Playwright's own user-facing dev tools. This PR extends the same correctness to `connectOverCDP`.

## Manual verification

I built this branch locally and manually verified:
1. Chrome launched with `--remote-debugging-port=9222` → attach Playwright → manually open a download link in the default context → ✅ file lands in `~/Downloads` with real filename.
2. Same setup, but create `browser.newContext({ acceptDownloads: true })` and use that new context → ✅ `page.waitForEvent('download')` fires, `download.saveAs()` works as before.

## Environment

- Branch: `sidsarasvati:fix/connectOverCDP-preserve-browser-downloads`
- Base: `microsoft/playwright:main` @ `19e0abb7c`
- Tested on: macOS 25.3 Tahoe, Node.js 22, Chrome 147

---

Related but closed: #10700, #12543, #34542, microsoft/playwright-python#2105.
Also related (still open): #38805 (cross-platform path issue — this PR doesn't directly fix but reduces the attack surface).
