### PR TITLE
chore: add playwright-devops skill for CI failure analysis

### DIFF
--- a/.claude/skills/playwright-devops/SKILL.md
+++ b/.claude/skills/playwright-devops/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: playwright-devops
+description: DevOps workflows for Playwright - CI failure analysis, workflow debugging, and release operations.
+user_invocable: true
+---
+
+# Playwright DevOps
+
+## Guides
+
+- [CI Commit Failure Report](commit-failures.md) — analyze GitHub Actions failures for the last commit on main
+- [fetch-commit-logs.sh](fetch-commit-logs.sh) — script to download failed job logs into `~/tmp/commit-<sha>/`

--- a/.claude/skills/playwright-devops/commit-failures.md
+++ b/.claude/skills/playwright-devops/commit-failures.md
@@ -1,0 +1,69 @@
+# CI Health Report
+
+Generate a CI health report for the last commit on the `main` branch of `microsoft/playwright`.
+This is an overall tree health report — not a commit regression analysis. The goal is to show
+the full picture of what's failing, grouping by root cause. If any failures appear to be
+regressions introduced by this specific commit, call that out, but most failures will be
+pre-existing flakes, infrastructure issues, or platform-specific problems.
+
+## Phase 1 — Fetch logs
+
+Run the fetch script to download all failed job logs into a local folder:
+
+```
+bash .claude/skills/playwright-devops/fetch-commit-logs.sh [<sha>]
+```
+
+- If no SHA is provided, it fetches the last commit on `main`.
+- Creates `~/tmp/commit-<short-sha>/` with:
+  - `summary.json` — commit info, failed workflows, and failed job metadata
+  - `<workflow-name>/<job-name>.log` — failed log output for each failed job
+
+**Note:** The script fetches failed jobs from both failed AND in-progress workflows.
+Workflows may still be running while some of their jobs have already failed — these
+must be included in the report. If any workflows are still in progress, note this in
+the report summary.
+
+## Phase 2 — Analyze
+
+1. **Read `summary.json`** to get the commit message and the list of failed workflows/jobs.
+
+2. **Read each `.log` file** and extract failing test names and error messages.
+
+3. **Compile the report leading with a summary**, then detailed tables:
+
+   ```markdown
+   # CI Health Report — <short-sha>
+
+   Commit: `<commit message>`
+
+   ## Summary
+
+   Brief overview: N workflows, N failed jobs, N total test failures.
+   Note if any workflows are still in progress.
+
+   ### Possible regressions (may be related to this commit)
+   - **N failures** in `test/file.spec.ts` across <browsers/platforms> — <brief description>
+
+   ### Pre-existing / flaky
+   - **N failures** in `test/file.spec.ts` — <brief description> (timeouts, infrastructure, platform-specific)
+
+   ### Infrastructure issues
+   - <description of non-test failures>
+
+   ---
+
+   ## Detailed Failures
+
+   ### Workflow: <name> (run <id>)
+
+   #### <job name> (job <id>) -- N failures
+   | Test | Error |
+   |------|-------|
+   | `path/to/test.spec.ts:line` -- test title | error message |
+   ```
+
+   The summary should appear first so readers immediately see what matters. Group related failures
+   (e.g. same test failing across browsers) into single summary bullet points rather than listing each individually.
+
+4. **Save the report** to `ci-failures-<short-sha>.md` in the repo root.

