### PR TITLE
feat(dashboard): add 'show --annotate' to capture annotations as PNG

### DIFF
--- a/packages/dashboard/src/annotations.tsx
+++ b/packages/dashboard/src/annotations.tsx
@@ -118,12 +118,12 @@ export const Annotations: React.FC<{
   screenRef: React.RefObject<HTMLDivElement | null>;
   viewportWidth: number;
   viewportHeight: number;
-}> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight }) => {
+  onSubmit?: (blob: Blob) => Promise<void> | void;
+}> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit }) => {
   const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
   const [draft, setDraft] = React.useState<{ startX: number; startY: number; x: number; y: number } | null>(null);
   const [selection, setSelection] = React.useState<Selection>(null);
   const [drag, setDrag] = React.useState<DragState | null>(null);
-  const [submittedJson, setSubmittedJson] = React.useState<string | null>(null);
   const [, setTick] = React.useState(0);
   const forceRender = React.useCallback(() => setTick(t => t + 1), []);
   const layerRef = React.useRef<HTMLDivElement>(null);
@@ -283,10 +283,81 @@ export const Annotations: React.FC<{
     }
   }
 
-  function submitAnnotations() {
-    const json = JSON.stringify({ viewportWidth, viewportHeight, annotations }, null, 2);
-    console.log('Annotations:', json);
-    setSubmittedJson(json);
+  async function submitAnnotations() {
+    const img = displayRef.current;
+    if (!img || !img.naturalWidth || !img.naturalHeight || !viewportWidth || !viewportHeight)
+      return;
+    const canvas = document.createElement('canvas');
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx)
+      return;
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const sx = canvas.width / viewportWidth;
+    const sy = canvas.height / viewportHeight;
+    const blue = 'rgb(54, 116, 209)';
+    const fontSize = Math.max(11, Math.round(14 * sy));
+    ctx.font = `500 ${fontSize}px -apple-system, system-ui, sans-serif`;
+    ctx.textBaseline = 'middle';
+    for (const a of annotations) {
+      const x = a.x * sx;
+      const y = a.y * sy;
+      const w = a.width * sx;
+      const h = a.height * sy;
+      ctx.fillStyle = 'rgba(54, 116, 209, 0.12)';
+      ctx.fillRect(x, y, w, h);
+      ctx.lineWidth = Math.max(2, Math.round(2 * sy));
+      ctx.strokeStyle = blue;
+      ctx.strokeRect(x, y, w, h);
+      if (a.text) {
+        const padX = Math.max(4, Math.round(6 * sy));
+        const padY = Math.max(2, Math.round(3 * sy));
+        const metrics = ctx.measureText(a.text);
+        const labelW = metrics.width + padX * 2;
+        const labelH = fontSize + padY * 2;
+        const labelX = x - ctx.lineWidth / 2;
+        const labelY = y - labelH;
+        ctx.fillStyle = blue;
+        ctx.fillRect(labelX, labelY, labelW, labelH);
+        ctx.fillStyle = '#fff';
+        ctx.fillText(a.text, labelX + padX, labelY + labelH / 2);
+      }
+    }
+    const blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/png'));
+    if (!blob)
+      return;
+    if (onSubmit) {
+      await onSubmit(blob);
+      return;
+    }
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const suggestedName = `annotations-${stamp}.png`;
+    const picker = (window as any).showSaveFilePicker as undefined | ((opts: any) => Promise<any>);
+    if (picker) {
+      try {
+        const handle = await picker({
+          suggestedName,
+          startIn: 'downloads',
+          types: [{ description: 'PNG image', accept: { 'image/png': ['.png'] } }],
+        });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } catch (e: any) {
+        if (e?.name !== 'AbortError')
+          throw e;
+      }
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = suggestedName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   }
 
   if (!active)
@@ -325,9 +396,9 @@ export const Annotations: React.FC<{
           className='annotate-action-btn primary'
           onClick={submitAnnotations}
           disabled={annotations.length === 0}
-          title='Submit annotations'
+          title='Save annotated image'
         >
-          Submit
+          Save
         </button>
       </div>
 
@@ -434,25 +505,6 @@ export const Annotations: React.FC<{
         );
       })()}
 
