### PR TITLE
chore(dashboard): consolidate backend state, drop inspector sidebar

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -18,51 +18,25 @@ import React from 'react';
 import './dashboard.css';
 import { DashboardClientContext } from './index';
 import { asLocator } from '@isomorphic/locatorGenerators';
-import { TraceModel } from '@isomorphic/trace/traceModel';
-import { SplitView } from '@web/components/splitView';
 import { ChevronLeftIcon, ChevronRightIcon, ReloadIcon } from './icons';
 import { Annotations, getImageLayout, clientToViewport } from './annotations';
 import { ToolbarButton } from '@web/components/toolbarButton';
-import { TabbedPaneTabModel, TabbedPane } from '@web/components/tabbedPane';
-import { ConsoleTab, useConsoleTabModel } from '@trace-viewer/ui/consoleTab';
-import { InspectorTab } from '@trace-viewer/ui/inspectorTab';
-import { NetworkTab, useNetworkTabModel } from '@trace-viewer/ui/networkTab';
-import { useSetting } from '@web/uiUtils';
 
 import type { Tab, DashboardChannelEvents } from './dashboardChannel';
-import { HighlightedElement } from '@trace-viewer/ui/snapshotTab';
-import { TraceModelContext } from '@trace-viewer/ui/traceModelContext';
 
 const BUTTONS = ['left', 'middle', 'right'] as const;
 type Mode = 'readonly' | 'interactive' | 'annotate';
 
