### PR TITLE
chore: remove unused _connectOverCDPTransport method

### DIFF
--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -52,7 +52,6 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['BrowserType.launch', { title: 'Launch browser', }],
   ['BrowserType.launchPersistentContext', { title: 'Launch persistent context', }],
   ['BrowserType.connectOverCDP', { title: 'Connect over CDP', }],
-  ['BrowserType.connectOverCDPTransport', { title: 'Connect over CDP transport', }],
   ['BrowserType.connectToWorker', { title: 'Connect to worker', }],
   ['Browser.startServer', { title: 'Start server', }],
   ['Browser.stopServer', { title: 'Stop server', }],

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -175,14 +175,4 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     return Worker.from(result.worker);
   }
 
-  async _connectOverCDPTransport(transport: /* ConnectionTransport */ any) {
-    if (this.name() !== 'chromium')
-      throw new Error('Connecting over CDP is only supported in Chromium.');
-    const result = await this._channel.connectOverCDPTransport({ transport });
-    const browser = Browser.from(result.browser);
-    browser._connectToBrowserType(this, {}, undefined);
-    if (result.defaultContext)
-      await this._instrumentation.runAfterCreateBrowserContext(BrowserContext.from(result.defaultContext));
-    return browser;
-  }
 }

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -637,13 +637,6 @@ scheme.BrowserTypeConnectOverCDPResult = tObject({
   browser: tChannel(['Browser']),
   defaultContext: tOptional(tChannel(['BrowserContext'])),
 });
-scheme.BrowserTypeConnectOverCDPTransportParams = tObject({
-  transport: tBinary,
-});
-scheme.BrowserTypeConnectOverCDPTransportResult = tObject({
-  browser: tChannel(['Browser']),
-  defaultContext: tOptional(tChannel(['BrowserContext'])),
-});
 scheme.BrowserTypeConnectToWorkerParams = tObject({
   endpoint: tString,
   timeout: tFloat,

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -290,10 +290,6 @@ export abstract class BrowserType extends SdkObject {
     throw new Error('CDP connections are only supported by Chromium');
   }
 
-  async connectOverCDPTransport(progress: Progress, transport: ConnectionTransport): Promise<Browser> {
-    throw new Error('CDP connections are only supported by Chromium');
-  }
-
   async connectToWorker(progress: Progress, endpoint: string): Promise<Worker> {
     throw new Error('CDP connections are only supported by Chromium');
   }

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -154,11 +154,6 @@ export class Chromium extends BrowserType {
     }
   }
 
-  override async connectOverCDPTransport(progress: Progress, transport: ConnectionTransport) {
-    const closeAndWait = async () => transport.close();
-    return this._connectOverCDPImpl(progress, transport, closeAndWait, { isLocal: true });
-  }
-
   override async connectToWorker(progress: Progress, endpoint: string) {
     const wsEndpoint = await urlToWSEndpoint(progress, endpoint, {});
     const transport = await WebSocketTransport.connect(progress, wsEndpoint);

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -65,15 +65,6 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
     };
   }
 