--- a/.claude/skills/playwright-devops/fetch-commit-logs.sh
+++ b/.claude/skills/playwright-devops/fetch-commit-logs.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: fetch-commit-logs.sh [<sha>]
+# Fetches CI failure logs for a commit into ~/tmp/commit-<short-sha>/
+
+REPO="microsoft/playwright"
+REF="${1:-main}"
+
+# Resolve commit
+COMMIT_JSON=$(gh api "repos/$REPO/commits/$REF" --jq '{sha: .sha, message: .commit.message}')
+SHA=$(echo "$COMMIT_JSON" | jq -r '.sha')
+SHORT_SHA="${SHA:0:7}"
+MESSAGE=$(echo "$COMMIT_JSON" | jq -r '.message' | head -1)
+
+OUTDIR="$HOME/tmp/commit-$SHORT_SHA"
+mkdir -p "$OUTDIR"
+
+echo "Commit: $SHORT_SHA — $MESSAGE"
+echo "Output: $OUTDIR"
+
+# Get all workflow runs for this commit
+RUNS_JSON=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=50" \
+  --jq '[.workflow_runs[] | {id, name, conclusion, workflow_id}]')
+
+# Filter to failed workflows
+FAILED_RUNS=$(echo "$RUNS_JSON" | jq -c '[.[] | select(.conclusion == "failure" or .conclusion == null)]')
+FAILED_COUNT=$(echo "$FAILED_RUNS" | jq 'length')
+
+if [ "$FAILED_COUNT" -eq 0 ]; then
+  echo "No failed workflows."
+  echo '{"sha":"'"$SHA"'","short_sha":"'"$SHORT_SHA"'","message":"'"$MESSAGE"'","workflows":[]}' | jq . > "$OUTDIR/summary.json"
+  echo "$OUTDIR"
+  exit 0
+fi
+
+echo "Found $FAILED_COUNT failed workflow(s). Fetching failed jobs..."
+
+# Build summary and collect jobs to fetch
+SUMMARY='{"sha":"'"$SHA"'","short_sha":"'"$SHORT_SHA"'","message":'"$(echo "$MESSAGE" | jq -Rs .)"',"workflows":[]}'
+
+sanitize() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//'
+}
+
+PIDS=()
+
+for i in $(seq 0 $((FAILED_COUNT - 1))); do
+  RUN=$(echo "$FAILED_RUNS" | jq -c ".[$i]")
+  RUN_ID=$(echo "$RUN" | jq -r '.id')
+  RUN_NAME=$(echo "$RUN" | jq -r '.name')
+  WORKFLOW_DIR=$(sanitize "$RUN_NAME")
+
+  # Get failed jobs for this run
+  JOBS_JSON=$(gh run view "$RUN_ID" --json jobs \
+    --jq '[.jobs[] | select(.conclusion == "failure") | {name: .name, id: .databaseId}]')
+  JOB_COUNT=$(echo "$JOBS_JSON" | jq 'length')
+
+  if [ "$JOB_COUNT" -eq 0 ]; then
+    continue
+  fi
+
+  mkdir -p "$OUTDIR/$WORKFLOW_DIR"
+
+  # Add to summary
+  WORKFLOW_ENTRY=$(jq -n \
+    --arg name "$RUN_NAME" \
+    --argjson id "$RUN_ID" \
+    --argjson jobs "$JOBS_JSON" \
+    '{name: $name, id: $id, failed_jobs: $jobs}')
+  SUMMARY=$(echo "$SUMMARY" | jq --argjson w "$WORKFLOW_ENTRY" '.workflows += [$w]')
+
+  # Fetch logs in parallel
+  for j in $(seq 0 $((JOB_COUNT - 1))); do
+    JOB=$(echo "$JOBS_JSON" | jq -c ".[$j]")
+    JOB_ID=$(echo "$JOB" | jq -r '.id')
+    JOB_NAME=$(echo "$JOB" | jq -r '.name')
+    JOB_FILE=$(sanitize "$JOB_NAME")
+    LOG_PATH="$OUTDIR/$WORKFLOW_DIR/$JOB_FILE.log"
+
+    (
+      echo "# $JOB_NAME" > "$LOG_PATH"
+      echo "" >> "$LOG_PATH"
+      gh run view --job "$JOB_ID" --log-failed 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed $'s/^[^\t]*\t[^\t]*\t\xef\xbb\xbf\{0,1\}[0-9T:.Z-]* //' >> "$LOG_PATH" || true
+      # If only header (e.g. workflow still in progress), fetch via jobs API
+      if [ "$(wc -l < "$LOG_PATH")" -le 3 ]; then
+        echo "# $JOB_NAME" > "$LOG_PATH"
+        echo "" >> "$LOG_PATH"
+        gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>&1 | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed $'s/\xef\xbb\xbf//g' | sed 's/^[0-9T:.Z-]* //' >> "$LOG_PATH" || true
+      fi
+      echo "  Fetched: $WORKFLOW_DIR/$JOB_FILE.log"
+    ) &
+    PIDS+=($!)
+  done
+done
+
+# Wait for all parallel fetches
+for pid in "${PIDS[@]}"; do
+  wait "$pid" 2>/dev/null || true
+done
+
+# Write summary
+echo "$SUMMARY" | jq . > "$OUTDIR/summary.json"
+
+echo ""
+echo "Done. Logs saved to: $OUTDIR"
+echo "$OUTDIR"


