### PR TITLE
chore(dashboard): session-aware show command

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -175,7 +175,12 @@ export async function program(options?: { embedderVersion?: string}) {
       return;
     case 'show': {
       const daemonScript = libPath('entry', 'dashboardApp.js');
-      const child = spawn(process.execPath, [daemonScript], {
+      const daemonArgs = [
+        daemonScript,
+        `--session=${sessionName}`,
+        `--workspace=${clientInfo.workspaceDir ?? ''}`,
+      ];
+      const child = spawn(process.execPath, daemonArgs, {
         detached: true,
         stdio: 'ignore',
       });

--- a/packages/playwright-core/src/tools/dashboard/DEPS.list
+++ b/packages/playwright-core/src/tools/dashboard/DEPS.list
@@ -5,6 +5,7 @@
 @isomorphic/**
 @utils/**
 ../../serverRegistry.ts
+../cli-client/minimist.ts
 ../cli-client/registry.ts
 ../trace/traceParser.ts
 ../utils/**

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -25,20 +25,26 @@ import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
+import { minimist } from '../cli-client/minimist';
 import { DashboardConnection } from './dashboardController';
 
 import type * as api from '../../..';
 
-async function innerOpenDashboardApp(): Promise<api.Page> {
+type RevealOptions = { sessionName?: string; workspaceDir?: string };
+
+async function innerOpenDashboardApp(initialReveal: RevealOptions): Promise<{ page: api.Page; reveal: (options: RevealOptions) => void }> {
   const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
 
   const connections = new Set<DashboardConnection>();
+  let currentReveal = initialReveal;
 
   httpServer.createWebSocket(() => {
     let connection: DashboardConnection;
     // eslint-disable-next-line prefer-const
     connection = new DashboardConnection(() => connections.delete(connection));
+    if (currentReveal.sessionName)
+      connection.revealSession(currentReveal.sessionName, currentReveal.workspaceDir);
     connections.add(connection);
     return connection;
   }, 'ws');
@@ -56,7 +62,16 @@ async function innerOpenDashboardApp(): Promise<api.Page> {
 
   const { page } = await launchApp('dashboard');
   await page.goto(url);
-  return page;
+
+  const reveal = (options: RevealOptions) => {
+    currentReveal = options;
+    if (!options.sessionName)
+      return;
+    for (const connection of connections)
+      connection.revealSession(options.sessionName, options.workspaceDir);
+  };
+
+  return { page, reveal };
 }
 
 async function launchApp(appName: string) {
@@ -130,7 +145,15 @@ function dashboardSocketPath() {
   return makeSocketPath('dashboard', 'app');
 }
 
-async function acquireSingleton(): Promise<net.Server> {
+function parseRevealArgs(): RevealOptions {
+  const args = minimist(process.argv.slice(2), { string: ['session', 'workspace'] });
+  return {
+    sessionName: (args.session as string) || undefined,
+    workspaceDir: (args.workspace as string) || undefined,
+  };
+}
+
+async function acquireSingleton(reveal: RevealOptions): Promise<net.Server> {
   const socketPath = dashboardSocketPath();
   if (process.platform !== 'win32')
     await fs.promises.mkdir(path.dirname(socketPath), { recursive: true });
@@ -142,7 +165,7 @@ async function acquireSingleton(): Promise<net.Server> {
       if (err.code !== 'EADDRINUSE')
         return reject(err);
       const client = net.connect(socketPath, () => {
-        client.write('bringToFront');
+        client.write(JSON.stringify({ command: 'bringToFront', ...reveal }));
         client.end();
         reject(new Error('already running'));
       });
@@ -156,6 +179,7 @@ async function acquireSingleton(): Promise<net.Server> {
 }
 
 export async function openDashboardApp() {
+  const revealOptions = parseRevealArgs();
   let server: net.Server | undefined;
   process.on('exit', () => server?.close());
   process.on('unhandledRejection', error => {
@@ -165,16 +189,27 @@ export async function openDashboardApp() {
   const underTest = !!process.env.PLAYWRIGHT_DASHBOARD_DEBUG_PORT;
   if (!underTest) {
     try {
-      server = await acquireSingleton();
+      server = await acquireSingleton(revealOptions);
     } catch {
       return;
     }
   }
-  const page = await innerOpenDashboardApp();
+  const { page, reveal } = await innerOpenDashboardApp(revealOptions);
   server?.on('connection', socket => {
-    socket.on('data', data => {
-      if (data.toString() === 'bringToFront')
-        page?.bringToFront().catch(() => {});
+    const chunks: Buffer[] = [];
+    socket.on('data', data => chunks.push(data));
+    socket.on('end', () => {
+      const message = Buffer.concat(chunks).toString();
+      let parsed: { command?: string; sessionName?: string; workspaceDir?: string } | undefined;
+      try {
+        parsed = JSON.parse(message);
+      } catch {
+        // no-op
+      }
+      if (parsed?.command !== 'bringToFront')
+        return;
+      page?.bringToFront().catch(() => {});
+      reveal({ sessionName: parsed.sessionName, workspaceDir: parsed.workspaceDir });
     });
   });
 }

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -49,6 +49,7 @@ export class DashboardConnection implements Transport {
   private _pushSessionsScheduled = false;
   private _pushTabsScheduled = false;
   private _visible = true;
+  private _pendingReveal: { sessionName: string; workspaceDir?: string } | undefined;
 
   _recordingDir: string;
 
@@ -137,6 +138,25 @@ export class DashboardConnection implements Transport {
       return;
     this._visible = params.visible;
     await this._attachedBrowser?.setScreencastActive(params.visible);
+  }
+
+  revealSession(sessionName: string, workspaceDir?: string) {
+    this._pendingReveal = { sessionName, workspaceDir };
+    void this._tryRevealPending();
+  }
+
+  private async _tryRevealPending() {
+    const pending = this._pendingReveal;
+    if (!pending)
+      return;
+    const slot = [...this._browsers.values()].find(s =>
+      s.descriptor.title === pending.sessionName
+        && (pending.workspaceDir === undefined || s.descriptor.workspaceDir === pending.workspaceDir));
+    if (!slot)
+      return;
+    this._pendingReveal = undefined;
+    await this._switchAttachedTo(slot.guid);
+    this._pushTabs();
   }
 
   async reveal(params: { path: string }) {
@@ -238,6 +258,7 @@ export class DashboardConnection implements Transport {
         for (const list of byWs.values())
           sessions.push(...list);
         await this._reconcile(sessions);
+        await this._tryRevealPending();
         this.emitSessions(sessions);
         this._pushTabs();
       } catch {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -29,7 +29,7 @@ import type { CommonFixtures } from '../config/commonFixtures';
 export { expect } from './fixtures';
 export const test = baseTest.extend<{
   cliEnv: Record<string, string>,
-  openDashboard: (options?: { cwd?: string }) => Promise<Page>,
+  openDashboard: (options?: { cwd?: string, session?: string }) => Promise<Page>,
   cli: (...args: any[]) => Promise<{
     output: string,
     error: string,
@@ -45,9 +45,13 @@ export const test = baseTest.extend<{
   },
   openDashboard: async ({ cli, waitForPort, findFreePort }, use) => {
     const dashboards: { dashboard: Page, browser: Browser }[] = [];
-    await use(async (options?: { cwd?: string }) => {
+    await use(async (options?: { cwd?: string, session?: string }) => {
       const debugPort = await findFreePort();
-      await cli('show', { cwd: options?.cwd, env: { PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(debugPort) } });
+      const showArgs: string[] = [];
+      if (options?.session)
+        showArgs.push(`-s=${options.session}`);
+      showArgs.push('show');
+      await cli(...showArgs, { cwd: options?.cwd, env: { PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(debugPort) } });
       await waitForPort(debugPort);
       const browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
       const dashboard = browser.contexts()[0].pages()[0];

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -66,6 +66,15 @@ test('should show current workspace sessions first', async ({ cli, server, openD
   });
 });
 
+test('should activate session when show is called with -s', async ({ cli, server, openDashboard }) => {
+  await cli('-s=sessA', 'open', server.EMPTY_PAGE);
+  await cli('-s=sessB', 'open', server.EMPTY_PAGE);
+
+  const dashboard = await openDashboard({ session: 'sessB' });
+  const activeSession = dashboard.locator('.sidebar-session:has(.sidebar-tab.active)');
+  await expect(activeSession.locator('.session-chip-name')).toHaveText('sessB');
+});
+
 test('should pick locator from browser', async ({ cli, server, openDashboard }) => {
   server.setContent('/', '<button style="position:fixed;inset:0;width:100vw;height:100vh">Submit</button>', 'text/html');
 


### PR DESCRIPTION
## Summary
- `playwright-cli show` forwards the resolved session (`-s`, defaults to `default`) and workspace to the dashboard app.
- Dashboard app reveals the matching session on first launch or sends it through the singleton `bringToFront` message when already running.