### PR TITLE
test(cli): add kill-all coverage with pid filter

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -185,6 +185,8 @@ export async function program(options?: { embedderVersion?: string}) {
         stdio: 'ignore',
       });
       child.unref();
+      if (process.env.PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST)
+        console.log(`### Dashboard opened with pid ${child.pid}.`);
       return;
     }
     default: {
@@ -249,11 +251,16 @@ const daemonProcessPatterns = ['run-mcp-server', 'run-cli-server', 'cli-daemon',
 
 async function killAllDaemons(): Promise<void> {
   const platform = os.platform();
+  const pidFilterEnv = process.env.PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST;
+  const pidFilter = pidFilterEnv ? new Set(pidFilterEnv.split(',').map(p => parseInt(p, 10)).filter(n => !isNaN(n))) : undefined;
   let killed = 0;
 
   try {
     if (platform === 'win32') {
-      const whereClause = daemonProcessPatterns.map(p => `$_.CommandLine -like '*${p}*'`).join(' -or ');
+      const clauses = [`(${daemonProcessPatterns.map(p => `$_.CommandLine -like '*${p}*'`).join(' -or ')})`];
+      if (pidFilter)
+        clauses.push(`(${[...pidFilter].map(p => `$_.ProcessId -eq ${p}`).join(' -or ')})`);
+      const whereClause = clauses.join(' -and ');
       const result = execSync(
           `powershell -NoProfile -NonInteractive -Command `
           + `"Get-CimInstance Win32_Process `
@@ -268,15 +275,18 @@ async function killAllDaemons(): Promise<void> {
         console.log(`Killed daemon process ${pid}`);
       killed = pids.length;
     } else {
-      const result = execSync('ps aux', { encoding: 'utf-8' });
+      const result = execSync('ps auxww', { encoding: 'utf-8' });
       const lines = result.split('\n');
       for (const line of lines) {
         if (daemonProcessPatterns.some(p => line.includes(p))) {
           const parts = line.trim().split(/\s+/);
           const pid = parts[1];
           if (pid && /^\d+$/.test(pid)) {
+            const numericPid = parseInt(pid, 10);
+            if (pidFilter && !pidFilter.has(numericPid))
+              continue;
             try {
-              process.kill(parseInt(pid, 10), 'SIGKILL');
+              process.kill(numericPid, 'SIGKILL');
               console.log(`Killed daemon process ${pid}`);
               killed++;
             } catch {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -121,10 +121,13 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
       ({ snapshot, inlineSnapshot } = await loadSnapshot(cli.stdout));
     const attachments = loadAttachments(cli.stdout);
 
-    const matches = cli.stdout.includes('### Browser') ? cli.stdout.match(/Browser `(.+)` opened with pid (\d+)\./) : undefined;
-    const [, sessionName, pid] = matches ?? [];
-    if (sessionName && pid)
-      sessions.push({ name: sessionName, pid: +pid });
+    const browserMatches = cli.stdout.includes('### Browser') ? cli.stdout.match(/Browser `(.+)` opened with pid (\d+)\./) : undefined;
+    const [, sessionName, browserPid] = browserMatches ?? [];
+    if (sessionName && browserPid)
+      sessions.push({ name: sessionName, pid: +browserPid });
+    const dashboardMatches = cli.stdout.includes('### Dashboard') ? cli.stdout.match(/Dashboard opened with pid (\d+)\./) : undefined;
+    const dashboardPid = dashboardMatches?.[1];
+    const pid = browserPid ?? dashboardPid;
     return {
       exitCode: await cli.exitCode,
       output: cli.stdout.trim(),

--- a/tests/mcp/cli-killall.spec.ts
+++ b/tests/mcp/cli-killall.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './cli-fixtures';
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('kill-all kills only filtered pid', async ({ cli, server }) => {
+  const { pid } = await cli('open', server.HELLO_WORLD);
+  expect(pid).toBeDefined();
+  expect(isAlive(pid!)).toBe(true);
+
+  const { output } = await cli('kill-all', {
+    env: { PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST: String(pid) },
+  });
+  expect(output).toContain(`Killed daemon process ${pid}`);
+  expect(output).toContain('Killed 1 daemon process.');
+
+  await expect.poll(() => isAlive(pid!)).toBe(false);
+});
+
+test('kill-all kills filtered dashboard pid', async ({ cli }) => {
+  const { pid } = await cli('show', { env: { PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST: '1' } });
+  expect(pid).toBeDefined();
+  await expect.poll(() => isAlive(pid!)).toBe(true);
+
+  try {
+    const { output } = await cli('kill-all', {
+      env: { PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST: String(pid) },
+    });
+    expect(output).toContain(`Killed daemon process ${pid}`);
+    expect(output).toContain('Killed 1 daemon process.');
+
+    await expect.poll(() => isAlive(pid!)).toBe(false);
+  } finally {
+    if (isAlive(pid!))
+      try { process.kill(pid!, 'SIGKILL'); } catch {}
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a test-only env var `PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST` that narrows `kill-all` to specific pids so tests don't kill unrelated daemons.
- Switches the POSIX path to `ps auxww` so long daemon command lines aren't truncated by terminal width.
- `cli show` prints its dashboard pid (gated on `PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST`) so tests can capture it.
- Adds `tests/mcp/cli-killall.spec.ts` covering both `cli open` and `cli show`.