### PR TITLE
fix(clock): reset ticks on first install to avoid realTime drift

### DIFF
--- a/packages/injected/src/clock.ts
+++ b/packages/injected/src/clock.ts
@@ -98,7 +98,7 @@ export class ClockController {
 
   install(time: number) {
     this._replayLogOnce();
-    this._innerSetTime(asWallTime(time));
+    this._innerInstall(asWallTime(time));
   }
 
   setSystemTime(time: number) {
@@ -134,6 +134,15 @@ export class ClockController {
     this._now.isFixedTime = false;
     if (this._now.origin < 0)
       this._now.origin = this._now.time;
+  }
+
+  private _innerInstall(time: WallTime) {
+    // On a fresh install, reset the monotonic counter so that drift
+    // accumulated by the realTime ticker before the user called install()
+    // does not leak into performance.now().
+    if (this._now.origin < 0)
+      this._now.ticks = 0 as Ticks;
+    this._innerSetTime(time);
   }
 
   private _innerSetFixedTime(time: WallTime) {
@@ -440,7 +449,7 @@ export class ClockController {
       lastLogTime = time;
 
       if (type === 'install') {
-        this._innerSetTime(asWallTime(param!));
+        this._innerInstall(asWallTime(param!));
       } else if (type === 'fastForward' || type === 'runFor') {
         this._advanceNow(shiftTicks(this._now.ticks, param!));
       } else if (type === 'pauseAt') {


### PR DESCRIPTION
## Summary
- Between `inject()` (which starts the realTime ticker) and the user's `install(time)` call, `_now.ticks` accumulates drift. Since `performance.now()` returns `ticks`, that drift leaked into values the page observed.
- Reset `ticks` to 0 on the first `install()` (when origin hasn't been set yet) so the monotonic counter starts from a pristine state.
- Exposed by flaky `library/page-clock.spec.ts:282 replaces global performance.timeOrigin` on Firefox.