-export const Dashboard: React.FC<{
-  browser: string;
-  autoInteractive?: boolean;
-  onAutoInteractiveConsumed?: () => void;
-}> = ({ browser, autoInteractive, onAutoInteractiveConsumed }) => {
-  const [sidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
+export const Dashboard: React.FC = () => {
   const client = React.useContext(DashboardClientContext);
   const [mode, setMode] = React.useState<Mode>('readonly');
-  const [sidebarVisible, setSidebarVisible] = useSetting<boolean>('propertiesSidebarVisible', false);
-
-  React.useEffect(() => {
-    if (!autoInteractive)
-      return;
-    setMode('interactive');
-    onAutoInteractiveConsumed?.();
-  }, [autoInteractive, onAutoInteractiveConsumed]);
   const [tabs, setTabs] = React.useState<Tab[] | null>(null);
   const [url, setUrl] = React.useState('');
   const [frame, setFrame] = React.useState<DashboardChannelEvents['frame']>();
-  const [pickingPage, setPickingPage] = React.useState<string | null>(null);
-  const [highlightedElement, setHighlightedElement] = React.useState<HighlightedElement>({ locator: undefined, ariaSnapshot: undefined, lastEdited: 'none' });
-  const [context, setContext] = React.useState<string | undefined>();
+  const [picking, setPicking] = React.useState(false);
   const [recording, setRecording] = React.useState(false);
   const [screenshotIcon, setScreenshotIcon] = React.useState<'device-camera' | 'clippy'>('device-camera');
   const [showInteractiveHint, setShowInteractiveHint] = React.useState(false);
-  const [traceModel, setTraceModel] = React.useState<TraceModel | undefined>();
-  const [selectedSidebarTab, setSelectedSidebarTab] = useSetting<string>('dashboardPropertiesTab', 'inspector');
 
   const displayRef = React.useRef<HTMLImageElement>(null);
   const screenRef = React.useRef<HTMLDivElement>(null);
@@ -96,20 +70,14 @@ export const Dashboard: React.FC<{
   React.useEffect(() => {
     if (!client)
       return;
-    let disposed = false;
     let resized = false;
-
     const onTabs = (params: DashboardChannelEvents['tabs']) => {
-      if (params.target.browser !== browser)
-        return;
       setTabs(params.tabs);
       const selected = params.tabs.find(t => t.selected);
       if (selected)
         setUrl(selected.url);
     };
     const onFrame = (params: DashboardChannelEvents['frame']) => {
-      if (params.target.browser !== browser)
-        return;
       if (modeRef.current === 'annotate')
         return;
       setFrame(params);
@@ -125,84 +93,33 @@ export const Dashboard: React.FC<{
       }
     };
     const onElementPicked = (params: DashboardChannelEvents['elementPicked']) => {
-      if (params.target.browser !== browser)
-        return;
       const locator = asLocator('javascript', params.selector);
       navigator.clipboard?.writeText(locator).catch(() => {});
-      setPickingPage(null);
-      setHighlightedElement({ locator, ariaSnapshot: params.ariaSnapshot, lastEdited: 'locator' });
+      setPicking(false);
     };
-
+    const onPickLocator = () => {
+      setMode('interactive');
+      setPicking(true);
+    };
     client.on('tabs', onTabs);
     client.on('frame', onFrame);
     client.on('elementPicked', onElementPicked);
-
-    client.attach({ browser }).then(result => {
-      if (!disposed)
-        setContext(result.context);
-    }).catch(() => {});
-
+    client.on('pickLocator', onPickLocator);
     return () => {
-      disposed = true;
       client.off('tabs', onTabs);
       client.off('frame', onFrame);
       client.off('elementPicked', onElementPicked);
-      setContext(undefined);
-      setTabs(null);
-      setFrame(undefined);
-      setTraceModel(undefined);
-      setMode('readonly');
-      setPickingPage(null);
-      setRecording(false);
+      client.off('pickLocator', onPickLocator);
     };
-  }, [client, browser]);
+  }, [client]);
 
   const selectedTab = tabs?.find(t => t.selected);
-  const ready = !!client && !!context && !!selectedTab;
-  const pageTarget = ready && selectedTab
-    ? { browser, context: context!, page: selectedTab.page }
-    : undefined;
+  const ready = !!client && !!selectedTab;
 
   React.useEffect(() => {
     setRecording(false);
+    setPicking(false);
   }, [selectedTab?.page]);
-
-  React.useEffect(() => {
-    if (!client || !context || !sidebarVisible)
-      return;
-    client.startTracing({ browser }).catch(() => {});
-  }, [client, browser, context, sidebarVisible]);
-
-  React.useEffect(() => {
-    if (!client || !context || !sidebarVisible) {
-      setTraceModel(undefined);
-      return;
-    }
-
-    let disposed = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const poll = async () => {
-      try {
-        const { tracesDir, contextEntries } = await client.traceContextEntries({ browser });
-        if (disposed)
-          return;
-        setTraceModel(new TraceModel(tracesDir, contextEntries));
-      } catch {
-        if (!disposed)
-          setTraceModel(undefined);
-      } finally {
-        if (!disposed)
-          timer = setTimeout(poll, 500);
-      }
-    };
-
-    poll().catch(() => {});
-    return () => {
-      disposed = true;
-      if (timer)
-        clearTimeout(timer);
-    };
-  }, [client, browser, context, sidebarVisible]);
 
   function imgCoords(e: React.MouseEvent): { x: number; y: number } {
     const vw = frame?.viewportWidth ?? 0;
@@ -216,10 +133,10 @@ export const Dashboard: React.FC<{
   }
 
   function sendMouseEvent(method: 'mousedown' | 'mouseup', e: React.MouseEvent) {
-    if (!pageTarget)
+    if (!client)
       return;
     const { x, y } = imgCoords(e);
-    client?.[method]({ ...pageTarget, x, y, button: BUTTONS[e.button] || 'left' });
+    client[method]({ x, y, button: BUTTONS[e.button] || 'left' });
   }
 
   function onScreenMouseDown(e: React.MouseEvent) {
@@ -244,44 +161,43 @@ export const Dashboard: React.FC<{
   }
 
   function onScreenMouseMove(e: React.MouseEvent) {
-    if (annotating || !interactive || !pageTarget)
+    if (annotating || !interactive || !client)
       return;
     const now = Date.now();
     if (now - moveThrottleRef.current < 32)
       return;
     moveThrottleRef.current = now;
     const { x, y } = imgCoords(e);
-    client?.mousemove({ ...pageTarget, x, y });
+    client.mousemove({ x, y });
   }
 
   function onScreenWheel(e: React.WheelEvent) {
-    if (annotating || !interactive || !pageTarget)
+    if (annotating || !interactive || !client)
       return;
     e.preventDefault();
-    client?.wheel({ ...pageTarget, deltaX: e.deltaX, deltaY: e.deltaY });
+    client.wheel({ deltaX: e.deltaX, deltaY: e.deltaY });
   }
 
   function onScreenKeyDown(e: React.KeyboardEvent) {
     if (annotating)
       return;
-    if (pickingPage !== null && e.key === 'Escape') {
+    if (picking && e.key === 'Escape') {
       e.preventDefault();
-      if (pageTarget)
-        client?.cancelPickLocator(pageTarget);
-      setPickingPage(null);
+      client?.cancelPickLocator();
+      setPicking(false);
       return;
     }
-    if (!interactive || !pageTarget)
+    if (!interactive || !client)
       return;
     e.preventDefault();
-    client?.keydown({ ...pageTarget, key: e.key });
+    client.keydown({ key: e.key });
   }
 
   function onScreenKeyUp(e: React.KeyboardEvent) {
-    if (annotating || !interactive || !pageTarget)
+    if (annotating || !interactive || !client)
       return;
     e.preventDefault();
-    client?.keyup({ ...pageTarget, key: e.key });
+    client.keyup({ key: e.key });
   }
 
   function onOmniboxKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -290,267 +206,190 @@ export const Dashboard: React.FC<{
       if (!/^https?:\/\//i.test(value))
         value = 'https://' + value;
       setUrl(value);
-      if (pageTarget)
-        client?.navigate({ ...pageTarget, url: value });
+      client?.navigate({ url: value });
       e.currentTarget.blur();
     }
   }
 
-  const picking = selectedTab?.page === pickingPage;
-  const boundaries = React.useMemo(() => ({ minimum: 0, maximum: Number.POSITIVE_INFINITY }), []);
-  const consoleModel = useConsoleTabModel(traceModel, undefined, selectedTab?.page);
-  const networkModel = useNetworkTabModel(traceModel, undefined, selectedTab?.page);
-
-  const inspectorTabs: TabbedPaneTabModel[] = [
-    {
-      id: 'inspector',
-      title: 'Locator',
-      render: () => <InspectorTab
-        sdkLanguage='javascript'
-        isInspecting={picking}
-        setIsInspecting={isInspecting => {
-          if (isInspecting) {
-            if (!pageTarget || !selectedTab)
-              return;
-            setMode('interactive');
-            setPickingPage(selectedTab.page);
-            screenRef.current?.focus();
-            client?.pickLocator(pageTarget);
-          } else {
-            if (pageTarget)
-              client?.cancelPickLocator(pageTarget);
-            setPickingPage(null);
-          }
-        }}
-        highlightedElement={highlightedElement}
-        setHighlightedElement={setHighlightedElement}
-      />,
-    },
-    {
-      id: 'console',
-      title: 'Console',
-      count: consoleModel.entries.length,
-      render: () => <ConsoleTab
-        consoleModel={consoleModel}
-        boundaries={boundaries}
-      />,
-    },
-    {
-      id: 'network',
-      title: 'Network',
-      count: networkModel.resources.length,
-      render: () => <NetworkTab
-        boundaries={boundaries}
-        networkModel={networkModel}
-        sdkLanguage='javascript'
-      />,
-    },
-  ];
-
   let overlayText: string | undefined;
-  if (!client || !context)
+  if (!client)
     overlayText = 'Disconnected';
   else if (tabs === null)
     overlayText = 'Loading...';
   else if (tabs.length === 0)
     overlayText = 'No tabs open';
+  else if (!selectedTab)
+    overlayText = 'Select a tab from the sidebar';
 
   return (
-    <TraceModelContext.Provider value={traceModel}>
-      <div className='vbox'>
-        <SplitView
-          sidebarHidden={!sidebarVisible}
-          orientation={sidebarLocation === 'bottom' ? 'vertical' : 'horizontal'}
-          sidebarSize={500}
-          minSidebarSize={300}
-          settingName='devtoolsInspector'
-          main={<div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '')}>
-            {/* Toolbar */}
-            <div ref={toolbarRef} className='toolbar'>
-              <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                pageTarget && client?.back(pageTarget);
-              }}>
-                <ChevronLeftIcon />
-              </button>
-              <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                pageTarget && client?.forward(pageTarget);
-              }}>
-                <ChevronRightIcon />
-              </button>
-              <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                pageTarget && client?.reload(pageTarget);
-              }}>
-                <ReloadIcon />
-              </button>
-              <input
-                id='omnibox'
-                className='omnibox'
-                type='text'
-                placeholder='Search or enter URL'
-                spellCheck={false}
-                autoComplete='off'
-                value={url}
-                onChange={e => {
-                  if (!interactive)
-                    return;
-                  setUrl(e.target.value);
-                }}
-                onKeyDown={e => {
-                  if (!interactive)
-                    return;
-                  onOmniboxKeyDown(e);
-                }}
-                onFocus={e => {
-                  if (!interactive) {
-                    flashInteractiveHint();
-                    e.target.blur();
-                    return;
-                  }
-                  e.target.select();
-                }}
-                aria-disabled={!interactive || undefined}
-                readOnly={!interactive}
-              />
-              <ToolbarButton
-                className='recording'
-                title={recording ? 'Stop recording' : 'Record video'}
-                icon='record'
-                toggled={recording}
-                style={{ color: recording ? (interactive ? 'var(--color-fg-on-emphasis)' : 'var(--color-scale-red-5)') : undefined }}
-                disabled={!ready}
-                onClick={async () => {
-                  if (!client || !pageTarget)
-                    return;
-                  if (recording) {
-                    const { path } = await client.stopRecording(pageTarget);
-                    await client.reveal({ path });
-                    setRecording(false);
-                  } else {
-                    await client.startRecording(pageTarget);
-                    setRecording(true);
-                  }
-                }}>
-                {recording && <span className='recording-label'>Recording...</span>}
-              </ToolbarButton>
-              <ToolbarButton
-                className='screenshot'
-                title='Copy screenshot to clipboard'
-                icon={screenshotIcon}
-                disabled={!ready}
-                onClick={async () => {
-                  if (!client || !pageTarget)
-                    return;
-                  const screenshot = await client.screenshot(pageTarget);
-                  const blob = await (await fetch('data:image/png;base64,' + screenshot)).blob();
-                  await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-                  setScreenshotIcon('clippy');
-                  setTimeout(() => setScreenshotIcon('device-camera'), 3000);
-                }}
-              />
-              <div style={{ marginLeft: 8, borderLeft: '1px solid var(--color-border-default)', paddingLeft: 8, display: 'flex', gap: 4 }}>
-                <div style={{ position: 'relative' }}>
-                  <ToolbarButton
-                    title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
-                    icon='inspect'
-                    toggled={interactive}
-                    disabled={!ready}
-                    onClick={() => {
-                      if (interactive) {
-                        if (pageTarget)
-                          client?.cancelPickLocator(pageTarget);
-                        setPickingPage(null);
-                        setMode('readonly');
-                        return;
-                      }
-                      if (pageTarget)
-                        client?.cancelPickLocator(pageTarget);
-                      setPickingPage(null);
-                      setMode('interactive');
-                    }}
-                  />
-                  {showInteractiveHint && <div className='interactive-hint-popover'>Enable interactive mode</div>}
-                </div>
-                <ToolbarButton
-                  title={annotating ? 'Disable annotation mode' : 'Enable annotation mode'}
-                  icon='edit'
-                  toggled={annotating}
-                  disabled={!ready || !frame}
-                  onClick={() => {
-                    if (annotating) {
-                      setMode('readonly');
-                      return;
-                    }
-                    if (pageTarget)
-                      client?.cancelPickLocator(pageTarget);
-                    setPickingPage(null);
-                    setMode('annotate');
-                  }}
-                />
-                <ToolbarButton
-                  title={sidebarVisible ? 'Hide sidebar' : 'Show sidebar'}
-                  icon={sidebarLocation === 'bottom' ? 'layout-panel' : 'layout-sidebar-right'}
-                  toggled={sidebarVisible}
-                  onClick={() => setSidebarVisible(!sidebarVisible)}
-                  disabled={!ready}
-                />
-              </div>
-            </div>
-
-            {/* Viewport */}
-            <div className='viewport-wrapper'>
-              <div className='viewport-main'>
-                <div
-                  ref={screenRef}
-                  className='screen'
-                  tabIndex={0}
-                  style={{ display: frame ? '' : 'none' }}
-                  onMouseDown={onScreenMouseDown}
-                  onMouseUp={onScreenMouseUp}
-                  onMouseMove={onScreenMouseMove}
-                  onWheel={onScreenWheel}
-                  onKeyDown={onScreenKeyDown}
-                  onKeyUp={onScreenKeyUp}
-                  onContextMenu={e => e.preventDefault()}
-                >
-                  <img
-                    ref={displayRef}
-                    id='display'
-                    className='display'
-                    alt='screencast'
-                    src={frame ? 'data:image/jpeg;base64,' + frame.data : undefined}
-                  />
-                  <Annotations
-                    active={annotating}
-                    displayRef={displayRef}
-                    screenRef={screenRef}
-                    viewportWidth={frame?.viewportWidth ?? 0}
-                    viewportHeight={frame?.viewportHeight ?? 0}
-                  />
-                </div>
-                {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
-              </div>
-            </div>
-          </div>}
-          sidebar={<TabbedPane
-            tabs={inspectorTabs}
-            selectedTab={selectedSidebarTab}
-            setSelectedTab={setSelectedSidebarTab}
-            mode='default'
-          />}
+    <div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '')}>
+      {/* Toolbar */}
+      <div ref={toolbarRef} className='toolbar'>
+        <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
+          if (!interactive) {
+            flashInteractiveHint();
+            return;
+          }
+          client?.back();
+        }}>
+          <ChevronLeftIcon />
+        </button>
+        <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
+          if (!interactive) {
+            flashInteractiveHint();
+            return;
+          }
+          client?.forward();
+        }}>
+          <ChevronRightIcon />
+        </button>
+        <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
+          if (!interactive) {
+            flashInteractiveHint();
+            return;
+          }
+          client?.reload();
+        }}>
+          <ReloadIcon />
+        </button>
+        <input
+          id='omnibox'
+          className='omnibox'
+          type='text'
+          placeholder='Search or enter URL'
+          spellCheck={false}
+          autoComplete='off'
+          value={url}
+          onChange={e => {
+            if (!interactive)
+              return;
+            setUrl(e.target.value);
+          }}
+          onKeyDown={e => {
+            if (!interactive)
+              return;
+            onOmniboxKeyDown(e);
+          }}
+          onFocus={e => {
+            if (!interactive) {
+              flashInteractiveHint();
+              e.target.blur();
+              return;
+            }
+            e.target.select();
+          }}
+          aria-disabled={!interactive || undefined}
+          readOnly={!interactive}
         />