-  async connectOverCDPTransport(params: channels.BrowserTypeConnectOverCDPTransportParams, progress: Progress): Promise<channels.BrowserTypeConnectOverCDPTransportResult> {
-    if (this._denyLaunch)
-      throw new Error(`Launching more browsers is not allowed.`);
-
-    const browser = await this._object.connectOverCDPTransport(progress, params.transport as any);
-    const browserDispatcher = new BrowserDispatcher(this, browser);
-    return { browser: browserDispatcher, defaultContext: browser._defaultContext ? BrowserContextDispatcher.from(browserDispatcher, browser._defaultContext) : undefined };
-  }
-
   async connectToWorker(params: channels.BrowserTypeConnectToWorkerParams, progress: Progress): Promise<channels.BrowserTypeConnectToWorkerResult> {
     if (this._denyLaunch)
       throw new Error(`Launching more browsers is not allowed.`);

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -893,7 +893,6 @@ export interface BrowserTypeChannel extends BrowserTypeEventTarget, Channel {
   launch(params: BrowserTypeLaunchParams, progress?: Progress): Promise<BrowserTypeLaunchResult>;
   launchPersistentContext(params: BrowserTypeLaunchPersistentContextParams, progress?: Progress): Promise<BrowserTypeLaunchPersistentContextResult>;
   connectOverCDP(params: BrowserTypeConnectOverCDPParams, progress?: Progress): Promise<BrowserTypeConnectOverCDPResult>;
-  connectOverCDPTransport(params: BrowserTypeConnectOverCDPTransportParams, progress?: Progress): Promise<BrowserTypeConnectOverCDPTransportResult>;
   connectToWorker(params: BrowserTypeConnectToWorkerParams, progress?: Progress): Promise<BrowserTypeConnectToWorkerResult>;
 }
 export type BrowserTypeLaunchParams = {
@@ -1141,16 +1140,6 @@ export type BrowserTypeConnectOverCDPOptions = {
   isLocal?: boolean,
 };
 export type BrowserTypeConnectOverCDPResult = {
-  browser: BrowserChannel,
-  defaultContext?: BrowserContextChannel,
-};
-export type BrowserTypeConnectOverCDPTransportParams = {
-  transport: Binary,
-};
-export type BrowserTypeConnectOverCDPTransportOptions = {
-
-};
-export type BrowserTypeConnectOverCDPTransportResult = {
   browser: BrowserChannel,
   defaultContext?: BrowserContextChannel,
 };

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1034,14 +1034,6 @@ BrowserType:
         browser: Browser
         defaultContext: BrowserContext?
 
-    connectOverCDPTransport:
-      title: Connect over CDP transport
-      parameters:
-        transport: binary
-      returns:
-        browser: Browser
-        defaultContext: BrowserContext?
-
     connectToWorker:
       title: Connect to worker
       parameters:

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -21,7 +21,7 @@ import fs from 'fs';
 import { getUserAgent, server as coreServer } from '../../../packages/playwright-core/lib/coreBundle';
 import { suppressCertificateWarning } from '../../config/utils';
 
-const { WebSocketTransport, nullProgress } = coreServer;
+const { nullProgress } = coreServer;
 type Frame = coreServer.Frame;
 
 test.skip(({ mode }) => mode === 'service2');
@@ -642,35 +642,6 @@ test('should get title and URL of existing page', async ({ browserType, mode, se
   } finally {
     for (const browser of browsers)
       await browser.close();
-    await browserServer.close();
-  }
-});
-
-test('should connect over CDP using a ConnectionTransport', async ({ browserType, mode, server }, testInfo) => {
-  test.skip(mode !== 'default', '_connectOverCDPTransport is only available in-process');
-
-  const port = 9339 + testInfo.workerIndex;
-  const browserServer = await browserType.launch({
-    args: ['--remote-debugging-port=' + port]
-  });
-  try {
-    const json = await new Promise<string>((resolve, reject) => {
-      http.get(`http://127.0.0.1:${port}/json/version/`, resp => {
-        let data = '';
-        resp.on('data', chunk => data += chunk);
-        resp.on('end', () => resolve(data));
-      }).on('error', reject);
-    });
-    const wsEndpoint = JSON.parse(json).webSocketDebuggerUrl;
-    const transport = await WebSocketTransport.connect(undefined, wsEndpoint);
-    const cdpBrowser = await (browserType as any)._connectOverCDPTransport(transport);
-    const contexts = cdpBrowser.contexts();
-    expect(contexts.length).toBe(1);
-    const page = await contexts[0].newPage();
-    await page.goto(server.EMPTY_PAGE);
-    expect(page.url()).toBe(server.EMPTY_PAGE);
-    await cdpBrowser.close();
-  } finally {
     await browserServer.close();
   }
 });


### PR DESCRIPTION
## Summary
- Remove the unused `_connectOverCDPTransport` client method along with its protocol entry, dispatcher, server implementation, and lone test.