### PR DESCRIPTION
# CI Failures for Commit e575acda2

Commit: `feat(dashboard): add 'show --annotate' to capture annotations as PNG (#40262)`

## Summary by Category

### Likely related to this commit (`feat(dashboard): add 'show --annotate'`)
- **11 failures** in `tests/mcp/dashboard.spec.ts` across all browsers on Windows — annotation output empty, endpoint undefined, annotate view not visible. These are the new tests from this PR.
- **1 failure** in `tests/mcp/cli-killall.spec.ts` — may be related to dashboard changes.

### Pre-existing / flaky (not related to this commit)
- **20+ failures** in `debug-controller.spec.ts` — worker teardown timeout (Edge bots on macOS)
- **70 failures** in macos-26-large webkit — entire suite timeout (infrastructure)
- **~6 failures** in Electron file upload tests — 50Mb transfer limit (known limitation)
- **~5 failures** in Firefox on macOS — various timeouts, dialog handling, CSP
- **2 failures** in webkit macOS — audio playback timing, folder upload timeout
- **1 failure** in stress test — Firefox context cycling timeout
- **1 error** in msedge-dev — `request.get is not a function`
- **2 failures** — NPM publish permissions, missing report artifacts

## Failing Workflows & Jobs

### 1. Workflow: `tests others` (run 24596749655)

#### Electron - windows-latest (job 71928064874) — 5 failures
| Test | Error |
|------|-------|
| `tests/electron/electron-app.spec.ts:93` — should fire console events with handles and complex objects | Execution context was destroyed (navigation) |
| `tests/page/page-filechooser.spec.ts:24` — should upload multiple large files | Cannot transfer files larger than 50Mb to non-co-located browser |
| `tests/page/page-set-input-files.spec.ts:146` — should upload large file | Same 50Mb transfer limit |
| `tests/page/page-set-input-files.spec.ts:203` — should upload large file with relative path | Same 50Mb transfer limit |
| `tests/page/page-aria-snapshot-ai.spec.ts:382` — should include active element information | Failed |

#### Electron - macos-latest (job 71928064885) — 1 failure
| Test | Error |
|------|-------|
| `tests/page/page-filechooser.spec.ts:24` — should upload multiple large files | Cannot transfer files larger than 50Mb to non-co-located browser |

#### Electron - ubuntu-latest (job 71928064893) — 3 failures
| Test | Error |
|------|-------|
| `tests/page/page-filechooser.spec.ts:24` — should upload multiple large files | Cannot transfer files larger than 50Mb to non-co-located browser |
| `tests/page/page-set-input-files.spec.ts:146` — should upload large file | Same 50Mb transfer limit |
| `tests/page/page-set-input-files.spec.ts:203` — should upload large file with relative path | Same 50Mb transfer limit |

#### Stress - macos-latest (job 71928064876) — 1 failure
| Test | Error |
|------|-------|
| `tests/stress/contexts.spec.ts:20` — cycle contexts 825 [firefox] | Test timeout 30000ms exceeded |

---

### 2. Workflow: `tests 2` (run 24596749656)

