### PR TITLE
fix(utils): respect PLAYWRIGHT_SOCKETS_DIR on Windows named pipes

### DIFF
--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -66,8 +66,11 @@ export function toPosixPath(aPath: string): string {
 
 export function makeSocketPath(domain: string, name: string): string {
   const userNameHash = calculateSha1(process.env.USERNAME || process.env.USER || 'default').slice(0, 8);
-  if (process.platform === 'win32')
-    return `\\\\.\\pipe\\pw-${userNameHash}-${domain}-${name}`;
+  if (process.platform === 'win32') {
+    const socketsDir = process.env.PLAYWRIGHT_SOCKETS_DIR;
+    const suffix = socketsDir ? `-${calculateSha1(socketsDir).slice(0, 8)}` : '';
+    return `\\\\.\\pipe\\pw-${userNameHash}-${domain}-${name}${suffix}`;
+  }
   const baseDir = process.env.PLAYWRIGHT_SOCKETS_DIR || path.join(os.tmpdir(), `pw-${userNameHash}`);
   const dir = path.join(baseDir, domain);
   const result = path.join(dir, `${name}.sock`);


### PR DESCRIPTION
## Summary
- `makeSocketPath()` on Windows ignored `PLAYWRIGHT_SOCKETS_DIR`, producing a fixed named pipe path (`\\.\pipe\pw-{hash}-dashboard-app`) for all processes
- Parallel test workers shared the same pipe, causing dashboard tests to cross-talk: annotate returning empty output and `connectToDashboard` unable to find the right server
- Hash `PLAYWRIGHT_SOCKETS_DIR` into the pipe name suffix when set; production behavior unchanged