### PR TITLE
feat(dashboard): unify sessions into a single WebSocket channel

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -16,14 +16,12 @@
 
 import React from 'react';
 import './dashboard.css';
-import { navigate } from './index';
-import { DashboardClient } from './dashboardClient';
+import { navigate, DashboardClientContext } from './index';
 import { asLocator } from '@isomorphic/locatorGenerators';
 import { SplitView } from '@web/components/splitView';
 import { ChevronLeftIcon, ChevronRightIcon, CloseIcon, PlusIcon, ReloadIcon, PickLocatorIcon, InspectorPanelIcon } from './icons';
 import { SettingsButton } from './settingsView';
 
-import type { DashboardClientChannel } from './dashboardClient';
 import type { Tab, DashboardChannelEvents } from './dashboardChannel';
 
 function tabFavicon(url: string): string {
@@ -38,16 +36,17 @@ function tabFavicon(url: string): string {
 
 const BUTTONS = ['left', 'middle', 'right'] as const;
 
-export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
+export const Dashboard: React.FC<{ browser: string }> = ({ browser }) => {
+  const client = React.useContext(DashboardClientContext);
   const [interactive, setInteractive] = React.useState(false);
   const [tabs, setTabs] = React.useState<Tab[] | null>(null);
   const [url, setUrl] = React.useState('');
   const [frame, setFrame] = React.useState<DashboardChannelEvents['frame']>();
   const [showInspector, setShowInspector] = React.useState(false);
-  const [pickingTabId, setPickingTabId] = React.useState<string | null>(null);
+  const [pickingPage, setPickingPage] = React.useState<string | null>(null);
   const [locatorToast, setLocatorToast] = React.useState<{ text: string; timer: ReturnType<typeof setTimeout> }>();
+  const [context, setContext] = React.useState<string | undefined>();
 
-  const [channel, setChannel] = React.useState<DashboardClientChannel | undefined>();
   const displayRef = React.useRef<HTMLImageElement>(null);
   const screenRef = React.useRef<HTMLDivElement>(null);
   const tabbarRef = React.useRef<HTMLDivElement>(null);
@@ -55,26 +54,22 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
   const moveThrottleRef = React.useRef(0);
 
   React.useEffect(() => {
-    if (!wsUrl)
+    if (!client)
       return;
-    const channel = DashboardClient.create(wsUrl);
+    let disposed = false;
+    let resized = false;
 
-    channel.onopen = () => {
-      setChannel(channel);
-      setInteractive(false);
-      setPickingTabId(null);
-    };
-
-    channel.on('tabs', params => {
+    const onTabs = (params: DashboardChannelEvents['tabs']) => {
+      if (params.target.browser !== browser)
+        return;
       setTabs(params.tabs);
       const selected = params.tabs.find(t => t.selected);
       if (selected)
         setUrl(selected.url);
-    });
-
-    let resized = false;
-
-    channel.on('frame', params => {
+    };
+    const onFrame = (params: DashboardChannelEvents['frame']) => {
+      if (params.target.browser !== browser)
+        return;
       setFrame(params);
       const tabbar = tabbarRef.current;
       const toolbar = toolbarRef.current;
@@ -87,29 +82,48 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
         const targetH = Math.min(params.viewportHeight + chromeHeight + extraH, screen.availHeight);
         window.resizeTo(targetW, targetH);
       }
-    });
-
-    channel.on('elementPicked', params => {
+    };
+    const onElementPicked = (params: DashboardChannelEvents['elementPicked']) => {
+      if (params.target.browser !== browser)
+        return;
       const locator = asLocator('javascript', params.selector);
       navigator.clipboard?.writeText(locator).catch(() => {});
-      setPickingTabId(null);
+      setPickingPage(null);
       setLocatorToast(old => {
         clearTimeout(old?.timer);
         return { text: locator, timer: setTimeout(() => setLocatorToast(undefined), 3000) };
       });
-    });
-
-    channel.onclose = () => {
-      setChannel(undefined);
-      setInteractive(false);
-      setPickingTabId(null);
-      setShowInspector(false);
     };
+
+    client.on('tabs', onTabs);
+    client.on('frame', onFrame);
+    client.on('elementPicked', onElementPicked);
+
+    client.attach({ browser }).then(result => {
+      if (!disposed)
+        setContext(result.context);
+    }).catch(() => {});
 
     return () => {
-      channel.close();
+      disposed = true;
+      client.off('tabs', onTabs);
+      client.off('frame', onFrame);
+      client.off('elementPicked', onElementPicked);
+      client.detach({ browser }).catch(() => {});
+      setContext(undefined);
+      setTabs(null);
+      setFrame(undefined);
+      setInteractive(false);
+      setPickingPage(null);
+      setShowInspector(false);
     };
-  }, [wsUrl]);
+  }, [client, browser]);
+
+  const selectedTab = tabs?.find(t => t.selected);
+  const ready = !!client && !!context && !!selectedTab;
+  const pageTarget = ready && selectedTab
+    ? { browser, context: context!, page: selectedTab.page }
+    : undefined;
 
   function imgCoords(e: React.MouseEvent): { x: number; y: number } {
     const vw = frame?.viewportWidth ?? 0;
@@ -143,14 +157,16 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
   }
 
   function sendMouseEvent(method: 'mousedown' | 'mouseup', e: React.MouseEvent) {
+    if (!pageTarget)
+      return;
     const { x, y } = imgCoords(e);
-    channel?.[method]({ x, y, button: BUTTONS[e.button] || 'left' });
+    client?.[method]({ ...pageTarget, x, y, button: BUTTONS[e.button] || 'left' });
   }
 
   function onScreenMouseDown(e: React.MouseEvent) {
     e.preventDefault();
     screenRef.current?.focus();
-    if (!channel)
+    if (!ready)
       return;
     if (!interactive) {
       setInteractive(true);
@@ -167,41 +183,42 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
   }
 
   function onScreenMouseMove(e: React.MouseEvent) {
-    if (!interactive)
+    if (!interactive || !pageTarget)
       return;
     const now = Date.now();
     if (now - moveThrottleRef.current < 32)
       return;
     moveThrottleRef.current = now;
     const { x, y } = imgCoords(e);
-    channel?.mousemove({ x, y });
+    client?.mousemove({ ...pageTarget, x, y });
   }
 
   function onScreenWheel(e: React.WheelEvent) {
-    if (!interactive)
+    if (!interactive || !pageTarget)
       return;
     e.preventDefault();
-    channel?.wheel({ deltaX: e.deltaX, deltaY: e.deltaY });
+    client?.wheel({ ...pageTarget, deltaX: e.deltaX, deltaY: e.deltaY });
   }
 
   function onScreenKeyDown(e: React.KeyboardEvent) {
-    if (pickingTabId !== null && e.key === 'Escape') {
+    if (pickingPage !== null && e.key === 'Escape') {
       e.preventDefault();
-      channel?.cancelPickLocator();
-      setPickingTabId(null);
+      if (pageTarget)
+        client?.cancelPickLocator(pageTarget);
+      setPickingPage(null);
       return;
     }
-    if (!interactive)
+    if (!interactive || !pageTarget)
       return;
     e.preventDefault();
-    channel?.keydown({ key: e.key });
+    client?.keydown({ ...pageTarget, key: e.key });
   }
 
   function onScreenKeyUp(e: React.KeyboardEvent) {
-    if (!interactive)
+    if (!interactive || !pageTarget)
       return;
     e.preventDefault();
-    channel?.keyup({ key: e.key });
+    client?.keyup({ ...pageTarget, key: e.key });
   }
 
   function onOmniboxKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -210,16 +227,16 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
       if (!/^https?:\/\//i.test(value))
         value = 'https://' + value;
       setUrl(value);
-      channel?.navigate({ url: value });
+      if (pageTarget)
+        client?.navigate({ ...pageTarget, url: value });
       e.currentTarget.blur();
     }
   }
 
-  const selectedTab = tabs?.find(t => t.selected);
-  const picking = selectedTab?.pageId === pickingTabId;
+  const picking = selectedTab?.page === pickingPage;
 
   let overlayText: string | undefined;
-  if (!channel)
+  if (!client || !context)
     overlayText = 'Disconnected';
   else if (tabs === null)
     overlayText = 'Loading...';
@@ -237,12 +254,12 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
       <div id='tabstrip' className='tabstrip' role='tablist'>
         {tabs?.map(tab => (
           <div
-            key={tab.pageId}
+            key={tab.page}
             className={'tab' + (tab.selected ? ' active' : '')}
             role='tab'
             aria-selected={tab.selected}
             title={tab.url || ''}
-            onClick={() => channel?.selectTab({ pageId: tab.pageId })}
+            onClick={() => client?.selectTab({ browser, context: tab.context, page: tab.page })}
           >
             <span className='tab-favicon' aria-hidden='true'>{tabFavicon(tab.url)}</span>
             <span className='tab-label'>{tab.title || 'New Tab'}</span>
@@ -251,7 +268,7 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
               title='Close tab'
               onClick={e => {
                 e.stopPropagation();
-                channel?.closeTab({ pageId: tab.pageId });
+                client?.closeTab({ browser, context: tab.context, page: tab.page });
               }}
             >
               <CloseIcon />
@@ -259,19 +276,23 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
           </div>
         ))}
       </div>
-      <button id='new-tab-btn' className='new-tab-btn' title='New Tab' onClick={() => channel?.newTab()}>
+      <button id='new-tab-btn' className='new-tab-btn' title='New Tab' onClick={() => {
+        if (context)
+          client?.newTab({ browser, context });
+      }}>
         <PlusIcon />
       </button>
       <div className='interactive-controls'>
         <div className={'segmented-control' + (interactive ? ' interactive' : '')} role='group' aria-label='Interaction mode' title={interactive ? 'Interactive mode: page input is forwarded' : 'Read-only mode: page input is blocked'}>
           <button
             className={'segmented-control-option' + (!interactive ? ' active' : '')}
-            disabled={!channel}
+            disabled={!ready}
             aria-pressed={!interactive}
             title='Read-only mode'
             onClick={() => {
-              channel?.cancelPickLocator();
-              setPickingTabId(null);
+              if (pageTarget)
+                client?.cancelPickLocator(pageTarget);
+              setPickingPage(null);
               setShowInspector(false);
               setInteractive(false);
             }}
@@ -280,7 +301,7 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
           </button>
           <button
             className={'segmented-control-option' + (interactive ? ' active' : '')}
-            disabled={!channel}
+            disabled={!ready}
             aria-pressed={interactive}
             title='Interactive mode'
             onClick={() => setInteractive(true)}
@@ -294,13 +315,13 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
 
     {/* Toolbar */}
     <div ref={toolbarRef} className='toolbar'>
-      <button className='nav-btn' title='Back' onClick={() => channel?.back()}>
+      <button className='nav-btn' title='Back' onClick={() => pageTarget && client?.back(pageTarget)}>
         <ChevronLeftIcon />
       </button>
-      <button className='nav-btn' title='Forward' onClick={() => channel?.forward()}>
+      <button className='nav-btn' title='Forward' onClick={() => pageTarget && client?.forward(pageTarget)}>
         <ChevronRightIcon />
       </button>
-      <button className='nav-btn' title='Reload' onClick={() => channel?.reload()}>
+      <button className='nav-btn' title='Reload' onClick={() => pageTarget && client?.reload(pageTarget)}>
         <ReloadIcon />
       </button>
       <input
@@ -319,16 +340,18 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
         className={'nav-btn' + (picking ? ' active-toggle' : '')}
         title='Pick locator'
         aria-pressed={picking}
-        disabled={!channel}
+        disabled={!ready}
         onClick={() => {
+          if (!pageTarget)
+            return;
           if (picking) {
-            channel?.cancelPickLocator();
-            setPickingTabId(null);
+            client?.cancelPickLocator(pageTarget);
+            setPickingPage(null);
           } else {
             setInteractive(true);
-            setPickingTabId(selectedTab?.pageId ?? null);
+            setPickingPage(selectedTab?.page ?? null);
             screenRef.current?.focus();
-            channel?.pickLocator();
+            client?.pickLocator(pageTarget);
           }
         }}
       >
@@ -339,7 +362,7 @@ export const Dashboard: React.FC<{ wsUrl?: string }> = ({ wsUrl }) => {
           className={'nav-btn' + (showInspector ? ' active-toggle' : '')}
           title='Chrome DevTools'
           aria-pressed={showInspector}
-          disabled={!channel}
+          disabled={!ready}
           onClick={() => {
             setInteractive(true);
             setShowInspector(!showInspector);

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -14,32 +14,56 @@
  * limitations under the License.
  */
 
-export type Tab = { pageId: string; title: string; url: string; selected: boolean; inspectorUrl?: string };
+import type { ClientInfo } from '../../playwright-core/src/tools/cli-client/registry';
+import type { SessionStatus } from './sessionModel';
 
-export type DashboardChannelEvents = {
-  frame: { data: string; viewportWidth: number; viewportHeight: number };
-  tabs: { tabs: Tab[] };
-  elementPicked: { selector: string };
+export type BrowserTarget = { browser: string };
+export type ContextTarget = { browser: string; context: string };
+export type PageTarget = { browser: string; context: string; page: string };
+
+export type Tab = {
+  browser: string;
+  context: string;
+  page: string;
+  title: string;
+  url: string;
+  selected: boolean;
+  inspectorUrl?: string;
 };
 
+export type DashboardChannelEvents = {
+  sessions: { sessions: SessionStatus[]; clientInfo: ClientInfo };
+  tabs: { target: ContextTarget; tabs: Tab[] };
+  frame: { target: PageTarget; data: string; viewportWidth: number; viewportHeight: number };
+  elementPicked: { target: PageTarget; selector: string };
+};
+
+export type MouseButton = 'left' | 'middle' | 'right';
+
 export interface DashboardChannel {
-  version: 1;
-  tabs(): Promise<{ tabs: Tab[] }>;
-  selectTab(params: { pageId: string }): Promise<void>;
-  closeTab(params: { pageId: string }): Promise<void>;
-  newTab(): Promise<void>;
-  navigate(params: { url: string }): Promise<void>;
-  back(): Promise<void>;
-  forward(): Promise<void>;
-  reload(): Promise<void>;
-  mousemove(params: { x: number; y: number }): Promise<void>;
-  mousedown(params: { x: number; y: number; button?: 'left' | 'right' | 'middle' }): Promise<void>;
-  mouseup(params: { x: number; y: number; button?: 'left' | 'right' | 'middle' }): Promise<void>;
-  wheel(params: { deltaX: number; deltaY: number }): Promise<void>;
-  keydown(params: { key: string }): Promise<void>;
-  keyup(params: { key: string }): Promise<void>;
-  pickLocator(): Promise<void>;
-  cancelPickLocator(): Promise<void>;
+  attach(params: BrowserTarget): Promise<{ context: string }>;
+  detach(params: BrowserTarget): Promise<void>;
+  closeSession(params: BrowserTarget): Promise<void>;
+  deleteSessionData(params: BrowserTarget): Promise<void>;
+  setVisible(params: { visible: boolean }): Promise<void>;
+
+  tabs(params: ContextTarget): Promise<{ tabs: Tab[] }>;
+  newTab(params: ContextTarget): Promise<{ page: string }>;
+
+  selectTab(params: PageTarget): Promise<void>;
+  closeTab(params: PageTarget): Promise<void>;
+  navigate(params: PageTarget & { url: string }): Promise<void>;
+  back(params: PageTarget): Promise<void>;
+  forward(params: PageTarget): Promise<void>;
+  reload(params: PageTarget): Promise<void>;
+  mousemove(params: PageTarget & { x: number; y: number }): Promise<void>;
+  mousedown(params: PageTarget & { x: number; y: number; button?: MouseButton }): Promise<void>;
+  mouseup(params: PageTarget & { x: number; y: number; button?: MouseButton }): Promise<void>;
+  wheel(params: PageTarget & { deltaX: number; deltaY: number }): Promise<void>;
+  keydown(params: PageTarget & { key: string }): Promise<void>;
+  keyup(params: PageTarget & { key: string }): Promise<void>;
+  pickLocator(params: PageTarget): Promise<void>;
+  cancelPickLocator(params: PageTarget): Promise<void>;
 
   on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;
   off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;

--- a/packages/dashboard/src/grid.tsx
+++ b/packages/dashboard/src/grid.tsx
@@ -16,13 +16,12 @@
 
 import React from 'react';
 import './grid.css';
-import { DashboardClient } from './dashboardClient';
-import { navigate } from './index';
+import { navigate, DashboardClientContext } from './index';
 import { Screencast } from './screencast';
 import { SettingsButton } from './settingsView';
 
 import type { BrowserDescriptor } from '../../playwright-core/src/serverRegistry';
-import type { Tab } from './dashboardChannel';
+import type { Tab, DashboardChannelEvents } from './dashboardChannel';
 import type { SessionModel, SessionStatus } from './sessionModel';
 
 export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
@@ -68,9 +67,8 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
       <SettingsButton />
     </div>
     <div className='grid-content'>
-      {model.loading && sessions.length === 0 && <div className='grid-loading'>Loading sessions...</div>}
-      {model.error && <div className='grid-error'>Error: {model.error}</div>}
-      {!model.loading && !model.error && sessions.length === 0 && <div className='grid-empty'>No sessions found.</div>}
+      {model.loading && <div className='grid-loading'>Loading sessions...</div>}
+      {!model.loading && sessions.length === 0 && <div className='grid-empty'>No sessions found.</div>}
 
       <div className='workspace-list'>
         {workspaceGroups.map(([workspace, entries], index) => {
@@ -92,7 +90,7 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
               </div>
               {isExpanded && (
                 <div className='session-chips'>
-                  {entries.map(session => <SessionChip key={session.browser.guid} descriptor={session} wsUrl={session.wsUrl} visible={isExpanded} model={model} />)}
+                  {entries.map(session => <SessionChip key={session.browser.guid} descriptor={session} canConnect={session.canConnect} visible={isExpanded} model={model} />)}
                 </div>
               )}
             </div>
@@ -103,45 +101,43 @@ export const Grid: React.FC<{ model: SessionModel }> = ({ model }) => {
   </div>);
 };
 
-const SessionChip: React.FC<{ descriptor: BrowserDescriptor; wsUrl: string | undefined; visible: boolean; model: SessionModel }> = ({ descriptor, wsUrl, visible, model }) => {
+const SessionChip: React.FC<{ descriptor: BrowserDescriptor; canConnect: boolean; visible: boolean; model: SessionModel }> = ({ descriptor, canConnect, visible, model }) => {
   const href = '#session=' + encodeURIComponent(descriptor.browser.guid);
-
-  const channel = React.useMemo(() => {
-    if (!wsUrl || !visible)
-      return undefined;
-    return DashboardClient.create(wsUrl);
-  }, [wsUrl, visible]);
-
+  const client = React.useContext(DashboardClientContext);
+  const browser = descriptor.browser.guid;
+  const attached = canConnect && visible && !!client;
   const [selectedTab, setSelectedTab] = React.useState<Tab | undefined>();
 
   React.useEffect(() => {
-    if (!channel)
+    if (!attached || !client)
       return;
-    const onTabs = (params: { tabs: Tab[] }) => {
+    const onTabs = (params: DashboardChannelEvents['tabs']) => {
+      if (params.target.browser !== browser)
+        return;
       setSelectedTab(params.tabs.find(t => t.selected));
     };
-    channel.tabs().then(onTabs);
-    channel.on('tabs', onTabs);
+    client.on('tabs', onTabs);
+    client.attach({ browser }).catch(() => {});
     return () => {
-      channel.off('tabs', onTabs);
-      channel.close();
+      client.off('tabs', onTabs);
+      client.detach({ browser }).catch(() => {});
     };
-  }, [channel]);
+  }, [attached, client, browser]);
 
   const chipTitle = selectedTab ? `[${descriptor.title}] ${selectedTab.url} \u2014 ${selectedTab.title}` : descriptor.title;
 
   return (
-    <a className={'session-chip' + (wsUrl ? '' : ' disconnected')} href={wsUrl ? href : undefined} title={chipTitle} onClick={e => {
+    <a className={'session-chip' + (canConnect ? '' : ' disconnected')} href={canConnect ? href : undefined} title={chipTitle} onClick={e => {
       e.preventDefault();
-      if (wsUrl)
+      if (canConnect)
         navigate(href);
     }}>
       <div className='session-chip-header'>
-        <div className={'session-status-dot ' + (wsUrl ? 'open' : 'closed')} />
+        <div className={'session-status-dot ' + (canConnect ? 'open' : 'closed')} />
         <span className='session-chip-name'>
           {selectedTab ? <>[{descriptor.title}] {selectedTab.url} <span className='session-chip-title'>&mdash; {selectedTab.title}</span></> : descriptor.title}
         </span>
-        {wsUrl && (
+        {canConnect && (
           <button
             className='session-chip-action'
             title='Close session'
@@ -157,7 +153,7 @@ const SessionChip: React.FC<{ descriptor: BrowserDescriptor; wsUrl: string | und
             </svg>
           </button>
         )}
-        {!wsUrl && (
+        {!canConnect && (
           <button
             className='session-chip-action'
             title='Delete session data'
@@ -176,8 +172,8 @@ const SessionChip: React.FC<{ descriptor: BrowserDescriptor; wsUrl: string | und
         )}
       </div>
       <div className='screencast-container'>
-        {channel && <Screencast channel={channel} />}
-        {!wsUrl && <div className='screencast-placeholder'>Session closed</div>}
+        {attached && client && <Screencast client={client} browser={browser} />}
+        {!canConnect && <div className='screencast-placeholder'>Session closed</div>}
       </div>
     </a>
   );

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -22,6 +22,9 @@ import { applyTheme } from '@web/theme';
 import { Dashboard } from './dashboard';
 import { Grid } from './grid';
 import { SessionModel } from './sessionModel';
+import { DashboardClient } from './dashboardClient';
+
+import type { DashboardClientChannel } from './dashboardClient';
 
 applyTheme();
 
@@ -38,32 +41,33 @@ function parseHash(): string | undefined {
   return undefined;
 }
 
-const model = new SessionModel();
+export const DashboardClientContext = React.createContext<DashboardClientChannel | undefined>(undefined);
+
+const client = DashboardClient.create('/ws');
+const model = new SessionModel(client);
+
+const pushVisibility = () => client.setVisible({ visible: !document.hidden }).catch(() => {});
+document.addEventListener('visibilitychange', pushVisibility);
+if (document.hidden)
+  pushVisibility();
 
 const App: React.FC = () => {
   const [, setRevision] = React.useState(0);
-  const [socketPath, setSocketPath] = React.useState<string | undefined>(parseHash);
+  const [sessionGuid, setSessionGuid] = React.useState<string | undefined>(parseHash);
+
+  React.useEffect(() => model.subscribe(() => setRevision(r => r + 1)), []);
 
   React.useEffect(() => {
-    model.startPolling();
-    const unsubscribe = model.subscribe(() => setRevision(r => r + 1));
-    return () => {
-      unsubscribe();
-      model.stopPolling();
-    };
-  }, [model]);
-
-  React.useEffect(() => {
-    const onPopState = () => setSocketPath(parseHash());
+    const onPopState = () => setSessionGuid(parseHash());
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  if (socketPath) {
-    const wsUrl = model.sessionByGuid(socketPath)?.wsUrl;
-    return <Dashboard wsUrl={wsUrl || undefined} />;
-  }
-  return <Grid model={model} />;
+  const content = sessionGuid
+    ? <Dashboard browser={sessionGuid} />
+    : <Grid model={model} />;
+
+  return <DashboardClientContext.Provider value={client}>{content}</DashboardClientContext.Provider>;
 };
 
-ReactDOM.createRoot(document.querySelector('#root')!).render(<App/>);
+ReactDOM.createRoot(document.querySelector('#root')!).render(<App />);

--- a/packages/dashboard/src/screencast.tsx
+++ b/packages/dashboard/src/screencast.tsx
@@ -17,17 +17,20 @@
 import React from 'react';
 
 import type { DashboardClientChannel } from './dashboardClient';
+import type { DashboardChannelEvents } from './dashboardChannel';
 
-export const Screencast: React.FC<{ channel: DashboardClientChannel }> = ({ channel }) => {
+export const Screencast: React.FC<{ client: DashboardClientChannel; browser: string }> = ({ client, browser }) => {
   const [frameSrc, setFrameSrc] = React.useState('');
 
   React.useEffect(() => {
-    const listener = (params: { data: string }) => {
+    const listener = (params: DashboardChannelEvents['frame']) => {
+      if (params.target.browser !== browser)
+        return;
       setFrameSrc('data:image/jpeg;base64,' + params.data);
     };
-    channel.on('frame', listener);
-    return () => channel.off('frame', listener);
-  }, [channel]);
+    client.on('frame', listener);
+    return () => client.off('frame', listener);
+  }, [client, browser]);
 
   if (!frameSrc)
     return <div className='screencast-placeholder'>Connecting...</div>;

--- a/packages/dashboard/src/sessionModel.ts
+++ b/packages/dashboard/src/sessionModel.ts
@@ -15,24 +15,37 @@
  */
 
 import type { ClientInfo } from '../../playwright-core/src/tools/cli-client/registry';
-import type { BrowserDescriptor } from '../../playwright-core/src/serverRegistry';
+import type { BrowserDescriptor, BrowserStatus } from '../../playwright-core/src/serverRegistry';
 
-export type SessionStatus = BrowserDescriptor & {
-  wsUrl?: string;
-};
+export type SessionStatus = BrowserStatus;
 
 type Listener = () => void;
+
+type SessionsChannel = {
+  on(event: 'sessions', listener: (params: { sessions: SessionStatus[]; clientInfo: ClientInfo }) => void): void;
+  off(event: 'sessions', listener: (params: { sessions: SessionStatus[]; clientInfo: ClientInfo }) => void): void;
+  closeSession(params: { browser: string }): Promise<void>;
+  deleteSessionData(params: { browser: string }): Promise<void>;
+};
 
 export class SessionModel {
   sessions: SessionStatus[] = [];
   clientInfo: ClientInfo | undefined;
-  error: string | undefined;
   loading = true;
 
-  private _pollActive = false;
-  private _pollTimeout: ReturnType<typeof setTimeout> | undefined;
-  private _lastJson = '';
+  private _client: SessionsChannel;
   private _listeners = new Set<Listener>();
+  private _onSessions = (params: { sessions: SessionStatus[]; clientInfo: ClientInfo }) => {
+    this.sessions = params.sessions;
+    this.clientInfo = params.clientInfo;
+    this.loading = false;
+    this._notify();
+  };
+
+  constructor(client: SessionsChannel) {
+    this._client = client;
+    this._client.on('sessions', this._onSessions);
+  }
 
   subscribe(listener: Listener): () => void {
     this._listeners.add(listener);
@@ -44,79 +57,20 @@ export class SessionModel {
       listener();
   }
 
-  startPolling() {
-    if (this._pollActive)
-      return;
-    this._pollActive = true;
-    const poll = async () => {
-      await this._fetchSessions();
-      if (this._pollActive)
-        this._pollTimeout = setTimeout(poll, 3000);
-    };
-    void poll();
-  }
-
-  stopPolling() {
-    this._pollActive = false;
-    if (this._pollTimeout) {
-      clearTimeout(this._pollTimeout);
-      this._pollTimeout = undefined;
-    }
-  }
-
   sessionByGuid(guid: string): SessionStatus | undefined {
     return this.sessions.find(s => s.browser.guid === guid);
   }
 
-  private async _fetchSessions() {
-    try {
-      this.loading = true;
-      const response = await fetch('/api/sessions/list');
-      if (!response.ok)
-        throw new Error(`HTTP ${response.status}`);
-      const text = await response.text();
-      if (text !== this._lastJson) {
-        this._lastJson = text;
-        const data = JSON.parse(text);
-        this.sessions = data.sessions;
-        this.clientInfo = data.clientInfo;
-        this._notify();
-
-
-      }
-      this.error = undefined;
-    } catch (e: any) {
-      this.error = e.message;
-    } finally {
-      this.loading = false;
-    }
-    this._notify();
-  }
-
-  async fetchSessions() {
-    await this._fetchSessions();
-  }
-
   async closeSession(descriptor: BrowserDescriptor) {
-    await fetch('/api/sessions/close', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ guid: descriptor.browser.guid }),
-    });
-    await this._fetchSessions();
+    await this._client.closeSession({ browser: descriptor.browser.guid });
   }
 
   async deleteSessionData(descriptor: BrowserDescriptor) {
-    await fetch('/api/sessions/delete-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ guid: descriptor.browser.guid }),
-    });
-    await this._fetchSessions();
+    await this._client.deleteSessionData({ browser: descriptor.browser.guid });
   }
 
   dispose() {
-    this.stopPolling();
+    this._client.off('sessions', this._onSessions);
     this._listeners.clear();
   }
 }

--- a/packages/playwright-core/src/DEPS.list
+++ b/packages/playwright-core/src/DEPS.list
@@ -54,3 +54,4 @@ node_modules/yaml
 [serverRegistry.ts]
 "strict"
 package.ts
+node_modules/chokidar

--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { EventEmitter } from 'events';
 import fs from 'fs';
 import net from 'net';
 import path from 'path';
 import os from 'os';
+import chokidar from 'chokidar';
 
 import { packageJSON, packageRoot } from './package';
 
@@ -48,43 +50,76 @@ export type BrowserDescriptor = EndpointInfo & {
 
 export type BrowserStatus = BrowserDescriptor & { canConnect: boolean };
 
-type BrowserEntry = BrowserStatus & { file: string };
+export interface ServerRegistryEvents {
+  added: (descriptor: BrowserDescriptor) => void;
+  removed: (guid: string) => void;
+  changed: (descriptor: BrowserDescriptor) => void;
+}
 
-class ServerRegistry {
+class ServerRegistry extends EventEmitter {
+  private _descriptors = new Map<string, BrowserDescriptor>();
+  private _watcher: chokidar.FSWatcher | undefined;
+  private _watcherRefs = 0;
+  private _ready: Promise<void> | undefined;
+
+  override on<K extends keyof ServerRegistryEvents>(event: K, listener: ServerRegistryEvents[K]): this {
+    return super.on(event, listener as (...args: any[]) => void);
+  }
+
+  override off<K extends keyof ServerRegistryEvents>(event: K, listener: ServerRegistryEvents[K]): this {
+    return super.off(event, listener as (...args: any[]) => void);
+  }
+
+  watch(): () => void {
+    this._watcherRefs++;
+    if (!this._watcher)
+      this._startWatcher();
+    let disposed = false;
+    return () => {
+      if (disposed)
+        return;
+      disposed = true;
+      this._watcherRefs--;
+      if (this._watcherRefs === 0)
+        this._stopWatcher();
+    };
+  }
+
+  ready(): Promise<void> {
+    return this._ready ?? Promise.resolve();
+  }
+
   async list(): Promise<Map<string, BrowserStatus[]>> {
-    const files = await fs.promises.readdir(this._browsersDir()).catch(() => []);
-    const result = new Map<string, Promise<BrowserEntry>[]>();
-    for (const file of files) {
-      try {
-        const filePath = path.join(this._browsersDir(), file);
-        const content = await fs.promises.readFile(filePath, 'utf-8');
-        const descriptor: BrowserDescriptor = JSON.parse(content);
+    const ownWatcher = !this._watcher;
+    let dispose: (() => void) | undefined;
+    if (ownWatcher)
+      dispose = this.watch();
+    try {
+      await this._ready;
+      const statuses = await Promise.all(
+          [...this._descriptors.values()].map(async descriptor => {
+            const canConnect = await canConnectTo(descriptor);
+            return { descriptor, canConnect };
+          }),
+      );
+      const result = new Map<string, BrowserStatus[]>();
+      for (const { descriptor, canConnect } of statuses) {
+        if (!canConnect) {
+          await fs.promises.unlink(path.join(this._browsersDir(), descriptor.browser.guid)).catch(() => {});
+          continue;
+        }
         const key = descriptor.workspaceDir ?? '';
         let list = result.get(key);
         if (!list) {
           list = [];
           result.set(key, list);
         }
-        list.push(canConnect(descriptor).then(connectable => ({ ...descriptor, canConnect: connectable, file: filePath })));
-      } catch {
+        list.push({ ...descriptor, canConnect });
       }
+      return result;
+    } finally {
+      dispose?.();
     }
-
-    const resolvedResult = new Map<string, BrowserStatus[]>();
-    for (const [key, promises] of result) {
-      const entries = await Promise.all(promises);
-      const descriptors = [];
-      for (const entry of entries) {
-        if (!entry.canConnect) {
-          await fs.promises.unlink(entry.file).catch(() => {});
-          continue;
-        }
-        descriptors.push(entry);
-      }
-      if (descriptors.length)
-        resolvedResult.set(key, descriptors);
-    }
-    return resolvedResult;
   }
 
   async create(browser: BrowserInfo, endpoint: EndpointInfo) {
@@ -116,10 +151,12 @@ class ServerRegistry {
   }
 
   readDescriptor(guid: string): BrowserDescriptor {
+    const cached = this._descriptors.get(guid);
+    if (cached)
+      return cached;
     const filePath = path.join(this._browsersDir(), guid);
     const content = fs.readFileSync(filePath, 'utf-8');
-    const descriptor: BrowserDescriptor = JSON.parse(content);
-    return descriptor;
+    return JSON.parse(content);
   }
 
   async find(name: string): Promise<BrowserDescriptor | null> {
@@ -136,9 +173,54 @@ class ServerRegistry {
   private _browsersDir() {
     return process.env.PLAYWRIGHT_SERVER_REGISTRY || registryDirectory;
   }
+
+  private _startWatcher() {
+    const dir = this._browsersDir();
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch {
+    }
+    const watcher = chokidar.watch(dir, {
+      ignoreInitial: false,
+      depth: 0,
+      awaitWriteFinish: { stabilityThreshold: 50, pollInterval: 20 },
+    });
+    this._watcher = watcher;
+    this._ready = new Promise<void>((resolve, reject) => {
+      watcher.once('ready', () => resolve());
+      watcher.once('error', reject);
+    });
+    watcher.on('add', file => this._onAddOrChange(file, 'added'));
+    watcher.on('change', file => this._onAddOrChange(file, 'changed'));
+    watcher.on('unlink', file => {
+      const guid = path.basename(file);
+      if (this._descriptors.delete(guid))
+        this.emit('removed', guid);
+    });
+  }
+
+  private _onAddOrChange(file: string, event: 'added' | 'changed') {
+    const guid = path.basename(file);
+    let descriptor: BrowserDescriptor;
+    try {
+      descriptor = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch {
+      return;
+    }
+    this._descriptors.set(guid, descriptor);
+    this.emit(event, descriptor);
+  }
+
+  private _stopWatcher() {
+    const watcher = this._watcher;
+    this._watcher = undefined;
+    this._ready = undefined;
+    this._descriptors.clear();
+    void watcher?.close();
+  }
 }
 
-async function canConnect(descriptor: BrowserDescriptor): Promise<boolean> {
+async function canConnectTo(descriptor: BrowserDescriptor): Promise<boolean> {
   if (!descriptor.endpoint)
     return false;
   if (descriptor.endpoint.startsWith('ws://') || descriptor.endpoint.startsWith('wss://')) {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -26,145 +26,34 @@ import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
 import { CDPConnection, DashboardConnection } from './dashboardController';
-import { serverRegistry } from '../../serverRegistry';
-import { connectToBrowserAcrossVersions } from '../utils/connect';
-import { createClientInfo } from '../cli-client/registry';
 
 import type * as api from '../../..';
-import type { SessionStatus } from '../../../../dashboard/src/sessionModel';
-
-function readBody(request: http.IncomingMessage): Promise<any> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    request.on('data', (chunk: Buffer) => chunks.push(chunk));
-    request.on('end', () => {
-      try {
-        const text = Buffer.concat(chunks).toString();
-        resolve(text ? JSON.parse(text) : {});
-      } catch (e) {
-        reject(e);
-      }
-    });
-    request.on('error', reject);
-  });
-}
-
-async function parseRequest(request: http.IncomingMessage): Promise<{ guid: string }> {
-  const body = await readBody(request);
-  if (!body.guid)
-    throw new Error('Dashboard app is too old, please close it and open again');
-  return { guid: body.guid };
-}
-
-function sendJSON(response: http.ServerResponse, data: any, statusCode = 200) {
-  response.statusCode = statusCode;
-  response.setHeader('Content-Type', 'application/json');
-  response.end(JSON.stringify(data));
-}
-
-async function loadBrowserDescriptorSessions(wsPath: string): Promise<SessionStatus[]> {
-  const entriesByWorkspace = await serverRegistry.list();
-  const sessions: SessionStatus[] = [];
-  for (const [, entries] of entriesByWorkspace) {
-    for (const entry of entries) {
-      let wsUrl: string | undefined;
-      if (entry.canConnect) {
-        const url = new URL(wsPath, 'http://localhost');
-        url.searchParams.set('guid', entry.browser.guid);
-        wsUrl = url.pathname + url.search;
-      }
-      sessions.push({ ...entry, wsUrl });
-    }
-  }
-  return sessions;
-}
-
-const browserGuidToDashboardConnection = new Map<string, DashboardConnection>();
-
-async function handleApiRequest(httpServer: HttpServer, request: http.IncomingMessage, response: http.ServerResponse) {
-  const url = new URL(request.url!,  httpServer.urlPrefix('human-readable'));
-  const apiPath = url.pathname;
-
-  if (apiPath === '/api/sessions/list' && request.method === 'GET') {
-    const sessions = await loadBrowserDescriptorSessions(httpServer.wsGuid()!);
-    const clientInfo = createClientInfo();
-    sendJSON(response, { sessions, clientInfo });
-    return;
-  }
-
-  if (apiPath === '/api/sessions/close' && request.method === 'POST') {
-    const { guid } = await parseRequest(request);
-    let browser: api.Browser;
-    try {
-      const browserDescriptor = serverRegistry.readDescriptor(guid);
-      browser = await connectToBrowserAcrossVersions(browserDescriptor);
-    } catch (e) {
-      sendJSON(response, { error: 'Failed to connect to browser socket: ' + e.message }, 500);
-      return;
-    }
-    try {
-      await Promise.all(browser.contexts().map(context => context.close()));
-      await browser.close();
-      sendJSON(response, { success: true });
-      return;
-    } catch (e) {
-      sendJSON(response, { error: 'Failed to close browser: ' + e.message }, 500);
-      return;
-    }
-  }
-
-  if (apiPath === '/api/sessions/delete-data' && request.method === 'POST') {
-    const { guid } = await parseRequest(request);
-    try {
-      await serverRegistry.deleteUserData(guid);
-    } catch (e) {
-      sendJSON(response, { error: 'Failed to delete session data: ' + e.message }, 500);
-      return;
-    }
-    sendJSON(response, { success: true });
-    return;
-  }
-
-  response.statusCode = 404;
-  response.end(JSON.stringify({ error: 'Not found' }));
-}
 
 async function innerOpenDashboardApp(): Promise<api.Page> {
   const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
 
-  httpServer.routePrefix('/api/', (request: http.IncomingMessage, response: http.ServerResponse) => {
-    handleApiRequest(httpServer, request, response).catch(e => {
-      response.statusCode = 500;
-      response.end(JSON.stringify({ error: e.message }));
-    });
-    return true;
-  });
+  const connections = new Set<DashboardConnection>();
 
   httpServer.createWebSocket(url => {
-    const guid = url.searchParams.get('guid');
-    if (!guid)
-      throw new Error('Unsupported WebSocket URL: ' + url.toString());
-    const browserDescriptor = serverRegistry.readDescriptor(guid);
-
     const cdpPageId = url.searchParams.get('cdpPageId');
     if (cdpPageId) {
-      const connection = browserGuidToDashboardConnection.get(guid);
-      if (!connection)
-        throw new Error('CDP connection not found for session: ' + guid);
-      const page = connection.pageForId(cdpPageId);
-      if (!page)
-        throw new Error('Page not found for page ID: ' + cdpPageId);
-      return new CDPConnection(page);
+      for (const conn of connections) {
+        const page = conn.pageForId(cdpPageId);
+        if (page)
+          return new CDPConnection(page);
+      }
+      throw new Error('Page not found for cdpPageId: ' + cdpPageId);
     }
 
     const cdpUrl = new URL(httpServer.urlPrefix('human-readable'));
-    cdpUrl.pathname = httpServer.wsGuid()!;
-    cdpUrl.searchParams.set('guid', guid);
-    const connection = new DashboardConnection(browserDescriptor, cdpUrl, () => browserGuidToDashboardConnection.delete(guid));
-    browserGuidToDashboardConnection.set(guid, connection);
+    cdpUrl.pathname = '/ws';
+    let connection: DashboardConnection;
+    // eslint-disable-next-line prefer-const
+    connection = new DashboardConnection(cdpUrl, () => connections.delete(connection));
+    connections.add(connection);
     return connection;
-  });
+  }, 'ws');
 
   httpServer.routePrefix('/', (request: http.IncomingMessage, response: http.ServerResponse) => {
     const pathname = new URL(request.url!, `http://${request.headers.host}`).pathname;

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -16,228 +16,372 @@
 
 import { eventsHelper } from '@utils/eventsHelper';
 import { connectToBrowserAcrossVersions } from '../utils/connect';
+import { serverRegistry } from '../../serverRegistry';
+import { createClientInfo } from '../cli-client/registry';
 
 import type * as api from '../../..';
 import type { Transport } from '@utils/httpServer';
-import type { DashboardChannel, DashboardChannelEvents, Tab } from '@dashboard/dashboardChannel';
-import type { BrowserDescriptor } from '../../serverRegistry';
+import type { Tab } from '@dashboard/dashboardChannel';
+import type { BrowserDescriptor, BrowserStatus } from '../../serverRegistry';
 
-export class DashboardConnection implements Transport, DashboardChannel {
-  readonly version = 1;
+type Disposable = { dispose: () => Promise<void> };
+
+export class DashboardConnection implements Transport {
+  readonly version = 2;
 
   sendEvent?: (method: string, params: any) => void;
   close?: () => void;
 
-  selectedPage: api.Page | null = null;
-  private _lastFrameData: string | null = null;
-  private _lastViewportSize: { width: number, height: number } | null = null;
-  private _pageListeners: { dispose: () => Promise<void> }[] = [];
-  private _contextListeners: { dispose: () => Promise<void> }[] = [];
-  private _eventListeners = new Map<string, Set<Function>>();
-
-  private _browserDescriptor: BrowserDescriptor;
+  private _attached = new Map<string, AttachedBrowser>();
   private _cdpUrl: URL;
   private _onclose: () => void;
+  private _serverRegistryDispose?: () => void;
+  private _pushSessionsScheduled = false;
+  private _visible = true;
 
-  private _initPromise?: Promise<void>;
-  private _context!: api.BrowserContext;
-  private _browser?: api.Browser;
-
-  constructor(browserDescriptor: BrowserDescriptor, cdpUrl: URL, onclose: () => void) {
-    this._browserDescriptor = browserDescriptor;
+  constructor(cdpUrl: URL, onclose: () => void) {
     this._cdpUrl = cdpUrl;
     this._onclose = onclose;
   }
 
-  on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void {
-    let set = this._eventListeners.get(event);
-    if (!set) {
-      set = new Set();
-      this._eventListeners.set(event, set);
-    }
-    set.add(listener);
-  }
-
-  off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void {
-    this._eventListeners.get(event)?.delete(listener);
-  }
-
-  private _emit<K extends keyof DashboardChannelEvents>(event: K, params: DashboardChannelEvents[K]): void {
-    this.sendEvent?.(event, params);
-    const set = this._eventListeners.get(event);
-    if (set) {
-      for (const fn of set)
-        fn(params);
-    }
-  }
-
   onconnect() {
-    this._initPromise = this._init();
-    this._initPromise.catch(() => this.close?.());
-  }
-
-  private async _init() {
-    this._browser = await connectToBrowserAcrossVersions(this._browserDescriptor);
-    this._context = this._browser.contexts()[0];
-
-    this._contextListeners.push(
-        eventsHelper.addEventListener(this._context, 'page', page => {
-          this._sendTabList();
-          if (!this.selectedPage)
-            this._selectPage(page);
-        }),
-    );
-
-    // Auto-select first page.
-    const pages = this._context.pages();
-    if (pages.length > 0)
-      this._selectPage(pages[0]);
-
-    this._sendCachedState();
+    this._serverRegistryDispose = serverRegistry.watch();
+    serverRegistry.on('added', this._pushSessions);
+    serverRegistry.on('removed', this._pushSessions);
+    serverRegistry.on('changed', this._pushSessions);
+    this._pushSessions();
   }
 
   onclose() {
-    this._deselectPage();
-    this._contextListeners.forEach(d => d.dispose());
-    this._contextListeners = [];
+    serverRegistry.off('added', this._pushSessions);
+    serverRegistry.off('removed', this._pushSessions);
+    serverRegistry.off('changed', this._pushSessions);
+    this._serverRegistryDispose?.();
+    this._serverRegistryDispose = undefined;
+    for (const att of this._attached.values())
+      att.dispose();
+    this._attached.clear();
     this._onclose();
-    this._browser?.close().catch(() => {});
   }
 
   async dispatch(method: string, params: any): Promise<any> {
-    await this._initPromise;
     // eslint-disable-next-line no-restricted-syntax
-    return (this as any)[method]?.(params);
+    const handler = (this as any)[method];
+    if (typeof handler === 'function')
+      return handler.call(this, params);
+    const att = params?.browser ? this._attached.get(params.browser) : undefined;
+    // eslint-disable-next-line no-restricted-syntax
+    const onAtt = att ? (att as any)[method] : undefined;
+    if (typeof onAtt === 'function')
+      return onAtt.call(att, params);
   }
 
-  async selectTab(params: { pageId: string }) {
-    const page = this._context.pages().find(p => this._pageId(p) === params.pageId);
+  async attach(params: { browser: string }): Promise<{ context: string }> {
+    if (this._attached.has(params.browser))
+      return { context: this._attached.get(params.browser)!.contextGuid };
+    const descriptor = serverRegistry.readDescriptor(params.browser);
+    const browser = await connectToBrowserAcrossVersions(descriptor);
+    const context = browser.contexts()[0];
+    const att = new AttachedBrowser(this, params.browser, descriptor, context);
+    this._attached.set(params.browser, att);
+    await att.init();
+    return { context: att.contextGuid };
+  }
+
+  async detach(params: { browser: string }) {
+    const att = this._attached.get(params.browser);
+    if (att) {
+      this._attached.delete(params.browser);
+      att.dispose();
+    }
+  }
+
+  async closeSession(params: { browser: string }) {
+    const descriptor = serverRegistry.readDescriptor(params.browser);
+    const browser = await connectToBrowserAcrossVersions(descriptor);
+    try {
+      await Promise.all(browser.contexts().map(context => context.close()));
+      await browser.close();
+    } catch {
+      // best-effort
+    }
+  }
+
+  async deleteSessionData(params: { browser: string }) {
+    await serverRegistry.deleteUserData(params.browser);
+  }
+
+  async setVisible(params: { visible: boolean }) {
+    if (this._visible === params.visible)
+      return;
+    this._visible = params.visible;
+    await Promise.all([...this._attached.values()].map(att => att.setScreencastActive(params.visible)));
+  }
+
+  visible(): boolean {
+    return this._visible;
+  }
+
+  pageForId(pageGuid: string): api.Page | undefined {
+    for (const att of this._attached.values()) {
+      const page = att.pageForId(pageGuid);
+      if (page)
+        return page;
+    }
+    return undefined;
+  }
+
+  cdpUrl(): URL {
+    return this._cdpUrl;
+  }
+
+  emitSessions(sessions: BrowserStatus[]) {
+    this.sendEvent?.('sessions', { sessions, clientInfo: createClientInfo() });
+  }
+
+  emitTabs(att: AttachedBrowser, tabs: Tab[]) {
+    this.sendEvent?.('tabs', { target: { browser: att.browserGuid, context: att.contextGuid }, tabs });
+  }
+
+  emitFrame(att: AttachedBrowser, pageGuid: string, data: string, viewportWidth: number, viewportHeight: number) {
+    this.sendEvent?.('frame', {
+      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
+      data, viewportWidth, viewportHeight,
+    });
+  }
+
+  emitElementPicked(att: AttachedBrowser, pageGuid: string, selector: string) {
+    this.sendEvent?.('elementPicked', {
+      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
+      selector,
+    });
+  }
+
+  private _pushSessions = () => {
+    if (this._pushSessionsScheduled)
+      return;
+    this._pushSessionsScheduled = true;
+    queueMicrotask(async () => {
+      this._pushSessionsScheduled = false;
+      try {
+        const byWs = await serverRegistry.list();
+        const sessions: BrowserStatus[] = [];
+        for (const list of byWs.values())
+          sessions.push(...list);
+        this.emitSessions(sessions);
+      } catch {
+        // best-effort
+      }
+    });
+  };
+}
+
+class AttachedBrowser {
+  readonly browserGuid: string;
+  readonly contextGuid: string;
+
+  private _owner: DashboardConnection;
+  private _descriptor: BrowserDescriptor;
+  private _context: api.BrowserContext;
+
+  private _selectedPage: api.Page | null = null;
+  private _screencastRunning = false;
+  private _pageListeners: Disposable[] = [];
+  private _contextListeners: Disposable[] = [];
+
+  constructor(owner: DashboardConnection, browserGuid: string, descriptor: BrowserDescriptor, context: api.BrowserContext) {
+    this._owner = owner;
+    this.browserGuid = browserGuid;
+    this._descriptor = descriptor;
+    this._context = context;
+    // eslint-disable-next-line no-restricted-syntax -- _guid is very conservative.
+    this.contextGuid = (context as any)._guid;
+  }
+
+  async init() {
+    this._contextListeners.push(
+        eventsHelper.addEventListener(this._context, 'page', page => {
+          this._pushTabs();
+          if (!this._selectedPage)
+            this._selectPage(page).catch(() => {});
+        }),
+    );
+    const pages = this._context.pages();
+    if (pages.length > 0)
+      await this._selectPage(pages[0]);
+    this._pushTabs();
+  }
+
+  dispose() {
+    this._contextListeners.forEach(d => d.dispose());
+    this._contextListeners = [];
+    this._pageListeners.forEach(d => d.dispose());
+    this._pageListeners = [];
+    if (this._selectedPage && this._screencastRunning)
+      this._selectedPage.screencast.stop().catch(() => {});
+    this._screencastRunning = false;
+    this._selectedPage = null;
+  }
+
+  async setScreencastActive(active: boolean) {
+    if (!this._selectedPage)
+      return;
+    if (active && !this._screencastRunning) {
+      this._screencastRunning = true;
+      await this._startScreencast(this._selectedPage);
+    } else if (!active && this._screencastRunning) {
+      this._screencastRunning = false;
+      await this._selectedPage.screencast.stop().catch(() => {});
+    }
+  }
+
+  pageForId(pageGuid: string): api.Page | undefined {
+    return this._context.pages().find(p => this._pageId(p) === pageGuid);
+  }
+
+  async tabs(): Promise<{ tabs: Tab[] }> {
+    return { tabs: await this._tabList() };
+  }
+
+  async newTab(): Promise<{ page: string }> {
+    const page = await this._context.newPage();
+    await this._selectPage(page);
+    return { page: this._pageId(page) };
+  }
+
+  async selectTab(params: { page: string }) {
+    const page = this.pageForId(params.page);
     if (page)
       await this._selectPage(page);
   }
 
-  async closeTab(params: { pageId: string }) {
-    const page = this._context.pages().find(p => this._pageId(p) === params.pageId);
+  async closeTab(params: { page: string }) {
+    const page = this.pageForId(params.page);
     if (page)
       await page.close({ reason: 'Closed in Dashboard' });
   }
 
-  async newTab() {
-    const page = await this._context.newPage();
-    await this._selectPage(page);
-  }
-
-  async navigate(params: { url: string }) {
-    if (!this.selectedPage || !params.url)
+  async navigate(params: { page: string; url: string }) {
+    if (!params.url)
       return;
-    const page = this.selectedPage;
-    await page.goto(params.url);
+    await this.pageForId(params.page)?.goto(params.url);
   }
 
-  async back() {
-    await this.selectedPage?.goBack();
+  async back(params: { page: string }) {
+    await this.pageForId(params.page)?.goBack();
   }
 
-  async forward() {
-    await this.selectedPage?.goForward();
+  async forward(params: { page: string }) {
+    await this.pageForId(params.page)?.goForward();
   }
 
-  async reload() {
-    await this.selectedPage?.reload();
+  async reload(params: { page: string }) {
+    await this.pageForId(params.page)?.reload();
   }
 
-  async mousemove(params: { x: number; y: number }) {
-    await this.selectedPage?.mouse.move(params.x, params.y);
+  async mousemove(params: { page: string; x: number; y: number }) {
+    await this.pageForId(params.page)?.mouse.move(params.x, params.y);
   }
 
-  async mousedown(params: { x: number; y: number; button?: 'left' | 'right' | 'middle' }) {
-    await this.selectedPage?.mouse.move(params.x, params.y);
-    await this.selectedPage?.mouse.down({ button: params.button || 'left' });
+  async mousedown(params: { page: string; x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
+    const page = this.pageForId(params.page);
+    if (!page)
+      return;
+    await page.mouse.move(params.x, params.y);
+    await page.mouse.down({ button: params.button || 'left' });
   }
 
-  async mouseup(params: { x: number; y: number; button?: 'left' | 'right' | 'middle' }) {
-    await this.selectedPage?.mouse.move(params.x, params.y);
-    await this.selectedPage?.mouse.up({ button: params.button || 'left' });
+  async mouseup(params: { page: string; x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
+    const page = this.pageForId(params.page);
+    if (!page)
+      return;
+    await page.mouse.move(params.x, params.y);
+    await page.mouse.up({ button: params.button || 'left' });
   }
 
-  async wheel(params: { deltaX: number; deltaY: number }) {
-    await this.selectedPage?.mouse.wheel(params.deltaX, params.deltaY);
+  async wheel(params: { page: string; deltaX: number; deltaY: number }) {
+    await this.pageForId(params.page)?.mouse.wheel(params.deltaX, params.deltaY);
   }
 
-  async keydown(params: { key: string }) {
-    await this.selectedPage?.keyboard.down(params.key);
+  async keydown(params: { page: string; key: string }) {
+    await this.pageForId(params.page)?.keyboard.down(params.key);
   }
 
-  async keyup(params: { key: string }) {
-    await this.selectedPage?.keyboard.up(params.key);
+  async keyup(params: { page: string; key: string }) {
+    await this.pageForId(params.page)?.keyboard.up(params.key);
+  }
+
+  async pickLocator(params: { page: string }) {
+    const page = this.pageForId(params.page);
+    if (!page)
+      return;
+    const locator = await page.pickLocator();
+    this._owner.emitElementPicked(this, this._pageId(page), locator.toString());
+  }
+
+  async cancelPickLocator(params: { page: string }) {
+    await this.pageForId(params.page)?.cancelPickLocator();
   }
 
   private async _selectPage(page: api.Page) {
-    if (this.selectedPage === page)
+    if (this._selectedPage === page)
       return;
 
-    if (this.selectedPage) {
+    if (this._selectedPage) {
       this._pageListeners.forEach(d => d.dispose());
       this._pageListeners = [];
-      await this.selectedPage.screencast.stop();
+      if (this._screencastRunning)
+        await this._selectedPage.screencast.stop();
+      this._screencastRunning = false;
     }
 
-    this.selectedPage = page;
-    this._lastFrameData = null;
-    this._lastViewportSize = null;
-    this._sendTabList();
+    this._selectedPage = page;
+    this._pushTabs();
 
     this._pageListeners.push(
         eventsHelper.addEventListener(page, 'close', () => {
           this._deselectPage();
           const pages = page.context().pages();
           if (pages.length > 0)
-            this._selectPage(pages[0]);
-          this._sendTabList();
+            this._selectPage(pages[0]).catch(() => {});
+          this._pushTabs();
         }),
         eventsHelper.addEventListener(page, 'framenavigated', frame => {
           if (frame === page.mainFrame())
-            this._sendTabList();
+            this._pushTabs();
         }),
     );
 
-    const size = { width: 1280, height: 800 };
+    if (this._owner.visible()) {
+      this._screencastRunning = true;
+      await this._startScreencast(page);
+    }
+  }
+
+  private async _startScreencast(page: api.Page) {
     await page.screencast.start({
-      onFrame: ({ data }: { data: Buffer }) => this._writeFrame(data, page.viewportSize()?.width ?? 0, page.viewportSize()?.height ?? 0),
-      size,
+      onFrame: ({ data }: { data: Buffer }) => this._writeFrame(page, data, page.viewportSize()?.width ?? 0, page.viewportSize()?.height ?? 0),
+      size: { width: 1280, height: 800 },
     });
   }
 
   private _deselectPage() {
-    if (!this.selectedPage)
+    if (!this._selectedPage)
       return;
     this._pageListeners.forEach(d => d.dispose());
     this._pageListeners = [];
-    this.selectedPage.screencast.stop().catch(() => {});
-    this.selectedPage = null;
-    this._lastFrameData = null;
-    this._lastViewportSize = null;
+    if (this._screencastRunning)
+      this._selectedPage.screencast.stop().catch(() => {});
+    this._screencastRunning = false;
+    this._selectedPage = null;
   }
 
-  async pickLocator() {
-    if (!this.selectedPage)
-      return;
-    const locator = await this.selectedPage.pickLocator();
-    this._emit('elementPicked', { selector: locator.toString() });
+  private _pushTabs() {
+    this._tabList().then(tabs => this._owner.emitTabs(this, tabs)).catch(() => {});
   }
 
-  async cancelPickLocator() {
-    await this.selectedPage?.cancelPickLocator();
-  }
-
-  private _sendCachedState() {
-    if (this._lastFrameData && this._lastViewportSize)
-      this._emit('frame', { data: this._lastFrameData, viewportWidth: this._lastViewportSize.width, viewportHeight: this._lastViewportSize.height });
-    this._sendTabList();
-  }
-
-  async tabs(): Promise<{ tabs: Tab[] }> {
-    return { tabs: await this._tabList() };
+  private _writeFrame(page: api.Page, frame: Buffer, viewportWidth: number, viewportHeight: number) {
+    this._owner.emitFrame(this, this._pageId(page), frame.toString('base64'), viewportWidth, viewportHeight);
   }
 
   private async _tabList(): Promise<Tab[]> {
@@ -248,17 +392,15 @@ export class DashboardConnection implements Transport, DashboardChannel {
     return await Promise.all(pages.map(async page => {
       const title = await page.title();
       return {
-        pageId: this._pageId(page),
+        browser: this.browserGuid,
+        context: this.contextGuid,
+        page: this._pageId(page),
         title,
         url: page.url(),
-        selected: page === this.selectedPage,
+        selected: page === this._selectedPage,
         inspectorUrl: devtoolsUrl ? await this._pageInspectorUrl(page, devtoolsUrl) : 'data:text/plain,Dashboard only supported in Chromium based browsers',
       };
     }));
-  }
-
-  pageForId(pageId: string) {
-    return this._context?.pages().find(p => this._pageId(p) === pageId);
   }
 
   private _pageId(p: api.Page): string {
@@ -266,9 +408,9 @@ export class DashboardConnection implements Transport, DashboardChannel {
     return (p as any)._guid;
   }
 
-  private async _devtoolsUrl(page: api.Page) {
+  private async _devtoolsUrl(page: api.Page): Promise<URL | null> {
     // eslint-disable-next-line no-restricted-syntax -- cdpPort is not in the public LaunchOptions type, fine if regresses.
-    const cdpPort = (this._browserDescriptor.browser.launchOptions as any).cdpPort;
+    const cdpPort = (this._descriptor.browser.launchOptions as any).cdpPort;
     if (cdpPort)
       return new URL(`http://localhost:${cdpPort}/devtools/`);
 
@@ -280,22 +422,10 @@ export class DashboardConnection implements Transport, DashboardChannel {
 
   private async _pageInspectorUrl(page: api.Page, devtoolsUrl: URL): Promise<string | undefined> {
     const inspector = new URL('./devtools_app.html', devtoolsUrl);
-    const cdp = new URL(this._cdpUrl);
+    const cdp = new URL(this._owner.cdpUrl());
     cdp.searchParams.set('cdpPageId', this._pageId(page));
     inspector.searchParams.set('ws', `${cdp.host}${cdp.pathname}${cdp.search}`);
-    const url = inspector.toString();
-    return url;
-  }
-
-  private _sendTabList() {
-    this._tabList().then(tabs => this._emit('tabs', { tabs }));
-  }
-
-  private _writeFrame(frame: Buffer, viewportWidth: number, viewportHeight: number) {
-    const data = frame.toString('base64');
-    this._lastFrameData = data;
-    this._lastViewportSize = { width: viewportWidth, height: viewportHeight };
-    this._emit('frame', { data, viewportWidth, viewportHeight });
+    return inspector.toString();
   }
 }
 

--- a/tests/installation/bundle-licenses.spec.ts
+++ b/tests/installation/bundle-licenses.spec.ts
@@ -21,6 +21,7 @@ import { test, expect } from './npmTest';
 // these, something is broken with bundle generation or dependencies were silently removed.
 const EXPECTED: Record<string, Record<string, number>> = {
   'playwright-core': {
+    'lib/serverRegistry.js.LICENSE': 10,
     'lib/utilsBundle.js.LICENSE': 80,
   },
   'playwright': {

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -564,12 +564,19 @@ steps.push(new EsbuildStep({
     // CLI client tools, should be a separate bundle.
     filePath('packages/playwright-core/src/tools/cli-client/*.ts'),
     filePath('packages/playwright-core/src/package.ts'),
-    filePath('packages/playwright-core/src/serverRegistry.ts'),
     filePath('packages/playwright-core/src/tools/utils/socketConnection.ts'),
   ],
   outdir: filePath('packages/playwright-core/lib'),
   plugins: [dynamicImportToRequirePlugin],
 }));
+
+// playwright-core/lib/serverRegistry.js
+steps.push(new EsbuildStep({
+  bundle: true,
+  entryPoints: [filePath('packages/playwright-core/src/serverRegistry.js')],
+  outfile: filePath('packages/playwright-core/lib/serverRegistry.js'),
+  external: ['fsevents'],
+}, [filePath('packages/playwright-core/src/*')]));
 
 const playwrightCoreSrc = filePath('packages/playwright-core/src');
 

--- a/utils/check_deps.js
+++ b/utils/check_deps.js
@@ -168,9 +168,19 @@ async function innerCheckDeps(root) {
         if (!allowImport(fileName, importPath, mergedDeps))
           errors.push(`Disallowed import ${path.relative(root, importPath)} in ${path.relative(root, fileName)}`);
         return;
-      } else {
-        if (mergedDeps.includes('"strict"') && !builtins.has(node.moduleSpecifier.text))
-          errors.push(`Disallowed import ${node.moduleSpecifier.text} in ${path.relative(root, fileName)}`);
+      }
+
+      // Per-folder explicit allow-list: `node_modules/<importName>` in DEPS.list
+      // declares the file may import that exact package specifier. When a
+      // DEPS.list authorizes the dep, do NOT add it to the package.json
+      // dependency check either — the per-file allowlist is the contract. This
+      // also bypasses the strict-mode external-import rejection below.
+      if (mergedDeps.includes('node_modules/' + importName))
+        return;
+
+      if (mergedDeps.includes('"strict"') && !builtins.has(node.moduleSpecifier.text)) {
+        errors.push(`Disallowed import ${node.moduleSpecifier.text} in ${path.relative(root, fileName)}`);
+        return;
       }
 
       const fullStart = node.getFullStart();
@@ -180,13 +190,6 @@ async function innerCheckDeps(root) {
           if (comment.includes('@no-check-deps'))
             return;
       }
-
-      // Per-folder explicit allow-list: `node_modules/<importName>` in DEPS.list
-      // declares the file may import that exact package specifier. When a
-      // DEPS.list authorizes the dep, do NOT add it to the package.json
-      // dependency check either — the per-file allowlist is the contract.
-      if (mergedDeps.includes('node_modules/' + importName))
-        return;
 
       const topLevel = importName.startsWith('@')
           ? importName.split('/').slice(0, 2).join('/')


### PR DESCRIPTION
## Summary
- Collapses per-browser dashboard WebSockets into one multiplexing channel per page load; every method/event carries a `{ browser, context?, page? }` target.
- Drops the polled `/api/sessions/list`; session state is now pushed over the same channel, including `closeSession` / `deleteSessionData`.
- Pauses screencasts server-side when the dashboard window is hidden (`document.visibilitychange` → `setVisible`).