### PR TITLE
chore(dashboard): server mode

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -181,10 +181,19 @@ export async function program(options?: { embedderVersion?: string}) {
         `--session=${sessionName}`,
         `--workspace=${clientInfo.workspaceDir ?? ''}`,
       ];
+      if (args.port !== undefined)
+        daemonArgs.push(`--port=${args.port}`);
+      if (args.host !== undefined)
+        daemonArgs.push(`--host=${args.host as string}`);
+      const foreground = args.port !== undefined;
       const child = spawn(process.execPath, daemonArgs, {
-        detached: true,
-        stdio: 'ignore',
+        detached: !foreground,
+        stdio: foreground ? 'inherit' : 'ignore',
       });
+      if (foreground) {
+        await new Promise<void>(resolve => child.on('exit', () => resolve()));
+        return;
+      }
       child.unref();
       if (process.env.PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST)
         console.log(`### Dashboard opened with pid ${child.pid}.`);

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -854,6 +854,10 @@ const devtoolsShow = declareCommand({
   description: 'Show browser DevTools',
   category: 'devtools',
   args: z.object({}),
+  options: z.object({
+    port: numberArg.optional().describe('Start as a blocking HTTP server on this port (use 0 for a random port)'),
+    host: z.string().optional().describe('Host to bind to when using --port (defaults to localhost)'),
+  }),
   toolName: '',
   toolParams: () => ({}),
 });

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -32,12 +32,12 @@ import type * as api from '../../..';
 
 type RevealOptions = { sessionName?: string; workspaceDir?: string };
 
