### PR TITLE
fix(cli): do not fall through open/attach args into session

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -55,18 +55,8 @@ type OpenOptions = {
 };
 
 const globalOptions: (keyof (GlobalOptions & OpenOptions & AttachOptions))[] = [
-  'cdp',
-  'endpoint',
-  'browser',
-  'config',
-  'extension',
-  'headed',
-  'help',
-  'persistent',
-  'profile',
   'raw',
   'session',
-  'version',
 ];
 
 const booleanOptions: (keyof (GlobalOptions & OpenOptions & AttachOptions & { all?: boolean }))[] = [
@@ -143,7 +133,10 @@ export async function program(options?: { embedderVersion?: string}) {
       return;
     }
     case 'open': {
-      await startSession(sessionName, registry, clientInfo, args);
+      await startSession(sessionName, registry, clientInfo, args, 'open');
+      const newEntry = await registry.loadEntry(clientInfo, sessionName);
+      const params = args._.slice(1);
+      await runInSession(newEntry, clientInfo, { _: ['goto', ...(params.length ? params : ['about:blank'])] });
       return;
     }
     case 'attach': {
@@ -160,7 +153,9 @@ export async function program(options?: { embedderVersion?: string}) {
       }
       const attachSessionName = explicitSessionName(args.session as string) ?? attachTarget ?? sessionName;
       args.session = attachSessionName;
-      await startSession(attachSessionName, registry, clientInfo, args);
+      await startSession(attachSessionName, registry, clientInfo, args, 'attach');
+      const newEntry = await registry.loadEntry(clientInfo, attachSessionName);
+      await runInSession(newEntry, clientInfo, { _: ['snapshot'], filename: '<auto>' });
       return;
     }
     case 'close':
@@ -202,14 +197,11 @@ export async function program(options?: { embedderVersion?: string}) {
   }
 }
 
