### PR TITLE
fix(selectOption): match label with html whitespace

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -786,16 +786,18 @@ export class InjectedScript {
     let remainingOptionsToSelect = optionsToSelect.slice();
     for (let index = 0; index < options.length; index++) {
       const option = options[index];
+      const normalizedOptionLabel = normalizeWhiteSpace(option.label);
       const filter = (optionToSelect: Node | { valueOrLabel?: string, value?: string, label?: string, index?: number }) => {
         if (optionToSelect instanceof Node)
           return option === optionToSelect;
+        const matchesLabel = (label: string) => label === option.label || normalizeWhiteSpace(label) === normalizedOptionLabel;
         let matches = true;
         if (optionToSelect.valueOrLabel !== undefined)
-          matches = matches && (optionToSelect.valueOrLabel === option.value || optionToSelect.valueOrLabel === option.label);
+          matches = matches && (optionToSelect.valueOrLabel === option.value || matchesLabel(optionToSelect.valueOrLabel));
         if (optionToSelect.value !== undefined)
           matches = matches && optionToSelect.value === option.value;
         if (optionToSelect.label !== undefined)
-          matches = matches && optionToSelect.label === option.label;
+          matches = matches && matchesLabel(optionToSelect.label);
         if (optionToSelect.index !== undefined)
           matches = matches && optionToSelect.index === index;
         return matches;

--- a/tests/page/page-select-option.spec.ts
+++ b/tests/page/page-select-option.spec.ts
@@ -48,6 +48,17 @@ it('should select single option by label', async ({ page, server }) => {
   expect(await page.evaluate(() => window['result'].onChange)).toEqual(['indigo']);
 });
 
+it('should select single option by label with html whitespace', async ({ page }) => {
+  await page.setContent(`
+    <select>
+      <option value="plain">Plain</option>
+      <option value="html">&nbsp;HTML</option>
+    </select>
+  `);
+  await page.selectOption('select', { label: 'HTML' });
+  expect(await page.evaluate(() => document.querySelector('select').value)).toBe('html');
+});
+
 it('should select single option by handle', async ({ page, server }) => {
   await page.goto(server.PREFIX + '/input/select.html');
   await page.selectOption('select', await page.$('[id=whiteOption]'));


### PR DESCRIPTION
## Summary
- `selectOption({ label })` now matches options whose text contains HTML whitespace entities (e.g. `&nbsp;`) by falling back to a normalized-whitespace comparison when the exact label does not match.

Fixes https://github.com/microsoft/playwright/issues/40210