### PR TITLE
feat(test-runner): error when overriding non-option fixture in config

### DIFF
--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -97,6 +97,14 @@ export class FixturePool {
         this._appendFixtureList({ fixtures: selectedOverrides, location: optionOverrides!.location }, !!disallowWorkerFixtures, true);
     }
 
+    if (optionOverrides) {
+      for (const key of overrideKeys) {
+        const registration = this._registrations.get(key);
+        if (registration && !registration.option)
+          this._addLoadError(`Fixture "${key}" cannot be overridden in the configuration "use" section. Only fixtures registered with { option: true } can be set in the config.`, optionOverrides.location);
+      }
+    }
+
     this.digest = this.validate();
   }
 

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -789,3 +789,30 @@ test('should report fixture teardown error after test error', async ({ runInline
   expect(result.output).toContain('Error from the fixture foo');
   expect(result.output).toContain('Error from the test');
 });
+
+test('should throw when overriding non-option fixture in config', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        use: {
+          foo: 'overridden',
+          headless: true,
+          unknownThing: 'ignored',
+        },
+      };
+    `,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        foo: async ({}, use) => await use('original'),
+      });
+      test('works', async ({ foo }) => {
+        expect(foo).toBe('original');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Fixture "foo" cannot be overridden in the configuration "use" section. Only fixtures registered with { option: true } can be set in the config.');
+  expect(result.output).not.toContain('Fixture "headless"');
+  expect(result.output).not.toContain('Fixture "unknownThing"');
+});


### PR DESCRIPTION
## Summary
- Setting a non-option fixture in a project's `use` section used to be silently ignored. Emit a load-time error pointing the user at `{ option: true }` or `test.extend()`.
- Unknown keys and option overrides remain unaffected.