### PR TITLE
chore(dashboard): style omnibox as input, smart URL completion

### DIFF
--- a/packages/dashboard/src/dashboard.css
+++ b/packages/dashboard/src/dashboard.css
@@ -154,17 +154,26 @@
   padding: 0 12px;
   font-size: 13px;
   font-family: inherit;
-  background: var(--color-canvas-default);
+  background: var(--color-canvas-inset);
   color: var(--color-fg-default);
-  border: 1px solid var(--color-border-muted);
+  border: 1px solid var(--color-border-default);
   border-radius: 16px;
   outline: none;
   min-width: 0;
 }
 
+:root.light-mode .omnibox {
+  background: var(--color-canvas-default);
+}
+
 .omnibox:focus {
   border-color: var(--color-accent-fg);
-  background: var(--color-canvas-subtle);
+  background: var(--color-canvas-default);
+  box-shadow: 0 0 0 2px var(--color-accent-muted);
+}
+
+:root.light-mode .omnibox:focus {
+  background: var(--color-canvas-default);
 }
 
 .omnibox::placeholder {

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -28,6 +28,22 @@ import type { Tab, DashboardChannelEvents } from './dashboardChannel';
 const BUTTONS = ['left', 'middle', 'right'] as const;
 type Mode = 'readonly' | 'interactive' | 'annotate';
 
+function smartUrl(input: string): string {
+  const value = input.trim();
+  if (!value)
+    return value;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value) || value.startsWith('about:') || value.startsWith('data:'))
+    return value;
+  const host = value.split(/[/?#]/, 1)[0];
+  const hasDot = host.includes('.');
+  const isLocalhost = /^localhost(:\d+)?$/i.test(host);
+  const hasPort = /:\d+$/.test(host);
+  const isIp = /^\d{1,3}(\.\d{1,3}){3}(:\d+)?$/.test(host);
+  if (hasDot || isLocalhost || hasPort || isIp)
+    return 'https://' + value;
+  return 'https://' + host + '.com' + value.slice(host.length);
+}
+
 export const Dashboard: React.FC = () => {
   const client = React.useContext(DashboardClientContext);
   const [mode, setMode] = React.useState<Mode>('readonly');
@@ -259,9 +275,7 @@ export const Dashboard: React.FC = () => {
 
   function onOmniboxKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
-      let value = (e.target as HTMLInputElement).value.trim();
-      if (!/^https?:\/\//i.test(value))
-        value = 'https://' + value;
+      const value = smartUrl((e.target as HTMLInputElement).value);
       setUrl(value);
       client?.navigate({ url: value });
       e.currentTarget.blur();


### PR DESCRIPTION
## Summary
- Render the dashboard omnibox as a proper input field (inset background, stronger border, focus ring).
- Smart navigation: bare words become \`https://<word>.com\`; dotted hosts, IPs, \`localhost:port\`, and explicit protocols pass through.