### PR TITLE
fix(mcp): no tombstones on the server registry level

### DIFF
--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -75,7 +75,7 @@ class ServerRegistry {
       const entries = await Promise.all(promises);
       const descriptors = [];
       for (const entry of entries) {
-        if (!entry.canConnect && !entry.browser.userDataDir) {
+        if (!entry.canConnect) {
           await fs.promises.unlink(entry.file).catch(() => {});
           continue;
         }

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -67,7 +67,7 @@ export class Session {
   }
 
   async deleteData() {
-    await this.stop();
+    await this.stop(true);
 
     const dataDirs = await fs.promises.readdir(this._sessionFile.daemonDir).catch(() => []);
     const matchingEntries = dataDirs.filter(file => file === `${this.name}.session` || file.startsWith(`ud-${this.name}-`));

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -163,17 +163,18 @@ export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionN
   if (result.browser.isolated === undefined)
     result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint && !result.extension;
 
-  if (!result.extension && !result.browser.isolated && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint) {
-    // No custom value provided, use the daemon data dir.
-    const browserToken = result.browser.launchOptions?.channel ?? result.browser?.browserName;
-    const userDataDir = path.resolve(daemonProfilesDir, `ud-${sessionName}-${browserToken}`);
-    result.browser.userDataDir = userDataDir;
-  }
-
   if (result.browser.launchOptions.headless === undefined)
     result.browser.launchOptions.headless = true;
 
   const browser = await validateBrowserConfig(result.browser);
+
+  if (!result.extension && !browser.isolated && !browser.userDataDir && !browser.remoteEndpoint && !browser.cdpEndpoint) {
+    // No custom value provided, use the daemon data dir.
+    const browserToken = browser.launchOptions?.channel ?? browser?.browserName;
+    const userDataDir = path.resolve(daemonProfilesDir, `ud-${sessionName}-${browserToken}`);
+    browser.userDataDir = userDataDir;
+  }
+
   return { ...result, browser, configFile, skillMode: true };
 }
 

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 import { tools } from '../../packages/playwright-core/lib/coreBundle';
 import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
@@ -27,11 +27,7 @@ const { resolveCLIConfigForCLI, resolveCLIConfigForMCP } = tools;
 // Empty env to isolate tests from the host environment.
 const emptyEnv = {};
 
-// ---------------------------------------------------------------------------
-// Shared behavior — browserName / channel resolution
-// These are tested via resolveCLIConfigForMCP; the underlying configFromCLIOptions
-// and validateBrowserConfig are shared with resolveCLIConfigForCLI.
-// ---------------------------------------------------------------------------
+test.skip(({ mcpBrowser }) => mcpBrowser !== 'chrome', 'Channel-agnostic tests.');
 
 test.describe('browserName and channel', () => {
   test('no browser option defaults to chromium / chrome', async () => {
@@ -376,7 +372,7 @@ test.describe('resolveCLIConfigForCLI - isolated and userDataDir', () => {
   test('auto userDataDir uses undefined token when no browser specified', async ({}, testInfo) => {
     const profilesDir = testInfo.outputPath('profiles');
     const config = await resolveCLI(profilesDir, 'default', { persistent: true });
-    expect(config.browser.userDataDir).toBe(path.resolve(profilesDir, 'ud-default-undefined'));
+    expect(config.browser.userDataDir).toBe(path.resolve(profilesDir, 'ud-default-chrome'));
   });
 
   test('no auto userDataDir when isolated', async ({}, testInfo) => {


### PR DESCRIPTION
## Summary
- Default `browserToken` to `'chrome'` when no browser is specified, avoiding `'undefined'` in userDataDir paths
- Simplify server registry cleanup to remove stale entries regardless of userDataDir presence
- Pass force flag to session stop during deleteData