+        <ToolbarButton
+          className='recording'
+          title={recording ? 'Stop recording' : 'Record video'}
+          icon='record'
+          toggled={recording}
+          style={{ color: recording ? (interactive ? 'var(--color-fg-on-emphasis)' : 'var(--color-scale-red-5)') : undefined }}
+          disabled={!ready}
+          onClick={async () => {
+            if (!client)
+              return;
+            if (recording) {
+              const { path } = await client.stopRecording();
+              await client.reveal({ path });
+              setRecording(false);
+            } else {
+              await client.startRecording();
+              setRecording(true);
+            }
+          }}>
+          {recording && <span className='recording-label'>Recording...</span>}
+        </ToolbarButton>
+        <ToolbarButton
+          className='screenshot'
+          title='Copy screenshot to clipboard'
+          icon={screenshotIcon}
+          disabled={!ready}
+          onClick={async () => {
+            if (!client)
+              return;
+            const screenshot = await client.screenshot();
+            const blob = await (await fetch('data:image/png;base64,' + screenshot)).blob();
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+            setScreenshotIcon('clippy');
+            setTimeout(() => setScreenshotIcon('device-camera'), 3000);
+          }}
+        />
+        <div style={{ marginLeft: 8, borderLeft: '1px solid var(--color-border-default)', paddingLeft: 8, display: 'flex', gap: 4 }}>
+          <div style={{ position: 'relative' }}>
+            <ToolbarButton
+              title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
+              icon='inspect'
+              toggled={interactive}
+              disabled={!ready}
+              onClick={() => {
+                if (interactive) {
+                  client?.cancelPickLocator();
+                  setPicking(false);
+                  setMode('readonly');
+                  return;
+                }
+                client?.cancelPickLocator();
+                setPicking(false);
+                setMode('interactive');
+              }}
+            />
+            {showInteractiveHint && <div className='interactive-hint-popover'>Enable interactive mode</div>}
+          </div>
+          <ToolbarButton
+            title={annotating ? 'Disable annotation mode' : 'Enable annotation mode'}
+            icon='edit'
+            toggled={annotating}
+            disabled={!ready || !frame}
+            onClick={() => {
+              if (annotating) {
+                setMode('readonly');
+                return;
+              }
+              client?.cancelPickLocator();
+              setPicking(false);
+              setMode('annotate');
+            }}
+          />
+        </div>
       </div>
-    </TraceModelContext.Provider>
+
+      {/* Viewport */}
+      <div className='viewport-wrapper'>
+        <div className='viewport-main'>
+          <div
+            ref={screenRef}
+            className='screen'
+            tabIndex={0}
+            style={{ display: frame ? '' : 'none' }}
+            onMouseDown={onScreenMouseDown}
+            onMouseUp={onScreenMouseUp}
+            onMouseMove={onScreenMouseMove}
+            onWheel={onScreenWheel}
+            onKeyDown={onScreenKeyDown}
+            onKeyUp={onScreenKeyUp}
+            onContextMenu={e => e.preventDefault()}
+          >
+            <img
+              ref={displayRef}
+              id='display'
+              className='display'
+              alt='screencast'
+              src={frame ? 'data:image/jpeg;base64,' + frame.data : undefined}
+            />
+            <Annotations
+              active={annotating}
+              displayRef={displayRef}
+              screenRef={screenRef}
+              viewportWidth={frame?.viewportWidth ?? 0}
+              viewportHeight={frame?.viewportHeight ?? 0}
+            />
+          </div>
+          {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
+        </div>
+      </div>
+    </div>
   );
 };

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -16,11 +16,6 @@
 
 import type { ClientInfo } from '../../playwright-core/src/tools/cli-client/registry';
 import type { SessionStatus } from './sessionModel';
