### PR TITLE
chore(mcp): rename Playwright MCP Bridge to Playwright Extension

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -283,7 +283,7 @@ Connect to your existing browser tabs instead of launching a new browser:
 playwright-cli attach --extension
 ```
 
-This requires the [Playwright MCP Bridge browser extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md) to be installed.
+This requires the [Playwright Extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md) to be installed.
 
 ## Quick Reference
 

--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -175,7 +175,7 @@ Playwright MCP supports three profile modes:
 
 -   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
--   **Browser extension**: Connect to your existing browser tabs with the [Playwright MCP Bridge extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). Pass `--extension` to enable.
+-   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). Pass `--extension` to enable.
 
 ### Configuration file
 

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -117,7 +117,7 @@ export class CDPRelayServer {
     await Promise.race([
       this._extensionConnectionPromise,
       new Promise((_, reject) => setTimeout(() => {
-        reject(new Error(`Extension connection timeout. Make sure the "Playwright MCP Bridge" extension is installed. See https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md for installation instructions.`));
+        reject(new Error(`Extension connection timeout. Make sure the "Playwright Extension" is installed. See https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md for installation instructions.`));
       }, process.env.PWMCP_TEST_CONNECTION_TIMEOUT ? parseInt(process.env.PWMCP_TEST_CONNECTION_TIMEOUT, 10) : 5_000)),
     ]);
     debugLogger('Extension connection established');

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -101,7 +101,7 @@ export type Config = {
   /**
    * Connect to a running browser instance (Edge/Chrome only). If specified, `browser`
    * config is ignored.
-   * Requires the "Playwright MCP Bridge" browser extension to be installed.
+   * Requires the "Playwright Extension" to be installed.
    */
   extension?: boolean;
 

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -47,7 +47,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--console-level <level>', 'level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.', enumParser.bind(null, '--console-level', ['error', 'warning', 'info', 'debug']))
       .option('--device <device>', 'device to emulate, for example: "iPhone 15"')
       .option('--executable-path <path>', 'path to the browser executable.')
-      .option('--extension', 'Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright MCP Bridge" browser extension to be installed.')
+      .option('--extension', 'Connect to a running browser instance (Edge/Chrome only). Requires the "Playwright Extension" to be installed.')
       .option('--endpoint <endpoint>', 'Bound browser endpoint to connect to.')
       .option('--grant-permissions <permissions...>', 'List of permissions to grant to the browser context, for example "geolocation", "clipboard-read", "clipboard-write".', commaSeparatedList)
       .option('--headless', 'run browser in headless mode, headed by default')


### PR DESCRIPTION
## Summary
- Update all references from "Playwright MCP Bridge" to "Playwright Extension" in docs, CLI help, error messages, and config types