### PR TITLE
fix(cli): kill-all should match cliDaemon.js entry point

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -254,7 +254,7 @@ async function killAllDaemons(): Promise<void> {
       const result = execSync(
           `powershell -NoProfile -NonInteractive -Command `
           + `"Get-CimInstance Win32_Process `
-          + `| Where-Object { $_.CommandLine -like '*run-mcp-server*' -or $_.CommandLine -like '*run-cli-server*' -or $_.CommandLine -like '*cli-daemon*' -or $_.CommandLine -like '*dashboardApp.js*' } `
+          + `| Where-Object { $_.CommandLine -like '*cliDaemon.js*' -or $_.CommandLine -like '*dashboardApp.js*' } `
           + `| ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue; $_.ProcessId }"`,
           { encoding: 'utf-8' }
       );
@@ -268,7 +268,7 @@ async function killAllDaemons(): Promise<void> {
       const result = execSync('ps aux', { encoding: 'utf-8' });
       const lines = result.split('\n');
       for (const line of lines) {
-        if (line.includes('run-mcp-server') || line.includes('run-cli-server') || line.includes('cli-daemon') || line.includes('dashboardApp.js')) {
+        if (line.includes('cliDaemon.js') || line.includes('dashboardApp.js')) {
           const parts = line.trim().split(/\s+/);
           const pid = parts[1];
           if (pid && /^\d+$/.test(pid)) {


### PR DESCRIPTION
Fixes #40165

### Problem

`playwright-cli kill-all` does not kill any main daemon processes because `killAllDaemons` in `tools/cli-client/program.ts` greps for substrings that don't match current daemon command lines. Full investigation and reproduction in the linked issue.

### Fix

Replace the three dead patterns (`run-mcp-server`, `run-cli-server`, `cli-daemon`) with `cliDaemon.js` — the actual entry-point filename for daemons spawned from `src/entry/cliDaemon.ts`. Keeps the working `dashboardApp.js` pattern from #40004.

### Verification

Empirically verified on macOS 26.2 / Darwin 25.2.0 arm64, `@playwright/cli@0.1.6` / playwright-core `1.60.0-alpha-1775584683000`:

1. Baseline: `pgrep -f cliDaemon.js` → 0 matches.
2. Spawn fresh daemon: `playwright-cli open` → "Browser `default` opened with pid 19665".
3. Confirm alive: `pgrep -lf cliDaemon.js` → PID 19665.
4. `playwright-cli kill-all` (with patched bundle): `Killed daemon process 19665. Killed 1 daemon processes.`
5. Verify dead: `pgrep -f cliDaemon.js` → 0 matches. `playwright-cli list` → `(no browsers)`.

Before the patch, step 4 produced `No daemon processes found` and the daemon survived.

### Notes

- No existing test covers `killAllDaemons`. Happy to add a spawn-and-kill test in a follow-up if the minimal fix is acceptable.
- `npm run lint` passes on the modified file locally.
- Secondary issue observed during investigation (out of scope): once a daemon is SIGKILL'd by `kill-all`, its child browser process becomes an orphan because SIGKILL prevents the daemon from running a cleanup handler. Worth a follow-up to SIGTERM first with a brief grace period. Separate concern from the pattern mismatch fixed here.
