### PR TITLE
fix(mcp): disable CDP timeout for extension connection

### DIFF
--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -35,5 +35,5 @@ export async function createExtensionBrowser(config: FullConfig, clientName: str
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);
 
   await relay.ensureExtensionConnectionForMCPContext(clientName);
-  return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true });
+  return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: config.browser.cdpTimeout ?? 0 });
 }

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -35,5 +35,5 @@ export async function createExtensionBrowser(config: FullConfig, clientName: str
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);
 
   await relay.ensureExtensionConnectionForMCPContext(clientName);
-  return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: config.browser.cdpTimeout ?? 0 });
+  return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0 });
 }


### PR DESCRIPTION
## Summary
- The extension connection flow requires user interaction (approving the tab in the connect UI). The default 30s CDP timeout causes spurious `Timeout 30000ms exceeded` errors when the user doesn't approve in time.
- Disable the CDP timeout (`timeout: 0`) for the extension flow since it inherently requires user interaction and should not have an arbitrary deadline.