### PR TITLE
feat(runner): Add alternative to serial to allow for more control parallelization

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -3498,6 +3498,19 @@ test.describe.serial('group', () => {
 
 Learn more in the [documentation](./api/class-test#test-describe-serial).
 
+#### 🧵 Sequential mode with [`describe.sequential`](./api/class-test#test-describe-sequential)
+
+Declares a group of tests that should always be run serially, but continues to execute subsequent tests even if one of them fails. All tests in a group are retried together.
+
+```js
+test.describe.sequential('group', () => {
+  test('runs first', async ({ page }) => { /* ... */ });
+  test('runs second', async ({ page }) => { /* ... */ });
+});
+```
+
+Learn more in the [documentation](./api/class-test#test-describe-sequential).
+
 #### 🐾 Steps API with [`test.step`](./api/class-test#test-step)
 
 Split long tests into multiple steps using `test.step()` API:

--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -493,6 +493,15 @@ Learn more about the execution modes [here](../test-parallel.md).
   test('runs second', async ({ page }) => {});
   ```
 
+* Running tests serially without skipping subsequent tests if one fails.
+
+  ```js
+  // Run tests one-by-one even when one fails.
+  test.describe.configure({ mode: 'sequential' });
+  test('runs first', async ({ page }) => {});
+  test('runs second', async ({ page }) => {});
+  ```
+
 * Configuring retries and timeout for each test.
 
   ```js
@@ -522,7 +531,7 @@ Learn more about the execution modes [here](../test-parallel.md).
 
 ### option: Test.describe.configure.mode
 * since: v1.10
-- `mode` <[TestMode]<"default"|"parallel"|"serial">>
+- `mode` <[TestMode]<"default"|"parallel"|"serial"|"sequential">>
 
 Execution mode. Learn more about the execution modes [here](../test-parallel.md).
 
@@ -858,6 +867,110 @@ See [`method: Test.describe`] for details description.
 - `callback` <[function]>
 
 A callback that is run immediately when calling [`method: Test.describe.serial.only`]. Any tests added in this callback will belong to the group.
+
+## method: Test.describe.sequential
+* since: v1.60
+* discouraged: See [`method: Test.describe.configure`] for the preferred way of configuring the execution mode.
+
+Declares a group of tests that should be run serially, but continues running subsequent tests even if one of them fails. All tests in the group are retried together.
+
+* `test.describe.sequential(title, callback)`
+* `test.describe.sequential(callback)`
+* `test.describe.sequential(title, details, callback)`
+
+**Usage**
+
+```js
+test.describe.sequential('group', () => {
+  test('runs first', async ({ page }) => {});
+  test('runs second', async ({ page }) => {});
+});
+```
+
+You can also omit the title.
+
+```js
+test.describe.sequential(() => {
+  // ...
+});
+```
+
+### param: Test.describe.sequential.title
+* since: v1.60
+- `title` ?<[string]>
+
+Group title.
+
+### param: Test.describe.sequential.details
+* since: v1.60
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
+### param: Test.describe.sequential.callback
+* since: v1.60
+- `callback` <[function]>
+
+A callback that is run immediately when calling [`method: Test.describe.sequential`]. Any tests added in this callback will belong to the group.
+
+## method: Test.describe.sequential.only
+* since: v1.60
+* discouraged: See [`method: Test.describe.configure`] for the preferred way of configuring the execution mode.
+
+Declares a focused group of tests that should be run serially, but continues running subsequent tests even if one of them fails. All tests in the group are retried together. If there are some focused tests or suites, all of them will be run but nothing else.
+
+:::note
+Using sequential is not recommended. It is usually better to make your tests isolated, so they can be run independently.
+:::
+
+* `test.describe.sequential.only(title, callback)`
+* `test.describe.sequential.only(title)`
+* `test.describe.sequential.only(title, details, callback)`
+
+**Usage**
+
+```js
+test.describe.sequential.only('group', () => {
+  test('runs first', async ({ page }) => {
+  });
+  test('runs second', async ({ page }) => {
+  });
+});
+```
+
+You can also omit the title.
+
+```js
+test.describe.sequential.only(() => {
+  // ...
+});
+```
+
+### param: Test.describe.sequential.only.title
+* since: v1.60
+- `title` <[string]>
+
+Group title.
+
+### param: Test.describe.sequential.only.details
+* since: v1.60
+- `details` ?<[Object]>
+  - `tag` ?<[string]|[Array]<[string]>>
+  - `annotation` ?<[Object]|[Array]<[Object]>>
+    - `type` <[string]>
+    - `description` ?<[string]>
+
+See [`method: Test.describe`] for details description.
+
+### param: Test.describe.sequential.only.callback
+* since: v1.60
+- `callback` <[function]>
+
+A callback that is run immediately when calling [`method: Test.describe.sequential.only`]. Any tests added in this callback will belong to the group.
 
 
 

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -55,7 +55,7 @@ export class Suite extends Base {
   // Explicitly declared tags that are not a part of the title.
   _tags: string[] = [];
   _modifiers: Modifier[] = [];
-  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
+  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' | 'sequential' = 'none';
   _fullProject: FullProjectInternal | undefined;
   _fileId: string | undefined;
   readonly _type: 'root' | 'project' | 'file' | 'describe';

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -50,6 +50,8 @@ export class TestTypeImpl {
     test.describe.parallel.only = wrapFunctionWithLocation(this._describe.bind(this, 'parallel.only'));
     test.describe.serial = wrapFunctionWithLocation(this._describe.bind(this, 'serial'));
     test.describe.serial.only = wrapFunctionWithLocation(this._describe.bind(this, 'serial.only'));
+    test.describe.sequential = wrapFunctionWithLocation(this._describe.bind(this, 'sequential'));
+    test.describe.sequential.only = wrapFunctionWithLocation(this._describe.bind(this, 'sequential.only'));
     test.describe.skip = wrapFunctionWithLocation(this._describe.bind(this, 'skip'));
     test.beforeEach = wrapFunctionWithLocation(this._hook.bind(this, 'beforeEach'));
     test.afterEach = wrapFunctionWithLocation(this._hook.bind(this, 'afterEach'));
@@ -121,7 +123,7 @@ export class TestTypeImpl {
       test.annotations.push({ type: 'fail', location });
   }
 
-  private _describe(type: 'default' | 'only' | 'serial' | 'serial.only' | 'parallel' | 'parallel.only' | 'skip' | 'fixme', location: Location, titleOrFn: string | Function, fnOrDetails?: TestDetails | Function, fn?: Function) {
+  private _describe(type: 'default' | 'only' | 'serial' | 'serial.only' | 'parallel' | 'parallel.only' | 'sequential' | 'sequential.only' | 'skip' | 'fixme', location: Location, titleOrFn: string | Function, fnOrDetails?: TestDetails | Function, fn?: Function) {
     throwIfRunningInsideJest();
     const suite = this._currentSuite(location, 'test.describe()');
     if (!suite)
@@ -153,10 +155,12 @@ export class TestTypeImpl {
     child._tags.push(...validatedDetails.tags);
     suite._addSuite(child);
 
-    if (type === 'only' || type === 'serial.only' || type === 'parallel.only')
+    if (type === 'only' || type === 'serial.only' || type === 'parallel.only' || type === 'sequential.only')
       child._only = true;
     if (type === 'serial' || type === 'serial.only')
       child._parallelMode = 'serial';
+    if (type === 'sequential' || type === 'sequential.only')
+      child._parallelMode = 'sequential';
     if (type === 'parallel' || type === 'parallel.only')
       child._parallelMode = 'parallel';
     if (type === 'skip' || type === 'fixme')
@@ -167,6 +171,8 @@ export class TestTypeImpl {
         throw new Error('describe.parallel cannot be nested inside describe.serial');
       if (parent._parallelMode === 'default' && child._parallelMode === 'parallel')
         throw new Error('describe.parallel cannot be nested inside describe with default mode');
+      if (parent._parallelMode === 'sequential' && child._parallelMode === 'parallel')
+        throw new Error('describe.parallel cannot be nested inside describe.sequential');
     }
 
     setCurrentlyLoadingFileSuite(child);
@@ -186,7 +192,7 @@ export class TestTypeImpl {
     suite._hooks.push({ type: name, fn: fn!, title, location });
   }
 
-  private _configure(location: Location, options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) {
+  private _configure(location: Location, options: { mode?: 'default' | 'parallel' | 'serial' | 'sequential', retries?: number, timeout?: number }) {
     throwIfRunningInsideJest();
     const suite = this._currentSuite(location, `test.describe.configure()`);
     if (!suite)

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -575,7 +575,7 @@ export class TeleSuite implements reporterTypes.Suite {
   _timeout: number | undefined;
   _retries: number | undefined;
   _project: TeleFullProject | undefined;
-  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
+  _parallelMode: 'none' | 'default' | 'serial' | 'parallel' | 'sequential' = 'none';
   private readonly _type: 'root' | 'project' | 'file' | 'describe';
 
   constructor(title: string, type: 'root' | 'project' | 'file' | 'describe') {

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -338,7 +338,7 @@ class JobDispatcher {
   private _addNonretriableTestAndSerialModeParents(test: testNs.TestCase) {
     this._failedWithNonRetriableError.add(test);
     for (let parent: testNs.Suite | undefined = test.parent; parent; parent = parent.parent) {
-      if (parent._parallelMode === 'serial')
+      if (parent._parallelMode === 'serial' || parent._parallelMode === 'sequential')
         this._failedWithNonRetriableError.add(parent);
     }
   }

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -82,7 +82,7 @@ export function createTestGroups(projectSuite: test.Suite, expectedParallelism: 
     let outerMostSequentialSuite: test.Suite | undefined;
     let hasAllHooks = false;
     for (let parent: test.Suite | undefined = test.parent; parent; parent = parent.parent) {
-      if (parent._parallelMode === 'serial' || parent._parallelMode === 'default')
+      if (parent._parallelMode === 'serial' || parent._parallelMode === 'default' || parent._parallelMode === 'sequential')
         outerMostSequentialSuite = parent;
       insideParallel = insideParallel || parent._parallelMode === 'parallel';
       hasAllHooks = hasAllHooks || parent._hooks.some(hook => hook.type === 'beforeAll' || hook.type === 'afterAll');

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -3869,6 +3869,275 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
      * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
      * the preferred way of configuring the execution mode.
      *
+     * Declares a group of tests that should be run serially, but continues running subsequent tests even if one of them
+     * fails. All tests in the group are retried together.
+     * - `test.describe.sequential(title, callback)`
+     * - `test.describe.sequential(callback)`
+     * - `test.describe.sequential(title, details, callback)`
+     *
+     * **Usage**
+     *
+     * ```js
+     * test.describe.sequential('group', () => {
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     * });
+     * ```
+     *
+     * You can also omit the title.
+     *
+     * ```js
+     * test.describe.sequential(() => {
+     *   // ...
+     * });
+     * ```
+     *
+     * @param title Group title.
+     * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+     * details description.
+     * @param callback A callback that is run immediately when calling
+     * [test.describe.sequential([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential).
+     * Any tests added in this callback will belong to the group.
+     */
+    sequential: {
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should be run serially, but continues running subsequent tests even if one of them
+       * fails. All tests in the group are retried together.
+       * - `test.describe.sequential(title, callback)`
+       * - `test.describe.sequential(callback)`
+       * - `test.describe.sequential(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, callback: () => void): void;
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should be run serially, but continues running subsequent tests even if one of them
+       * fails. All tests in the group are retried together.
+       * - `test.describe.sequential(title, callback)`
+       * - `test.describe.sequential(callback)`
+       * - `test.describe.sequential(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential).
+       * Any tests added in this callback will belong to the group.
+       */
+      (callback: () => void): void;
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a group of tests that should be run serially, but continues running subsequent tests even if one of them
+       * fails. All tests in the group are retried together.
+       * - `test.describe.sequential(title, callback)`
+       * - `test.describe.sequential(callback)`
+       * - `test.describe.sequential(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential('group', () => {
+       *   test('runs first', async ({ page }) => {});
+       *   test('runs second', async ({ page }) => {});
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential).
+       * Any tests added in this callback will belong to the group.
+       */
+      (title: string, details: TestDetails, callback: () => void): void;
+
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should be run serially, but continues running subsequent tests even if one
+       * of them fails. All tests in the group are retried together. If there are some focused tests or suites, all of them
+       * will be run but nothing else.
+       *
+       * **NOTE** Using sequential is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.sequential.only(title, callback)`
+       * - `test.describe.sequential.only(title)`
+       * - `test.describe.sequential.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, callback: () => void): void;
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should be run serially, but continues running subsequent tests even if one
+       * of them fails. All tests in the group are retried together. If there are some focused tests or suites, all of them
+       * will be run but nothing else.
+       *
+       * **NOTE** Using sequential is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.sequential.only(title, callback)`
+       * - `test.describe.sequential.only(title)`
+       * - `test.describe.sequential.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(callback: () => void): void;
+      /**
+       * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+       * the preferred way of configuring the execution mode.
+       *
+       * Declares a focused group of tests that should be run serially, but continues running subsequent tests even if one
+       * of them fails. All tests in the group are retried together. If there are some focused tests or suites, all of them
+       * will be run but nothing else.
+       *
+       * **NOTE** Using sequential is not recommended. It is usually better to make your tests isolated, so they can be run
+       * independently.
+       *
+       * - `test.describe.sequential.only(title, callback)`
+       * - `test.describe.sequential.only(title)`
+       * - `test.describe.sequential.only(title, details, callback)`
+       *
+       * **Usage**
+       *
+       * ```js
+       * test.describe.sequential.only('group', () => {
+       *   test('runs first', async ({ page }) => {
+       *   });
+       *   test('runs second', async ({ page }) => {
+       *   });
+       * });
+       * ```
+       *
+       * You can also omit the title.
+       *
+       * ```js
+       * test.describe.sequential.only(() => {
+       *   // ...
+       * });
+       * ```
+       *
+       * @param title Group title.
+       * @param details See [test.describe([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe) for
+       * details description.
+       * @param callback A callback that is run immediately when calling
+       * [test.describe.sequential.only(title[, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-sequential-only).
+       * Any tests added in this callback will belong to the group.
+       */
+      only(title: string, details: TestDetails, callback: () => void): void;
+    };
+
+    /**
+     * **NOTE** See [test.describe.configure([options])](https://playwright.dev/docs/api/class-test#test-describe-configure) for
+     * the preferred way of configuring the execution mode.
+     *
      * Declares a group of tests that could be run in parallel. By default, tests in a single test file run one after
      * another, but using
      * [test.describe.parallel([title, details, callback])](https://playwright.dev/docs/api/class-test#test-describe-parallel)
@@ -4177,6 +4446,15 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
      *   test('runs second', async ({ page }) => {});
      *   ```
      *
+     * - Running tests serially without skipping subsequent tests if one fails.
+     *
+     *   ```js
+     *   // Run tests one-by-one even when one fails.
+     *   test.describe.configure({ mode: 'sequential' });
+     *   test('runs first', async ({ page }) => {});
+     *   test('runs second', async ({ page }) => {});
+     *   ```
+     *
      * - Configuring retries and timeout for each test.
      *
      *   ```js
@@ -4206,7 +4484,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
      *
      * @param options
      */
-    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+    configure: (options: { mode?: 'default' | 'parallel' | 'serial' | 'sequential', retries?: number, timeout?: number }) => void;
   };
 
   /**

--- a/tests/playwright-test/test-serial.spec.ts
+++ b/tests/playwright-test/test-serial.spec.ts
@@ -446,3 +446,44 @@ test('serial skip + fail is failed', async ({ runInlineTest }) => {
   expect(result.interrupted).toBe(0);
   expect(result.didNotRun).toBe(1);
 });
+
+test('test.describe.sequential should work', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe.sequential('sequential suite', () => {
+        test('test1', async ({}) => {
+          console.log('\\n%%test1');
+        });
+        test('test2', async ({}) => {
+          console.log('\\n%%test2');
+        });
+
+        test.describe('inner suite', () => {
+          test('test3', async ({}) => {
+            console.log('\\n%%test3');
+            expect(1).toBe(2);
+          });
+          test('test4', async ({}) => {
+            console.log('\\n%%test4');
+          });
+        });
+
+        test('test5', async ({}) => {
+          console.log('\\n%%test5');
+        });
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(2);
+  expect(result.failed).toBe(1);
+  expect(result.didNotRun).toBe(0); // Tests should run even after failure
+  expect(result.outputLines).toEqual([
+    'test1',
+    'test2',
+    'test3',
+    'test4', // test4 should run even though test3 failed
+    'test5', // test5 should run even though test3 failed
+  ]);
+});

--- a/utils/generate_types/index.js
+++ b/utils/generate_types/index.js
@@ -579,6 +579,8 @@ class TypesGenerator {
         'PlaywrightWorkerArgs.playwright',
         'PlaywrightWorkerOptions.defaultBrowserType',
         'Project',
+        'TestType.describe.sequential',
+        'TestType.describe.sequential.only',
       ]),
       doNotExportClassNames: assertionClasses,
     });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -137,6 +137,16 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
       only(title: string, details: TestDetails, callback: () => void): void;
     };
 
+    sequential: {
+      (title: string, callback: () => void): void;
+      (callback: () => void): void;
+      (title: string, details: TestDetails, callback: () => void): void;
+
+      only(title: string, callback: () => void): void;
+      only(callback: () => void): void;
+      only(title: string, details: TestDetails, callback: () => void): void;
+    };
+
     parallel: {
       (title: string, callback: () => void): void;
       (callback: () => void): void;
@@ -147,7 +157,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
       only(title: string, details: TestDetails, callback: () => void): void;
     };
 
-    configure: (options: { mode?: 'default' | 'parallel' | 'serial', retries?: number, timeout?: number }) => void;
+    configure: (options: { mode?: 'default' | 'parallel' | 'serial' | 'sequential', retries?: number, timeout?: number }) => void;
   };
 
   skip(title: string, body: TestBody<TestArgs & WorkerArgs>): void;


### PR DESCRIPTION
Adds a describe.sequential test group that runs tests one after another within the same block, without stopping on failure.

Unlike describe.serial, it does not skip remaining tests after a failure, allowing full coverage of the block.

Useful when most tests can run in parallel, but a subset must stay sequential due to shared state, side effects, or lack of full isolation.

Multiple describe.sequential blocks can still run in parallel with each other and with other parallel tests.