-async function startSession(sessionName: string, registry: Registry, clientInfo: ClientInfo, args: MinimistArgs) {
+async function startSession(sessionName: string, registry: Registry, clientInfo: ClientInfo, args: MinimistArgs, mode: 'open' | 'attach') {
   const entry = registry.entry(clientInfo, sessionName);
   if (entry)
     await new Session(entry).stop(true);
-
-  await Session.startDaemon(clientInfo, args);
-  const newEntry = await registry.loadEntry(clientInfo, sessionName);
-  await runInSession(newEntry, clientInfo, args);
+  await Session.startDaemon(clientInfo, args, mode);
 }
 
 async function runInSession(entry: SessionFile, clientInfo: ClientInfo, args: MinimistArgs) {
@@ -307,8 +299,6 @@ async function killAllDaemons(): Promise<void> {
 }
 
 async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boolean): Promise<void> {
-  console.log('### Browsers');
-
   let count = 0;
   const runningSessions = new Set<string>();
   const entries = registry.entryMap();
@@ -316,26 +306,19 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
   for (const [workspaceKey, list] of entries) {
     if (!all && workspaceKey !== key)
       continue;
+    if (count === 0)
+      console.log('### Browsers');
     count += await gcAndPrintSessions(clientInfo, list.map(entry => new Session(entry)), all ? `${path.relative(process.cwd(), workspaceKey) || '/'}:` : undefined, runningSessions);
   }
 
   // Filter out server entries that already have an attached session.
   const serverEntries = await serverRegistry.list();
-  const filteredServerEntries = new Map<string, BrowserStatus[]>();
-  for (const [workspaceKey, list] of serverEntries) {
-    if (!all && workspaceKey !== key)
-      continue;
-    const unattached = list.filter(d => !runningSessions.has(d.title));
-    if (unattached.length)
-      filteredServerEntries.set(workspaceKey, unattached);
-  }
-
-  if (filteredServerEntries.size) {
+  if (serverEntries.size) {
     if (count)
       console.log('');
     console.log('### Browser servers available for attach');
   }
-  for (const [workspaceKey, list] of filteredServerEntries)
+  for (const [workspaceKey, list] of serverEntries)
     count += await gcAndPrintBrowserSessions(workspaceKey, list);
 
   if (!count)

--- a/packages/playwright-core/src/tools/cli-client/registry.ts
+++ b/packages/playwright-core/src/tools/cli-client/registry.ts
@@ -39,6 +39,7 @@ export type SessionConfig = {
   version: string;
   timestamp: number;
   socketPath: string;
+  attached?: boolean;
   cli: {
     persistent?: boolean;
   };

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -120,7 +120,7 @@ export class Session {
     return false;
   }
 
-  static async startDaemon(clientInfo: ClientInfo, cliArgs: MinimistArgs) {
+  static async startDaemon(clientInfo: ClientInfo, cliArgs: MinimistArgs, mode: 'open' | 'attach') {
     await fs.promises.mkdir(clientInfo.daemonProfilesDir, { recursive: true });
 
     const cliPath = libPath('entry', 'cliDaemon.js');
@@ -146,8 +146,10 @@ export class Session {
       args.push(`--config=${cliArgs.config}`);
     if (cliArgs.cdp)
       args.push(`--cdp=${cliArgs.cdp}`);
-    if (cliArgs.endpoint || process.env.PLAYWRIGHT_CLI_SESSION)
-      args.push(`--endpoint=${cliArgs.endpoint || process.env.PLAYWRIGHT_CLI_SESSION}`);
+    if (cliArgs.endpoint)
+      args.push(`--endpoint=${cliArgs.endpoint}`);
+    else if (mode === 'attach' && process.env.PLAYWRIGHT_CLI_SESSION)
+      args.push(`--endpoint=${process.env.PLAYWRIGHT_CLI_SESSION}`);
 
     const child = spawn(process.execPath, args, {
       detached: true,
@@ -228,13 +230,18 @@ export class Session {
 export function renderResolvedConfig(config: SessionConfig) {
   const channel = config.browser.launchOptions.channel ?? config.browser.browserName;
   const lines = [];
+  const isAttached = config.attached;
   if (channel)
-    lines.push(`  - browser-type: ${channel}`);
-  if (!config.cli.persistent)
-    lines.push(`  - user-data-dir: <in-memory>`);
-  else
-    lines.push(`  - user-data-dir: ${config.browser.userDataDir}`);
-  lines.push(`  - headed: ${!config.browser.launchOptions.headless}`);
+    lines.push(`  - browser-type: ${channel}${isAttached ? ' (attached)' : ''}`);
+
+  if (!isAttached) {
+    if (!config.cli.persistent)
+      lines.push(`  - user-data-dir: <in-memory>`);
+    else
+      lines.push(`  - user-data-dir: ${config.browser.userDataDir}`);
+    lines.push(`  - headed: ${!config.browser.launchOptions.headless}`);
+  }
+
   return lines;
 }
 

--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -191,6 +191,13 @@ playwright-cli open --profile=/path/to/profile
 # Connect to browser via extension
 playwright-cli attach --extension
 
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
 # Start with config file
 playwright-cli open --config=my-config.json
 

--- a/packages/playwright-core/src/tools/cli-client/skill/references/session-management.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/session-management.md
@@ -105,6 +105,46 @@ playwright-cli open https://example.com --persistent
 playwright-cli open https://example.com --profile=/path/to/profile
 ```
 
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
 ## Default Browser Session
 
 When `-s` is omitted, commands use the default browser session:

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -55,8 +55,8 @@ const open = declareCommand({
     persistent: z.boolean().optional().describe('Use persistent browser profile'),
     profile: z.string().optional().describe('Use persistent browser profile, store profile in specified directory.'),
   }),
-  toolName: ({ url }) => url ? 'browser_navigate' : 'browser_snapshot',
-  toolParams: ({ url }) => url ? ({ url: url || 'about:blank' }) : { filename: '<auto>' },
+  toolName: '',
+  toolParams: () => ({}),
 });
 
 const attach = declareCommand({

--- a/packages/playwright-core/src/tools/cli-daemon/daemon.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/daemon.ts
@@ -53,6 +53,7 @@ export async function startCliDaemonServer(
   clientInfo: ClientInfo,
   mcpClientInfo: McpClientInfo,
   options: {
+    ownership?: 'attached' | 'own',
     persistent?: boolean,
     exitOnClose?: boolean,
   }
@@ -150,6 +151,7 @@ function daemonSocketPath(clientInfo: ClientInfo, sessionName: string): string {
 }
 
 function createSessionConfig(clientInfo: ClientInfo, sessionName: string, browserInfo: BrowserInfo, options: {
+  ownership?: 'attached' | 'own',
   persistent?: boolean,
   exitOnStop?: boolean,
 } = {}): SessionConfig {
@@ -159,6 +161,7 @@ function createSessionConfig(clientInfo: ClientInfo, sessionName: string, browse
     timestamp: Date.now(),
     socketPath: daemonSocketPath(clientInfo, sessionName),
     workspaceDir: clientInfo.workspaceDir,
+    attached: options.ownership === 'attached' ? true : undefined,
     cli: { persistent: options.persistent },
     browser: {
       browserName: browserInfo.browserName,

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -58,14 +58,14 @@ export function decorateProgram(program: Command) {
         };
 
         try {
-          const { browser, browserInfo, canBind } = await createBrowserWithInfo(mcpConfig, mcpClientInfo);
+          const { browser, browserInfo, canBind, ownership } = await createBrowserWithInfo(mcpConfig, mcpClientInfo);
           if (canBind)
             await browser.bind(sessionName, { workspaceDir: clientInfo.workspaceDir });
           const browserContext = mcpConfig.browser.isolated ? await browser.newContext(mcpConfig.browser.contextOptions) : browser.contexts()[0];
           if (!browserContext)
             throw new Error('Error: unable to connect to a browser that does not have any contexts');
           const persistent = options.persistent || options.profile || mcpConfig.browser.userDataDir ? true : undefined;
-          const socketPath = await startCliDaemonServer(sessionName, browserContext, browserInfo, mcpConfig, clientInfo, mcpClientInfo, { persistent, exitOnClose: true });
+          const socketPath = await startCliDaemonServer(sessionName, browserContext, browserInfo, mcpConfig, clientInfo, mcpClientInfo, { persistent, exitOnClose: true, ownership });
           console.log(`### Success\nDaemon listening on ${socketPath}`);
           console.log('<EOF>');
         } catch (error) {

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -40,6 +40,7 @@ type BrowserWithInfo = {
   browser: playwrightTypes.Browser,
   browserInfo: BrowserInfo,
   canBind: boolean,
+  ownership: 'attached' | 'own',
 };
 
 export async function createBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {
@@ -53,20 +54,25 @@ export async function createBrowserWithInfo(config: FullConfig, clientInfo: Clie
 
   let browser: playwrightTypes.Browser;
   let canBind = false;
+  let ownership: 'attached' | 'own' = 'own';
   if (config.browser.cdpEndpoint) {
     browser = await createCDPBrowser(config);
     canBind = true;
+    ownership = 'attached';
   } else if (config.browser.isolated) {
     browser = await createIsolatedBrowser(config, clientInfo);
     canBind = true;
+    ownership = 'own';
   } else if (config.extension) {
     browser = await createExtensionBrowser(config, clientInfo.clientName);
+    ownership = 'attached';
   } else {
     browser = await createPersistentBrowser(config, clientInfo);
     canBind = true;
+    ownership = 'own';
   }
 
-  return { browser, browserInfo: browserInfo(browser, config), canBind };
+  return { browser, browserInfo: browserInfo(browser, config), canBind, ownership };
 }
 
 export interface BrowserContextFactory {
@@ -125,6 +131,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
         userDataDir: descriptor.browser.userDataDir
       },
       canBind: false,
+      ownership: 'attached'
     };
   }
 
@@ -133,7 +140,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
   const browser = await connectToBrowser(playwrightObject, { endpoint });
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
-  return { browser, browserInfo: browserInfo(browser, config), canBind: false };
+  return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
 }
 
 async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -163,7 +163,7 @@ export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionN
   if (result.browser.isolated === undefined)
     result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint && !result.extension;
 
-  if (!result.extension && !result.browser.isolated && !result.browser.userDataDir && !result.browser.remoteEndpoint) {
+  if (!result.extension && !result.browser.isolated && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint) {
     // No custom value provided, use the daemon data dir.
     const browserToken = result.browser.launchOptions?.channel ?? result.browser?.browserName;
     const userDataDir = path.resolve(daemonProfilesDir, `ud-${sessionName}-${browserToken}`);

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -36,6 +36,7 @@ import type { TestCase } from './common/test';
 
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core/package.json'));
+const PLAYWRIGHT_SRC_INFIX = ['', 'playwright', 'packages', ''].join(path.sep);
 
 export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace> } {
   const name = e.name ? e.name + ': ' : '';
@@ -52,9 +53,13 @@ export function filterStackTrace(e: Error): { message: string, stack: string, ca
 }
 
 export function filterStackFile(file: string) {
-  if (!process.env.PWDEBUGIMPL && file.startsWith(PLAYWRIGHT_TEST_PATH))
+  if (process.env.PWDEBUGIMPL)
+    return true;
+  if (file.startsWith(PLAYWRIGHT_TEST_PATH))
     return false;
-  if (!process.env.PWDEBUGIMPL && file.startsWith(PLAYWRIGHT_CORE_PATH))
+  if (file.startsWith(PLAYWRIGHT_CORE_PATH))
+    return false;
+  if (file.includes(PLAYWRIGHT_SRC_INFIX))
     return false;
   return true;
 }

--- a/tests/mcp/cli-cdp.spec.ts
+++ b/tests/mcp/cli-cdp.spec.ts
@@ -37,7 +37,17 @@ test('cdp server', async ({ cdpServer, cli, server }) => {
 browser.cdpEndpoint=${cdpServer.endpoint}
 browser.isolated=false
 `);
-  await cli('open', `--config=${configPath}`);
+  await cli('attach', `--config=${configPath}`);
+  const { inlineSnapshot } = await cli('snapshot');
+  expect(inlineSnapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
+});
+
+test('attach via cdp', async ({ cdpServer, cli, server }) => {
+  const browserContext = await cdpServer.start();
+  const [page] = browserContext.pages();
+  await page.goto(server.HELLO_WORLD);
+
+  await cli('attach', `--cdp=${cdpServer.endpoint}`);
   const { inlineSnapshot } = await cli('snapshot');
   expect(inlineSnapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
 });

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -23,8 +23,7 @@ import playwright from '../../packages/playwright-core';
 
 test('list', async ({ cli, server }) => {
   const { output: emptyOutput } = await cli('list');
-  expect(emptyOutput).toContain('### Browsers');
-  expect(emptyOutput).toContain('  (no browsers)');
+  expect(emptyOutput).toContain('(no browsers)');
 
   await cli('open', server.HELLO_WORLD);
 
@@ -182,7 +181,7 @@ test('workspace isolation - sessions in different workspaces are isolated', asyn
   await cli('close', { cwd: workspace1 });
 
   const { output: list1After } = await cli('list', { cwd: workspace1 });
-  expect(list1After).toContain('(no browsers)');
+  expect(list1After).not.toContain('### Browsers');
   const { output: list2After } = await cli('list', { cwd: workspace2 });
   expect(list2After).toContain('default');
 
@@ -306,8 +305,7 @@ test.describe('browser server', () => {
     await using browser = await playwright[browserName].launch({ headless: true });
     await browser.bind('foobar', { workspaceDir: 'workspace1' });
     const { output } = await cli('list', '--all');
-    expect(output).toBe(`### Browsers
-### Browser servers available for attach
+    expect(output).toBe(`### Browser servers available for attach
 workspace1:
 - browser "foobar":
   - browser: ${/* FIX browser._options */ mcpBrowser.replace('chrome', 'chromium')}
@@ -331,9 +329,16 @@ workspace1:
 /:
 - foobar:
   - status: open
-  - browser-type: ${/* FIX browser._options */ mcpBrowser.replace('chrome', 'chromium')}
-  - user-data-dir: <in-memory>
-  - headed: false`);
+  - browser-type: ${mcpBrowser.replace('chrome', 'chromium')} (attached)
+
+### Browser servers available for attach
+workspace1:
+- browser "foobar":
+  - browser: ${mcpBrowser.replace('chrome', 'chromium')}
+  - version: ${version}
+  - status: open
+  - data-dir: <in-memory>
+  - run \`playwright-cli attach "foobar"\` to attach`);
   });
 
   test('fail to attach to browser server without contexts', async ({ cli, mcpBrowser }) => {
@@ -350,7 +355,7 @@ workspace1:
     const page = await browser.newPage();
     await page.setContent('<title>Env Page</title><h1>Hello from env</h1>');
     await browser.bind('foobar', { workspaceDir: 'workspace1' });
-    const { output: openOutput, snapshot } = await cli('open', { env: { PLAYWRIGHT_CLI_SESSION: 'foobar' } });
+    const { output: openOutput, snapshot } = await cli('attach', { env: { PLAYWRIGHT_CLI_SESSION: 'foobar' } });
     expect(openOutput).toContain('### Browser `foobar` opened with pid');
     expect(openOutput).toContain('Env Page');
     expect(snapshot).toContain('Hello from env');
@@ -359,9 +364,16 @@ workspace1:
 /:
 - foobar:
   - status: open
-  - browser-type: ${mcpBrowser.replace('chrome', 'chromium')}
-  - user-data-dir: <in-memory>
-  - headed: false`);
+  - browser-type: ${mcpBrowser.replace('chrome', 'chromium')} (attached)
+
+### Browser servers available for attach
+workspace1:
+- browser "foobar":
+  - browser: ${mcpBrowser.replace('chrome', 'chromium')}
+  - version: ${version}
+  - status: open
+  - data-dir: <in-memory>
+  - run \`playwright-cli attach "foobar"\` to attach`);
   });
 
   test('attach with session alias', async ({ cli, mcpBrowser }) => {
@@ -385,8 +397,7 @@ workspace1:
     expect(openOutput).toContain('Session `foobar` created, attached to `foobar`');
     await cli('-s', 'foobar', 'close');
     const { output: listOutput } = await cli('list', '--all');
-    expect(listOutput).toBe(`### Browsers
-### Browser servers available for attach
+    expect(listOutput).toBe(`### Browser servers available for attach
 workspace1:
 - browser \"foobar\":
   - browser: ${/* FIX browser._options */ mcpBrowser.replace('chrome', 'chromium')}
@@ -394,18 +405,6 @@ workspace1:
   - status: open
   - data-dir: <in-memory>
   - run \`playwright-cli attach \"foobar\"\` to attach`);
-  });
-
-  test('attach --cdp', async ({ cli, cdpServer, server }) => {
-    const context = await cdpServer.start();
-    await context.pages()[0].goto(server.HELLO_WORLD);
-    const { output, snapshot } = await cli('attach', `--cdp=${cdpServer.endpoint}`);
-    expect(output).toContain(`### Page
-- Page URL: ${server.HELLO_WORLD}
-- Page Title: Title`);
-    expect(snapshot).toContain(`- generic [active] [ref=e1]: Hello, world!`);
-    await cli('goto', 'data:text/html,<title>CDP Title</title>');
-    expect(await context.pages()[0].title()).toBe('CDP Title');
   });
 });
 


### PR DESCRIPTION
## Summary
- Separate open/attach command handling so args don't fall through into session
- Track browser ownership (attached vs own) in session config
- Fix attach via CDP to work correctly with snapshot