### PR TITLE
fix(electron): pass isLocal to connectOverCDP

### DIFF
--- a/packages/playwright-electron/src/electron.ts
+++ b/packages/playwright-electron/src/electron.ts
@@ -167,7 +167,7 @@ export class Electron implements api.Electron {
       debuggerDisconnectPromise.then(() => worker.disconnect()).catch(() => {});
 
       const chromeMatch = await Promise.race([chromeMatchPromise, waitForXserverError]);
-      const browser = await chromium.connectOverCDP(chromeMatch[1], { timeout: progress.timeUntilDeadline() });
+      const browser = await chromium.connectOverCDP(chromeMatch[1], { timeout: progress.timeUntilDeadline(), isLocal: true });
 
       app = new ElectronApplication(worker, browser, launchedProcess);
       await progress.race(app._initialize());


### PR DESCRIPTION
## Summary
- The Electron package move (#40184) lost the `isLocal` flag when calling `connectOverCDP`, marking the browser as remote
- This triggered the 50MB file transfer limit, failing large file upload tests on all platforms