### PR TITLE
feat(dashboard): focus session when page.pickLocator is called

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -68,11 +68,11 @@ await context.CloseAsync();
 
 This event is not emitted.
 
-## event: BrowserContext.bringToFront
+## event: BrowserContext.pickLocator
 * since: v1.60
 - argument: <[Page]>
 
-Emitted when a client calls [`method: Page.bringToFront`] on a page in this context. The event is dispatched to all
+Emitted when a client calls [`method: Page.pickLocator`] on a page in this context. The event is dispatched to all
 clients connected to the context, including the one that initiated the call.
 
 ## property: BrowserContext.clock

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -36,9 +36,20 @@ function tabFavicon(url: string): string {
 
 const BUTTONS = ['left', 'middle', 'right'] as const;
 
-export const Dashboard: React.FC<{ browser: string }> = ({ browser }) => {
+export const Dashboard: React.FC<{
+  browser: string;
+  autoInteractive?: boolean;
+  onAutoInteractiveConsumed?: () => void;
+}> = ({ browser, autoInteractive, onAutoInteractiveConsumed }) => {
   const client = React.useContext(DashboardClientContext);
   const [interactive, setInteractive] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!autoInteractive)
+      return;
+    setInteractive(true);
+    onAutoInteractiveConsumed?.();
+  }, [autoInteractive, onAutoInteractiveConsumed]);
   const [tabs, setTabs] = React.useState<Tab[] | null>(null);
   const [url, setUrl] = React.useState('');
   const [frame, setFrame] = React.useState<DashboardChannelEvents['frame']>();

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -36,6 +36,7 @@ export type DashboardChannelEvents = {
   tabs: { target: ContextTarget; tabs: Tab[] };
   frame: { target: PageTarget; data: string; viewportWidth: number; viewportHeight: number };
   elementPicked: { target: PageTarget; selector: string };
+  pickLocator: { target: PageTarget };
 };
 
 export type MouseButton = 'left' | 'middle' | 'right';

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -24,6 +24,7 @@ import { Grid } from './grid';
 import { SessionModel } from './sessionModel';
 import { DashboardClient } from './dashboardClient';
 
+import type { DashboardChannelEvents } from './dashboardChannel';
 import type { DashboardClientChannel } from './dashboardClient';
 
 applyTheme();
