### PR TITLE
chore(dashboard): wrap screencast in a browser-window frame

### DIFF
--- a/packages/dashboard/src/dashboard.css
+++ b/packages/dashboard/src/dashboard.css
@@ -24,80 +24,41 @@
   overflow: hidden;
 }
 
-.dashboard-view.interactive .toolbar::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  width: 26%;
-  pointer-events: none;
-  background: linear-gradient(90deg,
-    rgb(var(--interactive-orange) / 0) 0%,
-    rgb(255 255 255 / 0.18) 45%,
-    rgb(var(--interactive-orange) / 0) 100%);
-  transform: translateX(140%);
-  animation: interactive-toolbar-shimmer-rtl 0.9s ease-out 1;
-  z-index: -1;
+/* -- Mode toggle buttons (interactive / annotate) -- */
+.toolbar-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-.dashboard-view.interactive .segmented-control::after {
-  content: '';
-  position: absolute;
-  left: 25%;
-  top: 50%;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  background: rgb(var(--interactive-orange) / 0.38);
-  transform: translate(-50%, -50%) scale(0.35);
-  box-shadow: 0 0 0 0 rgb(var(--interactive-orange) / 0.52);
-  z-index: -1;
-  animation: interactive-track-radial 420ms cubic-bezier(0.12, 0.72, 0.22, 1) forwards;
-}
-
-.dashboard-view.interactive .segmented-control.interactive::after {
-  left: 75%;
-}
-
-@keyframes interactive-toolbar-shimmer-rtl {
-  0% {
-    opacity: 0;
-    transform: translateX(140%);
-  }
-  16% {
-    opacity: 0.9;
-  }
-  100% {
-    opacity: 0;
-    transform: translateX(-420%);
-  }
-}
-
-@keyframes interactive-track-radial {
-  0% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(0.52);
-    box-shadow: 0 0 0 0 rgb(var(--interactive-orange) / 0.65);
-  }
-  35% {
-    opacity: 0.78;
-    transform: translate(-50%, -50%) scale(0.92);
-    box-shadow: 0 0 0 34px rgb(var(--interactive-orange) / 0.3);
-  }
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(1.14);
-    box-shadow: 0 0 0 74px rgb(var(--interactive-orange) / 0);
-  }
-}
-
-.interactive .toolbar .toolbar-button > .codicon {
+.mode-toggle.toolbar-button.toggled,
+.mode-toggle.toolbar-button.toggled > .codicon {
   color: var(--color-fg-on-emphasis);
 }
 
-.annotate .toolbar .toolbar-button > .codicon {
-  color: var(--color-fg-on-emphasis);
+.mode-toggle.toolbar-button.toggled.mode-interactive {
+  background: rgb(var(--interactive-orange));
+  box-shadow: 0 0 0 2px rgb(var(--interactive-orange) / 0.35);
+}
+
+.mode-toggle.toolbar-button.toggled.mode-annotate {
+  background: rgb(var(--annotate-blue));
+  box-shadow: 0 0 0 2px rgb(var(--annotate-blue) / 0.35);
+}
+
+.mode-toggle.flash {
+  animation: mode-toggle-flash 0.45s ease-in-out 4;
+}
+
+@keyframes mode-toggle-flash {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgb(var(--interactive-orange) / 0);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgb(var(--interactive-orange) / 0.6);
+    background: rgb(var(--interactive-orange) / 0.25);
+  }
 }
 
 /* -- Toolbar -- */
@@ -119,47 +80,45 @@
   background: var(--color-canvas-subtle);
 }
 
-.dashboard-view.interactive .toolbar {
-  background: rgb(var(--interactive-orange));
-  color: var(--color-fg-on-emphasis);
+/* -- Browser window / chrome (wraps the screencast to look like a browser) -- */
+/* width / height are set via inline style so the window tightly inscribes
+   the screencast aspect ratio instead of letting the image letterbox. */
+.browser-window {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border-default);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  background: var(--color-canvas-default);
+  position: relative;
 }
 
