### PR TITLE
feat(page): add 'bringtofront' event

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -68,6 +68,13 @@ await context.CloseAsync();
 
 This event is not emitted.
 
+## event: BrowserContext.bringToFront
+* since: v1.60
+- argument: <[Page]>
+
+Emitted when a client calls [`method: Page.bringToFront`] on a page in this context. The event is dispatched to all
+clients connected to the context, including the one that initiated the call.
+
 ## property: BrowserContext.clock
 * since: v1.45
 - type: <[Clock]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8226,6 +8226,13 @@ export interface BrowserContext {
   on(event: 'backgroundpage', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  on(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -8365,6 +8372,11 @@ export interface BrowserContext {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8416,6 +8428,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   addListener(event: 'backgroundpage', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  addListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8557,6 +8576,11 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8612,6 +8636,11 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8663,6 +8692,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   prependListener(event: 'backgroundpage', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  prependListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -9452,6 +9488,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   waitForEvent(event: 'backgroundpage', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  waitForEvent(event: 'bringtofront', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -149,6 +149,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
           dialog.dismiss().catch(() => {});
       }
     });
+    this._channel.on('bringToFront', ({ page }) => this.emit(Events.BrowserContext.BringToFront, Page.from(page)));
     this._channel.on('request', ({ request, page }) => this._onRequest(network.Request.from(request), Page.fromNullable(page)));
     this._channel.on('requestFailed', ({ request, failureText, responseEndTiming, page }) => this._onRequestFailed(network.Request.from(request), responseEndTiming, failureText, Page.fromNullable(page)));
     this._channel.on('requestFinished', params => this._onRequestFinished(params));

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -39,6 +39,7 @@ export const Events = {
   },
 
   BrowserContext: {
+    BringToFront: 'bringtofront',
     Console: 'console',
     Close: 'close',
     Dialog: 'dialog',

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -941,6 +941,9 @@ scheme.BrowserContextInitializer = tObject({
 scheme.BrowserContextBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),
 });
+scheme.BrowserContextBringToFrontEvent = tObject({
+  page: tChannel(['Page']),
+});
 scheme.BrowserContextConsoleEvent = tObject({
   type: tString,
   text: tString,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -45,6 +45,7 @@ import type * as types from './types';
 import type * as channels from '@protocol/channels';
 
 const BrowserContextEvent = {
+  BringToFront: 'bringtofront',
   Console: 'console',
   Close: 'close',
   Page: 'page',
@@ -65,6 +66,7 @@ const BrowserContextEvent = {
 } as const;
 
 export type BrowserContextEventMap = {
+  [BrowserContextEvent.BringToFront]: [page: Page];
   [BrowserContextEvent.Console]: [message: ConsoleMessage];
   [BrowserContextEvent.Close]: [];
   [BrowserContextEvent.Page]: [page: Page];

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -105,6 +105,9 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this.addObjectListener(BrowserContext.Events.Page, page => {
       this._dispatchEvent('page', { page: PageDispatcher.from(this, page) });
     });
+    this.addObjectListener(BrowserContext.Events.BringToFront, page => {
+      this._dispatchEvent('bringToFront', { page: PageDispatcher.from(this, page) });
+    });
     this.addObjectListener(BrowserContext.Events.Close, () => {
       this._dispatchEvent('close');
       this._dispose();

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -648,6 +648,7 @@ export class Page extends SdkObject<PageEventMap> {
 
   async bringToFront(progress: Progress): Promise<void> {
     await progress.race(this.delegate.bringToFront());
+    this.emitOnContext(BrowserContext.Events.BringToFront, this);
   }
 
   async addInitScript(progress: Progress, source: string) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8226,6 +8226,13 @@ export interface BrowserContext {
   on(event: 'backgroundpage', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  on(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -8365,6 +8372,11 @@ export interface BrowserContext {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8416,6 +8428,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   addListener(event: 'backgroundpage', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  addListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8557,6 +8576,11 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8612,6 +8636,11 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'bringtofront', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8663,6 +8692,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   prependListener(event: 'backgroundpage', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  prependListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -9452,6 +9488,13 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   waitForEvent(event: 'backgroundpage', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
+
+  /**
+   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
+   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  waitForEvent(event: 'bringtofront', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1647,6 +1647,7 @@ export type BrowserContextInitializer = {
 };
 export interface BrowserContextEventTarget {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;
+  on(event: 'bringToFront', callback: (params: BrowserContextBringToFrontEvent) => void): this;
   on(event: 'console', callback: (params: BrowserContextConsoleEvent) => void): this;
   on(event: 'close', callback: (params: BrowserContextCloseEvent) => void): this;
   on(event: 'dialog', callback: (params: BrowserContextDialogEvent) => void): this;
@@ -1699,6 +1700,9 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
 }
 export type BrowserContextBindingCallEvent = {
   binding: BindingCallChannel,
+};
+export type BrowserContextBringToFrontEvent = {
+  page: PageChannel,
 };
 export type BrowserContextConsoleEvent = {
   type: string,
@@ -2075,6 +2079,7 @@ export type BrowserContextClockSetSystemTimeResult = void;
 
 export interface BrowserContextEvents {
   'bindingCall': BrowserContextBindingCallEvent;
+  'bringToFront': BrowserContextBringToFrontEvent;
   'console': BrowserContextConsoleEvent;
   'close': BrowserContextCloseEvent;
   'dialog': BrowserContextDialogEvent;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1516,6 +1516,10 @@ BrowserContext:
       parameters:
         binding: BindingCall
 
+    bringToFront:
+      parameters:
+        page: Page
+
     console:
       parameters:
         $mixin: ConsoleMessage


### PR DESCRIPTION
## Summary
- Adds a new `bringtofront` event on `Page` that fires whenever any connected client calls `page.bringToFront()`.
- Server emits from `Page.bringToFront`; dispatcher forwards to every connected client (including the initiator).