### PR TITLE
fix(cli): show "(no browsers)" when list is empty without --all

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -326,6 +326,12 @@ async function listSessions(registry: Registry, clientInfo: ClientInfo, all: boo
     count += await gcAndPrintSessions(clientInfo, list.map(entry => new Session(entry)), all ? `${path.relative(process.cwd(), workspaceKey) || '/'}:` : undefined, runningSessions);
   }
 
+  if (!all) {
+    if (!count)
+      console.log('  (no browsers)');
+    return;
+  }
+
   // Filter out server entries that already have an attached session.
   const serverEntries = await serverRegistry.list();
   if (serverEntries.size) {

--- a/tests/mcp/mcp-server-bind.spec.ts
+++ b/tests/mcp/mcp-server-bind.spec.ts
@@ -26,6 +26,6 @@ test('browser started by MCP is bound to server registry', async ({ startClient,
     arguments: { url: server.HELLO_WORLD },
   });
 
-  const { output } = await cli('list');
+  const { output } = await cli('list', '--all');
   expect(output).toContain('My Agent');
 });


### PR DESCRIPTION
## Summary
- `cli list` without `--all` now prints `(no browsers)` when there are no sessions, and skips the server-entries section.