-import type { ContextEntry } from '@isomorphic/trace/entries';
-
-export type BrowserTarget = { browser: string };
-export type ContextTarget = { browser: string; context: string };
-export type PageTarget = { browser: string; context: string; page: string };
 
 export type Tab = {
   browser: string;
@@ -35,44 +30,38 @@ export type Tab = {
 
 export type DashboardChannelEvents = {
   sessions: { sessions: SessionStatus[]; clientInfo: ClientInfo };
-  tabs: { target: ContextTarget; tabs: Tab[] };
-  frame: { target: PageTarget; data: string; viewportWidth: number; viewportHeight: number };
-  elementPicked: { target: PageTarget; selector: string; ariaSnapshot?: string };
-  pickLocator: { target: PageTarget };
+  tabs: { tabs: Tab[] };
+  frame: { data: string; viewportWidth: number; viewportHeight: number };
+  elementPicked: { selector: string; ariaSnapshot?: string };
+  pickLocator: {};
 };
 
 export type MouseButton = 'left' | 'middle' | 'right';
 
 export interface DashboardChannel {
-  attach(params: BrowserTarget): Promise<{ context: string }>;
-  detach(params: BrowserTarget): Promise<void>;
-  closeSession(params: BrowserTarget): Promise<void>;
-  deleteSessionData(params: BrowserTarget): Promise<void>;
+  selectTab(params: { browser: string; page: string }): Promise<void>;
+  closeTab(params: { browser: string; page: string }): Promise<void>;
+  newTab(params: { browser: string }): Promise<void>;
+  closeSession(params: { browser: string }): Promise<void>;
+  deleteSessionData(params: { browser: string }): Promise<void>;
   setVisible(params: { visible: boolean }): Promise<void>;
-
-  tabs(params: ContextTarget): Promise<{ tabs: Tab[] }>;
-  newTab(params: ContextTarget): Promise<{ page: string }>;
-
-  selectTab(params: PageTarget): Promise<void>;
-  closeTab(params: PageTarget): Promise<void>;
-  navigate(params: PageTarget & { url: string }): Promise<void>;
-  back(params: PageTarget): Promise<void>;
-  forward(params: PageTarget): Promise<void>;
-  reload(params: PageTarget): Promise<void>;
-  mousemove(params: PageTarget & { x: number; y: number }): Promise<void>;
-  mousedown(params: PageTarget & { x: number; y: number; button?: MouseButton }): Promise<void>;
-  mouseup(params: PageTarget & { x: number; y: number; button?: MouseButton }): Promise<void>;
-  wheel(params: PageTarget & { deltaX: number; deltaY: number }): Promise<void>;
-  keydown(params: PageTarget & { key: string }): Promise<void>;
-  keyup(params: PageTarget & { key: string }): Promise<void>;
-  pickLocator(params: PageTarget): Promise<void>;
-  cancelPickLocator(params: PageTarget): Promise<void>;
-  startTracing(params: BrowserTarget): Promise<void>;
-  traceContextEntries(params: BrowserTarget): Promise<{ contextEntries: ContextEntry[], tracesDir: string }>;
-  startRecording(params: PageTarget): Promise<void>;
-  stopRecording(params: PageTarget): Promise<{ path: string }>;
-  screenshot(params: PageTarget): Promise<string>;
   reveal(params: { path: string }): Promise<void>;
+
+  navigate(params: { url: string }): Promise<void>;
+  back(): Promise<void>;
+  forward(): Promise<void>;
+  reload(): Promise<void>;
+  mousemove(params: { x: number; y: number }): Promise<void>;
+  mousedown(params: { x: number; y: number; button?: MouseButton }): Promise<void>;
+  mouseup(params: { x: number; y: number; button?: MouseButton }): Promise<void>;
+  wheel(params: { deltaX: number; deltaY: number }): Promise<void>;
+  keydown(params: { key: string }): Promise<void>;
+  keyup(params: { key: string }): Promise<void>;
+  pickLocator(): Promise<void>;
+  cancelPickLocator(): Promise<void>;
+  startRecording(): Promise<void>;
+  stopRecording(): Promise<{ path: string }>;
+  screenshot(): Promise<string>;
 
   on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;
   off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;

--- a/packages/dashboard/src/index.tsx
+++ b/packages/dashboard/src/index.tsx
@@ -26,23 +26,9 @@ import { DashboardClient } from './dashboardClient';
 import { SessionSidebar } from './sessionSidebar';
 import { SplitView } from '@web/components/splitView';
 
-import type { DashboardChannelEvents } from './dashboardChannel';
 import type { DashboardClientChannel } from './dashboardClient';
 
 applyTheme();
-
-export function navigate(hash: string) {
-  window.history.pushState(null, '', hash);
-  window.dispatchEvent(new PopStateEvent('popstate'));
-}
-
-function parseHash(): string | undefined {
-  const hash = window.location.hash;
-  const prefix = '#session=';
-  if (hash.startsWith(prefix))
-    return decodeURIComponent(hash.slice(prefix.length));
-  return undefined;
-}
 
 export const DashboardClientContext = React.createContext<DashboardClientChannel | undefined>(undefined);
 
@@ -55,46 +41,8 @@ if (document.hidden)
   pushVisibility();
 
 const App: React.FC = () => {
-  const [revision, setRevision] = React.useState(0);
-  const [sessionGuid, setSessionGuid] = React.useState<string | undefined>(parseHash());
-  const [autoInteractiveBrowser, setAutoInteractiveBrowser] = React.useState<string | undefined>();
-
+  const [, setRevision] = React.useState(0);
   React.useEffect(() => model.subscribe(() => setRevision(r => r + 1)), []);
-
-  React.useEffect(() => {
-    const onPopState = () => setSessionGuid(parseHash());
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
-  }, []);
-
-  React.useEffect(() => {
-    const onPickLocator = (params: DashboardChannelEvents['pickLocator']) => {
-      setAutoInteractiveBrowser(params.target.browser);
-      if (parseHash() !== params.target.browser)
-        navigate('#session=' + encodeURIComponent(params.target.browser));
-    };
-    client.on('pickLocator', onPickLocator);
-    return () => client.off('pickLocator', onPickLocator);
-  }, []);
-
-  React.useEffect(() => {
-    if (!sessionGuid || model.loading)
-      return;
-    const session = model.sessionByGuid(sessionGuid);
-    if (!session || !session.canConnect)
-      navigate('#');
-  }, [sessionGuid, revision]);
-
-  React.useEffect(() => {
-    if (sessionGuid || model.loading)
-      return;
-    const firstOpenSession = model.sessions.find(session => session.canConnect);
-    if (firstOpenSession)
-      navigate('#session=' + encodeURIComponent(firstOpenSession.browser.guid));
-  }, [sessionGuid, revision]);
-
-  const activeSession = sessionGuid ? model.sessionByGuid(sessionGuid) : undefined;
-  const activeBrowser = activeSession?.canConnect ? activeSession.browser.guid : undefined;
 
   return <DashboardClientContext.Provider value={client}>
     <SplitView
@@ -105,27 +53,12 @@ const App: React.FC = () => {
       settingName='dashboardSessionSidebar'
       sidebar={<SessionSidebar
         model={model}
-        activeBrowser={activeBrowser}
-        onSelectTab={tab => {
-          if (sessionGuid !== tab.browser)
-            navigate('#session=' + encodeURIComponent(tab.browser));
-          void client.selectTab({ browser: tab.browser, context: tab.context, page: tab.page });
-        }}
-        onCloseTab={tab => { void client.closeTab({ browser: tab.browser, context: tab.context, page: tab.page }); }}
-        onNewTab={(browser, context) => {
-          if (sessionGuid !== browser)
-            navigate('#session=' + encodeURIComponent(browser));
-          void client.newTab({ browser, context });
-        }}
+        onSelectTab={tab => { void client.selectTab({ browser: tab.browser, page: tab.page }); }}
+        onCloseTab={tab => { void client.closeTab({ browser: tab.browser, page: tab.page }); }}
+        onNewTab={browser => { void client.newTab({ browser }); }}
       />}
       main={<div className='dashboard-shell-main'>
-        {activeBrowser
-          ? <Dashboard
-            browser={activeBrowser}
-            autoInteractive={autoInteractiveBrowser === activeBrowser}
-            onAutoInteractiveConsumed={() => setAutoInteractiveBrowser(undefined)}
-          />
-          : <div className='dashboard-shell-empty'>Select an open tab in the sidebar.</div>}
+        <Dashboard />
       </div>}
     />
   </DashboardClientContext.Provider>;

--- a/packages/dashboard/src/screencast.tsx
+++ b/packages/dashboard/src/screencast.tsx
@@ -19,18 +19,16 @@ import React from 'react';
 import type { DashboardClientChannel } from './dashboardClient';
 import type { DashboardChannelEvents } from './dashboardChannel';
 
-export const Screencast: React.FC<{ client: DashboardClientChannel; browser: string }> = ({ client, browser }) => {
+export const Screencast: React.FC<{ client: DashboardClientChannel }> = ({ client }) => {
   const [frameSrc, setFrameSrc] = React.useState('');
 
   React.useEffect(() => {
     const listener = (params: DashboardChannelEvents['frame']) => {
-      if (params.target.browser !== browser)
-        return;
       setFrameSrc('data:image/jpeg;base64,' + params.data);
     };
     client.on('frame', listener);
     return () => client.off('frame', listener);
-  }, [client, browser]);
+  }, [client]);
 
   if (!frameSrc)
     return <div className='screencast-placeholder'>Connecting...</div>;

--- a/packages/dashboard/src/sessionSidebar.tsx
+++ b/packages/dashboard/src/sessionSidebar.tsx
@@ -26,10 +26,9 @@ import type { SessionModel, SessionStatus } from './sessionModel';
 
 type SessionSidebarProps = {
   model: SessionModel;
-  activeBrowser?: string;
   onSelectTab: (tab: Tab) => void;
   onCloseTab: (tab: Tab) => void;
-  onNewTab: (browser: string, context: string) => void;
+  onNewTab: (browser: string) => void;
 };
 
 function tabFavicon(url: string): string {
@@ -52,43 +51,35 @@ function normalizeWorkspacePath(workspace: string): string {
   return workspace;
 }
 
-export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, activeBrowser, onSelectTab, onCloseTab, onNewTab }) => {
+export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, onSelectTab, onCloseTab, onNewTab }) => {
   const client = React.useContext(DashboardClientContext);
   const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
   const openSessions = React.useMemo(() => model.sessions.filter(session => session.canConnect), [model.sessions]);
   const clientInfo = model.clientInfo;
-  const [browserState, setBrowserState] = React.useState<Record<string, { context: string; tabs?: Tab[]; }>>({});
+  const [allTabs, setAllTabs] = React.useState<Tab[] | null>(null);
 
   React.useEffect(() => {
     if (!client)
       return;
-
-    const onTabs = (params: DashboardChannelEvents['tabs']) => {
-      setBrowserState(prev => ({
-        ...prev,
-        [params.target.browser]: {
-          context: params.target.context,
-          tabs: params.tabs,
-        },
-      }));
-    };
-
+    const onTabs = (params: DashboardChannelEvents['tabs']) => setAllTabs(params.tabs);
     client.on('tabs', onTabs);
-
-    for (const session of openSessions) {
-      void client.attach({ browser: session.browser.guid }).then(result => {
-        setBrowserState(prev => ({
-          ...prev,
-          [session.browser.guid]: {
-            ...prev[session.browser.guid],
-            context: result.context,
-          },
-        }));
-      }).catch(() => {});
-    }
-
     return () => client.off('tabs', onTabs);
-  }, [client, openSessions]);
+  }, [client]);
+
+  const tabsByBrowser = React.useMemo(() => {
+    const map = new Map<string, Tab[]>();
+    for (const tab of allTabs ?? []) {
+      let list = map.get(tab.browser);
+      if (!list) {
+        list = [];
+        map.set(tab.browser, list);
+      }
+      list.push(tab);
+    }
+    return map;
+  }, [allTabs]);
+
+  const activeBrowser = React.useMemo(() => allTabs?.find(t => t.selected)?.browser, [allTabs]);
 
   const workspaceGroups = React.useMemo(() => {
     const groups = new Map<string, SessionStatus[]>();
@@ -130,9 +121,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, activeBro
               const guid = session.browser.guid;
               const browserType = session.browser.browserName;
               const browserInitial = browserType ? browserType[0].toUpperCase() : '?';
-              const sessionState = browserState[guid];
-              const tabs = sessionState?.tabs;
-              const context = sessionState?.context;
+              const tabs = allTabs === null ? undefined : (tabsByBrowser.get(guid) ?? []);
               return <div key={guid} className='session-chip sidebar-session' role='listitem' title={session.title}>
                 <div className='sidebar-session-row'>
                   <div className='session-browser-icon-wrap' title={browserType}>
@@ -150,11 +139,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, activeBro
                       className='sidebar-session-new-tab'
                       icon='add'
                       title='New tab'
-                      onClick={() => {
-                        if (context)
-                          onNewTab(guid, context);
-                      }}
-                      disabled={!context}
+                      onClick={() => onNewTab(guid)}
                     />
                   </div>
                 </div>

--- a/packages/dashboard/src/sessionSidebar.tsx
+++ b/packages/dashboard/src/sessionSidebar.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import './sessionSidebar.css';
 import { DashboardClientContext } from './index';
 import { SettingsButton } from './settingsView';
-import { useSetting } from '@web/uiUtils';
 import { ToolbarButton } from '@web/components/toolbarButton';
 
 import type { Tab, DashboardChannelEvents } from './dashboardChannel';
@@ -53,7 +52,6 @@ function normalizeWorkspacePath(workspace: string): string {
 
 export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, onSelectTab, onCloseTab, onNewTab }) => {
   const client = React.useContext(DashboardClientContext);
-  const [sidebarLocation, setSidebarLocation] = useSetting<'bottom' | 'right'>('propertiesSidebarLocation', 'bottom');
   const openSessions = React.useMemo(() => model.sessions.filter(session => session.canConnect), [model.sessions]);
   const clientInfo = model.clientInfo;
   const [allTabs, setAllTabs] = React.useState<Tab[] | null>(null);
@@ -105,7 +103,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, onSelectT
   return <nav className='dashboard-shell-sidebar' aria-label='Sessions'>
     <div className='dashboard-shell-sidebar-header'>
       <h2 className='dashboard-shell-sidebar-title'>Sessions</h2>
-      <SettingsButton sidebarLocation={sidebarLocation} setSidebarLocation={setSidebarLocation} />
+      <SettingsButton />
     </div>
     <div className='dashboard-shell-sidebar-content'>
       {model.loading && <div className='sidebar-empty' role='status' aria-live='polite'>Loading sessions...</div>}

--- a/packages/dashboard/src/settingsView.tsx
+++ b/packages/dashboard/src/settingsView.tsx
@@ -19,14 +19,7 @@ import './settingsView.css';
 import { kThemeOptions, type Theme, useThemeSetting } from '@web/theme';
 import { GearIcon } from './icons';
 
-type SidebarLocation = 'bottom' | 'right';
-
-type SettingsButtonProps = {
-  sidebarLocation?: SidebarLocation;
-  setSidebarLocation?: (location: SidebarLocation) => void;
-};
-
-export const SettingsButton: React.FC<SettingsButtonProps> = ({ sidebarLocation, setSidebarLocation }) => {
+export const SettingsButton: React.FC = () => {
   const [open, setOpen] = React.useState(false);
   const [theme, setTheme] = useThemeSetting();
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -75,25 +68,6 @@ export const SettingsButton: React.FC<SettingsButtonProps> = ({ sidebarLocation,
               ))}
             </div>
           </div>
-          {sidebarLocation && setSidebarLocation && (
-            <div className='setting-row'>
-              <span className='setting-label'>Inspector Dock</span>
-              <div className='setting-options'>
-                <div
-                  className={'setting-option' + (sidebarLocation === 'bottom' ? ' selected' : '')}
-                  onClick={() => { setSidebarLocation('bottom'); setOpen(false); }}
-                >
-                  Bottom
-                </div>
-                <div
-                  className={'setting-option' + (sidebarLocation === 'right' ? ' selected' : '')}
-                  onClick={() => { setSidebarLocation('right'); setOpen(false); }}
-                >
-                  Right
-                </div>
-              </div>
-            </div>
-          )}
         </div>
       )}
     </div>

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -22,7 +22,6 @@ import http from 'http';
 import { HttpServer } from '@utils/httpServer';
 import { makeSocketPath } from '@utils/fileUtils';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
-import { TraceLoader } from '@isomorphic/trace/traceLoader';
 import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
@@ -34,42 +33,15 @@ async function innerOpenDashboardApp(): Promise<api.Page> {
   const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
 
-  const traces = new Map<string, TraceLoader>();
   const connections = new Set<DashboardConnection>();
 
   httpServer.createWebSocket(() => {
     let connection: DashboardConnection;
     // eslint-disable-next-line prefer-const
-    connection = new DashboardConnection(() => connections.delete(connection), traces);
+    connection = new DashboardConnection(() => connections.delete(connection));
     connections.add(connection);
     return connection;
   }, 'ws');
-
-  httpServer.routePrefix('/sha1/', (request: http.IncomingMessage, response: http.ServerResponse) => {
-    const url = new URL(request.url!, `http://${request.headers.host}`);
-    const tracesDir = url.searchParams.get('trace');
-    if (!tracesDir)
-      throw new Error('Traces directory is missing');
-    const sha1 = url.pathname.split('/sha1/')[1];
-    const loader = traces.get(tracesDir);
-    if (!loader)
-      throw new Error('Trace is not loaded');
-    loader.resourceForSha1(sha1).then(async blob => {
-      if (!blob) {
-        response.statusCode = 404;
-        response.end('Not found');
-        return;
-      }
-      const buffer = await blob.arrayBuffer();
-      response.setHeader('Content-Type', blob.type);
-      response.end(Buffer.from(buffer));
-    }).catch(e => {
-      response.statusCode = 500;
-      response.setHeader('error', String(e));
-      response.end(String(e));
-    });
-    return true;
-  });
 
   httpServer.routePrefix('/', (request: http.IncomingMessage, response: http.ServerResponse) => {
     const pathname = new URL(request.url!, `http://${request.headers.host}`).pathname;

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -19,38 +19,41 @@ import os from 'os';
 import fs from 'fs';
 import { execFile } from 'child_process';
 import { eventsHelper } from '@utils/eventsHelper';
-import { TraceLoader } from '@isomorphic/trace/traceLoader';
 import { connectToBrowserAcrossVersions } from '../utils/connect';
 import { serverRegistry } from '../../serverRegistry';
 import { createClientInfo } from '../cli-client/registry';
-import { DirTraceLoaderBackend } from '../trace/traceParser';
 
 import type * as api from '../../..';
 import type { Transport } from '@utils/httpServer';
 import type { Tab } from '@dashboard/dashboardChannel';
-import type { ContextEntry } from '@isomorphic/trace/entries';
 import type { BrowserDescriptor, BrowserStatus } from '../../serverRegistry';
 
 type Disposable = { dispose: () => Promise<void> };
 
-export class DashboardConnection implements Transport {
-  readonly version = 2;
+type BrowserSlot = {
+  guid: string;
+  contextGuid: string;
+  descriptor: BrowserDescriptor;
+  context: api.BrowserContext;
+  listeners: Disposable[];
+};
 
+export class DashboardConnection implements Transport {
   sendEvent?: (method: string, params: any) => void;
   close?: () => void;
 
-  private _attached = new Map<string, AttachedBrowser>();
+  private _browsers = new Map<string, BrowserSlot>();
+  private _attachedBrowser: AttachedBrowser | undefined;
   private _onclose: () => void;
   private _serverRegistryDispose?: () => void;
   private _pushSessionsScheduled = false;
+  private _pushTabsScheduled = false;
   private _visible = true;
 
   _recordingDir: string;
-  _traceMap: Map<string, TraceLoader>;
 
-  constructor(onclose: () => void, traceMap: Map<string, TraceLoader>) {
+  constructor(onclose: () => void) {
     this._onclose = onclose;
-    this._traceMap = traceMap;
     this._recordingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'playwright-recordings-'));
   }
 
@@ -68,9 +71,11 @@ export class DashboardConnection implements Transport {
     serverRegistry.off('changed', this._pushSessions);
     this._serverRegistryDispose?.();
     this._serverRegistryDispose = undefined;
-    for (const att of this._attached.values())
-      att.dispose();
-    this._attached.clear();
+    this._attachedBrowser?.dispose();
+    this._attachedBrowser = undefined;
+    for (const slot of this._browsers.values())
+      slot.listeners.forEach(d => d.dispose());
+    this._browsers.clear();
     this._onclose();
   }
 
@@ -79,31 +84,37 @@ export class DashboardConnection implements Transport {
     const handler = (this as any)[method];
     if (typeof handler === 'function')
       return handler.call(this, params);
-    const att = params?.browser ? this._attached.get(params.browser) : undefined;
+    const attached = this._attachedBrowser;
+    if (!attached)
+      return;
     // eslint-disable-next-line no-restricted-syntax
-    const onAtt = att ? (att as any)[method] : undefined;
+    const onAtt = (attached as any)[method];
     if (typeof onAtt === 'function')
-      return onAtt.call(att, params);
+      return onAtt.call(attached, params);
   }
 
-  async attach(params: { browser: string }): Promise<{ context: string }> {
-    if (this._attached.has(params.browser))
-      return { context: this._attached.get(params.browser)!.contextGuid };
-    const descriptor = serverRegistry.readDescriptor(params.browser);
-    const browser = await connectToBrowserAcrossVersions(descriptor);
-    const context = browser.contexts()[0];
-    const att = new AttachedBrowser(this, params.browser, descriptor, context);
-    this._attached.set(params.browser, att);
-    await att.init();
-    return { context: att.contextGuid };
+  async selectTab(params: { browser: string; page: string }) {
+    await this._switchAttachedTo(params.browser);
+    await this._attachedBrowser?.selectPageByGuid(params.page);
+    this._pushTabs();
   }
 
-  async detach(params: { browser: string }) {
-    const att = this._attached.get(params.browser);
-    if (att) {
-      this._attached.delete(params.browser);
-      att.dispose();
-    }
+  async newTab(params: { browser: string }) {
+    const slot = this._browsers.get(params.browser);
+    if (!slot)
+      return;
+    const page = await slot.context.newPage();
+    await this._switchAttachedTo(params.browser);
+    await this._attachedBrowser?.selectPage(page);
+    this._pushTabs();
+  }
+
+  async closeTab(params: { browser: string; page: string }) {
+    const slot = this._browsers.get(params.browser);
+    if (!slot)
+      return;
+    const page = slot.context.pages().find(p => pageId(p) === params.page);
+    await page?.close({ reason: 'Closed in Dashboard' });
   }
 
   async closeSession(params: { browser: string }) {
@@ -125,7 +136,7 @@ export class DashboardConnection implements Transport {
     if (this._visible === params.visible)
       return;
     this._visible = params.visible;
-    await Promise.all([...this._attached.values()].map(att => att.setScreencastActive(params.visible)));
+    await this._attachedBrowser?.setScreencastActive(params.visible);
   }
 
   async reveal(params: { path: string }) {
@@ -146,42 +157,73 @@ export class DashboardConnection implements Transport {
     return this._visible;
   }
 
-  pageForId(pageGuid: string): api.Page | undefined {
-    for (const att of this._attached.values()) {
-      const page = att.pageForId(pageGuid);
-      if (page)
-        return page;
-    }
-    return undefined;
-  }
-
   emitSessions(sessions: BrowserStatus[]) {
     this.sendEvent?.('sessions', { sessions, clientInfo: createClientInfo() });
   }
 
-  emitTabs(att: AttachedBrowser, tabs: Tab[]) {
-    this.sendEvent?.('tabs', { target: { browser: att.browserGuid, context: att.contextGuid }, tabs });
+  emitTabs(tabs: Tab[]) {
+    this.sendEvent?.('tabs', { tabs });
   }
 
-  emitFrame(att: AttachedBrowser, pageGuid: string, data: string, viewportWidth: number, viewportHeight: number) {
-    this.sendEvent?.('frame', {
-      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
-      data, viewportWidth, viewportHeight,
+  emitFrame(data: string, viewportWidth: number, viewportHeight: number) {
+    this.sendEvent?.('frame', { data, viewportWidth, viewportHeight });
+  }
+
+  emitElementPicked(selector: string, ariaSnapshot?: string) {
+    this.sendEvent?.('elementPicked', { selector, ariaSnapshot });
+  }
+
+  emitPickLocator() {
+    this.sendEvent?.('pickLocator', {});
+  }
+
+  _pushTabs() {
+    if (this._pushTabsScheduled)
+      return;
+    this._pushTabsScheduled = true;
+    queueMicrotask(async () => {
+      this._pushTabsScheduled = false;
+      try {
+        const tabs = await this._aggregateTabs();
+        this.emitTabs(tabs);
+      } catch {
+        // best-effort
+      }
     });
   }
 
-  emitElementPicked(att: AttachedBrowser, pageGuid: string, selector: string, ariaSnapshot?: string) {
-    this.sendEvent?.('elementPicked', {
-      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
-      selector,
-      ariaSnapshot,
-    });
+  private async _aggregateTabs(): Promise<Tab[]> {
+    const tasks: Promise<Tab>[] = [];
+    for (const slot of this._browsers.values()) {
+      const selectedPage = this._attachedBrowser?.browserGuid === slot.guid
+        ? this._attachedBrowser.selectedPage()
+        : null;
+      for (const page of slot.context.pages()) {
+        tasks.push((async () => ({
+          browser: slot.guid,
+          context: slot.contextGuid,
+          page: pageId(page),
+          title: await page.title().catch(() => ''),
+          url: page.url(),
+          selected: page === selectedPage,
+          faviconUrl: await faviconUrl(page),
+        }))());
+      }
+    }
+    return await Promise.all(tasks);
   }
 
-  emitPickLocator(att: AttachedBrowser, pageGuid: string) {
-    this.sendEvent?.('pickLocator', {
-      target: { browser: att.browserGuid, context: att.contextGuid, page: pageGuid },
-    });
+  private async _switchAttachedTo(guid: string) {
+    if (this._attachedBrowser?.browserGuid === guid)
+      return;
+    this._attachedBrowser?.dispose();
+    this._attachedBrowser = undefined;
+    const slot = this._browsers.get(guid);
+    if (!slot)
+      return;
+    const attached = new AttachedBrowser(this, slot);
+    await attached.init();
+    this._attachedBrowser = attached;
   }
 
   private _pushSessions = () => {
@@ -195,55 +237,101 @@ export class DashboardConnection implements Transport {
         const sessions: BrowserStatus[] = [];
         for (const list of byWs.values())
           sessions.push(...list);
+        await this._reconcile(sessions);
         this.emitSessions(sessions);
       } catch {
         // best-effort
       }
     });
   };
+
+  private async _reconcile(sessions: BrowserStatus[]) {
+    const connectable = new Map<string, BrowserStatus>();
+    for (const status of sessions) {
+      if (status.canConnect)
+        connectable.set(status.browser.guid, status);
+    }
+
+    for (const [guid, slot] of this._browsers) {
+      if (connectable.has(guid))
+        continue;
+      if (this._attachedBrowser?.browserGuid === guid) {
+        this._attachedBrowser.dispose();
+        this._attachedBrowser = undefined;
+      }
+      slot.listeners.forEach(d => d.dispose());
+      this._browsers.delete(guid);
+    }
+
+    for (const [guid, status] of connectable) {
+      if (this._browsers.has(guid))
+        continue;
+      try {
+        const browser = await connectToBrowserAcrossVersions(status);
+        if (this._browsers.has(guid))
+          continue;
+        const context = browser.contexts()[0];
+        if (!context)
+          continue;
+        const slot: BrowserSlot = {
+          guid,
+          // eslint-disable-next-line no-restricted-syntax -- _guid is very conservative.
+          contextGuid: (context as any)._guid,
+          descriptor: status,
+          context,
+          listeners: [],
+        };
+        slot.listeners.push(
+            eventsHelper.addEventListener(context, 'page', () => this._pushTabs()),
+            eventsHelper.addEventListener(context, 'picklocator', (page: api.Page) => {
+              this._onPickLocator(guid, page).catch(() => {});
+            }),
+        );
+        this._browsers.set(guid, slot);
+        this._pushTabs();
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  private async _onPickLocator(guid: string, page: api.Page) {
+    await this._switchAttachedTo(guid);
+    await this._attachedBrowser?.selectPage(page);
+    this.emitPickLocator();
+  }
 }
 
 class AttachedBrowser {
-  readonly browserGuid: string;
-  readonly contextGuid: string;
-
   private _owner: DashboardConnection;
-  private _descriptor: BrowserDescriptor;
-  private _context: api.BrowserContext;
+  private _slot: BrowserSlot;
 
   private _selectedPage: api.Page | null = null;
   private _screencastRunning = false;
   private _recordingPath: string | null = null;
-  private _tracingStarted = false;
   private _pageListeners: Disposable[] = [];
   private _contextListeners: Disposable[] = [];
 
-  constructor(owner: DashboardConnection, browserGuid: string, descriptor: BrowserDescriptor, context: api.BrowserContext) {
+  constructor(owner: DashboardConnection, slot: BrowserSlot) {
     this._owner = owner;
-    this.browserGuid = browserGuid;
-    this._descriptor = descriptor;
-    this._context = context;
-    // eslint-disable-next-line no-restricted-syntax -- _guid is very conservative.
-    this.contextGuid = (context as any)._guid;
+    this._slot = slot;
   }
+
+  get browserGuid(): string { return this._slot.guid; }
+  get contextGuid(): string { return this._slot.contextGuid; }
+  private get _context(): api.BrowserContext { return this._slot.context; }
+  private get _descriptor(): BrowserDescriptor { return this._slot.descriptor; }
 
   async init() {
     this._contextListeners.push(
         eventsHelper.addEventListener(this._context, 'page', page => {
-          this._pushTabs();
           if (!this._selectedPage)
             this._selectPage(page).catch(() => {});
-        }),
-        eventsHelper.addEventListener(this._context, 'picklocator', page => {
-          this._selectPage(page)
-              .then(() => this._owner.emitPickLocator(this, this._pageId(page)))
-              .catch(() => {});
         }),
     );
     const pages = this._context.pages();
     if (pages.length > 0)
       await this._selectPage(pages[0]);
-    this._pushTabs();
   }
 
   dispose() {
@@ -255,13 +343,12 @@ class AttachedBrowser {
       this._selectedPage.screencast.stop().catch(() => {});
     this._screencastRunning = false;
     this._recordingPath = null;
-    if (this._tracingStarted)
-      this._context.tracing.stop().catch(() => {});
-    this._tracingStarted = false;
     this._selectedPage = null;
-    const tracesDir = this._descriptor.browser.launchOptions.tracesDir;
-    if (tracesDir)
-      this._owner._traceMap.delete(tracesDir);
+    this._owner._pushTabs();
+  }
+
+  selectedPage(): api.Page | null {
+    return this._selectedPage;
   }
 
   async setScreencastActive(active: boolean) {
@@ -276,139 +363,100 @@ class AttachedBrowser {
     }
   }
 
-  pageForId(pageGuid: string): api.Page | undefined {
-    return this._context.pages().find(p => this._pageId(p) === pageGuid);
-  }
-
-  async tabs(): Promise<{ tabs: Tab[] }> {
-    return { tabs: await this._tabList() };
-  }
-
-  async newTab(): Promise<{ page: string }> {
-    const page = await this._context.newPage();
+  async selectPage(page: api.Page) {
     await this._selectPage(page);
-    return { page: this._pageId(page) };
   }
 
-  async selectTab(params: { page: string }) {
-    const page = this.pageForId(params.page);
+  async selectPageByGuid(guid: string) {
+    const page = this._context.pages().find(p => pageId(p) === guid);
     if (page)
       await this._selectPage(page);
   }
 
-  async closeTab(params: { page: string }) {
-    const page = this.pageForId(params.page);
-    if (page)
-      await page.close({ reason: 'Closed in Dashboard' });
-  }
-
-  async navigate(params: { page: string; url: string }) {
+  async navigate(params: { url: string }) {
     if (!params.url)
       return;
-    await this.pageForId(params.page)?.goto(params.url);
+    await this._selectedPage?.goto(params.url);
   }
 
-  async back(params: { page: string }) {
-    await this.pageForId(params.page)?.goBack();
+  async back() {
+    await this._selectedPage?.goBack();
   }
 
-  async forward(params: { page: string }) {
-    await this.pageForId(params.page)?.goForward();
+  async forward() {
+    await this._selectedPage?.goForward();
   }
 
-  async reload(params: { page: string }) {
-    await this.pageForId(params.page)?.reload();
+  async reload() {
+    await this._selectedPage?.reload();
   }
 
-  async mousemove(params: { page: string; x: number; y: number }) {
-    await this.pageForId(params.page)?.mouse.move(params.x, params.y);
+  async mousemove(params: { x: number; y: number }) {
+    await this._selectedPage?.mouse.move(params.x, params.y);
   }
 
-  async mousedown(params: { page: string; x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
-    const page = this.pageForId(params.page);
+  async mousedown(params: { x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
+    const page = this._selectedPage;
     if (!page)
       return;
     await page.mouse.move(params.x, params.y);
     await page.mouse.down({ button: params.button || 'left' });
   }
 
-  async mouseup(params: { page: string; x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
-    const page = this.pageForId(params.page);
+  async mouseup(params: { x: number; y: number; button?: 'left' | 'middle' | 'right' }) {
+    const page = this._selectedPage;
     if (!page)
       return;
     await page.mouse.move(params.x, params.y);
     await page.mouse.up({ button: params.button || 'left' });
   }
 
-  async wheel(params: { page: string; deltaX: number; deltaY: number }) {
-    await this.pageForId(params.page)?.mouse.wheel(params.deltaX, params.deltaY);
+  async wheel(params: { deltaX: number; deltaY: number }) {
+    await this._selectedPage?.mouse.wheel(params.deltaX, params.deltaY);
   }
 
-  async keydown(params: { page: string; key: string }) {
-    await this.pageForId(params.page)?.keyboard.down(params.key);
+  async keydown(params: { key: string }) {
+    await this._selectedPage?.keyboard.down(params.key);
   }
 
-  async keyup(params: { page: string; key: string }) {
-    await this.pageForId(params.page)?.keyboard.up(params.key);
+  async keyup(params: { key: string }) {
+    await this._selectedPage?.keyboard.up(params.key);
   }
 
-  async pickLocator(params: { page: string }) {
-    const page = this.pageForId(params.page);
+  async pickLocator() {
+    const page = this._selectedPage;
     if (!page)
       return;
     const locator = await page.pickLocator();
-    this._owner.emitElementPicked(this, this._pageId(page), locator.toString(), await locator.ariaSnapshot());
+    this._owner.emitElementPicked(locator.toString(), await locator.ariaSnapshot());
   }
 
-  async cancelPickLocator(params: { page: string }) {
-    await this.pageForId(params.page)?.cancelPickLocator();
+  async cancelPickLocator() {
+    await this._selectedPage?.cancelPickLocator();
   }
 
-  async startTracing() {
-    if (this._tracingStarted)
-      return;
-    await this._context.tracing.start({
-      snapshots: true,
-      live: true,
-    });
-    this._tracingStarted = true;
-  }
-
-  async traceContextEntries(): Promise<{ contextEntries: ContextEntry[]; tracesDir: string }> {
-    const tracesDir = this._descriptor.browser.launchOptions.tracesDir;
-    if (!tracesDir)
-      throw new Error('Tracing requires launchOptions.tracesDir');
-    const backend = new DirTraceLoaderBackend(tracesDir);
-    const loader = new TraceLoader();
-    await loader.load(backend);
-    this._owner._traceMap.set(tracesDir, loader);
-    const contextEntries = loader.contextEntries.filter(entry => entry.contextId === this.contextGuid);
-    return { contextEntries, tracesDir };
-  }
-
-  async startRecording(params: { page: string }) {
-    const page = this.pageForId(params.page);
+  async startRecording() {
+    const page = this._selectedPage;
     if (!page)
       return;
     const artifactsDir = this._descriptor.browser.launchOptions.artifactsDir ?? this._owner._recordingDir;
     this._recordingPath = path.join(artifactsDir, `recording-${Date.now()}.webm`);
-    if (page === this._selectedPage && this._screencastRunning)
+    if (this._screencastRunning)
       await this._restartScreencast(page);
   }
 
-  async stopRecording(params: { page: string }): Promise<{ path: string }> {
-    const path = this._recordingPath;
-    if (!path)
+  async stopRecording(): Promise<{ path: string }> {
+    const p = this._recordingPath;
+    if (!p)
       throw new Error('No recording in progress');
     this._recordingPath = null;
-    const page = this.pageForId(params.page);
-    if (page && page === this._selectedPage && this._screencastRunning)
-      await this._restartScreencast(page);
-    return { path };
+    if (this._selectedPage && this._screencastRunning)
+      await this._restartScreencast(this._selectedPage);
+    return { path: p };
   }
 
-  async screenshot(params: { page: string }): Promise<string> {
-    const page = this.pageForId(params.page);
+  async screenshot(): Promise<string> {
+    const page = this._selectedPage;
     if (!page)
       throw new Error('No page selected');
     const buffer = await page.screenshot({ type: 'png' });
@@ -429,7 +477,7 @@ class AttachedBrowser {
     }
 
     this._selectedPage = page;
-    this._pushTabs();
+    this._owner._pushTabs();
 
     this._pageListeners.push(
         eventsHelper.addEventListener(page, 'close', () => {
@@ -437,11 +485,11 @@ class AttachedBrowser {
           const pages = page.context().pages();
           if (pages.length > 0)
             this._selectPage(pages[0]).catch(() => {});
-          this._pushTabs();
+          this._owner._pushTabs();
         }),
         eventsHelper.addEventListener(page, 'framenavigated', frame => {
           if (frame === page.mainFrame())
-            this._pushTabs();
+            this._owner._pushTabs();
         }),
     );
 
@@ -453,7 +501,7 @@ class AttachedBrowser {
 
   private async _startScreencast(page: api.Page) {
     await page.screencast.start({
-      onFrame: ({ data }: { data: Buffer }) => this._writeFrame(page, data, page.viewportSize()?.width ?? 0, page.viewportSize()?.height ?? 0),
+      onFrame: ({ data }: { data: Buffer }) => this._owner.emitFrame(data.toString('base64'), page.viewportSize()?.width ?? 0, page.viewportSize()?.height ?? 0),
       size: { width: 1280, height: 800 },
       ...(this._recordingPath ? { path: this._recordingPath } : {}),
     });
@@ -476,52 +524,26 @@ class AttachedBrowser {
     this._recordingPath = null;
     this._selectedPage = null;
   }
+}
 
-  private _pushTabs() {
-    this._tabList().then(tabs => this._owner.emitTabs(this, tabs)).catch(() => {});
-  }
+function pageId(p: api.Page): string {
+  // eslint-disable-next-line no-restricted-syntax -- _guid is very conservative.
+  return (p as any)._guid;
+}
 
-  private _writeFrame(page: api.Page, frame: Buffer, viewportWidth: number, viewportHeight: number) {
-    this._owner.emitFrame(this, this._pageId(page), frame.toString('base64'), viewportWidth, viewportHeight);
-  }
-
-  private async _tabList(): Promise<Tab[]> {
-    const pages = this._context.pages();
-    if (pages.length === 0)
-      return [];
-    return await Promise.all(pages.map(async page => {
-      const title = await page.title();
-      return {
-        browser: this.browserGuid,
-        context: this.contextGuid,
-        page: this._pageId(page),
-        title,
-        url: page.url(),
-        selected: page === this._selectedPage,
-        faviconUrl: await this._faviconUrl(page),
-      };
-    }));
-  }
-
-  private _pageId(p: api.Page): string {
-    // eslint-disable-next-line no-restricted-syntax -- _guid is very conservative.
-    return (p as any)._guid;
-  }
-
-  private async _faviconUrl(page: api.Page): Promise<string | undefined> {
-    const url = await page.evaluate(async () => {
-      const response = await fetch(document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.href ?? '/favicon.ico');
-      if (!response.ok)
-        return undefined;
-      const blob = await response.blob();
-      return await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result as string);
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-      });
-    }).catch(() => undefined);
-    const timeout = new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 3000));
-    return await Promise.race([url, timeout]);
-  }
+async function faviconUrl(page: api.Page): Promise<string | undefined> {
+  const url = page.evaluate(async () => {
+    const response = await fetch(document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.href ?? '/favicon.ico');
+    if (!response.ok)
+      return undefined;
+    const blob = await response.blob();
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }).catch(() => undefined);
+  const timeout = new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 3000));
+  return await Promise.race([url, timeout]);
 }

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -74,73 +74,18 @@ test('should pick locator from browser', async ({ cli, server, openDashboard }) 
   const dashboard = await openDashboard();
   await dashboard.locator('.sidebar-tab').first().click();
 
-  await dashboard.getByRole('button', { name: 'Show sidebar' }).click();
-  await dashboard.getByRole('button', { name: 'Pick locator' }).click();
+  const pickPromise = cli('pick');
+  let done = false;
+  void pickPromise.finally(() => { done = true; });
 
-  await expect(dashboard.locator('div.dashboard-view')).toContainClass('interactive');
+  await expect(dashboard.locator('div.dashboard-view.interactive')).toBeVisible();
 
   await expect(async () => {
     const box = await dashboard.locator('img#display').boundingBox();
     await dashboard.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
-    await expect(dashboard.locator('.cm-wrapper').first()).toContainText(`getByRole('button', { name: 'Submit' })`);
+    expect(done).toBe(true);
   }).toPass();
-});
 
-test('should show console and network tabs in sidebar', async ({ cli, server, openDashboard }) => {
-  server.setContent('/dashboard-network-marker', JSON.stringify({ marker: 'dashboard-response-payload-marker' }), 'application/json');
-  await cli('open', server.PREFIX);
-
-  const dashboard = await openDashboard();
-  await dashboard.locator('.session-chip').click();
-  await dashboard.getByRole('button', { name: 'Show sidebar' }).click();
-
-  await cli('run-code', `async (page) => {
-    await page.evaluate(async () => {
-      console.log('dashboard-console-marker');
-      await fetch('${server.PREFIX}/dashboard-network-marker');
-    });
-  }`);
-
-  await dashboard.getByRole('tab', { name: 'Console' }).click();
-  await expect(dashboard.locator('.console-tab')).toContainText('dashboard-console-marker');
-
-  await dashboard.getByRole('tab', { name: 'Network' }).click();
-  await expect(dashboard.getByLabel('Network requests')).toContainText('dashboard-network-marker');
-
-  await dashboard.getByLabel('Network requests').getByText('dashboard-network-marker').click();
-  await dashboard.getByRole('tab', { name: 'Response' }).click();
-  await expect(dashboard.locator('.network-response-body')).toContainText('dashboard-response-payload-marker');
-});
-
-test('sidebar', async ({ cli, server, openDashboard, mcpBrowser }) => {
-  test.fixme(mcpBrowser === 'firefox', 'firefox has bug around context creation that breaks this test');
-  await cli('open', server.PREFIX);
-
-  const dashboard = await openDashboard();
-  const sidebar = dashboard.getByRole('navigation', { name: 'Sessions' });
-  await expect(sidebar).toMatchAriaSnapshot(`
-- heading "Sessions"
-- list:
-  - listitem:
-    - text: default
-    - list:
-      - listitem:
-        - button "New Tab ${server.PREFIX}/"
-  `);
-
-  await cli('open', '--session=foo', server.PREFIX);
-  await expect(sidebar).toMatchAriaSnapshot(`
-- heading "Sessions"
-- list:
-  - listitem:
-    - text: default
-    - list "default tabs":
-      - listitem:
-        - button "New Tab ${server.PREFIX}/"
-  - listitem:
-    - text: foo
-    - list:
-      - listitem:
-        - button "New Tab ${server.PREFIX}/"
-  `);
+  const { output } = await pickPromise;
+  expect(output).toContain(`getByRole('button', { name: 'Submit' })`);
 });


### PR DESCRIPTION
## Summary

- DashboardConnection now owns browser connections directly: a single \`_attachedBrowser\` plus a map of lightweight \`BrowserSlot\`s. The \`AvailableBrowser\` class is gone.
- Emits a single consolidated \`tabs\` event spanning all known browsers; \`frame\`/\`elementPicked\`/\`pickLocator\` drop their per-target fields since only the attached browser produces them.
- \`attach\`/\`detach\` removed from the protocol. Selection is implicit: \`selectTab\` switches the attached browser. Per-page methods drop \`browser\`/\`context\`/\`page\` params.
- Frontend has no notion of the attached browser: \`Dashboard\` has no props, subscribes once to the channel, and is always mounted. Sidebar groups the consolidated tab list by browser and derives its highlight from the tab marked \`selected\`.
- Remove inspector sidebar (Inspector/Console/Network tabs), the tracing RPC pair, the trace-model polling, and the \`/sha1/\` trace-resource route.