### PR TITLE
fix(chromium): resolve allHeaders() for iframe worker scripts

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -726,10 +726,11 @@ type RequestInfo = {
 //   - Network.requestWillBeSentExtraInfo and Network.responseReceivedExtraInfo are dispatched on
 //     another channel. Those channels are not associated, so events come in random order.
 //
-// This class will associate responses with the new headers. These extra info headers will become
-// available to client reliably upon requestfinished event only. It consumes CDP
+// This class will associate responses with the new headers while Chromium delivers them before the
+// request finishes. If extra info is still missing at requestfinished, header access falls back to
+// provisional values. It consumes CDP
 // signals on one end and processResponse(network.Response) signals on the other hands. It then makes
-// sure that responses have all the extra headers in place by the time request finishes.
+// sure that responses have Chromium extra headers in place whenever they arrive before finish.
 //
 // The shape of the instrumentation API is deliberately following the CDP, so that it
 // is clear what is called when and what this means to the tracker without extra
@@ -827,13 +828,7 @@ class ResponseExtraInfoTracker {
     if (!info.loadingFinished && !info.loadingFailed)
       return;
 
-    if (info.responses.length <= info.responseReceivedExtraInfo.length) {
-      // We have extra info for each response.
-      this._stopTracking(info.requestId);
-      return;
-    }
-
-    // We are not done yet.
+    this._stopTracking(info.requestId);
   }
 
   private _stopTracking(requestId: string) {

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -215,7 +215,7 @@ export class Request extends SdkObject {
   }
 
   async rawRequestHeaders(progress: Progress): Promise<HeadersArray> {
-    return await progress.race(this._rawRequestHeaders());
+    return await progress.race(this._rawRequestHeadersOrProvisional());
   }
 
   async response(progress: Progress): Promise<Response | null> {
@@ -269,6 +269,16 @@ export class Request extends SdkObject {
 
   private async _rawRequestHeaders(): Promise<HeadersArray> {
     return this._overrides?.headers || this._rawRequestHeadersPromise;
+  }
+
+  private async _rawRequestHeadersOrProvisional(): Promise<HeadersArray> {
+    if (this._overrides?.headers)
+      return this._overrides.headers;
+    if (this._rawRequestHeadersPromise.isDone())
+      return await this._rawRequestHeadersPromise;
+    const response = await this._waitForResponse();
+    await response?.finished();
+    return this._rawRequestHeadersPromise.isDone() ? await this._rawRequestHeadersPromise : this._headers;
   }
 
   private _waitForResponse(): Promise<Response | null> {
@@ -327,7 +337,7 @@ export class Request extends SdkObject {
     headersSize += this.method().length;
     headersSize += (new URL(this.url())).pathname.length;
     headersSize += 8; // httpVersion
-    const headers = await this._rawRequestHeaders();
+    const headers = await this._rawRequestHeadersOrProvisional();
     for (const header of headers)
       headersSize += header.name.length + header.value.length + 4; // 4 = ': ' + '\r\n'
     return headersSize;
@@ -551,7 +561,7 @@ export class Response extends SdkObject {
   }
 
   async rawResponseHeaders(progress: Progress): Promise<NameValue[]> {
-    return await progress.race(this._rawResponseHeadersPromise);
+    return await progress.race(this._rawResponseHeadersOrProvisional());
   }
 
   async httpVersion(progress: Progress): Promise<string> {
@@ -671,7 +681,7 @@ export class Response extends SdkObject {
   }
 
   async responseHeadersSize(): Promise<number> {
-    const availableSize = await this._responseHeadersSizePromise;
+    const availableSize = await this._responseHeadersSizeOrUnavailable();
     if (availableSize !== null)
       return availableSize;
 
@@ -680,11 +690,25 @@ export class Response extends SdkObject {
     headersSize += 8; // httpVersion;
     headersSize += 3; // statusCode;
     headersSize += this.statusText().length;
-    const headers = await this._rawResponseHeadersPromise;
+    const headers = await this._rawResponseHeadersOrProvisional();
     for (const header of headers)
       headersSize += header.name.length + header.value.length + 4; // 4 = ': ' + '\r\n'
     headersSize += 2; // '\r\n'
     return headersSize;
+  }
+
+  private async _rawResponseHeadersOrProvisional(): Promise<NameValue[]> {
+    if (this._rawResponseHeadersPromise.isDone())
+      return await this._rawResponseHeadersPromise;
+    await this._finishedPromise;
+    return this._rawResponseHeadersPromise.isDone() ? await this._rawResponseHeadersPromise : this._headers;
+  }
+
+  private async _responseHeadersSizeOrUnavailable(): Promise<number | null> {
+    if (this._responseHeadersSizePromise.isDone())
+      return await this._responseHeadersSizePromise;
+    await this._finishedPromise;
+    return this._responseHeadersSizePromise.isDone() ? await this._responseHeadersSizePromise : null;
   }
 
   private async _sizes(): Promise<ResourceSizes> {

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -260,6 +260,20 @@ it('should report worker script as network request', {
   expect(text).toContain(`console.log('hello from the worker');`);
 });
 
+it('should resolve worker script allHeaders in iframe', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39948' },
+}, async function({ page, server, browserName }) {
+  it.skip(browserName !== 'chromium', 'Chromium only');
+
+  const [request] = await Promise.all([
+    page.waitForEvent('requestfinished', request => request.url() === server.PREFIX + '/worker/worker.js'),
+    attachFrame(page, 'frame1', server.PREFIX + '/worker/worker.html'),
+  ]);
+  const response = await request.response();
+  const headers = await response!.allHeaders();
+  expect(headers['content-type']).toBeTruthy();
+});
+
 it('should report worker script as network request after redirect', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35678' },
 }, async ({ page, server, browserName }) => {


### PR DESCRIPTION
 Fixes a Chromium issue where `response.allHeaders()` could hang for a worker script loaded inside an iframe.

Chromium does not always deliver `responseReceivedExtraInfo` before the request finishes for this worker/iframe case. Previously, Playwright kept waiting for the extra info event, which meant header access could hang indefinitely after `requestfinished`.

Tested on the provided example 

Without my change
<img width="647" height="292" alt="Screenshot 2026-04-14 at 10 26 06 pm" src="https://github.com/user-attachments/assets/c2e0689c-c096-4bfb-980a-4fc20fa887ac" />


With my change 
<img width="740" height="247" alt="Screenshot 2026-04-14 at 10 25 33 pm" src="https://github.com/user-attachments/assets/c3159eac-7112-4819-9ebe-c752451c3038" />


  Fixes #39948.
  
  