### PR TITLE
fix(mcp): throw clear error for tab creation in extension protocol v1

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelayV1.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelayV1.ts
@@ -74,6 +74,9 @@ export class ExtensionProtocolV1 implements ExtensionProtocolHandler {
       case 'Target.getTargetInfo': {
         return { result: this._connectedTabInfo?.targetInfo };
       }
+      case 'Target.createTarget': {
+        throw new Error('Tab creation is not supported yet.');
+      }
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary
- When `tab-new` is invoked with extension protocol v1 (default), `Target.createTarget` was not handled and fell through to `forwardToExtension`, causing a cryptic `Cannot read properties of undefined (reading '_page')` error.
- Now intercepts `Target.createTarget` in the v1 handler and throws a clear "Tab creation is not supported yet" message.