### PR TITLE
fix(chromium): handle unsupported Browser.setDownloadBehavior on CDP

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -29,6 +29,8 @@ import { CRConnection, ConnectionEvents } from './crConnection';
 import { CRPage } from './crPage';
 import { saveProtocolStream } from './crProtocolHelper';
 import { CRServiceWorker } from './crServiceWorker';
+import { isProtocolError } from '../protocolError';
+import { debugLogger } from '@utils/debugLogger';
 
 import type { InitScript, Worker } from '../page';
 import type { ConnectionTransport } from '../transport';
@@ -356,6 +358,11 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
         browserContextId: this._browserContextId,
         downloadPath: this._browser.options.downloadsPath,
         eventsEnabled: true,
+      }).catch((e: Error) => {
+        if (isProtocolError(e) && e.method === 'Browser.setDownloadBehavior')
+          debugLogger.log('browser', e.message);
+        else
+          throw e;
       }));
     }
     await Promise.all(promises);


### PR DESCRIPTION
## Motivation
When connecting to a remote browser via CDP (--cdp option), some embedded Chromium-based browsers do not implement the full Chrome DevTools Protocol. One common example is LG webOS TV, which exposes a remote Web Inspector via CDP but does not support Browser.setDownloadBehavior.

Currently, Playwright sends Browser.setDownloadBehavior unconditionally during CRBrowserContext.initialize(). If the remote browser rejects this command, the entire CDP connection fails with:

```Error: Protocol error (Browser.setDownloadBehavior): Browser context management is not supported.```

This blocks any use of Playwright for debugging, testing, or automation on these devices, even though download behavior management is irrelevant in that context.

## Change
File: packages/playwright-core/src/server/chromium/crBrowser.ts

In CRBrowserContext.initialize(), catch the ProtocolError from Browser.setDownloadBehavior using the existing isProtocolError utility and match on e.method, then log at debug level. Any other unexpected errors are re-thrown.

## Tested On
LG webOS TV (Cast shell remote debugging via CDP)

* Before: playwright-cli attach --cdp=http://<TV_IP>:<PORT> fails with Protocol error (Browser.setDownloadBehavior)
* After: Successfully connects; snapshot, eval, click, navigation all work correctly

Standard Chrome (desktop) - No behavior change, download tests pass as before