### PR TITLE
devops: use dafault worker count on ci

### DIFF
--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -65,7 +65,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   maxFailures: 0,
   timeout: 15 * 1000,
   globalTimeout: 90 * 60 * 1000,
-  workers: process.env.CI ? 4 : undefined,
+  workers: undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: 0, // No retries even on CI for now.

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -95,7 +95,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   maxFailures: 200,
   timeout: video ? 60000 : 30000,
   globalTimeout: 5400000,
-  workers: process.env.CI ? 4 : undefined,
+  workers: undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,

--- a/tests/mcp/playwright.config.ts
+++ b/tests/mcp/playwright.config.ts
@@ -51,7 +51,7 @@ export default defineConfig<TestOptions>({
   testDir: rootTestDir,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 2 : undefined,
+  workers: undefined,
   reporter: reporters(),
   tag: process.env.PW_TAG,
   projects: [

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -34,7 +34,7 @@ const reporters = () => {
 export default defineConfig({
   timeout: 30000,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 3 : undefined,
+  workers: undefined,
   snapshotPathTemplate: '__screenshots__/{testFilePath}/{arg}{ext}',
   projects: [
     {


### PR DESCRIPTION
Core count varies between platforms/architectures but previous configuration used the same number of workers regardless of the env, which resulted e.g. in 4 workers on each of the following 2 machines even though one has only 5 cores:


Runner Size | Architecture | Processor (CPU) | Memory (RAM) | Storage (SSD) | Workflow label
-- | -- | -- | -- | -- | --
Large | Intel | 12 | 30 GB | 14 GB | macos-latest-large, macos-14-large, macos-15-large (latest), macos-26-large
XLarge | arm64 (M2) | 5 (+ 8 GPU hardware acceleration) | 14 GB | 14 GB | macos-latest-xlarge, macos-14-xlarge, macos-15-xlarge (latest), macos-26-xlarge

Regular runners have the following size:


Virtual machine / container | Processor (CPU) | Memory (RAM) | Storage (SSD) | Architecture | Workflow label
-- | -- | -- | -- | -- | --
Linux | 4 | 16 GB | 14 GB | x64 | ubuntu-latest, ubuntu-24.04, ubuntu-22.04
Linux | 4 | 16 GB | 14 GB | arm64 | ubuntu-24.04-arm, ubuntu-22.04-arm
Windows | 4 | 16 GB | 14 GB | x64 | windows-latest, windows-2025, windows-2025-vs2026 (public preview), windows-2022
macOS | 4 | 14 GB | 14 GB | Intel | macos-15-intel, macos-26-intel
macOS | 3 (M1) | 7 GB | 14 GB | arm64 | macos-latest, macos-14, macos-15, macos-26

