### PR TITLE
chore(mcp): default to extension protocol v1

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -22,8 +22,8 @@
  * - /extension/guid - Extension connection
  *
  * Protocol version is controlled by PLAYWRIGHT_EXTENSION_PROTOCOL env variable:
- * - v1: single-tab, extension manages debugger attachment
- * - v2 (default): multi-tab, relay manages debugger via chrome.* APIs
+ * - v1 (default): single-tab, extension manages debugger attachment
+ * - v2: multi-tab, relay manages debugger via chrome.* APIs
  */
 
 import { spawn } from 'child_process';
@@ -77,7 +77,7 @@ export class CDPRelayServer {
     this._browserChannel = browserChannel;
     this._userDataDir = userDataDir;
     this._executablePath = executablePath;
-    this._protocolVersion = parseInt(process.env.PLAYWRIGHT_EXTENSION_PROTOCOL ?? protocol.VERSION.toString(), 10);
+    this._protocolVersion = parseInt(process.env.PLAYWRIGHT_EXTENSION_PROTOCOL ?? protocol.DEFAULT_VERSION.toString(), 10);
 
     const sendCommand = (method: string, params: any): Promise<any> => {
       if (!this._extensionConnection)

--- a/packages/playwright-core/src/tools/mcp/protocol.ts
+++ b/packages/playwright-core/src/tools/mcp/protocol.ts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-// Whenever the commands/events change, the version must be updated. The latest
-// extension version should be compatible with the old MCP clients.
-export const VERSION = 2;
+// The latest protocol version defined in this file. Bumped whenever the
+// commands/events change. The latest extension version should remain
+// compatible with older MCP clients.
+export const LATEST_VERSION = 2;
+
+// The protocol version used by default when PLAYWRIGHT_EXTENSION_PROTOCOL is
+// not set. May lag behind LATEST_VERSION while a new version is rolling out.
+export const DEFAULT_VERSION = 1;
 
 // Structural mirrors of @types/chrome shapes used over the wire. The extension
 // imports the real chrome.* types and they are structurally compatible.


### PR DESCRIPTION
## Summary
- Split `protocol.VERSION` into `LATEST_VERSION` and `DEFAULT_VERSION` to clarify intent
- Default extension protocol is v1 while v2 rolls out
- Opt into v2 via `PLAYWRIGHT_EXTENSION_PROTOCOL=2`