### PR TITLE
fix(test): avoid dev matchers clobbering stable runner in reporter tests

### DIFF
--- a/tests/playwright-test/playwright-test-fixtures.ts
+++ b/tests/playwright-test/playwright-test-fixtures.ts
@@ -27,8 +27,24 @@ import { serverFixtures } from '../config/serverFixtures';
 import type { TestInfo } from './stable-test-runner';
 import { expect } from './stable-test-runner';
 import { test as base } from './stable-test-runner';
+import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import { inheritAndCleanEnv } from '../config/utils';
 export { countTimes } from '../config/commonFixtures';
+
+export function startHtmlReportServer(folder: string): utils.HttpServer {
+  const server = new utils.HttpServer();
+  server.routePrefix('/', (request, response) => {
+    const parsed = new URL('http://localhost' + request.url);
+    let relativePath = parsed.pathname;
+    if (relativePath.startsWith('/trace/file'))
+      return server.serveFile(request, response, parsed.searchParams.get('path')!);
+    if (relativePath === '/')
+      relativePath = '/index.html';
+    const absolutePath = path.join(folder, ...relativePath.split('/'));
+    return server.serveFile(request, response, absolutePath);
+  });
+  return server;
+}
 
 type CliRunResult = {
   exitCode: number,

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -17,9 +17,7 @@
 import * as fs from 'fs';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import path from 'path';
-import { html } from '../../packages/playwright/lib/runner';
-const { startHtmlReportServer } = html;
-import { expect as baseExpect, test as baseTest, stripAnsi } from './playwright-test-fixtures';
+import { expect as baseExpect, test as baseTest, stripAnsi, startHtmlReportServer } from './playwright-test-fixtures';
 import { extractZip } from '../../packages/utils/third_party/extractZip';
 import * as yazl from 'yazl';
 import { utils, getUserAgent } from '../../packages/playwright-core/lib/coreBundle';

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -17,9 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
-import { test as baseTest, expect as baseExpect, createImage } from './playwright-test-fixtures';
-import { html } from '../../packages/playwright/lib/runner';
-const { startHtmlReportServer } = html;
+import { test as baseTest, expect as baseExpect, createImage, startHtmlReportServer } from './playwright-test-fixtures';
 import { iso, utils } from '../../packages/playwright-core/lib/coreBundle';
 
 type HttpServer = utils.HttpServer;

--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.60.0-alpha-2026-04-06"
+        "@playwright/test": "^1.60.0-alpha-2026-04-13"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-2026-04-06",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-2026-04-06.tgz",
-      "integrity": "sha512-RtA98sOfvb6hVi4sV9WjPb6MRgND8GQv0EeqKWUarjxcMnbU3DE0W1HHVjd6PZInJuuIz2gxy7KnQaH+mtyjaw==",
+      "version": "1.60.0-alpha-2026-04-13",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-2026-04-13.tgz",
+      "integrity": "sha512-J4VCqMkEfLvhjnkq5MJ71tA7dk+1eTl3HN4UiCGQuvK0rPxrJo2dth1k7wgpHCc5IPbWtwrZ22kE7B/dcW6Gmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-2026-04-06"
+        "playwright": "1.60.0-alpha-2026-04-13"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-2026-04-06",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-2026-04-06.tgz",
-      "integrity": "sha512-XYIVJkx10/bo+JXcuTIMxsvH1aA5Ue/ITGnp8oVNWCbYJIyyGSyUmo3dPrF2mRqiuUEripnXs0Apblfm9zZCxA==",
+      "version": "1.60.0-alpha-2026-04-13",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-2026-04-13.tgz",
+      "integrity": "sha512-BeFO7QP7SByPXrvEKRxdMrTZyvs3lAcyYdiwpBNspu40Du+xVrkd+QMZ+uCpal+0/sLxhba4Js8lwgnq9g+2VQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-2026-04-06"
+        "playwright-core": "1.60.0-alpha-2026-04-13"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-2026-04-06",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-2026-04-06.tgz",
-      "integrity": "sha512-iBJKirdBcH9mGKRjLG4sT05cKixhWO0EMFK6jpRZT6EflUf7ucPDB0lZo+SJfDuq6VIDIvjh0J4o9V81qkQUvQ==",
+      "version": "1.60.0-alpha-2026-04-13",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-2026-04-13.tgz",
+      "integrity": "sha512-MPqII482p7ujGxf3kMdAuX78VdDAoRZrzW/CX0/zq/bVh/IfPeTOZ3eHUk/jeFp1dQLCFyWiiL0hcthDX1fQBA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "^1.60.0-alpha-2026-04-06"
+    "@playwright/test": "^1.60.0-alpha-2026-04-13"
   }
 }


### PR DESCRIPTION
## Summary

- After updating the stable test runner to `1.60.0-alpha-2026-04-13`, all `toMatchAriaSnapshot` calls in `reporter-html.spec.ts` and `reporter-blob.spec.ts` fail with `toMatchAriaSnapshot() must be called during the test`.

**Root cause:** Both test files imported `startHtmlReportServer` from `../../packages/playwright/lib/runner`. This transitively loaded the dev code's `matchers/expect.js` bundle (via `runner → common → matchers/expect`). Because jest-expect stores matchers on `globalThis[Symbol.for("$$jest-matchers-object")]`, the dev matchers overwrote the stable test runner's matchers. When `toMatchAriaSnapshot` was later called, it executed the dev copy which references the dev code's `expectConfig()` — a module-level singleton where `testInfo` was never set (only the stable runner's worker sets it on its own copy). This was exposed by a120dec6d which changed `toMatchAriaSnapshot` from using `globals.currentTestInfo()` (a shared global) to `expectConfig().testInfo` (module-specific singleton).

**Fix:** Replace the runner import with a lightweight `startHtmlReportServer` helper in `playwright-test-fixtures.ts` that only depends on `playwright-core`'s `HttpServer` — no matchers loaded.

Closes https://github.com/microsoft/playwright/pull/40187