@@ -54,6 +55,7 @@ if (document.hidden)
 const App: React.FC = () => {
   const [, setRevision] = React.useState(0);
   const [sessionGuid, setSessionGuid] = React.useState<string | undefined>(parseHash);
+  const [autoInteractiveBrowser, setAutoInteractiveBrowser] = React.useState<string | undefined>();
 
   React.useEffect(() => model.subscribe(() => setRevision(r => r + 1)), []);
 
@@ -63,8 +65,22 @@ const App: React.FC = () => {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
+  React.useEffect(() => {
+    const onPickLocator = (params: DashboardChannelEvents['pickLocator']) => {
+      setAutoInteractiveBrowser(params.target.browser);
+      if (parseHash() !== params.target.browser)
+        navigate('#session=' + encodeURIComponent(params.target.browser));
+    };
+    client.on('pickLocator', onPickLocator);
+    return () => client.off('pickLocator', onPickLocator);
+  }, []);
+
   const content = sessionGuid
-    ? <Dashboard browser={sessionGuid} />
+    ? <Dashboard
+      browser={sessionGuid}
+      autoInteractive={autoInteractiveBrowser === sessionGuid}
+      onAutoInteractiveConsumed={() => setAutoInteractiveBrowser(undefined)}
+    />
     : <Grid model={model} />;
 
   return <DashboardClientContext.Provider value={client}>{content}</DashboardClientContext.Provider>;

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8226,13 +8226,6 @@ export interface BrowserContext {
   on(event: 'backgroundpage', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  on(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -8313,6 +8306,13 @@ export interface BrowserContext {
   on(event: 'page', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  on(event: 'picklocator', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8372,11 +8372,6 @@ export interface BrowserContext {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
-  once(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
   once(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8393,6 +8388,11 @@ export interface BrowserContext {
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
   once(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
+  once(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
@@ -8428,13 +8428,6 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   addListener(event: 'backgroundpage', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  addListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8517,6 +8510,13 @@ export interface BrowserContext {
   addListener(event: 'page', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  addListener(event: 'picklocator', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8576,11 +8576,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8597,6 +8592,11 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   removeListener(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
+  removeListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -8636,11 +8636,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  off(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   off(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8657,6 +8652,11 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   off(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
+  off(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -8692,13 +8692,6 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   prependListener(event: 'backgroundpage', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  prependListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8779,6 +8772,13 @@ export interface BrowserContext {
    *
    */
   prependListener(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  prependListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
@@ -9490,13 +9490,6 @@ export interface BrowserContext {
   waitForEvent(event: 'backgroundpage', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  waitForEvent(event: 'bringtofront', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
-
-  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -9575,6 +9568,13 @@ export interface BrowserContext {
    *
    */
   waitForEvent(event: 'page', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
+
+  /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  waitForEvent(event: 'picklocator', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -149,7 +149,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
           dialog.dismiss().catch(() => {});
       }
     });
-    this._channel.on('bringToFront', ({ page }) => this.emit(Events.BrowserContext.BringToFront, Page.from(page)));
+    this._channel.on('pickLocator', ({ page }) => this.emit(Events.BrowserContext.PickLocator, Page.from(page)));
     this._channel.on('request', ({ request, page }) => this._onRequest(network.Request.from(request), Page.fromNullable(page)));
     this._channel.on('requestFailed', ({ request, failureText, responseEndTiming, page }) => this._onRequestFailed(network.Request.from(request), responseEndTiming, failureText, Page.fromNullable(page)));
     this._channel.on('requestFinished', params => this._onRequestFinished(params));

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -39,7 +39,7 @@ export const Events = {
   },
 
   BrowserContext: {
-    BringToFront: 'bringtofront',
+    PickLocator: 'picklocator',
     Console: 'console',
     Close: 'close',
     Dialog: 'dialog',

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -941,7 +941,7 @@ scheme.BrowserContextInitializer = tObject({
 scheme.BrowserContextBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),
 });
-scheme.BrowserContextBringToFrontEvent = tObject({
+scheme.BrowserContextPickLocatorEvent = tObject({
   page: tChannel(['Page']),
 });
 scheme.BrowserContextConsoleEvent = tObject({

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -45,7 +45,7 @@ import type * as types from './types';
 import type * as channels from '@protocol/channels';
 
 const BrowserContextEvent = {
-  BringToFront: 'bringtofront',
+  PickLocator: 'picklocator',
   Console: 'console',
   Close: 'close',
   Page: 'page',
@@ -66,7 +66,7 @@ const BrowserContextEvent = {
 } as const;
 
 export type BrowserContextEventMap = {
-  [BrowserContextEvent.BringToFront]: [page: Page];
+  [BrowserContextEvent.PickLocator]: [page: Page];
   [BrowserContextEvent.Console]: [message: ConsoleMessage];
   [BrowserContextEvent.Close]: [];
   [BrowserContextEvent.Page]: [page: Page];

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -105,8 +105,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this.addObjectListener(BrowserContext.Events.Page, page => {
       this._dispatchEvent('page', { page: PageDispatcher.from(this, page) });
     });
-    this.addObjectListener(BrowserContext.Events.BringToFront, page => {
-      this._dispatchEvent('bringToFront', { page: PageDispatcher.from(this, page) });
+    this.addObjectListener(BrowserContext.Events.PickLocator, page => {
+      this._dispatchEvent('pickLocator', { page: PageDispatcher.from(this, page) });
     });
     this.addObjectListener(BrowserContext.Events.Close, () => {
       this._dispatchEvent('close');

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -648,7 +648,6 @@ export class Page extends SdkObject<PageEventMap> {
 
   async bringToFront(progress: Progress): Promise<void> {
     await progress.race(this.delegate.bringToFront());
-    this.emitOnContext(BrowserContext.Events.BringToFront, this);
   }
 
   async addInitScript(progress: Progress, source: string) {

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -274,6 +274,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async pickLocator(progress: Progress, page: Page): Promise<string> {
+    page.emitOnContext(BrowserContext.Events.PickLocator, page);
     if (this._mode !== 'none')
       await progress.race(this.setMode('none'));
 

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -157,6 +157,12 @@ export class DashboardConnection implements Transport {
     });
   }
 
+  emitPickLocator(att: AttachedBrowser, pageGuid: string) {
+    this.sendEvent?.('pickLocator', {
+      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
+    });
+  }
+
   private _pushSessions = () => {
     if (this._pushSessionsScheduled)
       return;
@@ -204,6 +210,11 @@ class AttachedBrowser {
           this._pushTabs();
           if (!this._selectedPage)
             this._selectPage(page).catch(() => {});
+        }),
+        eventsHelper.addEventListener(this._context, 'picklocator', page => {
+          this._selectPage(page)
+              .then(() => this._owner.emitPickLocator(this, this._pageId(page)))
+              .catch(() => {});
         }),
     );
     const pages = this._context.pages();

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8226,13 +8226,6 @@ export interface BrowserContext {
   on(event: 'backgroundpage', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  on(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -8313,6 +8306,13 @@ export interface BrowserContext {
   on(event: 'page', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  on(event: 'picklocator', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8372,11 +8372,6 @@ export interface BrowserContext {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
-  once(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
   once(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8393,6 +8388,11 @@ export interface BrowserContext {
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
   once(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
+  once(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
@@ -8428,13 +8428,6 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   addListener(event: 'backgroundpage', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  addListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8517,6 +8510,13 @@ export interface BrowserContext {
   addListener(event: 'page', listener: (page: Page) => any): this;
 
   /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  addListener(event: 'picklocator', listener: (page: Page) => any): this;
+
+  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8576,11 +8576,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8597,6 +8592,11 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   removeListener(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
+  removeListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -8636,11 +8636,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  off(event: 'bringtofront', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   off(event: 'close', listener: (browserContext: BrowserContext) => any): this;
 
   /**
@@ -8657,6 +8652,11 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   off(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
+  off(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -8692,13 +8692,6 @@ export interface BrowserContext {
    * This event is not emitted.
    */
   prependListener(event: 'backgroundpage', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  prependListener(event: 'bringtofront', listener: (page: Page) => any): this;
 
   /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
@@ -8779,6 +8772,13 @@ export interface BrowserContext {
    *
    */
   prependListener(event: 'page', listener: (page: Page) => any): this;
+
+  /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  prependListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
@@ -9490,13 +9490,6 @@ export interface BrowserContext {
   waitForEvent(event: 'backgroundpage', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
-   * Emitted when a client calls [page.bringToFront()](https://playwright.dev/docs/api/class-page#page-bring-to-front)
-   * on a page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  waitForEvent(event: 'bringtofront', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
-
-  /**
    * Emitted when Browser context gets closed. This might happen because of one of the following:
    * - Browser context is closed.
    * - Browser application is closed or crashed.
@@ -9575,6 +9568,13 @@ export interface BrowserContext {
    *
    */
   waitForEvent(event: 'page', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
+
+  /**
+   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
+   * page in this context. The event is dispatched to all clients connected to the context, including the one that
+   * initiated the call.
+   */
+  waitForEvent(event: 'picklocator', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1647,7 +1647,7 @@ export type BrowserContextInitializer = {
 };
 export interface BrowserContextEventTarget {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;
-  on(event: 'bringToFront', callback: (params: BrowserContextBringToFrontEvent) => void): this;
+  on(event: 'pickLocator', callback: (params: BrowserContextPickLocatorEvent) => void): this;
   on(event: 'console', callback: (params: BrowserContextConsoleEvent) => void): this;
   on(event: 'close', callback: (params: BrowserContextCloseEvent) => void): this;
   on(event: 'dialog', callback: (params: BrowserContextDialogEvent) => void): this;
@@ -1701,7 +1701,7 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
 export type BrowserContextBindingCallEvent = {
   binding: BindingCallChannel,
 };
-export type BrowserContextBringToFrontEvent = {
+export type BrowserContextPickLocatorEvent = {
   page: PageChannel,
 };
 export type BrowserContextConsoleEvent = {
@@ -2079,7 +2079,7 @@ export type BrowserContextClockSetSystemTimeResult = void;
 
 export interface BrowserContextEvents {
   'bindingCall': BrowserContextBindingCallEvent;
-  'bringToFront': BrowserContextBringToFrontEvent;
+  'pickLocator': BrowserContextPickLocatorEvent;
   'console': BrowserContextConsoleEvent;
   'close': BrowserContextCloseEvent;
   'dialog': BrowserContextDialogEvent;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1516,7 +1516,7 @@ BrowserContext:
       parameters:
         binding: BindingCall
 
-    bringToFront:
+    pickLocator:
       parameters:
         page: Page
 

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -181,6 +181,32 @@ test('pick', async ({ cdpServer, cli, server }) => {
   expect(output).toContain(`locator: getByRole('button', { name: 'Submit' })`);
 });
 
+test('pick activates dashboard session', async ({ cdpServer, cli, server, openDashboard }) => {
+  server.setContent('/', `<button>Submit</button>`, 'text/html');
+  const browserContext = await cdpServer.start();
+  const [page] = browserContext.pages();
+  await page.goto(server.PREFIX);
+
+  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('snapshot');
+
+  const dashboard = await openDashboard();
+  await expect(dashboard.locator('.session-chip')).toHaveCount(1);
+
+  const scriptReady = page.waitForEvent('console', msg => msg.text() === 'Recorder script ready for test');
+  const pickPromise = cli('pick');
+  await scriptReady;
+
+  await expect(dashboard.locator('div.dashboard-view.interactive')).toBeVisible();
+
+  const box = await page.getByRole('button', { name: 'Submit' }).boundingBox();
+  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+
+  const { output } = await pickPromise;
+  expect(output).toContain(`ref: e2`);
+  expect(output).toContain(`locator: getByRole('button', { name: 'Submit' })`);
+});
+
 test('highlight', async ({ cdpServer, cli, server }) => {
   server.setContent('/', `<button>Submit</button>`, 'text/html');
   const browserContext = await cdpServer.start();


### PR DESCRIPTION
## Summary
- Rename `BrowserContext.bringtofront` event to `BrowserContext.picklocator`; fire it from `page.pickLocator()` rather than `page.bringToFront()`.
- Dashboard listens to the new event, navigates to the session that raised it, and enters interactive mode so the user can pick immediately in the screencast.