### PR TITLE
docs(best-practices): delete random period and add space to "VS Code"…

### DIFF
--- a/docs/src/best-practices-js.md
+++ b/docs/src/best-practices-js.md
@@ -191,7 +191,7 @@ await expect(page.getByText('welcome')).toBeVisible();
 
 #### Local debugging
 
-For local debugging we recommend you [debug your tests live in VSCode.](./getting-started-vscode.md#debugging-your-tests) by installing the [VS Code extension](./getting-started-vscode.md). You can run tests in debug mode by right-clicking on the line next to the test you want to run which will open a browser window and pause at where the breakpoint is set.
+For local debugging we recommend you [debug your tests live in VS Code](./getting-started-vscode.md#debugging-your-tests) by installing the [VS Code extension](./getting-started-vscode.md). You can run tests in debug mode by right-clicking on the line next to the test you want to run which will open a browser window and pause at where the breakpoint is set.
 
 <img height="1240" width="2676" alt="debugging tests in vscode" loading="lazy" src="https://user-images.githubusercontent.com/13063165/212274675-5c6e1647-2aab-40fd-9804-8680c1ac2d16.png" />
 


### PR DESCRIPTION
… per convention