### PR TITLE
feat(test-runner): propagate dynamically added testInfo.tags to reporters

### DIFF
--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -217,9 +217,13 @@ Test function as passed to `test(title, testFunction)`.
 
 Tags that apply to the test. Learn more about [tags](../test-annotations.md#tag-tests).
 
-:::note
-Any changes made to this list while the test is running will not be visible to test reporters.
-:::
+Tags added dynamically during the test run will be reported, but cannot be used with the `--grep` CLI option because tests are selected before the run starts.
+
+```js
+test('my test', async ({ page }) => {
+  test.info().tags.push('@slow');
+});
+```
 
 ## property: TestInfo.testId
 * since: v1.32

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -111,6 +111,7 @@ export type TestEndPayload = {
   hasNonRetriableError: boolean;
   expectedStatus: TestStatus;
   annotations: { type: string, description?: string }[];
+  tags: string[];
   timeout: number;
 };
 

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -303,10 +303,15 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     this.parent._collectTagTitlePath(path);
     path.push(this.title);
     const titleTags = path.join(' ').match(/@[\S]+/g) || [];
-    return [
-      ...titleTags,
-      ...this._tags,
-    ];
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const tag of [...titleTags, ...this._tags]) {
+      if (!seen.has(tag)) {
+        seen.add(tag);
+        result.push(tag);
+      }
+    }
+    return result;
   }
 
   _serialize(): any {

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -79,6 +79,7 @@ export type JsonTestEnd = {
   testId: string;
   expectedStatus: reporterTypes.TestStatus;
   timeout: number;
+  tags?: string[];
   // Dropped in 1.52. Kept as empty array for backwards compatibility.
   annotations: [];
 };
@@ -384,6 +385,8 @@ export class TeleReporterReceiver {
     const test = this._tests.get(testEndPayload.testId)!;
     test.timeout = testEndPayload.timeout;
     test.expectedStatus = testEndPayload.expectedStatus;
+    if (testEndPayload.tags)
+      test.tags = testEndPayload.tags;
     const result = test.results.find(r => r._id === payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -92,6 +92,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       testId: test.id,
       expectedStatus: test.expectedStatus,
       timeout: test.timeout,
+      tags: test.tags,
       annotations: []
     };
     this._sendNewAttachments(result, test.id);

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -324,6 +324,7 @@ class JobDispatcher {
     result.status = params.status;
     result.annotations = params.annotations;
     test.annotations = [...params.annotations]; // last test result wins
+    test._tags = [...params.tags]; // last test result wins
     test.expectedStatus = params.expectedStatus;
     test.timeout = params.timeout;
     const isFailure = result.status !== 'skipped' && result.status !== test.expectedStatus;

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -126,7 +126,7 @@ export class TestInfoImpl implements TestInfo {
   readonly titlePath: string[];
   readonly file: string;
   readonly line: number;
-  readonly tags: string[];
+  tags: string[];
   readonly column: number;
   readonly fn: Function;
   expectedStatus: TestStatus;
@@ -193,7 +193,7 @@ export class TestInfoImpl implements TestInfo {
     this.file = test?.location.file ?? '';
     this.line = test?.location.line ?? 0;
     this.column = test?.location.column ?? 0;
-    this.tags = test?.tags ?? [];
+    this.tags = [...(test?.tags ?? [])];
     this.fn = test?.fn ?? (() => {});
     this.expectedStatus = test?.expectedStatus ?? 'skipped';
 

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -653,6 +653,7 @@ function buildTestEndPayload(testInfo: TestInfoImpl): ipc.TestEndPayload {
     hasNonRetriableError: testInfo._hasNonRetriableError,
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,
+    tags: testInfo.tags,
     timeout: testInfo.timeout,
   };
 }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2606,7 +2606,14 @@ export interface TestInfo {
   /**
    * Tags that apply to the test. Learn more about [tags](https://playwright.dev/docs/test-annotations#tag-tests).
    *
-   * **NOTE** Any changes made to this list while the test is running will not be visible to test reporters.
+   * Tags added dynamically during the test run will be reported, but cannot be used with the `--grep` CLI option
+   * because tests are selected before the run starts.
+   *
+   * ```js
+   * test('my test', async ({ page }) => {
+   *   test.info().tags.push('@slow');
+   * });
+   * ```
    *
    */
   tags: Array<string>;

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+
 import { test, expect } from './playwright-test-fixtures';
 
 test('should have correct tags', async ({ runInlineTest }) => {
@@ -181,6 +183,86 @@ test('should be included in testInfo if coming from describe or global tag', asy
     `,
   });
   expect(result.exitCode).toBe(0);
+});
+
+test('should report tags pushed during test execution', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onTestEnd(test, result) {
+          console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+        }
+        onError(error) {
+          console.log(error);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = { reporter: './reporter' };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('dynamic tag', async ({}, testInfo) => {
+        testInfo.tags.push('@dynamic');
+      });
+      test('preserves static tag @inline', { tag: '@static' }, async ({}, testInfo) => {
+        testInfo.tags.push('@dynamic');
+      });
+      test('dedups overlap with title @inline', async ({}, testInfo) => {
+        testInfo.tags.push('@inline');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=dynamic tag, tags=@dynamic',
+    'title=preserves static tag @inline, tags=@inline,@static,@dynamic',
+    'title=dedups overlap with title @inline, tags=@inline',
+  ]);
+});
+
+test('dynamic tags flow through merged blob report', async ({ runInlineTest, mergeReports }) => {
+  const reportDir = test.info().outputPath('blob-report');
+  const files = {
+    'echo-reporter.js': `
+      import fs from 'fs';
+
+      class EchoReporter {
+        log = [];
+        onTestEnd(test) {
+          this.log.push(test.title + ' => ' + test.tags.join(','));
+        }
+        onEnd() {
+          this.log.sort();
+          fs.writeFileSync('log.txt', this.log.join('\\n'));
+        }
+      }
+      module.exports = EchoReporter;
+    `,
+    'playwright.config.js': `
+      module.exports = { reporter: [['blob']] };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('dynamic only', async ({}, testInfo) => {
+        testInfo.tags.push('@runtime');
+      });
+      test('with static @inline', { tag: '@static' }, async ({}, testInfo) => {
+        testInfo.tags.push('@runtime');
+      });
+    `,
+  };
+  const result = await runInlineTest(files);
+  expect(result.exitCode).toBe(0);
+
+  const { exitCode } = await mergeReports(reportDir, {}, { additionalArgs: ['--reporter', test.info().outputPath('echo-reporter.js')] });
+  expect(exitCode).toBe(0);
+
+  const log = fs.readFileSync(test.info().outputPath('log.txt')).toString();
+  expect(log).toBe([
+    'dynamic only => @runtime',
+    'with static @inline => @inline,@static,@runtime',
+  ].join('\n'));
 });
 
 test('should not parse file names as tags', async ({ runInlineTest }) => {


### PR DESCRIPTION
## Summary
- Make `testInfo.tags` mutable. Tags pushed during a test now appear in HTML, JSON, list, blob (after merge) and UI-mode reporters.
- `--grep` and other pre-run tag filters continue to match only statically declared tags (title / `{ tag }` details), since test selection happens before the run.

Fixes https://github.com/microsoft/playwright/issues/33521