### PR TITLE
fix(server): close browsers when PlaywrightServer shuts down

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -319,6 +319,10 @@ export class PlaywrightServer {
 
   async close() {
     await this._wsServer.close();
+    // Close all browsers that were launched by this server (e.g. in reuse mode)
+    // to avoid leaking browser processes that may hold connections to test servers.
+    for (const browser of this._playwright.allBrowsers())
+      await browser.close(nullProgress, { reason: 'Server closed' });
   }
 }
 


### PR DESCRIPTION
## Summary

- In extension/reuse mode, `PlaywrightServer` launches browsers that intentionally outlive individual client connections (for reuse across reconnects). However, when the server itself shuts down via `close()`, those browsers were never cleaned up — leaking browser processes.
- This caused consistent worker teardown timeouts (30s) for `debug-controller.spec.ts` on all three Edge/macOS CI bots. The orphaned Edge process kept SmartScreen background connections alive, preventing clean shutdown of worker-scoped test fixtures.
- Fix: after closing the WebSocket server (which runs per-connection dispose callbacks), close any browsers still owned by the server's Playwright instance.