### PR TITLE
fix(trace-viewer): Prevent timeline overflowing horizontally

### DIFF
--- a/packages/trace-viewer/src/ui/timeline.css
+++ b/packages/trace-viewer/src/ui/timeline.css
@@ -28,6 +28,7 @@
   cursor: text;
   user-select: none;
   margin-left: 10px;
+  overflow-x: clip;
 }
 
 .timeline-divider {


### PR DESCRIPTION
For certain trace files with certain screen widths, the timeline overflows, causing the whole page to have a horizontal scrollbar (e.g. 1800px width for empty trace viewer, in incognito tab)
This has regressed in #39634

Fixes: #40172