### PR TITLE
Add file property to JUnit report entry

### DIFF
--- a/packages/playwright/src/reporters/junit.ts
+++ b/packages/playwright/src/reporters/junit.ts
@@ -152,6 +152,7 @@ class JUnitReporter implements ReporterV2 {
         name: namePrefix + test.titlePath().slice(3).join(' › '),
         // filename
         classname: suiteName,
+        file: suiteName,
       },
       children: [],
     };


### PR DESCRIPTION
Many tools look for the `file` attribute as a way of understanding where a test is located and attributing some statistics or codeowners.