### PR TITLE
fix(expect): don't sleep past the deadline in retry loop

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -24,6 +24,7 @@ import { assert } from '@isomorphic/assert';
 import { constructURLBasedOnBaseURL } from '@isomorphic/urlMatch';
 import { makeWaitForNextTask } from '@utils/task';
 import { renderTitleForCall } from '@isomorphic/protocolFormatter';
+import { monotonicTime } from '@isomorphic/time';
 import { BrowserContext } from './browserContext';
 import * as dom from './dom';
 import { TimeoutError } from './errors';
@@ -1104,7 +1105,14 @@ export class Frame extends SdkObject<FrameEventMap> {
     timeouts = [0, ...timeouts];
     let timeoutIndex = 0;
     while (true) {
-      const timeout = timeouts[Math.min(timeoutIndex++, timeouts.length - 1)];
+      let timeout = timeouts[Math.min(timeoutIndex++, timeouts.length - 1)];
+      if (timeout && progress.deadline) {
+        // Clamp the sleep to the remaining budget (minus a small margin for the
+        // next action) so we don't sleep past the deadline and miss a final check
+        // for a state that changed during the sleep — https://github.com/microsoft/playwright/issues/40281
+        const remaining = progress.deadline - monotonicTime();
+        timeout = Math.min(timeout, Math.max(0, remaining - 100));
+      }
       if (timeout) {
         // Make sure we react immediately upon page close or frame detach.
         // We need this to show expected/received values in time.

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -94,6 +94,19 @@ test('should not throw when navigating during first locator handler check', asyn
   await promise;
 });
 
+test('should not miss element that appears between retries before the deadline', async ({ page }) => {
+  // Regression: retry schedule is [0, 100, 250, 500, 1000, ...] (cumulative check times
+  // 0, 100, 350, 850, 1850, 2850). With a timeout in (1850, 2849], the deadline fires
+  // mid-sleep and the loop aborts without ever seeing the element.
+  await page.setContent(`<div id="target" style="display:none">content</div>`);
+  await page.evaluate(() => {
+    setTimeout(() => {
+      document.getElementById('target')!.style.display = 'block';
+    }, 1900);
+  });
+  await expect(page.locator('#target')).toBeVisible({ timeout: 2500 });
+});
+
 test('should timeout during first locator handler check', async ({ page, server }) => {
   await page.addLocatorHandler(page.locator('div'), async locator => {});
   await page.setContent(`<div>hello</div><span>bye</span>`);


### PR DESCRIPTION
## Summary
- `retryWithProgressAndTimeouts` could sleep past the assertion deadline and abort mid-sleep without a final check, so an element that appeared during that last sleep was missed.
- Clamp each sleep to the remaining budget (minus a small margin for the next action).

Fixes https://github.com/microsoft/playwright/issues/40281