### PR TITLE
fix(mcp): strip $schema field from tool inputSchema

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/tool.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/tool.ts
@@ -28,10 +28,12 @@ export type ToolSchema<Input extends z.Schema> = {
 
 export function toMcpTool(tool: ToolSchema<any>): mcpServer.Tool {
   const readOnly = tool.type === 'readOnly' || tool.type === 'assertion';
+  const jsonSchema = zod.toJSONSchema(tool.inputSchema);
+  delete jsonSchema.$schema;
   return {
     name: tool.name,
     description: tool.description,
-    inputSchema: zod.toJSONSchema(tool.inputSchema) as mcpServer.Tool['inputSchema'],
+    inputSchema: jsonSchema as mcpServer.Tool['inputSchema'],
     annotations: {
       title: tool.title,
       readOnlyHint: readOnly,


### PR DESCRIPTION
## Summary
Strip the `$schema` field from MCP tool `inputSchema` generated by `toMcpTool()`.

## Problem
Zod v4's `toJSONSchema()` automatically adds `"$schema": "https://json-schema.org/draft/2020-12/schema"`. MCP clients (Anthropic API, Kiro, Claude Desktop) reject this field, breaking all tool calls in the session.

Confirmed affected in Kiro IDE with error:
`Validation failed calling browser_snapshot with args {}: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`

## Fix
Remove `$schema` from the generated JSON Schema in `packages/playwright-core/src/tools/utils/mcp/tool.ts` before returning it as `inputSchema`. Per MCP spec, `inputSchema` defaults to JSON Schema 2020-12 when `$schema` is omitted, so removing it is safe and compliant.

Fixes #40043