-      {submittedJson !== null && (
-        <div className='annotation-modal-backdrop' onMouseDown={e => { e.stopPropagation(); setSubmittedJson(null); }}>
-          <div className='annotation-modal' onMouseDown={e => e.stopPropagation()}>
-            <div className='annotation-modal-header'>
-              <span>Annotations JSON</span>
-              <button className='annotate-action-btn' onClick={() => setSubmittedJson(null)}>Close</button>
-            </div>
-            <textarea className='annotation-modal-text' readOnly value={submittedJson} />
-            <div className='annotation-modal-actions'>
-              <button
-                className='annotate-action-btn primary'
-                onClick={() => { navigator.clipboard?.writeText(submittedJson).catch(() => {}); }}
-              >
-                Copy
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -38,6 +38,8 @@ export const Dashboard: React.FC = () => {
   const [recording, setRecording] = React.useState(false);
   const [screenshotIcon, setScreenshotIcon] = React.useState<'device-camera' | 'clippy'>('device-camera');
   const [showInteractiveHint, setShowInteractiveHint] = React.useState(false);
+  const [pendingAnnotate, setPendingAnnotate] = React.useState(false);
+  const [cliAnnotate, setCliAnnotate] = React.useState(false);
 
   const displayRef = React.useRef<HTMLImageElement>(null);
   const screenRef = React.useRef<HTMLDivElement>(null);
@@ -89,6 +91,32 @@ export const Dashboard: React.FC = () => {
     return () => clearTimeout(hintTimerRef.current);
   }, []);
 
+  React.useEffect(() => {
+    if (!pendingAnnotate || !frame)
+      return;
+    setMode('annotate');
+    setCliAnnotate(true);
+    setPendingAnnotate(false);
+  }, [pendingAnnotate, frame]);
+
+  React.useEffect(() => {
+    if (!annotating)
+      setCliAnnotate(false);
+  }, [annotating]);
+
+  const submitAnnotationToCli = React.useCallback(async (blob: Blob) => {
+    if (!client)
+      return;
+    const buffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++)
+      binary += String.fromCharCode(bytes[i]);
+    const data = btoa(binary);
+    await client.submitAnnotation({ data });
+    setMode('readonly');
+  }, [client]);
+
   function flashInteractiveHint() {
     clearTimeout(hintTimerRef.current);
     setShowInteractiveHint(true);
@@ -135,15 +163,18 @@ export const Dashboard: React.FC = () => {
       setMode('interactive');
       setPicking(true);
     };
+    const onAnnotate = () => setPendingAnnotate(true);
     client.on('tabs', onTabs);
     client.on('frame', onFrame);
     client.on('elementPicked', onElementPicked);
     client.on('pickLocator', onPickLocator);
+    client.on('annotate', onAnnotate);
     return () => {
       client.off('tabs', onTabs);
       client.off('frame', onFrame);
       client.off('elementPicked', onElementPicked);
       client.off('pickLocator', onPickLocator);
+      client.off('annotate', onAnnotate);
     };
   }, [client]);
 
