### PR TITLE
docs(claude): forbid pushing without explicit instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Never add "Generated with" in commit message.
 Never add test plan to PR description. Keep PR description short — a few bullet points at most.
 Branch naming for issue fixes: `fix-<issue-number>`
 
+**Never `git push` without an explicit instruction to push.** Applies even when a PR is already open for the branch — additional commits are immediately visible to reviewers. Commit locally, report what was committed, and wait. Only push when the user's message contains "push", "upload", "create PR", "ship it", or equivalent.
+
 ## Development Guides
 
 Detailed guides for common development tasks:


### PR DESCRIPTION
## Summary
- Add a rule to CLAUDE.md instructing Claude not to run `git push` without an explicit instruction from the user, even when a PR is already open for the branch.