#### Test msedge on macos-latest (job 71928065083) — 10 failures
All in `tests/library/debug-controller.spec.ts` (lines 85, 116, 144, 162, 176, 211, 246, 270, 296, 313).
**Root cause:** Worker teardown timeout of 30000ms exceeded.

#### Test msedge-beta on macos-latest (job 71928065047) — same pattern
Same 10 `debug-controller.spec.ts` tests. Worker teardown timeout.

#### Test msedge-dev on macos-latest (job 71928065074) — 1 error
| Test | Error |
|------|-------|
| `tests/library/global-fetch-cookie.spec.ts:292` | `request.get is not a function` (error not part of any test) |

#### macos-26-xlarge (firefox) (job 71928065075) — 2 failures
| Test | Error |
|------|-------|
| `tests/library/beforeunload.spec.ts:130` — should support dismissing the dialog multiple times | `page.waitForEvent: Target page, context or browser has been closed` |
| `tests/library/inspector/cli-codegen-1.spec.ts:1080` — should not throw csp directive violation errors | Promise resolved instead of rejected |

#### macos-26-large (firefox) (job 71928065081) — 3+ failures
| Test | Error |
|------|-------|
| `tests/library/defaultbrowsercontext-2.spec.ts:113` — should restore state from userDataDir | Timeout |
| `tests/library/defaultbrowsercontext-2.spec.ts:190` — should fire close event for a persistent context | Timeout |
| `tests/library/proxy.spec.ts:199` — should exclude patterns | Timeout |
Plus additional timeouts in inspector CLI codegen tests.

#### macos-15-large (firefox) (job 71928065058) — worker teardown
Worker teardown timeout pattern, similar to Edge bots.

#### macos-15-large (webkit) (job 71928065056) — 2 failures
| Test | Error |
|------|-------|
| `tests/library/capabilities.spec.ts:95` — should play audio @smoke | Audio playback 0.0016s, expected > 0.1 |
| `tests/library/browsertype-connect.spec.ts:776` — should upload a folder | Test timeout 90s exceeded |

#### macos-26-large (webkit) (job 71928065054) — 70 failures (suite timeout)
Entire suite timed out after 5400s. Mass failures across proxy, screencast, cli-codegen, role-utils, trace-viewer, etc.

---

### 3. Workflow: `MCP` (run 24596749661)

#### windows-latest - 1/2 (job 71928064909) — 5 failures
| Test | Error |
|------|-------|
| `[chrome] tests/mcp/dashboard.spec.ts:135` — should capture annotations via show --annotate | Empty output, expected annotation coords |
| `[chrome] tests/mcp/dashboard.spec.ts:156` — should start dashboard and annotate when no dashboard is running | `Cannot read properties of undefined (reading 'endpoint')` |
| `[chromium] tests/mcp/dashboard.spec.ts:135` — should capture annotations via show --annotate | Same endpoint undefined error |
| `[chromium] tests/mcp/dashboard.spec.ts:156` — should start dashboard and annotate when no dashboard is running | `locator('div.dashboard-view.annotate')` not visible |
| `[firefox] tests/mcp/cli-killall.spec.ts:42` — kill-all kills filtered dashboard pid | "No daemon processes found" instead of "Killed daemon process" |

#### windows-latest - 2/2 (job 71928064913) — 6 failures
| Test | Error |
|------|-------|
| `[firefox] tests/mcp/dashboard.spec.ts:135` — should capture annotations via show --annotate | Empty output |
| `[firefox] tests/mcp/dashboard.spec.ts:156` — should start dashboard and annotate when no dashboard is running | Endpoint undefined |
| `[webkit] tests/mcp/dashboard.spec.ts:135` — same | Empty output |
| `[webkit] tests/mcp/dashboard.spec.ts:156` — same | Endpoint undefined |
| `[msedge] tests/mcp/dashboard.spec.ts:135` — same | Empty output |
| `[msedge] tests/mcp/dashboard.spec.ts:156` — same | Endpoint undefined |