-.dashboard-view.annotate .toolbar {
-  background: rgb(var(--annotate-blue));
-  color: var(--color-fg-on-emphasis);
+.browser-chrome {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 8px;
+  background: var(--color-canvas-overlay);
+  border-bottom: 1px solid var(--color-border-muted);
+  position: relative;
+  overflow: visible;
 }
 
-.dashboard-view.interactive .toolbar .nav-btn,
-.dashboard-view.interactive .toolbar .omnibox {
-  color: var(--color-fg-on-emphasis);
+:root.light-mode .browser-chrome {
+  background: var(--color-canvas-subtle);
 }
 
-.dashboard-view.annotate .toolbar .nav-btn,
-.dashboard-view.annotate .toolbar .omnibox {
-  color: var(--color-fg-on-emphasis);
+.omnibox-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  position: relative;
+  min-width: 0;
 }
 
-:root.light-mode .dashboard-view.interactive .toolbar {
-  color: var(--color-fg-on-emphasis);
-}
-:root.light-mode .dashboard-view.interactive .toolbar .omnibox {
-  background: rgb(0 0 0 / 0.15);
-  color: var(--color-fg-on-emphasis);
-}
-:root.light-mode .dashboard-view.interactive .toolbar .omnibox::placeholder {
-  color: rgb(255 255 255 / 0.6);
-}
-
-:root.light-mode .dashboard-view.annotate .toolbar {
-  color: var(--color-fg-on-emphasis);
-}
-:root.light-mode .dashboard-view.annotate .toolbar .omnibox {
-  background: rgb(0 0 0 / 0.15);
-  color: var(--color-fg-on-emphasis);
-}
-:root.light-mode .dashboard-view.annotate .toolbar .omnibox::placeholder {
-  color: rgb(255 255 255 / 0.6);
-}
 
 .nav-btn {
   width: 32px;
@@ -221,38 +180,6 @@
   cursor: default;
 }
 
-/* -- Interactive hint popover -- */
-.interactive-hint-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  background: var(--color-canvas-overlay);
-  color: var(--color-fg-default);
-  font-size: 12px;
-  padding: 6px 12px;
-  border-radius: 6px;
-  white-space: nowrap;
-  border: 1px solid var(--color-border-default);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  pointer-events: none;
-  z-index: 1000;
-  animation: hint-fade-in 150ms ease;
-}
-
-.interactive-hint-popover::after {
-  content: '';
-  position: absolute;
-  bottom: 100%;
-  right: 10px;
-  border: 5px solid transparent;
-  border-bottom-color: var(--color-canvas-overlay);
-}
-
-@keyframes hint-fade-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
 /* -- Viewport -- */
 .viewport-wrapper {
   flex: 1;
@@ -265,16 +192,19 @@
 .viewport-main {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   position: relative;
   min-width: 0;
+  min-height: 0;
 }
 
 .screen {
   position: relative;
   outline: none;
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 100%;
 }
 
 .display {
@@ -283,10 +213,6 @@
   height: 100%;
   background: var(--color-canvas-subtle);
   object-fit: contain;
-}
-
-.dashboard-view.interactive .screen::after {
-  opacity: 1;
 }
 
 .screen-overlay {
@@ -352,11 +278,6 @@
   height: 100%;
   border: none;
   background: var(--color-canvas-default);
-}
-
-.nav-btn.active-toggle {
-  color: var(--color-accent-fg);
-  background: var(--color-accent-subtle);
 }
 
 .recording.toggled > .codicon {

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -21,6 +21,7 @@ import { asLocator } from '@isomorphic/locatorGenerators';
 import { ChevronLeftIcon, ChevronRightIcon, ReloadIcon } from './icons';
 import { Annotations, getImageLayout, clientToViewport } from './annotations';
 import { ToolbarButton } from '@web/components/toolbarButton';
+import { useMeasureForRef } from '@web/uiUtils';
 
 import type { Tab, DashboardChannelEvents } from './dashboardChannel';
 
@@ -41,9 +42,36 @@ export const Dashboard: React.FC = () => {
   const displayRef = React.useRef<HTMLImageElement>(null);
   const screenRef = React.useRef<HTMLDivElement>(null);
   const toolbarRef = React.useRef<HTMLDivElement>(null);
+  const viewportMainRef = React.useRef<HTMLDivElement>(null);
+  const browserChromeRef = React.useRef<HTMLDivElement>(null);
   const moveThrottleRef = React.useRef(0);
   const hintTimerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const modeRef = React.useRef<Mode>('readonly');
+
+  const aspect = frame && frame.viewportWidth && frame.viewportHeight
+    ? frame.viewportWidth / frame.viewportHeight
+    : null;
+
+  const [viewportRect] = useMeasureForRef(viewportMainRef);
+
+  const windowStyle = React.useMemo<React.CSSProperties | undefined>(() => {
+    const OUTER_MARGIN = 24;
+    const chromeHeight = browserChromeRef.current?.offsetHeight ?? 40;
+    const availW = viewportRect.width - OUTER_MARGIN;
+    const availH = viewportRect.height - OUTER_MARGIN;
+    if (availW <= 0 || availH <= 0)
+      return undefined;
+    if (aspect === null)
+      return { width: availW, height: availH };
+    const screenH = availH - chromeHeight;
+    let w = availW;
+    let h = w / aspect;
+    if (h > screenH) {
+      h = screenH;
+      w = h * aspect;
+    }
+    return { width: w, height: h + chromeHeight };
+  }, [viewportRect, aspect]);
 
   React.useEffect(() => {
     modeRef.current = mode;
@@ -67,13 +95,19 @@ export const Dashboard: React.FC = () => {
     hintTimerRef.current = setTimeout(() => setShowInteractiveHint(false), 2000);
   }
 
+  const prevTabsRef = React.useRef<Tab[] | null>(null);
+
   React.useEffect(() => {
     if (!client)
       return;
     let resized = false;
     const onTabs = (params: DashboardChannelEvents['tabs']) => {
-      setTabs(params.tabs);
+      const prev = prevTabsRef.current;
       const selected = params.tabs.find(t => t.selected);
+      if (prev && selected && !prev.some(t => t.page === selected.page))
+        setMode('interactive');
+      prevTabsRef.current = params.tabs;
+      setTabs(params.tabs);
       if (selected)
         setUrl(selected.url);
     };
@@ -214,143 +248,72 @@ export const Dashboard: React.FC = () => {
   let overlayText: string | undefined;
   if (!client)
     overlayText = 'Disconnected';
-  else if (tabs === null)
-    overlayText = 'Loading...';
-  else if (tabs.length === 0)
-    overlayText = 'No tabs open';
   else if (!selectedTab)
-    overlayText = 'Select a tab from the sidebar';
+    overlayText = 'Select a session';
 
   return (
     <div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '')}>
       {/* Toolbar */}
       <div ref={toolbarRef} className='toolbar'>
-        <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
-          if (!interactive) {
-            flashInteractiveHint();
-            return;
-          }
-          client?.back();
-        }}>
-          <ChevronLeftIcon />
-        </button>
-        <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
-          if (!interactive) {
-            flashInteractiveHint();
-            return;
-          }
-          client?.forward();
-        }}>
-          <ChevronRightIcon />
-        </button>
-        <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
-          if (!interactive) {
-            flashInteractiveHint();
-            return;
-          }
-          client?.reload();
-        }}>
-          <ReloadIcon />
-        </button>
-        <input
-          id='omnibox'
-          className='omnibox'
-          type='text'
-          placeholder='Search or enter URL'
-          spellCheck={false}
-          autoComplete='off'
-          value={url}
-          onChange={e => {
-            if (!interactive)
-              return;
-            setUrl(e.target.value);
+        <ToolbarButton
+          className={'mode-toggle mode-interactive' + (showInteractiveHint ? ' flash' : '')}
+          title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
+          icon='person'
+          toggled={interactive}
+          disabled={!ready}
+          onClick={() => {
+            client?.cancelPickLocator();
+            setPicking(false);
+            setMode(interactive ? 'readonly' : 'interactive');
           }}
-          onKeyDown={e => {
-            if (!interactive)
-              return;
-            onOmniboxKeyDown(e);
-          }}
-          onFocus={e => {
-            if (!interactive) {
-              flashInteractiveHint();
-              e.target.blur();
-              return;
-            }
-            e.target.select();
-          }}
-          aria-disabled={!interactive || undefined}
-          readOnly={!interactive}
         />
         <ToolbarButton
-          className='recording'
-          title={recording ? 'Stop recording' : 'Record video'}
-          icon='record'
-          toggled={recording}
-          style={{ color: recording ? (interactive ? 'var(--color-fg-on-emphasis)' : 'var(--color-scale-red-5)') : undefined }}
-          disabled={!ready}
-          onClick={async () => {
-            if (!client)
-              return;
-            if (recording) {
-              const { path } = await client.stopRecording();
-              await client.reveal({ path });
-              setRecording(false);
-            } else {
-              await client.startRecording();
-              setRecording(true);
-            }
-          }}>
-          {recording && <span className='recording-label'>Recording...</span>}
-        </ToolbarButton>
-        <ToolbarButton
-          className='screenshot'
-          title='Copy screenshot to clipboard'
-          icon={screenshotIcon}
-          disabled={!ready}
-          onClick={async () => {
-            if (!client)
-              return;
-            const screenshot = await client.screenshot();
-            const blob = await (await fetch('data:image/png;base64,' + screenshot)).blob();
-            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-            setScreenshotIcon('clippy');
-            setTimeout(() => setScreenshotIcon('device-camera'), 3000);
+          className='mode-toggle mode-annotate'
+          title={annotating ? 'Disable annotation mode' : 'Enable annotation mode'}
+          icon='comment-draft'
+          toggled={annotating}
+          disabled={!ready || !frame}
+          onClick={() => {
+            client?.cancelPickLocator();
+            setPicking(false);
+            setMode(annotating ? 'readonly' : 'annotate');
           }}
         />
-        <div style={{ marginLeft: 8, borderLeft: '1px solid var(--color-border-default)', paddingLeft: 8, display: 'flex', gap: 4 }}>
-          <div style={{ position: 'relative' }}>
-            <ToolbarButton
-              title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
-              icon='inspect'
-              toggled={interactive}
-              disabled={!ready}
-              onClick={() => {
-                if (interactive) {
-                  client?.cancelPickLocator();
-                  setPicking(false);
-                  setMode('readonly');
-                  return;
-                }
-                client?.cancelPickLocator();
-                setPicking(false);
-                setMode('interactive');
-              }}
-            />
-            {showInteractiveHint && <div className='interactive-hint-popover'>Enable interactive mode</div>}
-          </div>
+        <div className='toolbar-right'>
           <ToolbarButton
-            title={annotating ? 'Disable annotation mode' : 'Enable annotation mode'}
-            icon='edit'
-            toggled={annotating}
-            disabled={!ready || !frame}
-            onClick={() => {
-              if (annotating) {
-                setMode('readonly');
+            className='recording'
+            title={recording ? 'Stop recording' : 'Record video'}
+            icon='record'
+            toggled={recording}
+            style={{ color: recording ? 'var(--color-scale-red-5)' : undefined }}
+            disabled={!ready}
+            onClick={async () => {
+              if (!client)
                 return;
+              if (recording) {
+                const { path } = await client.stopRecording();
+                await client.reveal({ path });
+                setRecording(false);
+              } else {
+                await client.startRecording();
+                setRecording(true);
               }
-              client?.cancelPickLocator();
-              setPicking(false);
-              setMode('annotate');
+            }}>
+            {recording && <span className='recording-label'>Recording...</span>}
+          </ToolbarButton>
+          <ToolbarButton
+            className='screenshot'
+            title='Copy screenshot to clipboard'
+            icon={screenshotIcon}
+            disabled={!ready}
+            onClick={async () => {
+              if (!client)
+                return;
+              const screenshot = await client.screenshot();
+              const blob = await (await fetch('data:image/png;base64,' + screenshot)).blob();
+              await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+              setScreenshotIcon('clippy');
+              setTimeout(() => setScreenshotIcon('device-camera'), 3000);
             }}
           />
         </div>
@@ -358,36 +321,98 @@ export const Dashboard: React.FC = () => {
 
       {/* Viewport */}
       <div className='viewport-wrapper'>
-        <div className='viewport-main'>
-          <div
-            ref={screenRef}
-            className='screen'
-            tabIndex={0}
-            style={{ display: frame ? '' : 'none' }}
-            onMouseDown={onScreenMouseDown}
-            onMouseUp={onScreenMouseUp}
-            onMouseMove={onScreenMouseMove}
-            onWheel={onScreenWheel}
-            onKeyDown={onScreenKeyDown}
-            onKeyUp={onScreenKeyUp}
-            onContextMenu={e => e.preventDefault()}
-          >
-            <img
-              ref={displayRef}
-              id='display'
-              className='display'
-              alt='screencast'
-              src={frame ? 'data:image/jpeg;base64,' + frame.data : undefined}
-            />
-            <Annotations
-              active={annotating}
-              displayRef={displayRef}
-              screenRef={screenRef}
-              viewportWidth={frame?.viewportWidth ?? 0}
-              viewportHeight={frame?.viewportHeight ?? 0}
-            />
+        <div ref={viewportMainRef} className='viewport-main'>
+          <div className='browser-window' style={windowStyle}>
+            <div ref={browserChromeRef} className='browser-chrome'>
+              <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
+                if (!interactive) {
+                  flashInteractiveHint();
+                  return;
+                }
+                client?.back();
+              }}>
+                <ChevronLeftIcon />
+              </button>
+              <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
+                if (!interactive) {
+                  flashInteractiveHint();
+                  return;
+                }
+                client?.forward();
+              }}>
+                <ChevronRightIcon />
+              </button>
+              <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
+                if (!interactive) {
+                  flashInteractiveHint();
+                  return;
+                }
+                client?.reload();
+              }}>
+                <ReloadIcon />
+              </button>
+              <div className='omnibox-wrap'>
+                <input
+                  id='omnibox'
+                  className='omnibox'
+                  type='text'
+                  placeholder='Search or enter URL'
+                  spellCheck={false}
+                  autoComplete='off'
+                  value={url}
+                  onChange={e => {
+                    if (!interactive)
+                      return;
+                    setUrl(e.target.value);
+                  }}
+                  onKeyDown={e => {
+                    if (!interactive)
+                      return;
+                    onOmniboxKeyDown(e);
+                  }}
+                  onFocus={e => {
+                    if (!interactive) {
+                      flashInteractiveHint();
+                      e.target.blur();
+                      return;
+                    }
+                    e.target.select();
+                  }}
+                  aria-disabled={!interactive || undefined}
+                  readOnly={!interactive}
+                />
+              </div>
+            </div>
+            <div
+              ref={screenRef}
+              className='screen'
+              tabIndex={0}
+              style={{ display: frame ? '' : 'none' }}
+              onMouseDown={onScreenMouseDown}
+              onMouseUp={onScreenMouseUp}
+              onMouseMove={onScreenMouseMove}
+              onWheel={onScreenWheel}
+              onKeyDown={onScreenKeyDown}
+              onKeyUp={onScreenKeyUp}
+              onContextMenu={e => e.preventDefault()}
+            >
+              <img
+                ref={displayRef}
+                id='display'
+                className='display'
+                alt='screencast'
+                src={frame ? 'data:image/jpeg;base64,' + frame.data : undefined}
+              />
+              <Annotations
+                active={annotating}
+                displayRef={displayRef}
+                screenRef={screenRef}
+                viewportWidth={frame?.viewportWidth ?? 0}
+                viewportHeight={frame?.viewportHeight ?? 0}
+              />
+            </div>
+            {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
           </div>
-          {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
         </div>
       </div>
     </div>

--- a/packages/dashboard/src/sessionSidebar.css
+++ b/packages/dashboard/src/sessionSidebar.css
@@ -16,10 +16,12 @@
 
 .dashboard-shell-sidebar {
   width: 100%;
+  height: 100%;
   background: var(--color-canvas-default);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border-right: 1px solid var(--color-border-muted);
 }
 
 .dashboard-shell-sidebar-header {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -239,6 +239,7 @@ export class DashboardConnection implements Transport {
           sessions.push(...list);
         await this._reconcile(sessions);
         this.emitSessions(sessions);
+        this._pushTabs();
       } catch {
         // best-effort
       }
@@ -281,12 +282,27 @@ export class DashboardConnection implements Transport {
           context,
           listeners: [],
         };
+        const watchPage = (page: api.Page) => {
+          slot.listeners.push(
+              eventsHelper.addEventListener(page, 'load', () => this._pushTabs()),
+              eventsHelper.addEventListener(page, 'framenavigated', (frame: api.Frame) => {
+                if (frame === page.mainFrame())
+                  this._pushTabs();
+              }),
+              eventsHelper.addEventListener(page, 'close', () => this._pushTabs()),
+          );
+        };
         slot.listeners.push(
-            eventsHelper.addEventListener(context, 'page', () => this._pushTabs()),
+            eventsHelper.addEventListener(context, 'page', (page: api.Page) => {
+              watchPage(page);
+              this._pushTabs();
+            }),
             eventsHelper.addEventListener(context, 'picklocator', (page: api.Page) => {
               this._onPickLocator(guid, page).catch(() => {});
             }),
         );
+        for (const page of context.pages())
+          watchPage(page);
         this._browsers.set(guid, slot);
         this._pushTabs();
       } catch {


### PR DESCRIPTION
## Summary

- Pull back/forward/reload and the URL bar out of the top toolbar into a new browser-chrome header that sits above the screencast, wrapped together in a rounded, bordered \`browser-window\`. The screencast now looks like it's inside a real browser window.
- Size the window dynamically to inscribe the screencast aspect ratio exactly \u2014 no letterbox gaps on resize.
- Mode is now indicated by the toggle buttons themselves (filled orange for interactive, filled blue for annotate). Dropped the chrome tint and the interactive-hint popover; the toggle button flashes/glows instead when the user clicks in read-only mode.
- Creating a tab from the sidebar auto-enters interactive mode (client-side tabs diff picks up the newly-selected page).
- Move record and screenshot buttons to the right side of the top toolbar.
- Restore the sidebar's right border.
- Empty dashboard now shows \`Select a session\` instead of \`Loading...\`; controller pushes an initial empty tabs event on connect.