### PR TITLE
chore(dashboard): render workspace paths relative to home

### DIFF
--- a/packages/dashboard/src/sessionSidebar.tsx
+++ b/packages/dashboard/src/sessionSidebar.tsx
@@ -40,14 +40,19 @@ function tabFavicon(url: string): string {
   }
 }
 
-function normalizeWorkspacePath(workspace: string): string {
+function normalizeWorkspacePath(workspace: string, homeDir: string | undefined): string {
   if (!workspace || workspace === 'Global')
     return workspace;
-  if (workspace.startsWith('/') || workspace.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(workspace))
-    return workspace;
-  if (workspace.includes('/'))
-    return '/' + workspace;
-  return workspace;
+  let normalized = workspace;
+  if (!workspace.startsWith('/') && !workspace.startsWith('\\\\') && !/^[A-Za-z]:[\\/]/.test(workspace) && workspace.includes('/'))
+    normalized = '/' + workspace;
+  if (homeDir) {
+    if (normalized === homeDir)
+      return '~';
+    if (normalized.startsWith(homeDir + '/') || normalized.startsWith(homeDir + '\\'))
+      return '~' + normalized.slice(homeDir.length);
+  }
+  return normalized;
 }
 
 export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, onSelectTab, onCloseTab, onNewTab }) => {
@@ -109,7 +114,7 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model, onSelectT
       {model.loading && <div className='sidebar-empty' role='status' aria-live='polite'>Loading sessions...</div>}
       {!model.loading && openSessions.length === 0 && <div className='sidebar-empty' role='status' aria-live='polite'>No open sessions.</div>}
       {workspaceGroups.map(([workspace, entries]) => {
-        const workspacePath = normalizeWorkspacePath(workspace);
+        const workspacePath = normalizeWorkspacePath(workspace, clientInfo?.homeDir);
         return <section key={workspace} className='workspace-group'>
           <h3 className='workspace-header'>
             <span className='workspace-path-full' title={workspacePath}>{workspacePath}</span>

--- a/packages/playwright-core/src/tools/cli-client/registry.ts
+++ b/packages/playwright-core/src/tools/cli-client/registry.ts
@@ -28,6 +28,7 @@ export type ClientInfo = {
   workspaceDirHash: string;
   daemonProfilesDir: string;
   workspaceDir: string | undefined;
+  homeDir: string;
 };
 
 export function clientKey(clientInfo: ClientInfo): string {
@@ -170,6 +171,7 @@ export function createClientInfo(): ClientInfo {
     workspaceDir,
     workspaceDirHash,
     daemonProfilesDir: daemonProfilesDir(workspaceDirHash),
+    homeDir: os.homedir(),
   };
 }
 

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -15,9 +15,19 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { test, expect } from './cli-fixtures';
+
+function displayPath(p: string): string {
+  const home = os.homedir();
+  if (p === home)
+    return '~';
+  if (p.startsWith(home + path.sep))
+    return '~' + p.slice(home.length);
+  return p;
+}
 
 test.beforeEach(({}, testInfo) => {
   process.env.PLAYWRIGHT_SERVER_REGISTRY = testInfo.outputPath('registry');
@@ -47,11 +57,11 @@ test('should show current workspace sessions first', async ({ cli, server, openD
     await expect(workspaceGroups).toHaveCount(2);
 
     // Current workspace (first) should be first.
-    await expect(workspaceGroups.nth(0).locator('.workspace-path-full')).toContainText(first);
+    await expect(workspaceGroups.nth(0).locator('.workspace-path-full')).toHaveText(displayPath(first));
     await expect(workspaceGroups.nth(0).locator('.session-chip')).toHaveCount(1);
 
     // Other workspace (second) should be second.
-    await expect(workspaceGroups.nth(1).locator('.workspace-path-full')).toContainText(second);
+    await expect(workspaceGroups.nth(1).locator('.workspace-path-full')).toHaveText(displayPath(second));
     await expect(workspaceGroups.nth(1).locator('.session-chip')).toHaveCount(1);
 
     await dashboard.close();


### PR DESCRIPTION
## Summary
- Sidebar workspace headers now display paths under the user's home directory with a leading `~`.