### PR TITLE
fix(mcp): support page close via extension in protocol v2

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
@@ -114,6 +114,14 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
         const tabSession = await this._attachTab(tab.id);
         return { result: { targetId: tabSession.targetInfo?.targetId } };
       }
+      case 'Target.closeTarget': {
+        const targetId = params?.targetId;
+        const tabSession = this._findTabSessionByTargetId(targetId);
+        if (!tabSession)
+          return { result: { success: false } };
+        await this._sendCommand('chrome.tabs.remove', [tabSession.tabId]);
+        return { result: { success: true } };
+      }
       case 'Target.getTargetInfo': {
         if (!sessionId)
           return { result: undefined };
@@ -180,7 +188,10 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
     this._tabSessions.delete(tabId);
     this._sendToPlaywright({
       method: 'Target.detachedFromTarget',
-      params: { sessionId: tabSession.sessionId },
+      params: {
+        sessionId: tabSession.sessionId,
+        targetId: tabSession.targetInfo?.targetId,
+      },
     });
   }
 
@@ -195,6 +206,16 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
   private _findTabSessionByChildSessionId(childSessionId: string): TabSession | undefined {
     for (const session of this._tabSessions.values()) {
       if (session.childSessions.has(childSessionId))
+        return session;
+    }
+    return undefined;
+  }
+
+  private _findTabSessionByTargetId(targetId: string | undefined): TabSession | undefined {
+    if (!targetId)
+      return undefined;
+    for (const session of this._tabSessions.values()) {
+      if (session.targetInfo?.targetId === targetId)
         return session;
     }
     return undefined;

--- a/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
@@ -116,7 +116,7 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
       }
       case 'Target.closeTarget': {
         const targetId = params?.targetId;
-        const tabSession = this._findTabSessionByTargetId(targetId);
+        const tabSession = targetId ? this._findTabSession(s => s.targetInfo?.targetId === targetId) : undefined;
         if (!tabSession)
           return { result: { success: false } };
         await this._sendCommand('chrome.tabs.remove', [tabSession.tabId]);
@@ -125,7 +125,7 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
       case 'Target.getTargetInfo': {
         if (!sessionId)
           return { result: undefined };
-        return { result: this._findTabSessionBySessionId(sessionId)?.targetInfo };
+        return { result: this._findTabSession(s => s.sessionId === sessionId)?.targetInfo };
       }
     }
     return undefined;
@@ -138,10 +138,10 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
     // 1. sessionId is a relay-level tab session (pw-tab-N) → strip and route by tabId.
     // 2. sessionId is a child CDP session (worker, oopif) → route to its owning tab,
     //    keep the sessionId so the extension forwards it to chrome.debugger.
-    let tabSession = this._findTabSessionBySessionId(sessionId);
+    let tabSession = this._findTabSession(s => s.sessionId === sessionId);
     let cdpSessionId: string | undefined;
     if (!tabSession) {
-      tabSession = this._findTabSessionByChildSessionId(sessionId);
+      tabSession = this._findTabSession(s => s.childSessions.has(sessionId));
       cdpSessionId = sessionId;
     }
     if (!tabSession)
@@ -195,27 +195,9 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
     });
   }
 
-  private _findTabSessionBySessionId(sessionId: string): TabSession | undefined {
+  private _findTabSession(predicate: (session: TabSession) => boolean): TabSession | undefined {
     for (const session of this._tabSessions.values()) {
-      if (session.sessionId === sessionId)
-        return session;
-    }
-    return undefined;
-  }
-
-  private _findTabSessionByChildSessionId(childSessionId: string): TabSession | undefined {
-    for (const session of this._tabSessions.values()) {
-      if (session.childSessions.has(childSessionId))
-        return session;
-    }
-    return undefined;
-  }
-
-  private _findTabSessionByTargetId(targetId: string | undefined): TabSession | undefined {
-    if (!targetId)
-      return undefined;
-    for (const session of this._tabSessions.values()) {
-      if (session.targetInfo?.targetId === targetId)
+      if (predicate(session))
         return session;
     }
     return undefined;

--- a/packages/playwright-core/src/tools/mcp/protocol.ts
+++ b/packages/playwright-core/src/tools/mcp/protocol.ts
@@ -70,6 +70,11 @@ export type ExtensionCommandV2 = {
     params: [createProperties: TabCreateProperties];
     result: Tab;
   };
+  // chrome.tabs.remove(tabIds)
+  'chrome.tabs.remove': {
+    params: [tabIds: number | number[]];
+    result: void;
+  };
   // Playwright-specific: ask the user to pick a tab via the connect UI.
   'extension.selectTab': {
     params: [];


### PR DESCRIPTION
## Summary
- Handle `Target.closeTarget` in the v2 extension relay by locating the tab via `targetId` and calling `chrome.tabs.remove`.
- Include `targetId` in `Target.detachedFromTarget` events so `CrBrowser._onDetachedFromTarget` can dispose the closed `CrPage` and resolve `page.close()`'s closed promise.
- Allow `chrome.tabs.remove` in the extension protocol schema.