-async function innerOpenDashboardApp(initialReveal: RevealOptions): Promise<{ page: api.Page; reveal: (options: RevealOptions) => void }> {
+async function startDashboardServer(options: { port?: number; host?: string; reveal?: RevealOptions } = {}): Promise<{ url: string; reveal: (options: RevealOptions) => void }> {
   const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
 
   const connections = new Set<DashboardConnection>();
-  let currentReveal = initialReveal;
+  let currentReveal: RevealOptions = options.reveal ?? {};
 
   httpServer.createWebSocket(() => {
     let connection: DashboardConnection;
@@ -57,20 +57,23 @@ async function innerOpenDashboardApp(initialReveal: RevealOptions): Promise<{ pa
       return false;
     return httpServer.serveFile(request, response, resolved);
   });
-  await httpServer.start();
-  const url = httpServer.urlPrefix('human-readable');
+  await httpServer.start({ port: options.port, host: options.host });
 
-  const { page } = await launchApp('dashboard');
-  await page.goto(url);
-
-  const reveal = (options: RevealOptions) => {
-    currentReveal = options;
-    if (!options.sessionName)
+  const reveal = (next: RevealOptions) => {
+    currentReveal = next;
+    if (!next.sessionName)
       return;
     for (const connection of connections)
-      connection.revealSession(options.sessionName, options.workspaceDir);
+      connection.revealSession(next.sessionName, next.workspaceDir);
   };
 
+  return { url: httpServer.urlPrefix('human-readable'), reveal };
+}
+
+async function innerOpenDashboardApp(initialReveal: RevealOptions): Promise<{ page: api.Page; reveal: (options: RevealOptions) => void }> {
+  const { url, reveal } = await startDashboardServer({ reveal: initialReveal });
+  const { page } = await launchApp('dashboard');
+  await page.goto(url);
   return { page, reveal };
 }
 
@@ -145,11 +148,18 @@ function dashboardSocketPath() {
   return makeSocketPath('dashboard', 'app');
 }
 
-function parseRevealArgs(): RevealOptions {
-  const args = minimist(process.argv.slice(2), { string: ['session', 'workspace'] });
+type OpenArgs = { reveal: RevealOptions; port?: number; host?: string };
+
+function parseOpenArgs(): OpenArgs {
+  const args = minimist(process.argv.slice(2), { string: ['session', 'workspace', 'host'] });
+  const portStr = args.port as string | undefined;
   return {
-    sessionName: (args.session as string) || undefined,
-    workspaceDir: (args.workspace as string) || undefined,
+    reveal: {
+      sessionName: (args.session as string) || undefined,
+      workspaceDir: (args.workspace as string) || undefined,
+    },
+    port: portStr !== undefined ? Number(portStr) : undefined,
+    host: (args.host as string) || undefined,
   };
 }
 
@@ -179,13 +189,19 @@ async function acquireSingleton(reveal: RevealOptions): Promise<net.Server> {
 }
 
 export async function openDashboardApp() {
-  const revealOptions = parseRevealArgs();
-  let server: net.Server | undefined;
-  process.on('exit', () => server?.close());
+  const { reveal: revealOptions, port, host } = parseOpenArgs();
   process.on('unhandledRejection', error => {
     // eslint-disable-next-line no-console
     console.error('Unhandled promise rejection:', error);
   });
+  if (port !== undefined) {
+    const { url } = await startDashboardServer({ port, host, reveal: revealOptions });
+    // eslint-disable-next-line no-console
+    console.log(`Listening on ${url}`);
+    return;
+  }
+  let server: net.Server | undefined;
+  process.on('exit', () => server?.close());
   const underTest = !!process.env.PLAYWRIGHT_DASHBOARD_DEBUG_PORT;
   if (!underTest) {
     try {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -17,13 +17,11 @@
 import fs from 'fs';
 import path from 'path';
 
-import { chromium } from 'playwright-core';
-
 import { test as baseTest } from './fixtures';
 import { killProcessGroup } from '../config/commonFixtures';
 import { inheritAndCleanEnv } from '../config/utils';
 
-import type { Browser, Page } from 'playwright-core';
+import type { Page } from 'playwright-core';
 import type { CommonFixtures } from '../config/commonFixtures';
 
 export { expect } from './fixtures';
@@ -43,32 +41,19 @@ export const test = baseTest.extend<{
   cliEnv: async ({}, use) => {
     await use(cliEnv());
   },
-  openDashboard: async ({ cli, waitForPort, findFreePort }, use) => {
-    const dashboards: { dashboard: Page, browser: Browser }[] = [];
+  openDashboard: async ({ childProcess, page }, use) => {
     await use(async (options?: { cwd?: string, session?: string }) => {
-      const debugPort = await findFreePort();
-      const showArgs: string[] = [];
-      if (options?.session)
-        showArgs.push(`-s=${options.session}`);
-      showArgs.push('show');
-      await cli(...showArgs, { cwd: options?.cwd, env: { PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(debugPort) } });
-      await waitForPort(debugPort);
-      const browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
-      const dashboard = browser.contexts()[0].pages()[0];
-      dashboards.push({ dashboard, browser });
-      return dashboard;
+      const testInfo = test.info();
+      const showArgs = options?.session ? [`-s=${options.session}`, 'show'] : ['show'];
+      const serverProcess = childProcess({
+        command: [process.execPath, require.resolve('../../packages/playwright-core/lib/tools/cli-client/cli.js'), ...showArgs, '--port=0'],
+        cwd: options?.cwd ?? testInfo.outputPath(),
+        env: inheritAndCleanEnv(cliEnv()),
+      });
+      await serverProcess.waitForOutput('Listening on ');
+      await page.goto(serverProcess.output.match(/Listening on (http:\/\/\S+)/)![1]);
+      return page;
     });
-    for (const { dashboard, browser } of dashboards) {
-      if (!browser.isConnected())
-        continue;
-      if (test.info().error)
-        await test.info().attach('dashboard', { body: await dashboard.ariaSnapshot({ mode: 'ai' }), contentType: 'text/yaml' });
-      await Promise.all([
-        // Closing the page should close the browser.
-        new Promise(r => browser.on('disconnected', r)),
-        dashboard.close()
-      ]).catch(e => console.error('Error during dashboard close', e));
-    }
   },
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
     const sessions: { name: string, pid: number }[] = [];

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -53,8 +53,6 @@ test('should show current workspace sessions first', async ({ cli, server, openD
     // Other workspace (second) should be second.
     await expect(workspaceGroups.nth(1).locator('.workspace-path-full')).toContainText(second);
     await expect(workspaceGroups.nth(1).locator('.session-chip')).toHaveCount(1);
-
-    await dashboard.close();
   };
 
   await test.step('open dashboard in workspace A', async () => {
@@ -73,6 +71,31 @@ test('should activate session when show is called with -s', async ({ cli, server
   const dashboard = await openDashboard({ session: 'sessB' });
   const activeSession = dashboard.locator('.sidebar-session:has(.sidebar-tab.active)');
   await expect(activeSession.locator('.session-chip-name')).toHaveText('sessB');
+});
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test('daemon show: closing page exits the process', async ({ playwright, cli, findFreePort, waitForPort }) => {
+  const cdpPort = await findFreePort();
+  const { exitCode, pid } = await cli('show', { env: { PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST: '1', PLAYWRIGHT_DASHBOARD_DEBUG_PORT: String(cdpPort) } });
+  expect(exitCode).toBe(0);
+  expect(pid).toBeDefined();
+  expect(isAlive(pid!)).toBe(true);
+
+  await waitForPort(cdpPort);
+
+  const browser = await playwright.chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`);
+  const page = browser.contexts()[0].pages()[0];
+  await page.close();
+
+  await expect(() => expect(isAlive(pid!)).toBe(false)).toPass();
 });
 
 test('should pick locator from browser', async ({ cli, server, openDashboard }) => {


### PR DESCRIPTION
## Summary
- Adds `playwright-cli show --port=<N> [--host=<H>]` to run the dashboard as a blocking HTTP server.
- CLI forwards the flags to the detached dashboard entry; `openDashboardApp` branches on `--port` and calls `startDashboardServer` (the HTTP/WebSocket setup factored out of the app path).
- Replaces PR #40246.