@@ -409,6 +440,7 @@ export const Dashboard: React.FC = () => {
                 screenRef={screenRef}
                 viewportWidth={frame?.viewportWidth ?? 0}
                 viewportHeight={frame?.viewportHeight ?? 0}
+                onSubmit={cliAnnotate ? submitAnnotationToCli : undefined}
               />
             </div>
             {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -34,6 +34,7 @@ export type DashboardChannelEvents = {
   frame: { data: string; viewportWidth: number; viewportHeight: number };
   elementPicked: { selector: string; ariaSnapshot?: string };
   pickLocator: {};
+  annotate: {};
 };
 
 export type MouseButton = 'left' | 'middle' | 'right';
@@ -62,6 +63,7 @@ export interface DashboardChannel {
   startRecording(): Promise<void>;
   stopRecording(): Promise<{ path: string }>;
   screenshot(): Promise<string>;
+  submitAnnotation(params: { data: string }): Promise<void>;
 
   on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;
   off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -20,6 +20,8 @@
 import { execSync, spawn } from 'child_process';
 
 import crypto from 'crypto';
+import fs from 'fs';
+import net from 'net';
 import os from 'os';
 import path from 'path';
 import { clientKey, createClientInfo, explicitSessionName, Registry, resolveSessionName } from './registry';
@@ -175,13 +177,11 @@ export async function program(options?: { embedderVersion?: string}) {
       return;
     case 'show': {
       const daemonScript = libPath('entry', 'dashboardApp.js');
-      const child = spawn(process.execPath, [daemonScript], {
-        detached: true,
-        stdio: 'ignore',
-      });
-      child.unref();
-      if (process.env.PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST)
-        console.log(`### Dashboard opened with pid ${child.pid}.`);
+      if (args.annotate) {
+        await runAnnotate(daemonScript, sessionName);
+        return;
+      }
+      await runBringToFront(daemonScript, sessionName);
       return;
     }
     default: {
@@ -405,6 +405,72 @@ function validateFlags(args: MinimistArgs, command: { flags: Record<string, 'boo
     console.log(command.help);
     process.exit(1);
   }
+}
+
+function dashboardSocketPath(): string {
+  const userNameHash = calculateSha1(process.env.USERNAME || process.env.USER || 'default').slice(0, 8);
+  if (process.platform === 'win32')
+    return `\\\\.\\pipe\\pw-${userNameHash}-dashboard-app`;
+  const baseDir = process.env.PLAYWRIGHT_SOCKETS_DIR || path.join(os.tmpdir(), `pw-${userNameHash}`);
+  return path.join(baseDir, 'dashboard', 'app.sock');
+}
+
+async function connectToDashboard(daemonScript: string, spawnDeadlineMs: number): Promise<net.Socket | undefined> {
+  const socketPath = dashboardSocketPath();
+  const tryConnect = () => new Promise<net.Socket | undefined>(resolve => {
+    const s = net.connect(socketPath);
+    const onError = () => { s.destroy(); resolve(undefined); };
+    s.once('connect', () => { s.off('error', onError); resolve(s); });
+    s.once('error', onError);
+  });
+  let socket = await tryConnect();
+  if (socket)
+    return socket;
+  const child = spawn(process.execPath, [daemonScript], { detached: true, stdio: 'ignore' });
+  child.unref();
+  const deadline = Date.now() + spawnDeadlineMs;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 200));
+    socket = await tryConnect();
+    if (socket)
+      return socket;
+  }
+  return undefined;
+}
+
+async function runBringToFront(daemonScript: string, sessionName: string): Promise<void> {
+  const socket = await connectToDashboard(daemonScript, 2000);
+  if (!socket)
+    return;
+  await new Promise<void>(resolve => socket.write(`bringToFront:${sessionName}`, () => {
+    socket.destroy();
+    resolve();
+  }));
+}
+
+async function runAnnotate(daemonScript: string, sessionName: string): Promise<void> {
+  const socket = await connectToDashboard(daemonScript, 15000);
+  if (!socket) {
+    console.error('Dashboard did not start in time.');
+    process.exit(1);
+  }
+  socket.write(`annotate:${sessionName}`);
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    socket.on('data', chunk => chunks.push(chunk));
+    socket.on('end', () => resolve());
+    socket.on('error', reject);
+  });
+  socket.destroy();
+  const buffer = Buffer.concat(chunks);
+  if (buffer.length === 0)
+    return;
+  const outputDir = path.resolve(process.cwd(), '.playwright-cli');
+  fs.mkdirSync(outputDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const filePath = path.join(outputDir, `annotations-${timestamp}.png`);
+  fs.writeFileSync(filePath, buffer);
+  console.log(path.relative(process.cwd(), filePath));
 }
 
 export function calculateSha1(buffer: Buffer | string): string {

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -854,6 +854,9 @@ const devtoolsShow = declareCommand({
   description: 'Show browser DevTools',
   category: 'devtools',
   args: z.object({}),
+  options: z.object({
+    annotate: z.boolean().optional().describe('Switch the dashboard into annotation mode.'),
+  }),
   toolName: '',
   toolParams: () => ({}),
 });

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -29,16 +29,45 @@ import { DashboardConnection } from './dashboardController';
 
 import type * as api from '../../..';
 
-async function innerOpenDashboardApp(): Promise<api.Page> {
+type DashboardState = {
+  triggerAnnotate: () => void;
+  registerWaiter: (socket: net.Socket) => void;
+  revealSession: (sessionTitle: string) => void;
+};
+
+async function innerOpenDashboardApp(): Promise<{ page: api.Page, state: DashboardState }> {
   const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
 
   const connections = new Set<DashboardConnection>();
+  let pendingAnnotate = false;
+  let pendingRevealTitle: string | undefined;
+  const waitingSockets = new Set<net.Socket>();
+
+  const submitAnnotation = (base64Png: string) => {
+    if (waitingSockets.size === 0)
+      return;
+    const buffer = Buffer.from(base64Png, 'base64');
+    for (const socket of waitingSockets) {
+      socket.write(buffer);
+      socket.end();
+    }
+    waitingSockets.clear();
+  };
 
   httpServer.createWebSocket(() => {
     let connection: DashboardConnection;
     // eslint-disable-next-line prefer-const
-    connection = new DashboardConnection(() => connections.delete(connection));
+    connection = new DashboardConnection(() => connections.delete(connection), () => {
+      if (pendingRevealTitle) {
+        connection.revealSessionByTitle(pendingRevealTitle);
+        pendingRevealTitle = undefined;
+      }
+      if (pendingAnnotate) {
+        pendingAnnotate = false;
+        connection.emitAnnotate();
+      }
+    }, submitAnnotation);
     connections.add(connection);
     return connection;
   }, 'ws');
@@ -56,7 +85,35 @@ async function innerOpenDashboardApp(): Promise<api.Page> {
 
   const { page } = await launchApp('dashboard');
   await page.goto(url);
-  return page;
+
+  const triggerAnnotate = () => {
+    if (connections.size === 0) {
+      pendingAnnotate = true;
+      return;
+    }
+    for (const connection of connections)
+      connection.emitAnnotate();
+  };
+
+  const registerWaiter = (socket: net.Socket) => {
+    waitingSockets.add(socket);
+    const cleanup = () => waitingSockets.delete(socket);
+    socket.on('close', cleanup);
+    socket.on('error', cleanup);
+  };
+
+  const revealSession = (sessionTitle: string) => {
+    if (!sessionTitle)
+      return;
+    if (connections.size === 0) {
+      pendingRevealTitle = sessionTitle;
+      return;
+    }
+    for (const connection of connections)
+      connection.revealSessionByTitle(sessionTitle);
+  };
+
+  return { page, state: { triggerAnnotate, registerWaiter, revealSession } };
 }
 
 async function launchApp(appName: string) {
@@ -170,11 +227,22 @@ export async function openDashboardApp() {
       return;
     }
   }
-  const page = await innerOpenDashboardApp();
+  const { page, state } = await innerOpenDashboardApp();
   server?.on('connection', socket => {
     socket.on('data', data => {
-      if (data.toString() === 'bringToFront')
+      const message = data.toString();
+      const colon = message.indexOf(':');
+      const action = colon === -1 ? message : message.slice(0, colon);
+      const sessionTitle = colon === -1 ? '' : message.slice(colon + 1);
+      if (action === 'bringToFront') {
         page?.bringToFront().catch(() => {});
+        state.revealSession(sessionTitle);
+      } else if (action === 'annotate') {
+        page?.bringToFront().catch(() => {});
+        state.revealSession(sessionTitle);
+        state.triggerAnnotate();
+        state.registerWaiter(socket);
+      }
     });
   });
 }

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -45,6 +45,8 @@ export class DashboardConnection implements Transport {
   private _browsers = new Map<string, BrowserSlot>();
   private _attachedBrowser: AttachedBrowser | undefined;
   private _onclose: () => void;
+  private _onconnected?: () => void;
+  private _onAnnotationSubmit?: (base64Png: string) => void;
   private _serverRegistryDispose?: () => void;
   private _pushSessionsScheduled = false;
   private _pushTabsScheduled = false;
@@ -52,8 +54,10 @@ export class DashboardConnection implements Transport {
 
   _recordingDir: string;
 
-  constructor(onclose: () => void) {
+  constructor(onclose: () => void, onconnected?: () => void, onAnnotationSubmit?: (base64Png: string) => void) {
     this._onclose = onclose;
+    this._onconnected = onconnected;
+    this._onAnnotationSubmit = onAnnotationSubmit;
     this._recordingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'playwright-recordings-'));
   }
 
@@ -63,6 +67,7 @@ export class DashboardConnection implements Transport {
     serverRegistry.on('removed', this._pushSessions);
     serverRegistry.on('changed', this._pushSessions);
     this._pushSessions();
+    this._onconnected?.();
   }
 
   onclose() {
@@ -139,6 +144,10 @@ export class DashboardConnection implements Transport {
     await this._attachedBrowser?.setScreencastActive(params.visible);
   }
 
+  async submitAnnotation(params: { data: string }) {
+    this._onAnnotationSubmit?.(params.data);
+  }
+
   async reveal(params: { path: string }) {
     switch (os.platform()) {
       case 'darwin':
@@ -175,6 +184,10 @@ export class DashboardConnection implements Transport {
 
   emitPickLocator() {
     this.sendEvent?.('pickLocator', {});
+  }
+
+  emitAnnotate() {
+    this.sendEvent?.('annotate', {});
   }
 
   _pushTabs() {
@@ -240,11 +253,37 @@ export class DashboardConnection implements Transport {
         await this._reconcile(sessions);
         this.emitSessions(sessions);
         this._pushTabs();
+        if (this._pendingRevealTitle)
+          this._tryRevealPendingSession();
       } catch {
         // best-effort
       }
     });
   };
+
+  private _pendingRevealTitle: string | undefined;
+
+  revealSessionByTitle(title: string) {
+    this._pendingRevealTitle = title;
+    this._tryRevealPendingSession();
+  }
+
+  private _tryRevealPendingSession() {
+    const title = this._pendingRevealTitle;
+    if (!title)
+      return;
+    let target: BrowserSlot | undefined;
+    for (const slot of this._browsers.values()) {
+      if (slot.descriptor.title === title) {
+        target = slot;
+        break;
+      }
+    }
+    if (!target)
+      return;
+    this._pendingRevealTitle = undefined;
+    void this._switchAttachedTo(target.guid).then(() => this._pushTabs());
+  }
 
   private async _reconcile(sessions: BrowserStatus[]) {
     const connectable = new Map<string, BrowserStatus>();


### PR DESCRIPTION
## Summary
- New `playwright-cli [-s=session] show --annotate` reveals the session's browser in the dashboard, enters annotation mode, and blocks until the user clicks Save.
- On Save, the annotated screenshot is written to `.playwright-cli/annotations-<timestamp>.png` (relative to cwd) and the path is printed to stdout.
- `show` is now session-aware — it reveals the browser whose title matches the CLI session name.