### PR TITLE
chore(extension): hardcode public key in manifest.json

### DIFF
--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -16,8 +16,6 @@ jobs:
         run: npm ci
       - name: Build extension
         run: npm run build-extension
-        env:
-          SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST: 1
       - name: Package extension
         working-directory: ./packages/extension
         run: |

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -30,5 +30,6 @@
     "32": "icons/icon-32.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
-  }
+  },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB"
 }

--- a/packages/extension/vite.config.mts
+++ b/packages/extension/vite.config.mts
@@ -19,10 +19,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
-// Public key matching the Chrome Web Store listing — used to fix the extension ID across installs.
-// Set SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST=1 in release builds to inject it into the manifest.
-const extensionPublicKey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB';
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -35,14 +31,7 @@ export default defineConfig({
         },
         {
           src: '../../manifest.json',
-          dest: '.',
-          ...(!!process.env.SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST ? {
-            transform: (content: string) => {
-              const manifest = JSON.parse(content);
-              manifest.key = extensionPublicKey;
-              return JSON.stringify(manifest, null, 2);
-            }
-          } : {})
+          dest: '.'
         }
       ]
     })

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -50,7 +50,6 @@ type WorkerFixtures = {
   _protocolEnv: void;
 };
 
-export const extensionPublicKey = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB';
 export const extensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
 export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOptions>({
@@ -67,13 +66,6 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
     const extensionDir = testInfo.outputPath('extension');
     const srcDir = path.resolve(__dirname, '../../packages/extension/dist');
     await fs.cp(srcDir, extensionDir, { recursive: true });
-    const manifestPath = path.join(extensionDir, 'manifest.json');
-    const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
-    // We don't hardcode the key in manifest, but for the tests we set the key field
-    // to ensure that locally installed extension has the same id as the one published
-    // in the store.
-    manifest.key = extensionPublicKey;
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
     await use(extensionDir);
   },
 
@@ -137,10 +129,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
 export { expect };
 
 export const testWithOldExtensionVersion = test.extend({
-  pathToExtension: async ({ pathToExtension }, use, testInfo) => {
+  pathToExtension: async ({ pathToExtension }, use) => {
     const manifestPath = path.join(pathToExtension, 'manifest.json');
     const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
-    manifest.key = extensionPublicKey;
     manifest.version = '0.0.1';
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
     await use(pathToExtension);


### PR DESCRIPTION
## Summary
- Move extension public key directly into `manifest.json` instead of injecting it at build time
- Remove `SET_EXTENSION_PUBLIC_KEY_IN_MANIFEST` env var from build and CI
- Simplify extension test fixtures that no longer need to patch the key