### PR TITLE
chore(test-runner): vendor the expect library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3913,22 +3913,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5109,24 +5093,6 @@
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.2.0",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/express": {
@@ -6541,21 +6507,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jest-mock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "jest-util": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/jest-regex-util": {
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
@@ -6565,31 +6516,6 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
-    },
-    "node_modules/jest-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -9664,12 +9590,13 @@
         "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
+        "@jest/expect-utils": "30.2.0",
         "@types/babel__code-frame": "^7.0.6",
         "@types/babel__core": "^7.20.5",
         "@types/babel__helper-plugin-utils": "^7.10.3",
         "@types/babel__traverse": "^7.20.6",
-        "expect": "30.2.0",
-        "jest-matcher-utils": "30.2.0"
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0"
       },
       "engines": {
         "node": ">=18"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -83,8 +83,9 @@
     "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/babel__traverse": "^7.20.6",
-    "expect": "30.2.0",
-    "jest-matcher-utils": "30.2.0"
+    "@jest/expect-utils": "30.2.0",
+    "jest-matcher-utils": "30.2.0",
+    "jest-message-util": "30.2.0"
   },
   "optionalDependencies": {
     "fsevents": "2.3.2"

--- a/packages/playwright/src/matchers/DEPS.list
+++ b/packages/playwright/src/matchers/DEPS.list
@@ -2,6 +2,8 @@
 @isomorphic/**
 @utils/**
 node_modules/colors/safe
+
+[expectLibrary.ts]
 node_modules/@jest/expect-utils
 node_modules/jest-matcher-utils
 node_modules/jest-message-util

--- a/packages/playwright/src/matchers/DEPS.list
+++ b/packages/playwright/src/matchers/DEPS.list
@@ -2,4 +2,6 @@
 @isomorphic/**
 @utils/**
 node_modules/colors/safe
-node_modules/expect
+node_modules/@jest/expect-utils
+node_modules/jest-matcher-utils
+node_modules/jest-message-util

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -16,14 +16,43 @@
 
 import path from 'path';
 
+import { equals } from '@jest/expect-utils';
 import { parseStackFrame, captureRawStack } from '@isomorphic/stackTrace';
 import { escapeWithQuotes, isString } from '@isomorphic/stringUtils';
 import { pollAgainstDeadline } from '@isomorphic/timeoutRunner';
 import { currentZone } from '@utils/zones';
 import {
-  expect as expectLibrary,
-} from './expectLibrary';
+  RECEIVED_COLOR,
+  matcherErrorMessage,
+  matcherHint,
+  printReceived,
+  printWithType,
+  stringify,
+} from 'jest-matcher-utils';
 
+import {
+  AsymmetricMatcher,
+  INTERNAL_MATCHER_FLAG,
+  any,
+  anything,
+  arrayContaining,
+  arrayNotContaining,
+  arrayOf,
+  closeTo,
+  createThrowMatcher,
+  isPromise,
+  matchers as builtinMatchers,
+  notArrayOf,
+  notCloseTo,
+  objectContaining,
+  objectNotContaining,
+  stringContaining,
+  stringMatching,
+  stringNotContaining,
+  stringNotMatching,
+  toThrowMatchers,
+  utils,
+} from './expectLibrary';
 import { ExpectError, isJestError } from './matcherHint';
 import {
   computeMatcherTitleSuffix,
@@ -61,6 +90,7 @@ import {
 import { toMatchAriaSnapshot } from './toMatchAriaSnapshot';
 import { toHaveScreenshot, toMatchSnapshot } from './toMatchSnapshot';
 
+import type { ExpectationResult, MatcherContext, MatchersObject, RawMatcherFn, SyncExpectationResult } from './expectLibrary';
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
@@ -466,6 +496,350 @@ async function pollMatcher(qualifiedMatcherName: string, info: ExpectMetaInfo, p
     throw new Error(message);
   }
 }
+
+// #region
+// Based on https://github.com/jestjs/jest/tree/v30.2.0/packages/expect
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found here
+ * https://github.com/jestjs/jest/blob/v30.2.0/LICENSE
+ */
+
+type ThrowingMatcherFn = (...args: Array<any>) => any;
+type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
+
+type AsymmetricMatchers = {
+  any(sample: unknown): AsymmetricMatcher<any>;
+  anything(): AsymmetricMatcher<any>;
+  arrayContaining(sample: Array<unknown>): AsymmetricMatcher<any>;
+  arrayOf(sample: unknown): AsymmetricMatcher<any>;
+  closeTo(sample: number, precision?: number): AsymmetricMatcher<any>;
+  objectContaining(sample: Record<string, unknown>): AsymmetricMatcher<any>;
+  stringContaining(sample: string): AsymmetricMatcher<any>;
+  stringMatching(sample: string | RegExp): AsymmetricMatcher<any>;
+};
+
+interface BaseExpect {
+  extend(matchers: MatchersObject): void;
+}
+
+type LibraryExpect = (<T = unknown>(actual: T) => any) &
+  BaseExpect &
+  AsymmetricMatchers & {
+    not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
+  };
+
+class JestAssertionError extends Error {
+  matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
+}
+
+const allMatchers: MatchersObject = Object.create(null);
+
+const setMatchers = (
+  matchers: MatchersObject,
+  isInternal: boolean,
+  expect: LibraryExpect,
+): void => {
+  for (const key of Object.keys(matchers)) {
+    const matcher = matchers[key];
+
+    if (typeof matcher !== 'function')
+      throw new TypeError(`expect.extend: \`${key}\` is not a valid matcher. Must be a function, is "${typeof matcher}"`);
+
+    Object.defineProperty(matcher, INTERNAL_MATCHER_FLAG, {
+      value: isInternal,
+    });
+
+    if (!isInternal) {
+      // expect is defined
+
+      class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
+        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
+          super(sample, inverse);
+        }
+
+        asymmetricMatch(other: unknown) {
+          const { pass } = matcher.call(
+              this.getMatcherContext(),
+              other,
+              ...this.sample,
+          ) as SyncExpectationResult;
+
+          return this.inverse ? !pass : pass;
+        }
+
+        toString() {
+          return `${this.inverse ? 'not.' : ''}${key}`;
+        }
+
+        override getExpectedType() {
+          return 'any';
+        }
+
+        override toAsymmetricMatcher() {
+          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
+        }
+      }
+
+      Object.defineProperty(expect, key, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...Array<unknown>]) =>
+          new CustomMatcher(false, ...sample),
+        writable: true,
+      });
+      Object.defineProperty(expect.not, key, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...Array<unknown>]) =>
+          new CustomMatcher(true, ...sample),
+        writable: true,
+      });
+    }
+  }
+
+  Object.assign(allMatchers, matchers);
+};
+
+const getPromiseMatcher = (name: string) => {
+  if (name === 'toThrow')
+    return createThrowMatcher(name, true);
+  return null;
+};
+
+const expectLibrary: LibraryExpect = ((actual: any, ...rest: Array<any>) => {
+  if (rest.length > 0)
+    throw new Error('Expect takes at most one argument.');
+
+  const expectation: any = {
+    not: {},
+    rejects: { not: {} },
+    resolves: { not: {} },
+  };
+
+  const err = new JestAssertionError();
+
+  for (const name of Object.keys(allMatchers)) {
+    const matcher = allMatchers[name];
+    const promiseMatcher = getPromiseMatcher(name) || matcher;
+    expectation[name] = makeThrowingMatcher(matcher, false, '', actual);
+    expectation.not[name] = makeThrowingMatcher(matcher, true, '', actual);
+
+    expectation.resolves[name] = makeResolveMatcher(name, promiseMatcher, false, actual, err);
+    expectation.resolves.not[name] = makeResolveMatcher(name, promiseMatcher, true, actual, err);
+
+    expectation.rejects[name] = makeRejectMatcher(name, promiseMatcher, false, actual, err);
+    expectation.rejects.not[name] = makeRejectMatcher(name, promiseMatcher, true, actual, err);
+  }
+
+  return expectation;
+}) as LibraryExpect;
+
+const getMessage = (message?: () => string) =>
+  (message && message()) ||
+  RECEIVED_COLOR('No message was specified for this matcher.');
+
+const makeResolveMatcher =
+  (
+    matcherName: string,
+    matcher: RawMatcherFn,
+    isNot: boolean,
+    actual: Promise<any> | (() => Promise<any>),
+    outerErr: JestAssertionError,
+  ): PromiseMatcherFn =>
+    (...args: Array<any>) => {
+      const options = { isNot, promise: 'resolves' };
+
+      const actualWrapper: Promise<any> =
+        typeof actual === 'function' ? actual() : actual;
+
+      if (!isPromise(actualWrapper)) {
+        throw new JestAssertionError(
+            matcherErrorMessage(
+                matcherHint(matcherName, undefined, '', options),
+                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+                printWithType('Received', actual, printReceived),
+            ),
+        );
+      }
+
+      const innerErr = new JestAssertionError();
+
+      return actualWrapper.then(
+          result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
+          error => {
+            outerErr.message =
+              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+          'Received promise rejected instead of resolved\n' +
+          `Rejected to value: ${printReceived(error)}`;
+            throw outerErr;
+          },
+      );
+    };
+
+const makeRejectMatcher =
+  (
+    matcherName: string,
+    matcher: RawMatcherFn,
+    isNot: boolean,
+    actual: Promise<any> | (() => Promise<any>),
+    outerErr: JestAssertionError,
+  ): PromiseMatcherFn =>
+    (...args: Array<any>) => {
+      const options = { isNot, promise: 'rejects' };
+
+      const actualWrapper: Promise<any> =
+        typeof actual === 'function' ? actual() : actual;
+
+      if (!isPromise(actualWrapper)) {
+        throw new JestAssertionError(
+            matcherErrorMessage(
+                matcherHint(matcherName, undefined, '', options),
+                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+                printWithType('Received', actual, printReceived),
+            ),
+        );
+      }
+
+      const innerErr = new JestAssertionError();
+
+      return actualWrapper.then(
+          result => {
+            outerErr.message =
+              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+          'Received promise resolved instead of rejected\n' +
+          `Resolved to value: ${printReceived(result)}`;
+            throw outerErr;
+          },
+          error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
+      );
+    };
+
+const makeThrowingMatcher = (
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  promise: string,
+  actual: any,
+  err?: JestAssertionError,
+): ThrowingMatcherFn =>
+  function throwingMatcher(this: void, ...args: Array<any>): any {
+    const matcherContext: MatcherContext = {
+      customTesters: [],
+      equals,
+      utils,
+      error: err,
+      isNot,
+      promise,
+    };
+
+    const processResult = (
+      result: SyncExpectationResult,
+      asyncError?: JestAssertionError,
+    ) => {
+      _validateResult(result);
+
+      if ((result.pass && isNot) || (!result.pass && !isNot)) {
+        const message = getMessage(result.message);
+        let error;
+
+        if (err) {
+          error = err;
+          error.message = message;
+        } else if (asyncError) {
+          error = asyncError;
+          error.message = message;
+        } else {
+          error = new JestAssertionError(message);
+
+          if (Error.captureStackTrace)
+            Error.captureStackTrace(error, throwingMatcher);
+        }
+        error.matcherResult = { ...result, message };
+        throw error;
+      }
+    };
+
+    const handleError = (error: Error) => {
+      if (
+        matcher[INTERNAL_MATCHER_FLAG] === true &&
+        !(error instanceof JestAssertionError) &&
+        error.name !== 'PrettyFormatPluginError' &&
+        Error.captureStackTrace
+      )
+        Error.captureStackTrace(error, throwingMatcher);
+      throw error;
+    };
+
+    let potentialResult: ExpectationResult;
+
+    try {
+      potentialResult =
+        matcher[INTERNAL_MATCHER_FLAG] === true
+          ? matcher.call(matcherContext, actual, ...args)
+          : (function __EXTERNAL_MATCHER_TRAP__() {
+            return matcher.call(matcherContext, actual, ...args);
+          })();
+
+      if (isPromise(potentialResult)) {
+        const asyncError = new JestAssertionError();
+        if (Error.captureStackTrace)
+          Error.captureStackTrace(asyncError, throwingMatcher);
+
+        return potentialResult
+            .then(aResult => processResult(aResult, asyncError))
+            .catch(handleError);
+      }
+      return processResult(potentialResult);
+    } catch (error: any) {
+      return handleError(error);
+    }
+  };
+
+expectLibrary.extend = (matchers: MatchersObject) => setMatchers(matchers, false, expectLibrary);
+
+expectLibrary.anything = anything;
+expectLibrary.any = any;
+
+expectLibrary.not = {
+  arrayContaining: arrayNotContaining,
+  arrayOf: notArrayOf,
+  closeTo: notCloseTo,
+  objectContaining: objectNotContaining,
+  stringContaining: stringNotContaining,
+  stringMatching: stringNotMatching,
+};
+
+expectLibrary.arrayContaining = arrayContaining;
+expectLibrary.arrayOf = arrayOf;
+expectLibrary.closeTo = closeTo;
+expectLibrary.objectContaining = objectContaining;
+expectLibrary.stringContaining = stringContaining;
+expectLibrary.stringMatching = stringMatching;
+
+const _validateResult = (result: any) => {
+  if (
+    typeof result !== 'object' ||
+    typeof result.pass !== 'boolean' ||
+    (result.message &&
+      typeof result.message !== 'string' &&
+      typeof result.message !== 'function')
+  ) {
+    throw new Error(
+        'Unexpected return from a matcher function.\n' +
+        'Matcher functions should ' +
+        'return an object in the following format:\n' +
+        '  {message?: string | function, pass: boolean}\n' +
+        `'${stringify(result)}' was returned`,
+    );
+  }
+};
+
+// Register built-in matchers.
+setMatchers(builtinMatchers, true, expectLibrary);
+setMatchers(toThrowMatchers, true, expectLibrary);
+
+// #endregion
 
 export const expect: Expect<{}> = createExpect({}, [], {}).extend(customMatchers as any);
 

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -26,7 +26,6 @@ import {
   matcherHint,
   printReceived,
   printWithType,
-  stringify,
 } from 'jest-matcher-utils';
 
 import {
@@ -37,7 +36,9 @@ import {
   arrayNotContaining,
   arrayOf,
   closeTo,
-  createThrowMatcher,
+  getPromiseMatcher,
+  getMessage,
+  validateMatcherResult,
   isPromise,
   matchers as expectMatchers,
   notArrayOf,
@@ -51,7 +52,7 @@ import {
   toThrowMatchers,
   utils,
 } from './expectLibrary';
-import { ExpectError, isJestError } from './matcherHint';
+import { ExpectError } from './matcherHint';
 import {
   computeMatcherTitleSuffix,
   deadlineForMatcher,
@@ -88,7 +89,7 @@ import {
 import { toMatchAriaSnapshot } from './toMatchAriaSnapshot';
 import { toHaveScreenshot, toMatchSnapshot } from './toMatchSnapshot';
 
-import type { ExpectationResult, MatcherContext, MatchersObject, RawMatcherFn, SyncExpectationResult } from './expectLibrary';
+import type { MatcherContext, MatchersObject, RawMatcherFn, SyncExpectationResult } from './expectLibrary';
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
@@ -178,30 +179,6 @@ type ExpectMetaInfo = {
 };
 
 const META_INFO = Symbol('expectMetaInfo');
-
-// Expect wraps matchers, so there is no way to pass this information to the raw Playwright matcher.
-// Rely on sync call sequence to seed each matcher call with the context.
-type MatcherCallContext = {
-  expectInfo: ExpectMetaInfo;
-  testInfo: ExpectTestInfo | null;
-  step?: ExpectStepInfo;
-};
-
-let matcherCallContext: MatcherCallContext | undefined;
-
-function setMatcherCallContext(context: MatcherCallContext) {
-  matcherCallContext = context;
-}
-
-function takeMatcherCallContext(): MatcherCallContext | undefined {
-  try {
-    return matcherCallContext;
-  } finally {
-    // Any subsequent matcher following the first is assumed to be an unsupported legacy asymmetric matcher.
-    // Lacking call context in these scenarios is not particularly important.
-    matcherCallContext = undefined;
-  }
-}
 
 const defaultExpectTimeout = 5000;
 
@@ -384,20 +361,19 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
     Object.defineProperty(result, 'rejects', { get: () => throwUnsupported('rejects'), enumerable: true });
   }
 
-  const err = new JestAssertionError();
   const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
 
   const addMatcher = (name: string, matcher: RawMatcherFn) => {
     const promiseMatcher = getPromiseMatcher(name) || matcher;
 
-    result[name] = wrapMatcherCall(name, info, actual, makeThrowingMatcher(matcher, false, '', actual));
-    result.not[name] = wrapMatcherCall(name, notInfo, actual, makeThrowingMatcher(matcher, true, '', actual));
+    result[name] = wrapMatcherCall(name, info, actual, matcher);
+    result.not[name] = wrapMatcherCall(name, notInfo, actual, matcher);
 
     if (!info.poll) {
-      result.resolves[name] = wrapMatcherCall(name, info, actual, makeResolveMatcher(name, promiseMatcher, false, actual as any, err));
-      result.resolves.not[name] = wrapMatcherCall(name, notInfo, actual, makeResolveMatcher(name, promiseMatcher, true, actual as any, err));
-      result.rejects[name] = wrapMatcherCall(name, info, actual, makeRejectMatcher(name, promiseMatcher, false, actual as any, err));
-      result.rejects.not[name] = wrapMatcherCall(name, notInfo, actual, makeRejectMatcher(name, promiseMatcher, true, actual as any, err));
+      result.resolves[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'resolves');
+      result.resolves.not[name] = wrapMatcherCall(name, notInfo, actual, promiseMatcher, 'resolves');
+      result.rejects[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'rejects');
+      result.rejects.not[name] = wrapMatcherCall(name, notInfo, actual, promiseMatcher, 'rejects');
     }
   };
 
@@ -409,19 +385,9 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
   return result;
 }
 
-function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcherImpl: (...args: any[]) => any) {
+function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, promise?: 'resolves' | 'rejects') {
   return (...args: any[]) => {
-    if (info.poll) {
-      if ((customAsyncMatchers as any)[matcherName] || matcherName === 'resolves' || matcherName === 'rejects')
-        throw new Error(`\`expect.poll()\` does not support "${matcherName}" matcher.`);
-      matcherImpl = (...args: any[]) => pollMatcher(matcherName, info, ...args);
-    }
-
     const testInfo = expectConfig().testInfo;
-    setMatcherCallContext({ expectInfo: info, testInfo });
-    if (!testInfo)
-      return matcherImpl(...args);
-
     const customMessage = info.message || '';
     const suffixes = computeMatcherTitleSuffix(matcherName, actual, args);
     const defaultTitle = `${info.poll ? 'poll ' : ''}${info.isSoft ? 'soft ' : ''}${info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
@@ -435,7 +401,7 @@ function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unkn
 
     // toPass and poll matchers can contain other steps, expects and API calls,
     // so they behave like a retriable step.
-    const stepInfo = {
+    const stepData = {
       category: 'expect' as const,
       apiName,
       title: longTitle,
@@ -444,278 +410,143 @@ function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unkn
       infectParentStepsWithError: info.isSoft,
     };
 
-    const step = testInfo._addStep(stepInfo);
+    const step = testInfo?._addStep(stepData);
 
-    const reportStepError = (e: Error | unknown) => {
-      const jestError = isJestError(e) ? e : null;
-      const expectError = jestError ? new ExpectError(jestError, customMessage, stackFrames) : undefined;
-      if (jestError?.matcherResult.suggestedRebaseline) {
-        // NOTE: this is a workaround for the fact that we can't pass the suggested rebaseline
-        // for passing matchers. See toMatchAriaSnapshot for a counterpart.
-        step.complete({ suggestedRebaseline: jestError?.matcherResult.suggestedRebaseline });
-        return;
-      }
-
-      const error = expectError ?? e;
-      step.complete({ error });
-
-      if (info.isSoft)
+    const reportStepError = (error: Error | unknown) => {
+      step?.complete({ error });
+      if (info.isSoft && testInfo)
         testInfo._failWithError(error);
       else
         throw error;
     };
 
-    const finalizer = () => {
-      step.complete({});
+    const finalizer = (result: SyncExpectationResult & { suggestedRebaseline?: string }) => {
+      validateMatcherResult(result);
+      if (result.pass === !!info.isNot) {
+        const withMessage = { ...result, name: matcherName, message: getMessage(result.message) };
+        reportStepError(new ExpectError(withMessage, customMessage, stackFrames));
+      } else {
+        step?.complete({ suggestedRebaseline: result.suggestedRebaseline });
+      }
     };
 
     try {
-      setMatcherCallContext({ expectInfo: info, testInfo, step: step.info });
-      const callback = () => matcherImpl(...args);
-      const result = currentZone().with('stepZone', step).run(callback);
+      const invoke = () => info.poll
+        ? pollMatcher(matcherName, info, matcher, actual, args, promise, step?.info)
+        : invokeMatcher(matcherName, info, matcher, actual, args, promise, step?.info);
+      const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
       if (result instanceof Promise)
         return result.then(finalizer).catch(reportStepError);
-      finalizer();
-      return result;
+      finalizer(result);
     } catch (e) {
       void reportStepError(e);
     }
   };
 }
 
-async function pollMatcher(matcherName: string, info: ExpectMetaInfo, ...args: any[]) {
+function invokeMatcher(
+  matcherName: string,
+  info: ExpectMetaInfo,
+  matcher: RawMatcherFn,
+  actual: unknown,
+  args: any[],
+  promise: 'resolves' | 'rejects' | undefined,
+  stepInfo: ExpectStepInfo | undefined,
+): SyncExpectationResult | Promise<SyncExpectationResult> {
+  const isNot = !!info.isNot;
+  const matcherHintOptions = { isNot, promise: promise ?? '' };
+  const timeout = info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
+  const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
+    customTesters: [],
+    isNot,
+    promise: promise ?? '',
+    utils,
+    timeout,
+    _stepInfo: stepInfo,
+    equals: throwUnsupportedExpectMatcherError as any,
+  };
+
+  if (promise) {
+    if (typeof actual === 'function')
+      actual = actual();
+
+    if (!isPromise(actual)) {
+      return {
+        pass: false,
+        message: () => matcherErrorMessage(
+            matcherHint(matcherName, undefined, '', matcherHintOptions),
+            `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+            printWithType('Received', actual, printReceived),
+        ),
+      };
+    }
+
+    if (promise === 'resolves') {
+      return actual.then(
+          result => matcher.call(matcherContext, result, ...args),
+          error => ({
+            pass: false,
+            message: () => `${matcherHint(matcherName, undefined, '', matcherHintOptions)}\n\n` +
+              'Received promise rejected instead of resolved\n' +
+              `Rejected to value: ${printReceived(error)}`,
+          }),
+      );
+    }
+
+    return actual.then(
+        result => ({
+          pass: false,
+          message: () => `${matcherHint(matcherName, undefined, '', matcherHintOptions)}\n\n` +
+            'Received promise resolved instead of rejected\n' +
+            `Resolved to value: ${printReceived(result)}`,
+        }),
+        error => matcher.call(matcherContext, error, ...args),
+    );
+  }
+
+  return matcher.call(matcherContext, actual, ...args);
+}
+
+async function pollMatcher(
+  matcherName: string,
+  info: ExpectMetaInfo,
+  matcher: RawMatcherFn,
+  actual: unknown,
+  args: any[],
+  promise: 'resolves' | 'rejects' | undefined,
+  stepInfo: ExpectStepInfo | undefined,
+): Promise<SyncExpectationResult> {
+  if (promise || (customAsyncMatchers as any)[matcherName])
+    throw new Error(`\`expect.poll()\` does not support "${promise ?? matcherName}" matcher.`);
+
   const testInfo = expectConfig().testInfo;
   const poll = info.poll!;
   const timeout = poll.timeout ?? info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
   const { deadline, timeoutMessage } = deadlineForMatcher(testInfo, timeout);
 
-  const result = await pollAgainstDeadline<Error|undefined>(async () => {
+  const polled = await pollAgainstDeadline<SyncExpectationResult | undefined>(async () => {
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
 
-    // Inner matchers run without poll and without soft (soft is outside of poll, not inside).
-    // Strip isNot here and route to the .not branch below so step title matches.
-    const effectiveIsNot = !!info.isNot;
-    const innerInfo: ExpectMetaInfo = {
-      ...info,
-      isNot: false,
-      isSoft: false,
-      poll: undefined,
-    };
     const value = await poll.generator();
-    try {
-      const matchers = createMatchers(value, innerInfo);
-      if (effectiveIsNot)
-        matchers.not[matcherName](...args);
-      else
-        matchers[matcherName](...args);
-      return { continuePolling: false, result: undefined };
-    } catch (error) {
-      return { continuePolling: true, result: error };
-    }
+    const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined, stepInfo);
+    if (result.pass === !info.isNot)
+      return { continuePolling: false, result };
+    return { continuePolling: true, result };
   }, deadline, poll.intervals ?? [100, 250, 500, 1000]);
 
-  if (result.timedOut) {
-    const message = result.result ? [
-      result.result.message,
+  const result = polled.result ?? { pass: !!info.isNot, message: () => '' };
+  if (polled.timedOut) {
+    const message = polled.result ? [
+      getMessage(polled.result.message),
       '',
       `Call Log:`,
       `- ${timeoutMessage}`,
     ].join('\n') : timeoutMessage;
-
-    throw new Error(message);
+    result.message = () => message;
   }
+  return result;
 }
-
-// #region
-// Based on https://github.com/jestjs/jest/tree/v30.2.0/packages/expect
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found here
- * https://github.com/jestjs/jest/blob/v30.2.0/LICENSE
- */
-
-type ThrowingMatcherFn = (...args: Array<any>) => any;
-type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
-
-class JestAssertionError extends Error {
-  matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
-}
-
-const getPromiseMatcher = (name: string) => {
-  if (name === 'toThrow')
-    return createThrowMatcher(name, true);
-  return null;
-};
-
-const getMessage = (message?: () => string) =>
-  (message && message()) ||
-  RECEIVED_COLOR('No message was specified for this matcher.');
-
-const makeResolveMatcher = (
-  matcherName: string,
-  matcher: RawMatcherFn,
-  isNot: boolean,
-  actual: Promise<any> | (() => Promise<any>),
-  outerErr: JestAssertionError,
-): PromiseMatcherFn =>
-  (...args: Array<any>) => {
-    const options = { isNot, promise: 'resolves' };
-
-    const actualWrapper: Promise<any> =
-      typeof actual === 'function' ? actual() : actual;
-
-    if (!isPromise(actualWrapper)) {
-      throw new JestAssertionError(
-          matcherErrorMessage(
-              matcherHint(matcherName, undefined, '', options),
-              `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-              printWithType('Received', actual, printReceived),
-          ),
-      );
-    }
-
-    const innerErr = new JestAssertionError();
-
-    return actualWrapper.then(
-        result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
-        error => {
-          outerErr.message =
-            `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-            'Received promise rejected instead of resolved\n' +
-            `Rejected to value: ${printReceived(error)}`;
-          throw outerErr;
-        },
-    );
-  };
-
-const makeRejectMatcher = (
-  matcherName: string,
-  matcher: RawMatcherFn,
-  isNot: boolean,
-  actual: Promise<any> | (() => Promise<any>),
-  outerErr: JestAssertionError,
-): PromiseMatcherFn =>
-  (...args: Array<any>) => {
-    const options = { isNot, promise: 'rejects' };
-
-    const actualWrapper: Promise<any> =
-      typeof actual === 'function' ? actual() : actual;
-
-    if (!isPromise(actualWrapper)) {
-      throw new JestAssertionError(
-          matcherErrorMessage(
-              matcherHint(matcherName, undefined, '', options),
-              `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-              printWithType('Received', actual, printReceived),
-          ),
-      );
-    }
-
-    const innerErr = new JestAssertionError();
-
-    return actualWrapper.then(
-        result => {
-          outerErr.message =
-            `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-            'Received promise resolved instead of rejected\n' +
-            `Resolved to value: ${printReceived(result)}`;
-          throw outerErr;
-        },
-        error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
-    );
-  };
-
-const makeThrowingMatcher = (
-  matcher: RawMatcherFn,
-  isNot: boolean,
-  promise: string,
-  actual: any,
-  err?: JestAssertionError,
-): ThrowingMatcherFn =>
-  function throwingMatcher(this: void, ...args: Array<any>): any {
-    const callContext = takeMatcherCallContext();
-    const timeout = callContext?.expectInfo.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
-    const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
-      customTesters: [],
-      isNot,
-      promise: promise as any,
-      utils,
-      error: err,
-      timeout,
-      _stepInfo: callContext?.step,
-      equals: throwUnsupportedExpectMatcherError as any,
-    };
-
-    const processResult = (
-      result: SyncExpectationResult,
-      asyncError?: JestAssertionError,
-    ) => {
-      _validateResult(result);
-
-      if ((result.pass && isNot) || (!result.pass && !isNot)) {
-        const message = getMessage(result.message);
-        let error;
-
-        if (err) {
-          error = err;
-          error.message = message;
-        } else if (asyncError) {
-          error = asyncError;
-          error.message = message;
-        } else {
-          error = new JestAssertionError(message);
-
-          if (Error.captureStackTrace)
-            Error.captureStackTrace(error, throwingMatcher);
-        }
-        error.matcherResult = { ...result, message };
-        throw error;
-      }
-    };
-
-    const handleError = (error: Error) => {
-      throw error;
-    };
-
-    try {
-      const potentialResult: ExpectationResult = matcher.call(matcherContext, actual, ...args);
-
-      if (isPromise(potentialResult)) {
-        const asyncError = new JestAssertionError();
-        if (Error.captureStackTrace)
-          Error.captureStackTrace(asyncError, throwingMatcher);
-
-        return potentialResult
-            .then(aResult => processResult(aResult, asyncError))
-            .catch(handleError);
-      }
-      return processResult(potentialResult);
-    } catch (error: any) {
-      return handleError(error);
-    }
-  };
-
-const _validateResult = (result: any) => {
-  if (
-    typeof result !== 'object' ||
-    typeof result.pass !== 'boolean' ||
-    (result.message &&
-      typeof result.message !== 'string' &&
-      typeof result.message !== 'function')
-  ) {
-    throw new Error(
-        'Unexpected return from a matcher function.\n' +
-        'Matcher functions should ' +
-        'return an object in the following format:\n' +
-        '  {message?: string | function, pass: boolean}\n' +
-        `'${stringify(result)}' was returned`,
-    );
-  }
-};
-
-// #endregion
 
 export const expect: Expect<{}> = createExpect({ userMatchers: {} });
 

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -91,7 +91,13 @@ import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
 
 interface ExpectStep {
-  complete(result: { error?: Error | unknown, suggestedRebaseline?: string, attachments?: MatcherAttachment[] }): void;
+  complete(result: {
+    error?: Error | unknown,
+    softError?: Error | unknown,
+    shouldNotRetryTest?: boolean,
+    suggestedRebaseline?: string,
+    attachments?: MatcherAttachment[],
+  }): void;
 }
 
 export interface ExpectTestInfo {
@@ -104,7 +110,6 @@ export interface ExpectTestInfo {
     infectParentStepsWithError?: boolean;
   }): ExpectStep;
   _deadline(): { deadline: number; timeout: number };
-  _failWithError(error: Error | unknown, shouldNotRetry?: 'shouldNotRetry'): void;
   _resolveSnapshotPaths(kind: 'snapshot' | 'screenshot' | 'aria', name: string | string[] | undefined, updateSnapshotIndex: 'updateSnapshotIndex' | 'dontUpdateSnapshotIndex', anonymousExtension?: string): { absoluteSnapshotPath: string; relativeOutputPath: string };
   _getOutputPath(...pathSegments: string[]): string;
 }
@@ -338,20 +343,21 @@ function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown,
     const step = testInfo?._addStep(stepData);
 
     const reportStepError = (stepResult: Parameters<ExpectStep['complete']>[0]) => {
-      step?.complete(stepResult);
-      if (info.isSoft && testInfo)
-        testInfo._failWithError(stepResult.error);
-      else
+      if (info.isSoft && step) {
+        step.complete({ ...stepResult, error: undefined, softError: stepResult.error });
+      } else {
+        step?.complete(stepResult);
         throw stepResult.error;
+      }
     };
 
     const finalizer = (result: MatcherResult) => {
       validateMatcherResult(result);
       if (result.pass === !!info.isNot) {
         const error = new ExpectError({ ...result, name: matcherName, message: getMessage(result.message) }, customMessage, stackFrames);
-        reportStepError({ error, suggestedRebaseline: result.suggestedRebaseline, attachments: result.attachments });
+        reportStepError({ ...result, error });
       } else {
-        step?.complete({ suggestedRebaseline: result.suggestedRebaseline, attachments: result.attachments });
+        step?.complete(result);
       }
     };
 
@@ -364,7 +370,7 @@ function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown,
         return result.then(finalizer).catch(error => reportStepError({ error }));
       finalizer(result);
     } catch (error) {
-      void reportStepError({ error });
+      reportStepError({ error });
     }
   };
 }

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -29,14 +29,14 @@ import {
 } from 'jest-matcher-utils';
 
 import {
-  AsymmetricMatcher,
   any,
   anything,
   arrayContaining,
   arrayNotContaining,
   arrayOf,
+  buildCustomAsymmetricMatcher,
   closeTo,
-  getPromiseMatcher,
+  createThrowMatcher,
   getMessage,
   validateMatcherResult,
   isPromise,
@@ -49,7 +49,6 @@ import {
   stringMatching,
   stringNotContaining,
   stringNotMatching,
-  toThrowMatchers,
   utils,
 } from './expectLibrary';
 import { ExpectError } from './matcherHint';
@@ -220,39 +219,18 @@ const customAsyncMatchers = {
   toPass,
 };
 
-const allBuiltinMatchers: MatchersObject = { ...expectMatchers, ...toThrowMatchers, ...customAsyncMatchers, toMatchSnapshot } as any;
+const allBuiltinMatchers: MatchersObject = {
+  ...expectMatchers,
+  toThrow: createThrowMatcher('toThrow'),
+  toThrowError: createThrowMatcher('toThrowError'),
+  ...customAsyncMatchers,
+  toMatchSnapshot,
+} as any;
 
-function buildCustomAsymmetricMatcher(matcherName: string, matcher: RawMatcherFn) {
-  class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
-    constructor(inverse: boolean = false, ...sample: [unknown, ...Array<unknown>]) {
-      super(sample, inverse);
-    }
-
-    asymmetricMatch(other: unknown) {
-      const { pass } = matcher.call(
-          (this as any).getMatcherContext(),
-          other,
-          ...this.sample,
-      ) as SyncExpectationResult;
-      return this.inverse ? !pass : pass;
-    }
-
-    toString() {
-      return `${this.inverse ? 'not.' : ''}${matcherName}`;
-    }
-
-    override getExpectedType() {
-      return 'any';
-    }
-
-    override toAsymmetricMatcher() {
-      return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
-    }
-  }
-  const positive = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(false, ...sample);
-  const inverse = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(true, ...sample);
-  return { positive, inverse };
-}
+const promiseThrowMatchers: MatchersObject = {
+  toThrow: createThrowMatcher('toThrow', true),
+  toThrowError: createThrowMatcher('toThrowError', true),
+};
 
 function createExpect(info: ExpectMetaInfo): Expect<{}> {
   const expectFn: any = (actual: unknown, messageOrOptions?: ExpectMessage) => {
@@ -364,12 +342,10 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
   const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
 
   const addMatcher = (name: string, matcher: RawMatcherFn) => {
-    const promiseMatcher = getPromiseMatcher(name) || matcher;
-
     result[name] = wrapMatcherCall(name, info, actual, matcher);
     result.not[name] = wrapMatcherCall(name, notInfo, actual, matcher);
-
     if (!info.poll) {
+      const promiseMatcher = promiseThrowMatchers[name] ?? matcher;
       result.resolves[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'resolves');
       result.resolves.not[name] = wrapMatcherCall(name, notInfo, actual, promiseMatcher, 'resolves');
       result.rejects[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'rejects');
@@ -398,9 +374,6 @@ function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unkn
     // This looks like it is unnecessary, but it isn't - we need to filter
     // out all the frames that belong to the test runner from caught runtime errors.
     const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
-
-    // toPass and poll matchers can contain other steps, expects and API calls,
-    // so they behave like a retriable step.
     const stepData = {
       category: 'expect' as const,
       apiName,
@@ -409,7 +382,6 @@ function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unkn
       params: args[0] ? { expected: args[0] } : undefined,
       infectParentStepsWithError: info.isSoft,
     };
-
     const step = testInfo?._addStep(stepData);
 
     const reportStepError = (error: Error | unknown) => {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -84,19 +84,14 @@ import {
 import { toMatchAriaSnapshot } from './toMatchAriaSnapshot';
 import { toHaveScreenshot, toMatchSnapshot } from './toMatchSnapshot';
 
-import type { MatcherContext, MatchersObject, RawMatcherFn, SyncExpectationResult } from './expectLibrary';
+import type { MatcherContext, MatchersObject, RawMatcherFn } from './expectLibrary';
+import type { MatcherAttachment, MatcherResult } from './matcherHint';
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
 
-export interface ExpectStepInfo {
-  // !!! return attachments in MatcherResult instead and pass to step.complete()
-  _attachToStep(attachment: { name: string; contentType: string; path?: string; body?: string | Buffer }): void;
-}
-
 interface ExpectStep {
-  complete(result: { error?: Error | unknown, suggestedRebaseline?: string }): void;
-  info: ExpectStepInfo;
+  complete(result: { error?: Error | unknown, suggestedRebaseline?: string, attachments?: MatcherAttachment[] }): void;
 }
 
 export interface ExpectTestInfo {
@@ -342,34 +337,34 @@ function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown,
     };
     const step = testInfo?._addStep(stepData);
 
-    const reportStepError = (error: Error | unknown) => {
-      step?.complete({ error });
+    const reportStepError = (stepResult: Parameters<ExpectStep['complete']>[0]) => {
+      step?.complete(stepResult);
       if (info.isSoft && testInfo)
-        testInfo._failWithError(error);
+        testInfo._failWithError(stepResult.error);
       else
-        throw error;
+        throw stepResult.error;
     };
 
-    const finalizer = (result: SyncExpectationResult & { suggestedRebaseline?: string }) => {
+    const finalizer = (result: MatcherResult) => {
       validateMatcherResult(result);
       if (result.pass === !!info.isNot) {
-        const withMessage = { ...result, name: matcherName, message: getMessage(result.message) };
-        reportStepError(new ExpectError(withMessage, customMessage, stackFrames));
+        const error = new ExpectError({ ...result, name: matcherName, message: getMessage(result.message) }, customMessage, stackFrames);
+        reportStepError({ error, suggestedRebaseline: result.suggestedRebaseline, attachments: result.attachments });
       } else {
-        step?.complete({ suggestedRebaseline: result.suggestedRebaseline });
+        step?.complete({ suggestedRebaseline: result.suggestedRebaseline, attachments: result.attachments });
       }
     };
 
     try {
       const invoke = () => info.poll
-        ? invokePollMatcher(matcherName, info, matcher, actual, args, promise, step?.info)
-        : invokeMatcher(matcherName, info, matcher, actual, args, promise, step?.info);
+        ? invokePollMatcher(matcherName, info, matcher, actual, args, promise)
+        : invokeMatcher(matcherName, info, matcher, actual, args, promise);
       const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
       if (result instanceof Promise)
-        return result.then(finalizer).catch(reportStepError);
+        return result.then(finalizer).catch(error => reportStepError({ error }));
       finalizer(result);
-    } catch (e) {
-      void reportStepError(e);
+    } catch (error) {
+      void reportStepError({ error });
     }
   };
 }
@@ -381,8 +376,7 @@ function invokeMatcher(
   actual: unknown,
   args: any[],
   promise: 'resolves' | 'rejects' | undefined,
-  stepInfo: ExpectStepInfo | undefined,
-): SyncExpectationResult | Promise<SyncExpectationResult> {
+): MatcherResult | Promise<MatcherResult> {
   const isNot = !!info.isNot;
   const timeout = info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
   const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
@@ -391,12 +385,11 @@ function invokeMatcher(
     promise: promise ?? '',
     utils,
     timeout,
-    _stepInfo: stepInfo,
     equals: throwUnsupportedExpectMatcherError as any,
   };
 
   if (!promise)
-    return matcher.call(matcherContext, actual, ...args);
+    return matcher.call(matcherContext, actual, ...args) as MatcherResult | Promise<MatcherResult>;
 
   if (typeof actual === 'function')
     actual = actual();
@@ -405,13 +398,13 @@ function invokeMatcher(
 
   if (promise === 'resolves') {
     return actual.then(
-        result => matcher.call(matcherContext, result, ...args),
+        result => matcher.call(matcherContext, result, ...args) as MatcherResult | Promise<MatcherResult>,
         error => ({ pass: false, message: createExpectedToResolveMessage(matcherName, isNot, promise, error) }),
     );
   } else {
     return actual.then(
         result => ({ pass: false, message: createExpectedToRejectMessage(matcherName, isNot, promise, result) }),
-        error => matcher.call(matcherContext, error, ...args),
+        error => matcher.call(matcherContext, error, ...args) as MatcherResult | Promise<MatcherResult>,
     );
   }
 }
@@ -423,8 +416,7 @@ async function invokePollMatcher(
   actual: unknown,
   args: any[],
   promise: 'resolves' | 'rejects' | undefined,
-  stepInfo: ExpectStepInfo | undefined,
-): Promise<SyncExpectationResult> {
+): Promise<MatcherResult> {
   if (typeof actual !== 'function')
     throw new Error('`expect.poll()` accepts only function as a first argument');
   if (promise || (customAsyncMatchers as any)[matcherName])
@@ -435,11 +427,11 @@ async function invokePollMatcher(
   const timeout = poll.timeout ?? info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
   const { deadline, timeoutMessage } = deadlineForMatcher(testInfo, timeout);
 
-  const polled = await pollAgainstDeadline<SyncExpectationResult | undefined>(async () => {
+  const polled = await pollAgainstDeadline<MatcherResult<unknown, unknown> | undefined>(async () => {
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
     const value = await actual();
-    const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined, stepInfo);
+    const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined);
     if (result.pass === !info.isNot)
       return { continuePolling: false, result };
     return { continuePolling: true, result };

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -20,13 +20,6 @@ import { parseStackFrame, captureRawStack } from '@isomorphic/stackTrace';
 import { escapeWithQuotes, isString } from '@isomorphic/stringUtils';
 import { pollAgainstDeadline } from '@isomorphic/timeoutRunner';
 import { currentZone } from '@utils/zones';
-import {
-  RECEIVED_COLOR,
-  matcherErrorMessage,
-  matcherHint,
-  printReceived,
-  printWithType,
-} from 'jest-matcher-utils';
 
 import {
   any,
@@ -50,6 +43,9 @@ import {
   stringNotContaining,
   stringNotMatching,
   utils,
+  createExpectedPromiseMessage,
+  createExpectedToResolveMessage,
+  createExpectedToRejectMessage,
 } from './expectLibrary';
 import { ExpectError } from './matcherHint';
 import {
@@ -94,10 +90,11 @@ import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
 
 export interface ExpectStepInfo {
+  // !!! return attachments in MatcherResult instead and pass to step.complete()
   _attachToStep(attachment: { name: string; contentType: string; path?: string; body?: string | Buffer }): void;
 }
 
-export interface ExpectStep {
+interface ExpectStep {
   complete(result: { error?: Error | unknown, suggestedRebaseline?: string }): void;
   info: ExpectStepInfo;
 }
@@ -365,7 +362,7 @@ function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown,
 
     try {
       const invoke = () => info.poll
-        ? pollMatcher(matcherName, info, matcher, actual, args, promise, step?.info)
+        ? invokePollMatcher(matcherName, info, matcher, actual, args, promise, step?.info)
         : invokeMatcher(matcherName, info, matcher, actual, args, promise, step?.info);
       const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
       if (result instanceof Promise)
@@ -387,7 +384,6 @@ function invokeMatcher(
   stepInfo: ExpectStepInfo | undefined,
 ): SyncExpectationResult | Promise<SyncExpectationResult> {
   const isNot = !!info.isNot;
-  const matcherHintOptions = { isNot, promise: promise ?? '' };
   const timeout = info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
   const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
     customTesters: [],
@@ -399,48 +395,28 @@ function invokeMatcher(
     equals: throwUnsupportedExpectMatcherError as any,
   };
 
-  if (promise) {
-    if (typeof actual === 'function')
-      actual = actual();
+  if (!promise)
+    return matcher.call(matcherContext, actual, ...args);
 
-    if (!isPromise(actual)) {
-      return {
-        pass: false,
-        message: () => matcherErrorMessage(
-            matcherHint(matcherName, undefined, '', matcherHintOptions),
-            `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-            printWithType('Received', actual, printReceived),
-        ),
-      };
-    }
+  if (typeof actual === 'function')
+    actual = actual();
+  if (!isPromise(actual))
+    return { pass: false, message: createExpectedPromiseMessage(matcherName, isNot, promise, actual) };
 
-    if (promise === 'resolves') {
-      return actual.then(
-          result => matcher.call(matcherContext, result, ...args),
-          error => ({
-            pass: false,
-            message: () => `${matcherHint(matcherName, undefined, '', matcherHintOptions)}\n\n` +
-              'Received promise rejected instead of resolved\n' +
-              `Rejected to value: ${printReceived(error)}`,
-          }),
-      );
-    }
-
+  if (promise === 'resolves') {
     return actual.then(
-        result => ({
-          pass: false,
-          message: () => `${matcherHint(matcherName, undefined, '', matcherHintOptions)}\n\n` +
-            'Received promise resolved instead of rejected\n' +
-            `Resolved to value: ${printReceived(result)}`,
-        }),
+        result => matcher.call(matcherContext, result, ...args),
+        error => ({ pass: false, message: createExpectedToResolveMessage(matcherName, isNot, promise, error) }),
+    );
+  } else {
+    return actual.then(
+        result => ({ pass: false, message: createExpectedToRejectMessage(matcherName, isNot, promise, result) }),
         error => matcher.call(matcherContext, error, ...args),
     );
   }
-
-  return matcher.call(matcherContext, actual, ...args);
 }
 
-async function pollMatcher(
+async function invokePollMatcher(
   matcherName: string,
   info: ExpectMetaInfo,
   matcher: RawMatcherFn,
@@ -462,7 +438,6 @@ async function pollMatcher(
   const polled = await pollAgainstDeadline<SyncExpectationResult | undefined>(async () => {
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
-
     const value = await actual();
     const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined, stepInfo);
     if (result.pass === !info.isNot)

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -416,20 +416,6 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
     }
   }
 
-  // toThrowError is a legacy alias for toThrow.
-  const aliasToThrow = (obj: any) => {
-    if (obj && Object.prototype.hasOwnProperty.call(obj, 'toThrow'))
-      obj.toThrowError = obj.toThrow;
-  };
-  aliasToThrow(result);
-  aliasToThrow(result.not);
-  if (!info.poll) {
-    aliasToThrow(result.resolves);
-    aliasToThrow(result.resolves.not);
-    aliasToThrow(result.rejects);
-    aliasToThrow(result.rejects.not);
-  }
-
   return result;
 }
 

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -107,7 +107,6 @@ export interface ExpectTestInfo {
     title: string;
     shortTitle: string;
     params?: Record<string, any>;
-    infectParentStepsWithError?: boolean;
   }): ExpectStep;
   _deadline(): { deadline: number; timeout: number };
   _resolveSnapshotPaths(kind: 'snapshot' | 'screenshot' | 'aria', name: string | string[] | undefined, updateSnapshotIndex: 'updateSnapshotIndex' | 'dontUpdateSnapshotIndex', anonymousExtension?: string): { absoluteSnapshotPath: string; relativeOutputPath: string };
@@ -308,71 +307,72 @@ function createMatchers(actual: unknown, originalInfo: ExpectMetaInfo, messageOr
   const result: any = { not: {}, resolves: { not: {} }, rejects: { not: {} } };
   const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
   for (const [name, matcher] of Object.entries({ ...allBuiltinMatchers, ...info.userMatchers })) {
-    result[name] = wrapMatcher(name, info, actual, matcher);
-    result.not[name] = wrapMatcher(name, notInfo, actual, matcher);
+    result[name] = createMatcher(name, info, actual, matcher);
+    result.not[name] = createMatcher(name, notInfo, actual, matcher);
     const promiseMatcher = promiseThrowMatchers[name] ?? matcher;
-    result.resolves[name] = wrapMatcher(name, info, actual, promiseMatcher, 'resolves');
-    result.resolves.not[name] = wrapMatcher(name, notInfo, actual, promiseMatcher, 'resolves');
-    result.rejects[name] = wrapMatcher(name, info, actual, promiseMatcher, 'rejects');
-    result.rejects.not[name] = wrapMatcher(name, notInfo, actual, promiseMatcher, 'rejects');
+    result.resolves[name] = createMatcher(name, info, actual, promiseMatcher, 'resolves');
+    result.resolves.not[name] = createMatcher(name, notInfo, actual, promiseMatcher, 'resolves');
+    result.rejects[name] = createMatcher(name, info, actual, promiseMatcher, 'rejects');
+    result.rejects.not[name] = createMatcher(name, notInfo, actual, promiseMatcher, 'rejects');
   }
   return result;
 }
 
-function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, promise?: 'resolves' | 'rejects') {
-  return (...args: any[]) => {
-    const testInfo = expectConfig().testInfo;
-    const customMessage = info.message || '';
-    const suffixes = computeMatcherTitleSuffix(matcherName, actual, args);
-    const defaultTitle = `${info.poll ? 'poll ' : ''}${info.isSoft ? 'soft ' : ''}${info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
-    const shortTitle = customMessage || `Expect ${escapeWithQuotes(defaultTitle, '"')}`;
-    const longTitle = shortTitle + (suffixes.long || '');
-    const apiName = `expect${info.poll ? '.poll ' : ''}${info.isSoft ? '.soft ' : ''}${info.isNot ? '.not' : ''}.${matcherName}${suffixes.short || ''}`;
+function createMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, promise?: 'resolves' | 'rejects') {
+  return (...args: any[]) => callMatcherAsStep(matcherName, info, actual, matcher, args, promise);
+}
 
-    // This looks like it is unnecessary, but it isn't - we need to filter
-    // out all the frames that belong to the test runner from caught runtime errors.
-    const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
-    const stepData = {
-      category: 'expect' as const,
-      apiName,
-      title: longTitle,
-      shortTitle,
-      params: args[0] ? { expected: args[0] } : undefined,
-      infectParentStepsWithError: info.isSoft,
-    };
-    const step = testInfo?._addStep(stepData);
+function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, args: any[], promise?: 'resolves' | 'rejects') {
+  const testInfo = expectConfig().testInfo;
+  const customMessage = info.message || '';
+  const suffixes = computeMatcherTitleSuffix(matcherName, actual, args);
+  const defaultTitle = `${info.poll ? 'poll ' : ''}${info.isSoft ? 'soft ' : ''}${info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
+  const shortTitle = customMessage || `Expect ${escapeWithQuotes(defaultTitle, '"')}`;
+  const longTitle = shortTitle + (suffixes.long || '');
+  const apiName = `expect${info.poll ? '.poll ' : ''}${info.isSoft ? '.soft ' : ''}${info.isNot ? '.not' : ''}.${matcherName}${suffixes.short || ''}`;
 
-    const reportStepError = (stepResult: Parameters<ExpectStep['complete']>[0]) => {
-      if (info.isSoft && step) {
-        step.complete({ ...stepResult, error: undefined, softError: stepResult.error });
-      } else {
-        step?.complete(stepResult);
-        throw stepResult.error;
-      }
-    };
+  // This looks like it is unnecessary, but it isn't - we need to filter
+  // out all the frames that belong to the test runner from caught runtime errors.
+  const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
+  const stepData = {
+    category: 'expect' as const,
+    apiName,
+    title: longTitle,
+    shortTitle,
+    params: args[0] ? { expected: args[0] } : undefined,
+  };
+  const step = testInfo?._addStep(stepData);
 
-    const finalizer = (result: MatcherResult) => {
-      validateMatcherResult(result);
-      if (result.pass === !!info.isNot) {
-        const error = new ExpectError({ ...result, name: matcherName, message: getMessage(result.message) }, customMessage, stackFrames);
-        reportStepError({ ...result, error });
-      } else {
-        step?.complete(result);
-      }
-    };
-
-    try {
-      const invoke = () => info.poll
-        ? invokePollMatcher(matcherName, info, matcher, actual, args, promise)
-        : invokeMatcher(matcherName, info, matcher, actual, args, promise);
-      const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
-      if (result instanceof Promise)
-        return result.then(finalizer).catch(error => reportStepError({ error }));
-      finalizer(result);
-    } catch (error) {
-      reportStepError({ error });
+  const handleError = (error: Error, result?: MatcherResult) => {
+    if (info.isSoft && step) {
+      step.complete({ ...result, error, softError: error });
+    } else {
+      step?.complete({ ...result, error });
+      throw error;
     }
   };
+
+  const finalizer = (result: MatcherResult) => {
+    validateMatcherResult(result);
+    if (result.pass === !!info.isNot) {
+      const error = new ExpectError({ ...result, name: matcherName, message: getMessage(result.message) }, customMessage, stackFrames);
+      handleError(error, result);
+    } else {
+      step?.complete(result);
+    }
+  };
+
+  try {
+    const invoke = () => info.poll
+      ? invokePollMatcher(matcherName, info, matcher, actual, args, promise)
+      : invokeMatcher(matcherName, info, matcher, actual, args, promise);
+    const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
+    if (result instanceof Promise)
+      return result.then(finalizer, handleError);
+    finalizer(result);
+  } catch (error) {
+    handleError(error);
+  }
 }
 
 function invokeMatcher(
@@ -433,27 +433,27 @@ async function invokePollMatcher(
   const timeout = poll.timeout ?? info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
   const { deadline, timeoutMessage } = deadlineForMatcher(testInfo, timeout);
 
-  const polled = await pollAgainstDeadline<MatcherResult<unknown, unknown> | undefined>(async () => {
+  const result = await pollAgainstDeadline<Error | undefined>(async () => {
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
     const value = await actual();
-    const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined);
-    if (result.pass === !info.isNot)
-      return { continuePolling: false, result };
-    return { continuePolling: true, result };
+    try {
+      await callMatcherAsStep(matcherName, { ...info, poll: undefined, isSoft: false }, value, matcher, args);
+      return { continuePolling: false, result: undefined };
+    } catch (error) {
+      return { continuePolling: true, result: error };
+    }
   }, deadline, poll.intervals ?? [100, 250, 500, 1000]);
-
-  const result = polled.result ?? { pass: !!info.isNot, message: () => '' };
-  if (polled.timedOut) {
-    const message = polled.result ? [
-      getMessage(polled.result.message),
+  if (result.timedOut) {
+    const message = result.result ? [
+      result.result.message,
       '',
       `Call Log:`,
       `- ${timeoutMessage}`,
     ].join('\n') : timeoutMessage;
-    result.message = () => message;
+    return { pass: !!info.isNot, message: () => message };
   }
-  return result;
+  return { pass: !info.isNot, message: () => '' };
 }
 
 export const expect: Expect<{}> = createExpect({ userMatchers: {} });

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -31,7 +31,6 @@ import {
 
 import {
   AsymmetricMatcher,
-  INTERNAL_MATCHER_FLAG,
   any,
   anything,
   arrayContaining,
@@ -40,7 +39,7 @@ import {
   closeTo,
   createThrowMatcher,
   isPromise,
-  matchers as builtinMatchers,
+  matchers as expectMatchers,
   notArrayOf,
   notCloseTo,
   objectContaining,
@@ -175,8 +174,7 @@ type ExpectMetaInfo = {
     generator: PollGenerator;
   };
   timeout?: number;
-  allMatchers: MatchersObject;
-  userMatchers: Record<string, Function>;
+  userMatchers: MatchersObject;
 };
 
 const META_INFO = Symbol('expectMetaInfo');
@@ -245,10 +243,7 @@ const customAsyncMatchers = {
   toPass,
 };
 
-const customMatchers = {
-  ...customAsyncMatchers,
-  toMatchSnapshot,
-};
+const allBuiltinMatchers: MatchersObject = { ...expectMatchers, ...toThrowMatchers, ...customAsyncMatchers, toMatchSnapshot } as any;
 
 function buildCustomAsymmetricMatcher(matcherName: string, matcher: RawMatcherFn) {
   class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
@@ -315,9 +310,7 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
   };
   expectFn.not = notAsymmetric;
 
-  for (const [name, matcher] of Object.entries(info.allMatchers)) {
-    if ((matcher as any)[INTERNAL_MATCHER_FLAG])
-      continue;
+  for (const [name, matcher] of Object.entries(info.userMatchers)) {
     const { positive, inverse } = buildCustomAsymmetricMatcher(name, matcher);
     expectFn[name] = positive;
     notAsymmetric[name] = inverse;
@@ -354,21 +347,15 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
   };
 
   expectFn.extend = (matchers: MatchersObject) => {
-    const wrapped: MatchersObject = {};
     for (const [name, m] of Object.entries(matchers)) {
       if (typeof m !== 'function')
         throw new TypeError(`expect.extend: \`${name}\` is not a valid matcher. Must be a function, is "${typeof m}"`);
-      const fn = m as RawMatcherFn;
-      if (!Object.prototype.hasOwnProperty.call(fn, INTERNAL_MATCHER_FLAG))
-        Object.defineProperty(fn, INTERNAL_MATCHER_FLAG, { value: false });
-      wrapped[name] = fn;
     }
 
     // Legacy behavior: `expect.extend({...})` without capturing the return value
     // must make the new matchers available on the same expect instance.
-    Object.assign(info.allMatchers, wrapped);
     Object.assign(info.userMatchers, matchers);
-    for (const [name, matcher] of Object.entries(wrapped)) {
+    for (const [name, matcher] of Object.entries(matchers)) {
       const { positive, inverse } = buildCustomAsymmetricMatcher(name, matcher);
       expectFn[name] = positive;
       notAsymmetric[name] = inverse;
@@ -377,7 +364,6 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
 
     return createExpect({
       ...info,
-      allMatchers: { ...info.allMatchers, ...wrapped },
       userMatchers: { ...info.userMatchers, ...matchers },
     });
   };
@@ -401,8 +387,7 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
   const err = new JestAssertionError();
   const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
 
-  for (const name of Object.keys(info.allMatchers)) {
-    const matcher = info.allMatchers[name];
+  const addMatcher = (name: string, matcher: RawMatcherFn) => {
     const promiseMatcher = getPromiseMatcher(name) || matcher;
 
     result[name] = wrapMatcherCall(name, info, actual, makeThrowingMatcher(matcher, false, '', actual));
@@ -414,7 +399,12 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
       result.rejects[name] = wrapMatcherCall(name, info, actual, makeRejectMatcher(name, promiseMatcher, false, actual as any, err));
       result.rejects.not[name] = wrapMatcherCall(name, notInfo, actual, makeRejectMatcher(name, promiseMatcher, true, actual as any, err));
     }
-  }
+  };
+
+  for (const [name, matcher] of Object.entries(allBuiltinMatchers))
+    addMatcher(name, matcher);
+  for (const [name, matcher] of Object.entries(info.userMatchers))
+    addMatcher(name, matcher);
 
   return result;
 }
@@ -503,7 +493,6 @@ async function pollMatcher(matcherName: string, info: ExpectMetaInfo, ...args: a
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
 
-    // !!!
     // Inner matchers run without poll and without soft (soft is outside of poll, not inside).
     // Strip isNot here and route to the .not branch below so step title matches.
     const effectiveIsNot = !!info.isNot;
@@ -646,7 +635,6 @@ const makeThrowingMatcher = (
   err?: JestAssertionError,
 ): ThrowingMatcherFn =>
   function throwingMatcher(this: void, ...args: Array<any>): any {
-    const isInternal = matcher[INTERNAL_MATCHER_FLAG] === true;
     const callContext = takeMatcherCallContext();
     const timeout = callContext?.expectInfo.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
     const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
@@ -688,24 +676,11 @@ const makeThrowingMatcher = (
     };
 
     const handleError = (error: Error) => {
-      if (
-        isInternal &&
-        !(error instanceof JestAssertionError) &&
-        error.name !== 'PrettyFormatPluginError' &&
-        Error.captureStackTrace
-      )
-        Error.captureStackTrace(error, throwingMatcher);
       throw error;
     };
 
-    let potentialResult: ExpectationResult;
-
     try {
-      potentialResult = isInternal
-        ? matcher.call(matcherContext, actual, ...args)
-        : (function __EXTERNAL_MATCHER_TRAP__() {
-          return matcher.call(matcherContext, actual, ...args);
-        })();
+      const potentialResult: ExpectationResult = matcher.call(matcherContext, actual, ...args);
 
       if (isPromise(potentialResult)) {
         const asyncError = new JestAssertionError();
@@ -742,18 +717,7 @@ const _validateResult = (result: any) => {
 
 // #endregion
 
-// Stamp the vendored jest matchers as internal so makeThrowingMatcher handles them as built-ins.
-for (const m of Object.values(builtinMatchers))
-  Object.defineProperty(m, INTERNAL_MATCHER_FLAG, { value: true });
-for (const m of Object.values(toThrowMatchers))
-  Object.defineProperty(m, INTERNAL_MATCHER_FLAG, { value: true });
-
-const BASE_MATCHERS: MatchersObject = { ...builtinMatchers, ...toThrowMatchers };
-
-export const expect: Expect<{}> = createExpect({
-  allMatchers: { ...BASE_MATCHERS },
-  userMatchers: {},
-}).extend(customMatchers as any);
+export const expect: Expect<{}> = createExpect({ userMatchers: {} });
 
 export function mergeExpects(...expects: any[]) {
   let merged = expect;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -267,8 +267,6 @@ function throwUnsupportedExpectMatcherError() {
   throw new Error('It looks like you are using custom expect matchers that are not compatible with Playwright. See https://aka.ms/playwright/expect-compatibility');
 }
 
-expectLibrary.setState({ expand: false });
-
 const customAsyncMatchers = {
   toBeAttached,
   toBeChecked,

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -16,13 +16,13 @@
 
 import path from 'path';
 
-import {
-  expect as expectLibrary,
-} from 'expect';
 import { parseStackFrame, captureRawStack } from '@isomorphic/stackTrace';
 import { escapeWithQuotes, isString } from '@isomorphic/stringUtils';
 import { pollAgainstDeadline } from '@isomorphic/timeoutRunner';
 import { currentZone } from '@utils/zones';
+import {
+  expect as expectLibrary,
+} from './expectLibrary';
 
 import { ExpectError, isJestError } from './matcherHint';
 import {

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -94,6 +94,7 @@ import type { ExpectationResult, MatcherContext, MatchersObject, RawMatcherFn, S
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
+import { monotonicTime } from '@isomorphic/time';
 
 export interface ExpectStepInfo {
   _attachToStep(attachment: { name: string; contentType: string; path?: string; body?: string | Buffer }): void;
@@ -164,91 +165,23 @@ export function expectConfig(): ExpectConfig {
 
 type ExpectMessage = string | { message?: string };
 
-function createMatchers(actual: unknown, info: ExpectMetaInfo, prefix: string[]): any {
-  return new Proxy(expectLibrary(actual), new ExpectMetaInfoProxyHandler(actual, info, prefix));
-}
+type PollGenerator = () => any;
 
-const userMatchersSymbol = Symbol('userMatchers');
-
-function qualifiedMatcherName(qualifier: string[], matcherName: string) {
-  return qualifier.join(':') + '$' + matcherName;
-}
-
-let lastExtendId = 0;
-
-function createExpect(info: ExpectMetaInfo, prefix: string[], userMatchers: Record<string, Function>) {
-  const expectInstance: Expect<{}> = new Proxy(expectLibrary, {
-    apply: function(target: any, thisArg: any, argumentsList: [unknown, ExpectMessage?]) {
-      const [actual, messageOrOptions] = argumentsList;
-      const message = isString(messageOrOptions) ? messageOrOptions : messageOrOptions?.message || info.message;
-      const newInfo = { ...info, message };
-      if (newInfo.poll) {
-        if (typeof actual !== 'function')
-          throw new Error('`expect.poll()` accepts only function as a first argument');
-        newInfo.poll.generator = actual as any;
-      }
-      return createMatchers(actual, newInfo, prefix);
-    },
-
-    get: function(target: any, property: string | typeof userMatchersSymbol) {
-      if (property === 'configure')
-        return configure;
-
-      if (property === 'extend') {
-        return (matchers: any) => {
-          const qualifier = [...prefix, String(++lastExtendId)];
-
-          const wrappedMatchers: any = {};
-          for (const [name, matcher] of Object.entries(matchers)) {
-            wrappedMatchers[name] = wrapPlaywrightMatcherToPassNiceThis(matcher);
-            const key = qualifiedMatcherName(qualifier, name);
-            wrappedMatchers[key] = wrappedMatchers[name];
-            Object.defineProperty(wrappedMatchers[key], 'name', { value: name });
-          }
-          expectLibrary.extend(wrappedMatchers);
-          return createExpect(info, qualifier, { ...userMatchers, ...matchers });
-        };
-      }
-
-      if (property === 'soft') {
-        return (actual: unknown, messageOrOptions?: ExpectMessage) => {
-          return configure({ soft: true })(actual, messageOrOptions) as any;
-        };
-      }
-
-      if (property === userMatchersSymbol)
-        return userMatchers;
-
-      if (property === 'poll') {
-        return (actual: unknown, messageOrOptions?: ExpectMessage & { timeout?: number, intervals?: number[] }) => {
-          const poll = isString(messageOrOptions) ? {} : messageOrOptions || {};
-          return configure({ _poll: poll })(actual, messageOrOptions) as any;
-        };
-      }
-      return (expectLibrary as any)[property];
-    },
-  });
-
-  const configure = (configuration: { message?: string, timeout?: number, soft?: boolean, _poll?: boolean | { timeout?: number, intervals?: number[] } }) => {
-    const newInfo = { ...info };
-    if ('message' in configuration)
-      newInfo.message = configuration.message;
-    if ('timeout' in configuration)
-      newInfo.timeout = configuration.timeout;
-    if ('soft' in configuration)
-      newInfo.isSoft = configuration.soft;
-    if ('_poll' in configuration) {
-      newInfo.poll = configuration._poll ? { ...info.poll, generator: () => {} } : undefined;
-      if (typeof configuration._poll === 'object') {
-        newInfo.poll!.timeout = configuration._poll.timeout ?? newInfo.poll!.timeout;
-        newInfo.poll!.intervals = configuration._poll.intervals ?? newInfo.poll!.intervals;
-      }
-    }
-    return createExpect(newInfo, prefix, userMatchers);
+type ExpectMetaInfo = {
+  message?: string;
+  isNot?: boolean;
+  isSoft?: boolean;
+  poll?: {
+    timeout?: number;
+    intervals?: number[];
+    generator: PollGenerator;
   };
+  timeout?: number;
+  allMatchers: MatchersObject;
+  userMatchers: Record<string, Function>;
+};
 
-  return expectInstance;
-}
+const META_INFO = Symbol('expectMetaInfo');
 
 // Expect wraps matchers, so there is no way to pass this information to the raw Playwright matcher.
 // Rely on sync call sequence to seed each matcher call with the context.
@@ -276,6 +209,7 @@ function takeMatcherCallContext(): MatcherCallContext | undefined {
 
 const defaultExpectTimeout = 5000;
 
+// !!!
 function wrapPlaywrightMatcherToPassNiceThis(matcher: any) {
   return function(this: any, ...args: any[]) {
     const { isNot, promise, utils } = this;
@@ -336,129 +270,282 @@ const customMatchers = {
   toMatchSnapshot,
 };
 
-type Generator = () => any;
+function buildCustomAsymmetricMatcher(matcherName: string, matcher: RawMatcherFn) {
+  class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
+    constructor(inverse: boolean = false, ...sample: [unknown, ...Array<unknown>]) {
+      super(sample, inverse);
+    }
 
-type ExpectMetaInfo = {
-  message?: string;
-  isNot?: boolean;
-  isSoft?: boolean;
-  poll?: {
-    timeout?: number;
-    intervals?: number[];
-    generator: Generator;
-  };
-  timeout?: number;
-};
+    asymmetricMatch(other: unknown) {
+      const { pass } = matcher.call(
+          (this as any).getMatcherContext(),
+          other,
+          ...this.sample,
+      ) as SyncExpectationResult;
+      return this.inverse ? !pass : pass;
+    }
 
-class ExpectMetaInfoProxyHandler implements ProxyHandler<any> {
-  private _actual: any;
-  private _info: ExpectMetaInfo;
-  private _prefix: string[];
+    toString() {
+      return `${this.inverse ? 'not.' : ''}${matcherName}`;
+    }
 
-  constructor(actual: any, info: ExpectMetaInfo, prefix: string[]) {
-    this._actual = actual;
-    this._info = { ...info };
-    this._prefix = prefix;
+    override getExpectedType() {
+      return 'any';
+    }
+
+    override toAsymmetricMatcher() {
+      return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
+    }
   }
-
-  get(target: Object, matcherName: string | symbol, receiver: any): any {
-    if (matcherName === 'toThrowError')
-      matcherName = 'toThrow';
-    let matcher = Reflect.get(target, matcherName, receiver);
-    if (typeof matcherName !== 'string')
-      return matcher;
-
-    let resolvedMatcherName = matcherName;
-    for (let i = this._prefix.length; i > 0; i--) {
-      const qualifiedName = qualifiedMatcherName(this._prefix.slice(0, i), matcherName);
-      if (Reflect.has(target, qualifiedName)) {
-        matcher = Reflect.get(target, qualifiedName, receiver);
-        resolvedMatcherName = qualifiedName;
-        break;
-      }
-    }
-
-    if (matcher === undefined)
-      throw new Error(`expect: Property '${matcherName}' not found.`);
-    if (typeof matcher !== 'function') {
-      if (matcherName === 'not')
-        this._info.isNot = !this._info.isNot;
-      return new Proxy(matcher, this);
-    }
-    if (this._info.poll) {
-      if ((customAsyncMatchers as any)[matcherName] || matcherName === 'resolves' || matcherName === 'rejects')
-        throw new Error(`\`expect.poll()\` does not support "${matcherName}" matcher.`);
-      matcher = (...args: any[]) => pollMatcher(resolvedMatcherName, this._info, this._prefix, ...args);
-    }
-    return (...args: any[]) => {
-      const testInfo = expectConfig().testInfo;
-      setMatcherCallContext({ expectInfo: this._info, testInfo });
-      if (!testInfo)
-        return matcher.call(target, ...args);
-
-      const customMessage = this._info.message || '';
-      const suffixes = computeMatcherTitleSuffix(matcherName, this._actual, args);
-      const defaultTitle = `${this._info.poll ? 'poll ' : ''}${this._info.isSoft ? 'soft ' : ''}${this._info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
-      const shortTitle = customMessage || `Expect ${escapeWithQuotes(defaultTitle, '"')}`;
-      const longTitle = shortTitle + (suffixes.long || '');
-      const apiName = `expect${this._info.poll ? '.poll ' : ''}${this._info.isSoft ? '.soft ' : ''}${this._info.isNot ? '.not' : ''}.${matcherName}${suffixes.short || ''}`;
-
-      // This looks like it is unnecessary, but it isn't - we need to filter
-      // out all the frames that belong to the test runner from caught runtime errors.
-      const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
-
-      // toPass and poll matchers can contain other steps, expects and API calls,
-      // so they behave like a retriable step.
-      const stepInfo = {
-        category: 'expect' as const,
-        apiName,
-        title: longTitle,
-        shortTitle,
-        params: args[0] ? { expected: args[0] } : undefined,
-        infectParentStepsWithError: this._info.isSoft,
-      };
-
-      const step = testInfo._addStep(stepInfo);
-
-      const reportStepError = (e: Error | unknown) => {
-        const jestError = isJestError(e) ? e : null;
-        const expectError = jestError ? new ExpectError(jestError, customMessage, stackFrames) : undefined;
-        if (jestError?.matcherResult.suggestedRebaseline) {
-          // NOTE: this is a workaround for the fact that we can't pass the suggested rebaseline
-          // for passing matchers. See toMatchAriaSnapshot for a counterpart.
-          step.complete({ suggestedRebaseline: jestError?.matcherResult.suggestedRebaseline });
-          return;
-        }
-
-        const error = expectError ?? e;
-        step.complete({ error });
-
-        if (this._info.isSoft)
-          testInfo._failWithError(error);
-        else
-          throw error;
-      };
-
-      const finalizer = () => {
-        step.complete({});
-      };
-
-      try {
-        setMatcherCallContext({ expectInfo: this._info, testInfo, step: step.info });
-        const callback = () => matcher.call(target, ...args);
-        const result = currentZone().with('stepZone', step).run(callback);
-        if (result instanceof Promise)
-          return result.then(finalizer).catch(reportStepError);
-        finalizer();
-        return result;
-      } catch (e) {
-        void reportStepError(e);
-      }
-    };
-  }
+  const positive = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(false, ...sample);
+  const inverse = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(true, ...sample);
+  return { positive, inverse };
 }
 
-async function pollMatcher(qualifiedMatcherName: string, info: ExpectMetaInfo, prefix: string[], ...args: any[]) {
+function createExpect(info: ExpectMetaInfo): Expect<{}> {
+  const expectFn: any = (actual: unknown, messageOrOptions?: ExpectMessage) => {
+    const message = isString(messageOrOptions) ? messageOrOptions : messageOrOptions?.message || info.message;
+    const newInfo: ExpectMetaInfo = { ...info, message };
+    if (newInfo.poll) {
+      if (typeof actual !== 'function')
+        throw new Error('`expect.poll()` accepts only function as a first argument');
+      newInfo.poll = { ...newInfo.poll, generator: actual as PollGenerator };
+    }
+    return createMatchers(actual, newInfo);
+  };
+
+  Object.defineProperty(expectFn, META_INFO, { value: info });
+
+  expectFn.any = any;
+  expectFn.anything = anything;
+  expectFn.arrayContaining = arrayContaining;
+  expectFn.arrayOf = arrayOf;
+  expectFn.closeTo = closeTo;
+  expectFn.objectContaining = objectContaining;
+  expectFn.stringContaining = stringContaining;
+  expectFn.stringMatching = stringMatching;
+
+  const notAsymmetric: any = {
+    arrayContaining: arrayNotContaining,
+    arrayOf: notArrayOf,
+    closeTo: notCloseTo,
+    objectContaining: objectNotContaining,
+    stringContaining: stringNotContaining,
+    stringMatching: stringNotMatching,
+  };
+  expectFn.not = notAsymmetric;
+
+  for (const [name, matcher] of Object.entries(info.allMatchers)) {
+    if ((matcher as any)[INTERNAL_MATCHER_FLAG])
+      continue;
+    const { positive, inverse } = buildCustomAsymmetricMatcher(name, matcher);
+    expectFn[name] = positive;
+    notAsymmetric[name] = inverse;
+  }
+
+  expectFn.getState = () => ({});
+
+  const configure = (configuration: { message?: string, timeout?: number, soft?: boolean, _poll?: boolean | { timeout?: number, intervals?: number[] } }) => {
+    const newInfo: ExpectMetaInfo = { ...info };
+    if ('message' in configuration)
+      newInfo.message = configuration.message;
+    if ('timeout' in configuration)
+      newInfo.timeout = configuration.timeout;
+    if ('soft' in configuration)
+      newInfo.isSoft = configuration.soft;
+    if ('_poll' in configuration) {
+      newInfo.poll = configuration._poll ? { ...info.poll, generator: () => {} } : undefined;
+      if (typeof configuration._poll === 'object') {
+        newInfo.poll!.timeout = configuration._poll.timeout ?? newInfo.poll!.timeout;
+        newInfo.poll!.intervals = configuration._poll.intervals ?? newInfo.poll!.intervals;
+      }
+    }
+    return createExpect(newInfo);
+  };
+  expectFn.configure = configure;
+
+  expectFn.soft = (actual: unknown, messageOrOptions?: ExpectMessage) => {
+    return configure({ soft: true })(actual, messageOrOptions) as any;
+  };
+
+  expectFn.poll = (actual: unknown, messageOrOptions?: ExpectMessage & { timeout?: number, intervals?: number[] }) => {
+    const poll = isString(messageOrOptions) ? {} : messageOrOptions || {};
+    return configure({ _poll: poll })(actual, messageOrOptions) as any;
+  };
+
+  expectFn.extend = (matchers: MatchersObject) => {
+    const wrapped: MatchersObject = {};
+    for (const [name, m] of Object.entries(matchers)) {
+      if (typeof m !== 'function')
+        throw new TypeError(`expect.extend: \`${name}\` is not a valid matcher. Must be a function, is "${typeof m}"`);
+      const wrappedFn = wrapPlaywrightMatcherToPassNiceThis(m) as RawMatcherFn;
+      // !!!
+      Object.defineProperty(wrappedFn, INTERNAL_MATCHER_FLAG, { value: false });
+      wrapped[name] = wrappedFn;
+    }
+
+    // Legacy behavior: `expect.extend({...})` without capturing the return value
+    // must make the new matchers available on the same expect instance.
+    Object.assign(info.allMatchers, wrapped);
+    Object.assign(info.userMatchers, matchers);
+    for (const [name, matcher] of Object.entries(wrapped)) {
+      const { positive, inverse } = buildCustomAsymmetricMatcher(name, matcher);
+      expectFn[name] = positive;
+      notAsymmetric[name] = inverse;
+    }
+    // End of legacy behavior.
+
+    return createExpect({
+      ...info,
+      allMatchers: { ...info.allMatchers, ...wrapped },
+      userMatchers: { ...info.userMatchers, ...matchers },
+    });
+  };
+
+  return expectFn as Expect<{}>;
+}
+
+function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
+  const result: any = { not: {} };
+  if (!info.poll) {
+    result.resolves = { not: {} };
+    result.rejects = { not: {} };
+  } else {
+    const throwUnsupported = (name: 'resolves' | 'rejects') => {
+      throw new Error(`\`expect.poll()\` does not support "${name}" matcher.`);
+    };
+    Object.defineProperty(result, 'resolves', { get: () => throwUnsupported('resolves'), enumerable: true });
+    Object.defineProperty(result, 'rejects', { get: () => throwUnsupported('rejects'), enumerable: true });
+  }
+
+  const err = new JestAssertionError();
+  const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
+
+  for (const name of Object.keys(info.allMatchers)) {
+    const matcher = info.allMatchers[name];
+    const promiseMatcher = getPromiseMatcher(name) || matcher;
+
+    result[name] = wrapMatcherCall(name, info, actual, makeThrowingMatcher(matcher, false, '', actual));
+    result.not[name] = wrapMatcherCall(name, notInfo, actual, makeThrowingMatcher(matcher, true, '', actual));
+
+    if (!info.poll) {
+      result.resolves[name] = wrapMatcherCall(name, info, actual, makeResolveMatcher(name, promiseMatcher, false, actual as any, err));
+      result.resolves.not[name] = wrapMatcherCall(name, notInfo, actual, makeResolveMatcher(name, promiseMatcher, true, actual as any, err));
+      result.rejects[name] = wrapMatcherCall(name, info, actual, makeRejectMatcher(name, promiseMatcher, false, actual as any, err));
+      result.rejects.not[name] = wrapMatcherCall(name, notInfo, actual, makeRejectMatcher(name, promiseMatcher, true, actual as any, err));
+    }
+  }
+
+  // toThrowError is a legacy alias for toThrow.
+  const aliasToThrow = (obj: any) => {
+    if (obj && Object.prototype.hasOwnProperty.call(obj, 'toThrow'))
+      obj.toThrowError = obj.toThrow;
+  };
+  aliasToThrow(result);
+  aliasToThrow(result.not);
+  if (!info.poll) {
+    aliasToThrow(result.resolves);
+    aliasToThrow(result.resolves.not);
+    aliasToThrow(result.rejects);
+    aliasToThrow(result.rejects.not);
+  }
+
+  result.not = wrapUnknownMatcherProxy(result.not);
+  if (!info.poll) {
+    result.resolves.not = wrapUnknownMatcherProxy(result.resolves.not);
+    result.resolves = wrapUnknownMatcherProxy(result.resolves);
+    result.rejects.not = wrapUnknownMatcherProxy(result.rejects.not);
+    result.rejects = wrapUnknownMatcherProxy(result.rejects);
+  }
+  return wrapUnknownMatcherProxy(result);
+}
+
+// !!!
+function wrapUnknownMatcherProxy(obj: any): any {
+  return new Proxy(obj, {
+    get(target, prop, receiver) {
+      if (typeof prop !== 'string' || prop in target)
+        return Reflect.get(target, prop, receiver);
+      throw new Error(`expect: Property '${prop}' not found.`);
+    },
+  });
+}
+
+function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcherImpl: (...args: any[]) => any) {
+  return (...args: any[]) => {
+    if (info.poll) {
+      if ((customAsyncMatchers as any)[matcherName] || matcherName === 'resolves' || matcherName === 'rejects')
+        throw new Error(`\`expect.poll()\` does not support "${matcherName}" matcher.`);
+      matcherImpl = (...args: any[]) => pollMatcher(matcherName, info, ...args);
+    }
+
+    const testInfo = expectConfig().testInfo;
+    setMatcherCallContext({ expectInfo: info, testInfo });
+    if (!testInfo)
+      return matcherImpl(...args);
+
+    const customMessage = info.message || '';
+    const suffixes = computeMatcherTitleSuffix(matcherName, actual, args);
+    const defaultTitle = `${info.poll ? 'poll ' : ''}${info.isSoft ? 'soft ' : ''}${info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
+    const shortTitle = customMessage || `Expect ${escapeWithQuotes(defaultTitle, '"')}`;
+    const longTitle = shortTitle + (suffixes.long || '');
+    const apiName = `expect${info.poll ? '.poll ' : ''}${info.isSoft ? '.soft ' : ''}${info.isNot ? '.not' : ''}.${matcherName}${suffixes.short || ''}`;
+
+    // This looks like it is unnecessary, but it isn't - we need to filter
+    // out all the frames that belong to the test runner from caught runtime errors.
+    const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
+
+    // toPass and poll matchers can contain other steps, expects and API calls,
+    // so they behave like a retriable step.
+    const stepInfo = {
+      category: 'expect' as const,
+      apiName,
+      title: longTitle,
+      shortTitle,
+      params: args[0] ? { expected: args[0] } : undefined,
+      infectParentStepsWithError: info.isSoft,
+    };
+
+    const step = testInfo._addStep(stepInfo);
+
+    const reportStepError = (e: Error | unknown) => {
+      const jestError = isJestError(e) ? e : null;
+      const expectError = jestError ? new ExpectError(jestError, customMessage, stackFrames) : undefined;
+      if (jestError?.matcherResult.suggestedRebaseline) {
+        // NOTE: this is a workaround for the fact that we can't pass the suggested rebaseline
+        // for passing matchers. See toMatchAriaSnapshot for a counterpart.
+        step.complete({ suggestedRebaseline: jestError?.matcherResult.suggestedRebaseline });
+        return;
+      }
+
+      const error = expectError ?? e;
+      step.complete({ error });
+
+      if (info.isSoft)
+        testInfo._failWithError(error);
+      else
+        throw error;
+    };
+
+    const finalizer = () => {
+      step.complete({});
+    };
+
+    try {
+      setMatcherCallContext({ expectInfo: info, testInfo, step: step.info });
+      const callback = () => matcherImpl(...args);
+      const result = currentZone().with('stepZone', step).run(callback);
+      if (result instanceof Promise)
+        return result.then(finalizer).catch(reportStepError);
+      finalizer();
+      return result;
+    } catch (e) {
+      void reportStepError(e);
+    }
+  };
+}
+
+async function pollMatcher(matcherName: string, info: ExpectMetaInfo, ...args: any[]) {
   const testInfo = expectConfig().testInfo;
   const poll = info.poll!;
   const timeout = poll.timeout ?? info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
@@ -468,17 +555,23 @@ async function pollMatcher(qualifiedMatcherName: string, info: ExpectMetaInfo, p
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
 
+    // !!!
+    // Inner matchers run without poll and without soft (soft is outside of poll, not inside).
+    // Strip isNot here and route to the .not branch below so step title matches.
+    const effectiveIsNot = !!info.isNot;
     const innerInfo: ExpectMetaInfo = {
       ...info,
-      isSoft: false, // soft is outside of poll, not inside
+      isNot: false,
+      isSoft: false,
       poll: undefined,
     };
     const value = await poll.generator();
     try {
-      let matchers = createMatchers(value, innerInfo, prefix);
-      if (info.isNot)
-        matchers = matchers.not;
-      matchers[qualifiedMatcherName](...args);
+      const matchers = createMatchers(value, innerInfo);
+      if (effectiveIsNot)
+        matchers.not[matcherName](...args);
+      else
+        matchers[matcherName](...args);
       return { continuePolling: false, result: undefined };
     } catch (error) {
       return { continuePolling: true, result: error };
@@ -509,98 +602,9 @@ async function pollMatcher(qualifiedMatcherName: string, info: ExpectMetaInfo, p
 type ThrowingMatcherFn = (...args: Array<any>) => any;
 type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
 
-type AsymmetricMatchers = {
-  any(sample: unknown): AsymmetricMatcher<any>;
-  anything(): AsymmetricMatcher<any>;
-  arrayContaining(sample: Array<unknown>): AsymmetricMatcher<any>;
-  arrayOf(sample: unknown): AsymmetricMatcher<any>;
-  closeTo(sample: number, precision?: number): AsymmetricMatcher<any>;
-  objectContaining(sample: Record<string, unknown>): AsymmetricMatcher<any>;
-  stringContaining(sample: string): AsymmetricMatcher<any>;
-  stringMatching(sample: string | RegExp): AsymmetricMatcher<any>;
-};
-
-interface BaseExpect {
-  extend(matchers: MatchersObject): void;
-}
-
-type LibraryExpect = (<T = unknown>(actual: T) => any) &
-  BaseExpect &
-  AsymmetricMatchers & {
-    not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
-  };
-
 class JestAssertionError extends Error {
   matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
 }
-
-const allMatchers: MatchersObject = Object.create(null);
-
-const setMatchers = (
-  matchers: MatchersObject,
-  isInternal: boolean,
-  expect: LibraryExpect,
-): void => {
-  for (const key of Object.keys(matchers)) {
-    const matcher = matchers[key];
-
-    if (typeof matcher !== 'function')
-      throw new TypeError(`expect.extend: \`${key}\` is not a valid matcher. Must be a function, is "${typeof matcher}"`);
-
-    Object.defineProperty(matcher, INTERNAL_MATCHER_FLAG, {
-      value: isInternal,
-    });
-
-    if (!isInternal) {
-      // expect is defined
-
-      class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
-        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
-          super(sample, inverse);
-        }
-
-        asymmetricMatch(other: unknown) {
-          const { pass } = matcher.call(
-              this.getMatcherContext(),
-              other,
-              ...this.sample,
-          ) as SyncExpectationResult;
-
-          return this.inverse ? !pass : pass;
-        }
-
-        toString() {
-          return `${this.inverse ? 'not.' : ''}${key}`;
-        }
-
-        override getExpectedType() {
-          return 'any';
-        }
-
-        override toAsymmetricMatcher() {
-          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
-        }
-      }
-
-      Object.defineProperty(expect, key, {
-        configurable: true,
-        enumerable: true,
-        value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(false, ...sample),
-        writable: true,
-      });
-      Object.defineProperty(expect.not, key, {
-        configurable: true,
-        enumerable: true,
-        value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(true, ...sample),
-        writable: true,
-      });
-    }
-  }
-
-  Object.assign(allMatchers, matchers);
-};
 
 const getPromiseMatcher = (name: string) => {
   if (name === 'toThrow')
@@ -608,113 +612,83 @@ const getPromiseMatcher = (name: string) => {
   return null;
 };
 
-const expectLibrary: LibraryExpect = ((actual: any, ...rest: Array<any>) => {
-  if (rest.length > 0)
-    throw new Error('Expect takes at most one argument.');
-
-  const expectation: any = {
-    not: {},
-    rejects: { not: {} },
-    resolves: { not: {} },
-  };
-
-  const err = new JestAssertionError();
-
-  for (const name of Object.keys(allMatchers)) {
-    const matcher = allMatchers[name];
-    const promiseMatcher = getPromiseMatcher(name) || matcher;
-    expectation[name] = makeThrowingMatcher(matcher, false, '', actual);
-    expectation.not[name] = makeThrowingMatcher(matcher, true, '', actual);
-
-    expectation.resolves[name] = makeResolveMatcher(name, promiseMatcher, false, actual, err);
-    expectation.resolves.not[name] = makeResolveMatcher(name, promiseMatcher, true, actual, err);
-
-    expectation.rejects[name] = makeRejectMatcher(name, promiseMatcher, false, actual, err);
-    expectation.rejects.not[name] = makeRejectMatcher(name, promiseMatcher, true, actual, err);
-  }
-
-  return expectation;
-}) as LibraryExpect;
-
 const getMessage = (message?: () => string) =>
   (message && message()) ||
   RECEIVED_COLOR('No message was specified for this matcher.');
 
-const makeResolveMatcher =
-  (
-    matcherName: string,
-    matcher: RawMatcherFn,
-    isNot: boolean,
-    actual: Promise<any> | (() => Promise<any>),
-    outerErr: JestAssertionError,
-  ): PromiseMatcherFn =>
-    (...args: Array<any>) => {
-      const options = { isNot, promise: 'resolves' };
+const makeResolveMatcher = (
+  matcherName: string,
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  actual: Promise<any> | (() => Promise<any>),
+  outerErr: JestAssertionError,
+): PromiseMatcherFn =>
+  (...args: Array<any>) => {
+    const options = { isNot, promise: 'resolves' };
 
-      const actualWrapper: Promise<any> =
-        typeof actual === 'function' ? actual() : actual;
+    const actualWrapper: Promise<any> =
+      typeof actual === 'function' ? actual() : actual;
 
-      if (!isPromise(actualWrapper)) {
-        throw new JestAssertionError(
-            matcherErrorMessage(
-                matcherHint(matcherName, undefined, '', options),
-                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-                printWithType('Received', actual, printReceived),
-            ),
-        );
-      }
-
-      const innerErr = new JestAssertionError();
-
-      return actualWrapper.then(
-          result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
-          error => {
-            outerErr.message =
-              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-          'Received promise rejected instead of resolved\n' +
-          `Rejected to value: ${printReceived(error)}`;
-            throw outerErr;
-          },
+    if (!isPromise(actualWrapper)) {
+      throw new JestAssertionError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, '', options),
+              `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+              printWithType('Received', actual, printReceived),
+          ),
       );
-    };
+    }
 
-const makeRejectMatcher =
-  (
-    matcherName: string,
-    matcher: RawMatcherFn,
-    isNot: boolean,
-    actual: Promise<any> | (() => Promise<any>),
-    outerErr: JestAssertionError,
-  ): PromiseMatcherFn =>
-    (...args: Array<any>) => {
-      const options = { isNot, promise: 'rejects' };
+    const innerErr = new JestAssertionError();
 
-      const actualWrapper: Promise<any> =
-        typeof actual === 'function' ? actual() : actual;
+    return actualWrapper.then(
+        result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
+        error => {
+          outerErr.message =
+            `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+            'Received promise rejected instead of resolved\n' +
+            `Rejected to value: ${printReceived(error)}`;
+          throw outerErr;
+        },
+    );
+  };
 
-      if (!isPromise(actualWrapper)) {
-        throw new JestAssertionError(
-            matcherErrorMessage(
-                matcherHint(matcherName, undefined, '', options),
-                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-                printWithType('Received', actual, printReceived),
-            ),
-        );
-      }
+const makeRejectMatcher = (
+  matcherName: string,
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  actual: Promise<any> | (() => Promise<any>),
+  outerErr: JestAssertionError,
+): PromiseMatcherFn =>
+  (...args: Array<any>) => {
+    const options = { isNot, promise: 'rejects' };
 
-      const innerErr = new JestAssertionError();
+    const actualWrapper: Promise<any> =
+      typeof actual === 'function' ? actual() : actual;
 
-      return actualWrapper.then(
-          result => {
-            outerErr.message =
-              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-          'Received promise resolved instead of rejected\n' +
-          `Resolved to value: ${printReceived(result)}`;
-            throw outerErr;
-          },
-          error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
+    if (!isPromise(actualWrapper)) {
+      throw new JestAssertionError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, '', options),
+              `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+              printWithType('Received', actual, printReceived),
+          ),
       );
-    };
+    }
+
+    const innerErr = new JestAssertionError();
+
+    return actualWrapper.then(
+        result => {
+          outerErr.message =
+            `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+            'Received promise resolved instead of rejected\n' +
+            `Resolved to value: ${printReceived(result)}`;
+          throw outerErr;
+        },
+        error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
+    );
+  };
 
 const makeThrowingMatcher = (
   matcher: RawMatcherFn,
@@ -796,27 +770,6 @@ const makeThrowingMatcher = (
     }
   };
 
-expectLibrary.extend = (matchers: MatchersObject) => setMatchers(matchers, false, expectLibrary);
-
-expectLibrary.anything = anything;
-expectLibrary.any = any;
-
-expectLibrary.not = {
-  arrayContaining: arrayNotContaining,
-  arrayOf: notArrayOf,
-  closeTo: notCloseTo,
-  objectContaining: objectNotContaining,
-  stringContaining: stringNotContaining,
-  stringMatching: stringNotMatching,
-};
-
-expectLibrary.arrayContaining = arrayContaining;
-expectLibrary.arrayOf = arrayOf;
-expectLibrary.closeTo = closeTo;
-expectLibrary.objectContaining = objectContaining;
-expectLibrary.stringContaining = stringContaining;
-expectLibrary.stringMatching = stringMatching;
-
 const _validateResult = (result: any) => {
   if (
     typeof result !== 'object' ||
@@ -835,21 +788,28 @@ const _validateResult = (result: any) => {
   }
 };
 
-// Register built-in matchers.
-setMatchers(builtinMatchers, true, expectLibrary);
-setMatchers(toThrowMatchers, true, expectLibrary);
-
 // #endregion
 
-export const expect: Expect<{}> = createExpect({}, [], {}).extend(customMatchers as any);
+// Stamp the vendored jest matchers as internal so makeThrowingMatcher handles them as built-ins.
+for (const m of Object.values(builtinMatchers))
+  Object.defineProperty(m, INTERNAL_MATCHER_FLAG, { value: true });
+for (const m of Object.values(toThrowMatchers))
+  Object.defineProperty(m, INTERNAL_MATCHER_FLAG, { value: true });
+
+const BASE_MATCHERS: MatchersObject = { ...builtinMatchers, ...toThrowMatchers };
+
+export const expect: Expect<{}> = createExpect({
+  allMatchers: { ...BASE_MATCHERS },
+  userMatchers: {},
+}).extend(customMatchers as any);
 
 export function mergeExpects(...expects: any[]) {
   let merged = expect;
   for (const e of expects) {
-    const internals = e[userMatchersSymbol];
-    if (!internals) // non-playwright expects mutate the global expect, so we don't need to do anything special
+    const info: ExpectMetaInfo | undefined = e[META_INFO];
+    if (!info) // non-playwright expects mutate the global expect, so we don't need to do anything special
       continue;
-    merged = merged.extend(internals);
+    merged = merged.extend(info.userMatchers as any) as typeof merged;
   }
   return merged;
 }

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -16,7 +16,6 @@
 
 import path from 'path';
 
-import { equals } from '@jest/expect-utils';
 import { parseStackFrame, captureRawStack } from '@isomorphic/stackTrace';
 import { escapeWithQuotes, isString } from '@isomorphic/stringUtils';
 import { pollAgainstDeadline } from '@isomorphic/timeoutRunner';
@@ -94,7 +93,6 @@ import type { ExpectationResult, MatcherContext, MatchersObject, RawMatcherFn, S
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
 import type { StackFrame } from '@protocol/channels';
-import { monotonicTime } from '@isomorphic/time';
 
 export interface ExpectStepInfo {
   _attachToStep(attachment: { name: string; contentType: string; path?: string; body?: string | Buffer }): void;
@@ -208,24 +206,6 @@ function takeMatcherCallContext(): MatcherCallContext | undefined {
 }
 
 const defaultExpectTimeout = 5000;
-
-// !!!
-function wrapPlaywrightMatcherToPassNiceThis(matcher: any) {
-  return function(this: any, ...args: any[]) {
-    const { isNot, promise, utils } = this;
-    const context = takeMatcherCallContext();
-    const timeout = context?.expectInfo.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
-    const newThis: ExpectMatcherStateInternal = {
-      isNot,
-      promise,
-      utils,
-      timeout,
-      _stepInfo: context?.step,
-    };
-    (newThis as any).equals = throwUnsupportedExpectMatcherError;
-    return matcher.call(newThis, ...args);
-  };
-}
 
 function throwUnsupportedExpectMatcherError() {
   throw new Error('It looks like you are using custom expect matchers that are not compatible with Playwright. See https://aka.ms/playwright/expect-compatibility');
@@ -378,10 +358,10 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
     for (const [name, m] of Object.entries(matchers)) {
       if (typeof m !== 'function')
         throw new TypeError(`expect.extend: \`${name}\` is not a valid matcher. Must be a function, is "${typeof m}"`);
-      const wrappedFn = wrapPlaywrightMatcherToPassNiceThis(m) as RawMatcherFn;
-      // !!!
-      Object.defineProperty(wrappedFn, INTERNAL_MATCHER_FLAG, { value: false });
-      wrapped[name] = wrappedFn;
+      const fn = m as RawMatcherFn;
+      if (!Object.prototype.hasOwnProperty.call(fn, INTERNAL_MATCHER_FLAG))
+        Object.defineProperty(fn, INTERNAL_MATCHER_FLAG, { value: false });
+      wrapped[name] = fn;
     }
 
     // Legacy behavior: `expect.extend({...})` without capturing the return value
@@ -698,13 +678,18 @@ const makeThrowingMatcher = (
   err?: JestAssertionError,
 ): ThrowingMatcherFn =>
   function throwingMatcher(this: void, ...args: Array<any>): any {
-    const matcherContext: MatcherContext = {
+    const isInternal = matcher[INTERNAL_MATCHER_FLAG] === true;
+    const callContext = takeMatcherCallContext();
+    const timeout = callContext?.expectInfo.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
+    const matcherContext: MatcherContext & ExpectMatcherStateInternal = {
       customTesters: [],
-      equals,
+      isNot,
+      promise: promise as any,
       utils,
       error: err,
-      isNot,
-      promise,
+      timeout,
+      _stepInfo: callContext?.step,
+      equals: throwUnsupportedExpectMatcherError as any,
     };
 
     const processResult = (
@@ -736,7 +721,7 @@ const makeThrowingMatcher = (
 
     const handleError = (error: Error) => {
       if (
-        matcher[INTERNAL_MATCHER_FLAG] === true &&
+        isInternal &&
         !(error instanceof JestAssertionError) &&
         error.name !== 'PrettyFormatPluginError' &&
         Error.captureStackTrace
@@ -748,12 +733,11 @@ const makeThrowingMatcher = (
     let potentialResult: ExpectationResult;
 
     try {
-      potentialResult =
-        matcher[INTERNAL_MATCHER_FLAG] === true
-          ? matcher.call(matcherContext, actual, ...args)
-          : (function __EXTERNAL_MATCHER_TRAP__() {
-            return matcher.call(matcherContext, actual, ...args);
-          })();
+      potentialResult = isInternal
+        ? matcher.call(matcherContext, actual, ...args)
+        : (function __EXTERNAL_MATCHER_TRAP__() {
+          return matcher.call(matcherContext, actual, ...args);
+        })();
 
       if (isPromise(potentialResult)) {
         const asyncError = new JestAssertionError();

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -162,8 +162,6 @@ export function expectConfig(): ExpectConfig {
 
 type ExpectMessage = string | { message?: string };
 
-type PollGenerator = () => any;
-
 type ExpectMetaInfo = {
   message?: string;
   isNot?: boolean;
@@ -171,7 +169,6 @@ type ExpectMetaInfo = {
   poll?: {
     timeout?: number;
     intervals?: number[];
-    generator: PollGenerator;
   };
   timeout?: number;
   userMatchers: MatchersObject;
@@ -233,17 +230,7 @@ const promiseThrowMatchers: MatchersObject = {
 };
 
 function createExpect(info: ExpectMetaInfo): Expect<{}> {
-  const expectFn: any = (actual: unknown, messageOrOptions?: ExpectMessage) => {
-    const message = isString(messageOrOptions) ? messageOrOptions : messageOrOptions?.message || info.message;
-    const newInfo: ExpectMetaInfo = { ...info, message };
-    if (newInfo.poll) {
-      if (typeof actual !== 'function')
-        throw new Error('`expect.poll()` accepts only function as a first argument');
-      newInfo.poll = { ...newInfo.poll, generator: actual as PollGenerator };
-    }
-    return createMatchers(actual, newInfo);
-  };
-
+  const expectFn: any = (actual: unknown, messageOrOptions?: ExpectMessage) => createMatchers(actual, info, messageOrOptions);
   Object.defineProperty(expectFn, META_INFO, { value: info });
 
   expectFn.any = any;
@@ -273,7 +260,7 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
 
   expectFn.getState = () => ({});
 
-  const configure = (configuration: { message?: string, timeout?: number, soft?: boolean, _poll?: boolean | { timeout?: number, intervals?: number[] } }) => {
+  expectFn.configure = (configuration: { message?: string, timeout?: number, soft?: boolean }) => {
     const newInfo: ExpectMetaInfo = { ...info };
     if ('message' in configuration)
       newInfo.message = configuration.message;
@@ -281,24 +268,16 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
       newInfo.timeout = configuration.timeout;
     if ('soft' in configuration)
       newInfo.isSoft = configuration.soft;
-    if ('_poll' in configuration) {
-      newInfo.poll = configuration._poll ? { ...info.poll, generator: () => {} } : undefined;
-      if (typeof configuration._poll === 'object') {
-        newInfo.poll!.timeout = configuration._poll.timeout ?? newInfo.poll!.timeout;
-        newInfo.poll!.intervals = configuration._poll.intervals ?? newInfo.poll!.intervals;
-      }
-    }
     return createExpect(newInfo);
   };
-  expectFn.configure = configure;
 
   expectFn.soft = (actual: unknown, messageOrOptions?: ExpectMessage) => {
-    return configure({ soft: true })(actual, messageOrOptions) as any;
+    return createMatchers(actual, { ... info, isSoft: true }, messageOrOptions);
   };
 
   expectFn.poll = (actual: unknown, messageOrOptions?: ExpectMessage & { timeout?: number, intervals?: number[] }) => {
     const poll = isString(messageOrOptions) ? {} : messageOrOptions || {};
-    return configure({ _poll: poll })(actual, messageOrOptions) as any;
+    return createMatchers(actual, { ...info, poll: { timeout: poll.timeout, intervals: poll.intervals } }, messageOrOptions);
   };
 
   expectFn.extend = (matchers: MatchersObject) => {
@@ -326,42 +305,24 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
   return expectFn as Expect<{}>;
 }
 
-function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
-  const result: any = { not: {} };
-  if (!info.poll) {
-    result.resolves = { not: {} };
-    result.rejects = { not: {} };
-  } else {
-    const throwUnsupported = (name: 'resolves' | 'rejects') => {
-      throw new Error(`\`expect.poll()\` does not support "${name}" matcher.`);
-    };
-    Object.defineProperty(result, 'resolves', { get: () => throwUnsupported('resolves'), enumerable: true });
-    Object.defineProperty(result, 'rejects', { get: () => throwUnsupported('rejects'), enumerable: true });
-  }
-
+function createMatchers(actual: unknown, originalInfo: ExpectMetaInfo, messageOrOptions?: ExpectMessage): any {
+  const message = isString(messageOrOptions) ? messageOrOptions : messageOrOptions?.message || originalInfo.message;
+  const info = { ...originalInfo, message };
+  const result: any = { not: {}, resolves: { not: {} }, rejects: { not: {} } };
   const notInfo: ExpectMetaInfo = { ...info, isNot: !info.isNot };
-
-  const addMatcher = (name: string, matcher: RawMatcherFn) => {
-    result[name] = wrapMatcherCall(name, info, actual, matcher);
-    result.not[name] = wrapMatcherCall(name, notInfo, actual, matcher);
-    if (!info.poll) {
-      const promiseMatcher = promiseThrowMatchers[name] ?? matcher;
-      result.resolves[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'resolves');
-      result.resolves.not[name] = wrapMatcherCall(name, notInfo, actual, promiseMatcher, 'resolves');
-      result.rejects[name] = wrapMatcherCall(name, info, actual, promiseMatcher, 'rejects');
-      result.rejects.not[name] = wrapMatcherCall(name, notInfo, actual, promiseMatcher, 'rejects');
-    }
-  };
-
-  for (const [name, matcher] of Object.entries(allBuiltinMatchers))
-    addMatcher(name, matcher);
-  for (const [name, matcher] of Object.entries(info.userMatchers))
-    addMatcher(name, matcher);
-
+  for (const [name, matcher] of Object.entries({ ...allBuiltinMatchers, ...info.userMatchers })) {
+    result[name] = wrapMatcher(name, info, actual, matcher);
+    result.not[name] = wrapMatcher(name, notInfo, actual, matcher);
+    const promiseMatcher = promiseThrowMatchers[name] ?? matcher;
+    result.resolves[name] = wrapMatcher(name, info, actual, promiseMatcher, 'resolves');
+    result.resolves.not[name] = wrapMatcher(name, notInfo, actual, promiseMatcher, 'resolves');
+    result.rejects[name] = wrapMatcher(name, info, actual, promiseMatcher, 'rejects');
+    result.rejects.not[name] = wrapMatcher(name, notInfo, actual, promiseMatcher, 'rejects');
+  }
   return result;
 }
 
-function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, promise?: 'resolves' | 'rejects') {
+function wrapMatcher(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcher: RawMatcherFn, promise?: 'resolves' | 'rejects') {
   return (...args: any[]) => {
     const testInfo = expectConfig().testInfo;
     const customMessage = info.message || '';
@@ -488,6 +449,8 @@ async function pollMatcher(
   promise: 'resolves' | 'rejects' | undefined,
   stepInfo: ExpectStepInfo | undefined,
 ): Promise<SyncExpectationResult> {
+  if (typeof actual !== 'function')
+    throw new Error('`expect.poll()` accepts only function as a first argument');
   if (promise || (customAsyncMatchers as any)[matcherName])
     throw new Error(`\`expect.poll()\` does not support "${promise ?? matcherName}" matcher.`);
 
@@ -500,7 +463,7 @@ async function pollMatcher(
     if (testInfo && expectConfig().testInfo !== testInfo)
       return { continuePolling: false, result: undefined };
 
-    const value = await poll.generator();
+    const value = await actual();
     const result = await invokeMatcher(matcherName, { ...info, poll: undefined }, matcher, value, args, undefined, stepInfo);
     if (result.pass === !info.isNot)
       return { continuePolling: false, result };

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -430,25 +430,7 @@ function createMatchers(actual: unknown, info: ExpectMetaInfo): any {
     aliasToThrow(result.rejects.not);
   }
 
-  result.not = wrapUnknownMatcherProxy(result.not);
-  if (!info.poll) {
-    result.resolves.not = wrapUnknownMatcherProxy(result.resolves.not);
-    result.resolves = wrapUnknownMatcherProxy(result.resolves);
-    result.rejects.not = wrapUnknownMatcherProxy(result.rejects.not);
-    result.rejects = wrapUnknownMatcherProxy(result.rejects);
-  }
-  return wrapUnknownMatcherProxy(result);
-}
-
-// !!!
-function wrapUnknownMatcherProxy(obj: any): any {
-  return new Proxy(obj, {
-    get(target, prop, receiver) {
-      if (typeof prop !== 'string' || prop in target)
-        return Reflect.get(target, prop, receiver);
-      throw new Error(`expect: Property '${prop}' not found.`);
-    },
-  });
+  return result;
 }
 
 function wrapMatcherCall(matcherName: string, info: ExpectMetaInfo, actual: unknown, matcherImpl: (...args: any[]) => any) {

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -1711,3 +1711,25 @@ export const validateMatcherResult = (result: any) => {
     );
   }
 };
+
+export function createExpectedPromiseMessage(matcherName: string, isNot: boolean, promise: 'resolves' | 'rejects', actual: unknown) {
+  return () => matcherErrorMessage(
+      matcherHint(matcherName, undefined, '', { isNot, promise }),
+      `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+      printWithType('Received', actual, printReceived),
+  );
+}
+
+export function createExpectedToResolveMessage(matcherName: string, isNot: boolean, promise: 'resolves' | 'rejects', actual: unknown) {
+  return () =>
+    `${matcherHint(matcherName, undefined, '', { isNot, promise })}\n\n` +
+    'Received promise rejected instead of resolved\n' +
+    `Rejected to value: ${printReceived(actual)}`;
+}
+
+export function createExpectedToRejectMessage(matcherName: string, isNot: boolean, promise: 'resolves' | 'rejects', actual: unknown) {
+  return () =>
+    `${matcherHint(matcherName, undefined, '', { isNot, promise })}\n\n` +
+    'Received promise resolved instead of rejected\n' +
+    `Resolved to value: ${printReceived(actual)}`;
+}

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -8,6 +8,16 @@
 
 // Based on https://github.com/jestjs/jest/tree/v30.2.0/packages/expect
 
+// - Files merged into one.
+// - Reformatted to follow the coding style.
+// - Removed spy matchers: toHaveBeenCalled, toHaveReturned, etc.
+// - Removed expect.assertions() and expect.hasAssertions() support.
+// - Removed global state, INTERNAL_MATCHER_FLAG, addCustomEqualityTesters.
+// - MatcherContext has only stubs for customTesters, getState and dontThrow.
+// - MatcherState has no expand, currentTestName, assertionCalls, etc.
+// - Extracted explicit buildCustomAsymmetricMatcher, createExpectedPromiseMessage,
+//   createExpectedToResolveMessage, createExpectedToRejectMessage from internals.
+
 import {
   arrayBufferEquality,
   equals,

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -61,7 +61,6 @@ export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
 export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
   (this: Context, actual: any, ...expected: Array<any>): ExpectationResult;
-  [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
 export type MatchersObject = {
@@ -132,8 +131,6 @@ export function isPromise<T>(candidate: unknown): candidate is Promise<T> {
       && (typeof candidate === 'object' || typeof candidate === 'function')
       && typeof (candidate as any).then === 'function';
 }
-
-export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
 
 // -----------------------------------------------------------------------------
 // Asymmetric matchers (asymmetricMatchers.ts)

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -1662,3 +1662,31 @@ function isObject(obj: unknown) {
 function messageAndCause(error: Error) {
   return error.cause === undefined ? 'message' : 'message and cause';
 }
+
+export const getPromiseMatcher = (name: string) => {
+  if (name === 'toThrow')
+    return createThrowMatcher(name, true);
+  return null;
+};
+
+export const getMessage = (message?: () => string) =>
+  (message && message()) ||
+  RECEIVED_COLOR('No message was specified for this matcher.');
+
+export const validateMatcherResult = (result: any) => {
+  if (
+    typeof result !== 'object' ||
+    typeof result.pass !== 'boolean' ||
+    (result.message &&
+      typeof result.message !== 'string' &&
+      typeof result.message !== 'function')
+  ) {
+    throw new Error(
+        'Unexpected return from a matcher function.\n' +
+        'Matcher functions should ' +
+        'return an object in the following format:\n' +
+        '  {message?: string | function, pass: boolean}\n' +
+        `'${stringify(result)}' was returned`,
+    );
+  }
+};

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -50,26 +50,23 @@ import type { MatcherHintOptions } from 'jest-matcher-utils';
 // Types
 // -----------------------------------------------------------------------------
 
-type SyncExpectationResult = {
+export type SyncExpectationResult = {
   pass: boolean;
   message(): string;
 };
 
 type AsyncExpectationResult = Promise<SyncExpectationResult>;
 
-type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
+export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
-type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
+export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
   (this: Context, actual: any, ...expected: Array<any>): ExpectationResult;
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
-type MatchersObject = {
+export type MatchersObject = {
   [name: string]: RawMatcherFn;
 };
-
-type ThrowingMatcherFn = (...args: Array<any>) => any;
-type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
 
 interface MatcherUtils {
   customTesters: Array<Tester>;
@@ -86,7 +83,7 @@ interface MatcherState {
   promise?: string;
 }
 
-type MatcherContext = MatcherUtils & Readonly<MatcherState>;
+export type MatcherContext = MatcherUtils & Readonly<MatcherState>;
 
 type AsymmetricMatcherInterface = {
   asymmetricMatch(other: unknown): boolean;
@@ -94,10 +91,6 @@ type AsymmetricMatcherInterface = {
   getExpectedType?(): string;
   toAsymmetricMatcher?(): string;
 };
-
-// -----------------------------------------------------------------------------
-// Global matchers object and state (jestMatchersObject.ts)
-// -----------------------------------------------------------------------------
 
 function getType(value: unknown): string {
   if (value === undefined)
@@ -134,86 +127,13 @@ function getType(value: unknown): string {
 
 const isPrimitive = (value: unknown): boolean => Object(value) !== value;
 
-function isPromise<T>(candidate: unknown): candidate is Promise<T> {
+export function isPromise<T>(candidate: unknown): candidate is Promise<T> {
   return candidate !== null && candidate !== undefined
       && (typeof candidate === 'object' || typeof candidate === 'function')
       && typeof (candidate as any).then === 'function';
 }
 
-const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
-
-const allMatchers: MatchersObject = Object.create(null);
-
-const setMatchers = (
-  matchers: MatchersObject,
-  isInternal: boolean,
-  expect: Expect,
-): void => {
-  for (const key of Object.keys(matchers)) {
-    const matcher = matchers[key];
-
-    if (typeof matcher !== 'function') {
-      throw new TypeError(
-          `expect.extend: \`${key}\` is not a valid matcher. Must be a function, is "${getType(
-              matcher,
-          )}"`,
-      );
-    }
-
-    Object.defineProperty(matcher, INTERNAL_MATCHER_FLAG, {
-      value: isInternal,
-    });
-
-    if (!isInternal) {
-      // expect is defined
-
-      class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
-        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
-          super(sample, inverse);
-        }
-
-        asymmetricMatch(other: unknown) {
-          const { pass } = matcher.call(
-              this.getMatcherContext(),
-              other,
-              ...this.sample,
-          ) as SyncExpectationResult;
-
-          return this.inverse ? !pass : pass;
-        }
-
-        toString() {
-          return `${this.inverse ? 'not.' : ''}${key}`;
-        }
-
-        override getExpectedType() {
-          return 'any';
-        }
-
-        override toAsymmetricMatcher() {
-          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
-        }
-      }
-
-      Object.defineProperty(expect, key, {
-        configurable: true,
-        enumerable: true,
-        value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(false, ...sample),
-        writable: true,
-      });
-      Object.defineProperty(expect.not, key, {
-        configurable: true,
-        enumerable: true,
-        value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(true, ...sample),
-        writable: true,
-      });
-    }
-  }
-
-  Object.assign(allMatchers, matchers);
-};
+export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
 
 // -----------------------------------------------------------------------------
 // Asymmetric matchers (asymmetricMatchers.ts)
@@ -231,7 +151,7 @@ function fnNameFor(func: () => unknown) {
   return matches ? matches[1] : '<anonymous>';
 }
 
-const utils = Object.freeze({
+export const utils = Object.freeze({
   ...matcherUtils,
   iterableEquality,
   subsetEquality,
@@ -245,7 +165,7 @@ function hasProperty(obj: object | null, property: string | symbol): boolean {
   return hasProperty(Object.getPrototypeOf(obj), property);
 }
 
-abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface {
+export abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface {
   $$typeof = Symbol.for('jest.asymmetricMatcher');
 
   constructor(
@@ -523,20 +443,20 @@ class CloseTo extends AsymmetricMatcher<number> {
   }
 }
 
-const any = (expectedObject: unknown): Any => new Any(expectedObject);
-const anything = (): Anything => new Anything();
-const arrayContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample);
-const arrayNotContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample, true);
-const arrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample);
-const notArrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample, true);
-const objectContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample);
-const objectNotContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample, true);
-const stringContaining = (expected: string): StringContaining => new StringContaining(expected);
-const stringNotContaining = (expected: string): StringContaining => new StringContaining(expected, true);
-const stringMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected);
-const stringNotMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected, true);
-const closeTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision);
-const notCloseTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision, true);
+export const any = (expectedObject: unknown): Any => new Any(expectedObject);
+export const anything = (): Anything => new Anything();
+export const arrayContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample);
+export const arrayNotContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample, true);
+export const arrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample);
+export const notArrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample, true);
+export const objectContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample);
+export const objectNotContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample, true);
+export const stringContaining = (expected: string): StringContaining => new StringContaining(expected);
+export const stringNotContaining = (expected: string): StringContaining => new StringContaining(expected, true);
+export const stringMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected);
+export const stringNotMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected, true);
+export const closeTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision);
+export const notCloseTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision, true);
 
 // -----------------------------------------------------------------------------
 // Print helpers (print.ts)
@@ -660,7 +580,7 @@ type ContainIterable =
   | DOMTokenList
   | HTMLCollectionOf<any>;
 
-const matchers: MatchersObject = {
+export const matchers: MatchersObject = {
   toBe(received: unknown, expected: unknown) {
     const matcherName = 'toBe';
     const options: MatcherHintOptions = {
@@ -1384,7 +1304,7 @@ const getThrown = (e: any): Thrown => {
   };
 };
 
-const createThrowMatcher = (matcherName: string, fromPromise?: boolean): RawMatcherFn =>
+export const createThrowMatcher = (matcherName: string, fromPromise?: boolean): RawMatcherFn =>
   function(this: MatcherContext, received: any, expected: any): ExpectationResult {
     const options = { isNot: this.isNot, promise: this.promise };
 
@@ -1432,7 +1352,7 @@ const createThrowMatcher = (matcherName: string, fromPromise?: boolean): RawMatc
     );
   };
 
-const toThrowMatchers: MatchersObject = {
+export const toThrowMatchers: MatchersObject = {
   toThrow: createThrowMatcher('toThrow'),
 };
 
@@ -1744,271 +1664,3 @@ function isObject(obj: unknown) {
 function messageAndCause(error: Error) {
   return error.cause === undefined ? 'message' : 'message and cause';
 }
-
-// -----------------------------------------------------------------------------
-// expect function (index.ts)
-// -----------------------------------------------------------------------------
-
-class JestAssertionError extends Error {
-  matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
-}
-
-const getPromiseMatcher = (name: string) => {
-  if (name === 'toThrow')
-    return createThrowMatcher(name, true);
-  return null;
-};
-
-type AsymmetricMatchers = {
-  any(sample: unknown): AsymmetricMatcher<any>;
-  anything(): AsymmetricMatcher<any>;
-  arrayContaining(sample: Array<unknown>): AsymmetricMatcher<any>;
-  arrayOf(sample: unknown): AsymmetricMatcher<any>;
-  closeTo(sample: number, precision?: number): AsymmetricMatcher<any>;
-  objectContaining(sample: Record<string, unknown>): AsymmetricMatcher<any>;
-  stringContaining(sample: string): AsymmetricMatcher<any>;
-  stringMatching(sample: string | RegExp): AsymmetricMatcher<any>;
-};
-
-interface BaseExpect {
-  extend(matchers: MatchersObject): void;
-}
-
-type Expect = (<T = unknown>(actual: T) => any) &
-  BaseExpect &
-  AsymmetricMatchers & {
-    not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
-  };
-
-export const expect: Expect = ((actual: any, ...rest: Array<any>) => {
-  if (rest.length > 0)
-    throw new Error('Expect takes at most one argument.');
-
-  const expectation: any = {
-    not: {},
-    rejects: { not: {} },
-    resolves: { not: {} },
-  };
-
-  const err = new JestAssertionError();
-
-  for (const name of Object.keys(allMatchers)) {
-    const matcher = allMatchers[name];
-    const promiseMatcher = getPromiseMatcher(name) || matcher;
-    expectation[name] = makeThrowingMatcher(matcher, false, '', actual);
-    expectation.not[name] = makeThrowingMatcher(matcher, true, '', actual);
-
-    expectation.resolves[name] = makeResolveMatcher(name, promiseMatcher, false, actual, err);
-    expectation.resolves.not[name] = makeResolveMatcher(name, promiseMatcher, true, actual, err);
-
-    expectation.rejects[name] = makeRejectMatcher(name, promiseMatcher, false, actual, err);
-    expectation.rejects.not[name] = makeRejectMatcher(name, promiseMatcher, true, actual, err);
-  }
-
-  return expectation;
-}) as Expect;
-
-const getMessage = (message?: () => string) =>
-  (message && message()) ||
-  RECEIVED_COLOR('No message was specified for this matcher.');
-
-const makeResolveMatcher =
-  (
-    matcherName: string,
-    matcher: RawMatcherFn,
-    isNot: boolean,
-    actual: Promise<any> | (() => Promise<any>),
-    outerErr: JestAssertionError,
-  ): PromiseMatcherFn =>
-    (...args: Array<any>) => {
-      const options = { isNot, promise: 'resolves' };
-
-      const actualWrapper: Promise<any> =
-        typeof actual === 'function' ? actual() : actual;
-
-      if (!isPromise(actualWrapper)) {
-        throw new JestAssertionError(
-            matcherErrorMessage(
-                matcherHint(matcherName, undefined, '', options),
-                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-                printWithType('Received', actual, printReceived),
-            ),
-        );
-      }
-
-      const innerErr = new JestAssertionError();
-
-      return actualWrapper.then(
-          result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
-          error => {
-            outerErr.message =
-              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-          'Received promise rejected instead of resolved\n' +
-          `Rejected to value: ${printReceived(error)}`;
-            throw outerErr;
-          },
-      );
-    };
-
-const makeRejectMatcher =
-  (
-    matcherName: string,
-    matcher: RawMatcherFn,
-    isNot: boolean,
-    actual: Promise<any> | (() => Promise<any>),
-    outerErr: JestAssertionError,
-  ): PromiseMatcherFn =>
-    (...args: Array<any>) => {
-      const options = { isNot, promise: 'rejects' };
-
-      const actualWrapper: Promise<any> =
-        typeof actual === 'function' ? actual() : actual;
-
-      if (!isPromise(actualWrapper)) {
-        throw new JestAssertionError(
-            matcherErrorMessage(
-                matcherHint(matcherName, undefined, '', options),
-                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
-                printWithType('Received', actual, printReceived),
-            ),
-        );
-      }
-
-      const innerErr = new JestAssertionError();
-
-      return actualWrapper.then(
-          result => {
-            outerErr.message =
-              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
-          'Received promise resolved instead of rejected\n' +
-          `Resolved to value: ${printReceived(result)}`;
-            throw outerErr;
-          },
-          error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
-      );
-    };
-
-const makeThrowingMatcher = (
-  matcher: RawMatcherFn,
-  isNot: boolean,
-  promise: string,
-  actual: any,
-  err?: JestAssertionError,
-): ThrowingMatcherFn =>
-  function throwingMatcher(this: void, ...args: Array<any>): any {
-    const matcherContext: MatcherContext = {
-      customTesters: [],
-      equals,
-      utils,
-      error: err,
-      isNot,
-      promise,
-    };
-
-    const processResult = (
-      result: SyncExpectationResult,
-      asyncError?: JestAssertionError,
-    ) => {
-      _validateResult(result);
-
-      if ((result.pass && isNot) || (!result.pass && !isNot)) {
-        const message = getMessage(result.message);
-        let error;
-
-        if (err) {
-          error = err;
-          error.message = message;
-        } else if (asyncError) {
-          error = asyncError;
-          error.message = message;
-        } else {
-          error = new JestAssertionError(message);
-
-          if (Error.captureStackTrace)
-            Error.captureStackTrace(error, throwingMatcher);
-        }
-        error.matcherResult = { ...result, message };
-        throw error;
-      }
-    };
-
-    const handleError = (error: Error) => {
-      if (
-        matcher[INTERNAL_MATCHER_FLAG] === true &&
-        !(error instanceof JestAssertionError) &&
-        error.name !== 'PrettyFormatPluginError' &&
-        Error.captureStackTrace
-      )
-        Error.captureStackTrace(error, throwingMatcher);
-      throw error;
-    };
-
-    let potentialResult: ExpectationResult;
-
-    try {
-      potentialResult =
-        matcher[INTERNAL_MATCHER_FLAG] === true
-          ? matcher.call(matcherContext, actual, ...args)
-          : (function __EXTERNAL_MATCHER_TRAP__() {
-            return matcher.call(matcherContext, actual, ...args);
-          })();
-
-      if (isPromise(potentialResult)) {
-        const asyncError = new JestAssertionError();
-        if (Error.captureStackTrace)
-          Error.captureStackTrace(asyncError, throwingMatcher);
-
-        return potentialResult
-            .then(aResult => processResult(aResult, asyncError))
-            .catch(handleError);
-      }
-      return processResult(potentialResult);
-    } catch (error: any) {
-      return handleError(error);
-    }
-  };
-
-expect.extend = (matchers: MatchersObject) => setMatchers(matchers, false, expect);
-
-expect.anything = anything;
-expect.any = any;
-
-expect.not = {
-  arrayContaining: arrayNotContaining,
-  arrayOf: notArrayOf,
-  closeTo: notCloseTo,
-  objectContaining: objectNotContaining,
-  stringContaining: stringNotContaining,
-  stringMatching: stringNotMatching,
-};
-
-expect.arrayContaining = arrayContaining;
-expect.arrayOf = arrayOf;
-expect.closeTo = closeTo;
-expect.objectContaining = objectContaining;
-expect.stringContaining = stringContaining;
-expect.stringMatching = stringMatching;
-
-const _validateResult = (result: any) => {
-  if (
-    typeof result !== 'object' ||
-    typeof result.pass !== 'boolean' ||
-    (result.message &&
-      typeof result.message !== 'string' &&
-      typeof result.message !== 'function')
-  ) {
-    throw new Error(
-        'Unexpected return from a matcher function.\n' +
-        'Matcher functions should ' +
-        'return an object in the following format:\n' +
-        '  {message?: string | function, pass: boolean}\n' +
-        `'${stringify(result)}' was returned`,
-    );
-  }
-};
-
-// Register built-in matchers.
-setMatchers(matchers, true, expect);
-setMatchers(toThrowMatchers, true, expect);
-
-// #endregion

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -1,0 +1,2060 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found here
+ * https://github.com/jestjs/jest/blob/v30.2.0/LICENSE
+ */
+
+// Based on https://github.com/jestjs/jest/tree/v30.2.0/packages/expect
+
+import {
+  arrayBufferEquality,
+  equals,
+  getObjectKeys,
+  getObjectSubset,
+  getPath,
+  isA,
+  isError,
+  iterableEquality,
+  pathAsArray,
+  sparseArrayEquality,
+  subsetEquality,
+  typeEquality,
+} from '@jest/expect-utils';
+import * as matcherUtils from 'jest-matcher-utils';
+import {
+  DIM_COLOR,
+  EXPECTED_COLOR,
+  INVERTED_COLOR,
+  RECEIVED_COLOR,
+  SUGGEST_TO_CONTAIN_EQUAL,
+  ensureExpectedIsNonNegativeInteger,
+  ensureNoExpected,
+  ensureNumbers,
+  getLabelPrinter,
+  matcherErrorMessage,
+  matcherHint,
+  printDiffOrStringify,
+  printExpected,
+  printReceived,
+  printWithType,
+  stringify,
+} from 'jest-matcher-utils';
+import { formatExecError, formatStackTrace, separateMessageFromStack } from 'jest-message-util';
+
+import type { EqualsFunction, Tester } from '@jest/expect-utils';
+import type { MatcherHintOptions } from 'jest-matcher-utils';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export type SyncExpectationResult = {
+  pass: boolean;
+  message(): string;
+};
+
+export type AsyncExpectationResult = Promise<SyncExpectationResult>;
+
+export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
+
+export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
+  (this: Context, actual: any, ...expected: Array<any>): ExpectationResult;
+  [INTERNAL_MATCHER_FLAG]?: boolean;
+};
+
+export type MatchersObject = {
+  [name: string]: RawMatcherFn;
+};
+
+export type ThrowingMatcherFn = (...args: Array<any>) => any;
+export type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
+
+export interface MatcherUtils {
+  customTesters: Array<Tester>;
+  dontThrow(): void;
+  equals: EqualsFunction;
+  utils: typeof matcherUtils & {
+    iterableEquality: Tester;
+    subsetEquality: Tester;
+  };
+}
+
+export interface MatcherState {
+  currentTestName?: string;
+  error?: Error;
+  expand?: boolean;
+  isNot?: boolean;
+  promise?: string;
+  testPath?: string;
+}
+
+export type MatcherContext = MatcherUtils & Readonly<MatcherState>;
+
+export type AsymmetricMatcherInterface = {
+  asymmetricMatch(other: unknown): boolean;
+  toString(): string;
+  getExpectedType?(): string;
+  toAsymmetricMatcher?(): string;
+};
+
+// -----------------------------------------------------------------------------
+// Global matchers object and state (jestMatchersObject.ts)
+// -----------------------------------------------------------------------------
+
+function getType(value: unknown): string {
+  if (value === undefined)
+    return 'undefined';
+  if (value === null)
+    return 'null';
+  if (Array.isArray(value))
+    return 'array';
+  if (typeof value === 'boolean')
+    return 'boolean';
+  if (typeof value === 'function')
+    return 'function';
+  if (typeof value === 'number')
+    return 'number';
+  if (typeof value === 'string')
+    return 'string';
+  if (typeof value === 'bigint')
+    return 'bigint';
+  if (typeof value === 'object') {
+    if ((value as object).constructor === RegExp)
+      return 'regexp';
+    if ((value as object).constructor === Map)
+      return 'map';
+    if ((value as object).constructor === Set)
+      return 'set';
+    if ((value as object).constructor === Date)
+      return 'date';
+    return 'object';
+  }
+  if (typeof value === 'symbol')
+    return 'symbol';
+  throw new Error(`value of unknown type: ${value as any}`);
+}
+
+const isPrimitive = (value: unknown): boolean => Object(value) !== value;
+
+function isPromise<T>(candidate: unknown): candidate is Promise<T> {
+  return candidate !== null && candidate !== undefined
+      && (typeof candidate === 'object' || typeof candidate === 'function')
+      && typeof (candidate as any).then === 'function';
+}
+
+const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
+export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
+
+if (!Object.prototype.hasOwnProperty.call(globalThis, JEST_MATCHERS_OBJECT)) {
+  const defaultState: MatcherState = {};
+  Object.defineProperty(globalThis, JEST_MATCHERS_OBJECT, {
+    value: {
+      matchers: Object.create(null),
+      state: defaultState,
+    },
+  });
+}
+
+export const getState = <State extends MatcherState = MatcherState>(): State =>
+  (globalThis as any)[JEST_MATCHERS_OBJECT].state;
+
+export const setState = <State extends MatcherState = MatcherState>(
+  state: Partial<State>,
+): void => {
+  Object.assign((globalThis as any)[JEST_MATCHERS_OBJECT].state, state);
+};
+
+const getMatchers = (): MatchersObject =>
+  (globalThis as any)[JEST_MATCHERS_OBJECT].matchers;
+
+const setMatchers = (
+  matchers: MatchersObject,
+  isInternal: boolean,
+  expect: Expect,
+): void => {
+  for (const key of Object.keys(matchers)) {
+    const matcher = matchers[key];
+
+    if (typeof matcher !== 'function') {
+      throw new TypeError(
+          `expect.extend: \`${key}\` is not a valid matcher. Must be a function, is "${getType(
+              matcher,
+          )}"`,
+      );
+    }
+
+    Object.defineProperty(matcher, INTERNAL_MATCHER_FLAG, {
+      value: isInternal,
+    });
+
+    if (!isInternal) {
+      // expect is defined
+
+      class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
+        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
+          super(sample, inverse);
+        }
+
+        asymmetricMatch(other: unknown) {
+          const { pass } = matcher.call(
+              this.getMatcherContext(),
+              other,
+              ...this.sample,
+          ) as SyncExpectationResult;
+
+          return this.inverse ? !pass : pass;
+        }
+
+        toString() {
+          return `${this.inverse ? 'not.' : ''}${key}`;
+        }
+
+        override getExpectedType() {
+          return 'any';
+        }
+
+        override toAsymmetricMatcher() {
+          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
+        }
+      }
+
+      Object.defineProperty(expect, key, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...Array<unknown>]) =>
+          new CustomMatcher(false, ...sample),
+        writable: true,
+      });
+      Object.defineProperty(expect.not, key, {
+        configurable: true,
+        enumerable: true,
+        value: (...sample: [unknown, ...Array<unknown>]) =>
+          new CustomMatcher(true, ...sample),
+        writable: true,
+      });
+    }
+  }
+
+  Object.assign((globalThis as any)[JEST_MATCHERS_OBJECT].matchers, matchers);
+};
+
+// -----------------------------------------------------------------------------
+// Asymmetric matchers (asymmetricMatchers.ts)
+// -----------------------------------------------------------------------------
+
+const functionToString = Function.prototype.toString;
+
+function fnNameFor(func: () => unknown) {
+  if (func.name)
+    return func.name;
+
+  const matches = functionToString
+      .call(func)
+      .match(/^(?:async)?\s*function\s*\*?\s*([\w$]+)\s*\(/);
+  return matches ? matches[1] : '<anonymous>';
+}
+
+const utils = Object.freeze({
+  ...matcherUtils,
+  iterableEquality,
+  subsetEquality,
+});
+
+function hasProperty(obj: object | null, property: string | symbol): boolean {
+  if (!obj)
+    return false;
+  if (Object.prototype.hasOwnProperty.call(obj, property))
+    return true;
+  return hasProperty(Object.getPrototypeOf(obj), property);
+}
+
+export abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface {
+  $$typeof = Symbol.for('jest.asymmetricMatcher');
+
+  constructor(
+    protected sample: T,
+    protected inverse = false,
+  ) {}
+
+  protected getMatcherContext(): MatcherContext {
+    return {
+      customTesters: [],
+      dontThrow: () => {},
+      ...getState<MatcherState>(),
+      equals,
+      isNot: this.inverse,
+      utils,
+    };
+  }
+
+  abstract asymmetricMatch(other: unknown): boolean;
+  abstract toString(): string;
+  getExpectedType?(): string;
+  toAsymmetricMatcher?(): string;
+}
+
+class Any extends AsymmetricMatcher<any> {
+  constructor(sample: unknown) {
+    if (sample === undefined) {
+      throw new TypeError(
+          'any() expects to be passed a constructor function. ' +
+          'Please pass one or use anything() to match any object.',
+      );
+    }
+    super(sample);
+  }
+
+  asymmetricMatch(other: unknown) {
+    if (this.sample === String)
+      return typeof other === 'string' || other instanceof String;
+    if (this.sample === Number)
+      return typeof other === 'number' || other instanceof Number;
+    if (this.sample === Function)
+      return typeof other === 'function' || other instanceof Function;
+    if (this.sample === Boolean)
+      return typeof other === 'boolean' || other instanceof Boolean;
+    if (this.sample === BigInt)
+      return typeof other === 'bigint' || other instanceof BigInt;
+    if (this.sample === Symbol)
+      return typeof other === 'symbol' || other instanceof Symbol;
+    if (this.sample === Object)
+      return typeof other === 'object';
+    if (this.sample === Array)
+      return Array.isArray(other);
+    return other instanceof this.sample;
+  }
+
+  toString() {
+    return 'Any';
+  }
+
+  override getExpectedType() {
+    if (this.sample === String)
+      return 'string';
+    if (this.sample === Number)
+      return 'number';
+    if (this.sample === Function)
+      return 'function';
+    if (this.sample === Object)
+      return 'object';
+    if (this.sample === Boolean)
+      return 'boolean';
+    if (this.sample === Array)
+      return 'array';
+    return fnNameFor(this.sample);
+  }
+
+  override toAsymmetricMatcher() {
+    return `Any<${fnNameFor(this.sample)}>`;
+  }
+}
+
+class Anything extends AsymmetricMatcher<void> {
+  asymmetricMatch(other: unknown) {
+    return other !== null && other !== undefined;
+  }
+
+  toString() {
+    return 'Anything';
+  }
+
+  override toAsymmetricMatcher() {
+    return 'Anything';
+  }
+}
+
+class ArrayContaining extends AsymmetricMatcher<Array<unknown>> {
+  constructor(sample: Array<unknown>, inverse = false) {
+    super(sample, inverse);
+  }
+
+  asymmetricMatch(other: unknown) {
+    if (!Array.isArray(this.sample)) {
+      throw new TypeError(
+          `You must provide an array to ${this.toString()}, not '${typeof this
+              .sample}'.`,
+      );
+    }
+
+    const matcherContext = this.getMatcherContext();
+    const result =
+      this.sample.length === 0 ||
+      (Array.isArray(other) &&
+        this.sample.every(item =>
+          other.some(another =>
+            equals(item, another, matcherContext.customTesters),
+          ),
+        ));
+
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `Array${this.inverse ? 'Not' : ''}Containing`;
+  }
+
+  override getExpectedType() {
+    return 'array';
+  }
+}
+
+class ArrayOf extends AsymmetricMatcher<unknown> {
+  asymmetricMatch(other: unknown) {
+    const matcherContext = this.getMatcherContext();
+    const result =
+      Array.isArray(other) &&
+      other.every(item =>
+        equals(this.sample, item, matcherContext.customTesters),
+      );
+
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `${this.inverse ? 'Not' : ''}ArrayOf`;
+  }
+
+  override getExpectedType() {
+    return 'array';
+  }
+}
+
+class ObjectContaining extends AsymmetricMatcher<Record<string | symbol, unknown>> {
+  constructor(sample: Record<string | symbol, unknown>, inverse = false) {
+    super(sample, inverse);
+  }
+
+  asymmetricMatch(other: any) {
+    if (typeof this.sample !== 'object') {
+      throw new TypeError(
+          `You must provide an object to ${this.toString()}, not '${typeof this
+              .sample}'.`,
+      );
+    }
+
+    if (typeof other !== 'object' || Array.isArray(other))
+      return false;
+
+    let result = true;
+
+    const matcherContext = this.getMatcherContext();
+    const objectKeys = getObjectKeys(this.sample);
+
+    for (const key of objectKeys) {
+      if (
+        !hasProperty(other, key) ||
+        !equals(this.sample[key], other[key], matcherContext.customTesters)
+      ) {
+        result = false;
+        break;
+      }
+    }
+
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `Object${this.inverse ? 'Not' : ''}Containing`;
+  }
+
+  override getExpectedType() {
+    return 'object';
+  }
+}
+
+class StringContaining extends AsymmetricMatcher<string> {
+  constructor(sample: string, inverse = false) {
+    if (!isA('String', sample))
+      throw new Error('Expected is not a string');
+    super(sample, inverse);
+  }
+
+  asymmetricMatch(other: unknown) {
+    const result = isA<string>('String', other) && other.includes(this.sample);
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `String${this.inverse ? 'Not' : ''}Containing`;
+  }
+
+  override getExpectedType() {
+    return 'string';
+  }
+}
+
+class StringMatching extends AsymmetricMatcher<RegExp> {
+  constructor(sample: string | RegExp, inverse = false) {
+    if (!isA('String', sample) && !isA('RegExp', sample))
+      throw new Error('Expected is not a String or a RegExp');
+    super(new RegExp(sample), inverse);
+  }
+
+  asymmetricMatch(other: unknown) {
+    const result = isA<string>('String', other) && this.sample.test(other);
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `String${this.inverse ? 'Not' : ''}Matching`;
+  }
+
+  override getExpectedType() {
+    return 'string';
+  }
+}
+
+class CloseTo extends AsymmetricMatcher<number> {
+  private readonly precision: number;
+
+  constructor(sample: number, precision = 2, inverse = false) {
+    if (!isA('Number', sample))
+      throw new Error('Expected is not a Number');
+    if (!isA('Number', precision))
+      throw new Error('Precision is not a Number');
+
+    super(sample);
+    this.inverse = inverse;
+    this.precision = precision;
+  }
+
+  asymmetricMatch(other: unknown) {
+    if (!isA<number>('Number', other))
+      return false;
+    let result = false;
+    if (other === Number.POSITIVE_INFINITY && this.sample === Number.POSITIVE_INFINITY)
+      result = true;
+    else if (other === Number.NEGATIVE_INFINITY && this.sample === Number.NEGATIVE_INFINITY)
+      result = true;
+    else
+      result = Math.abs(this.sample - other) < Math.pow(10, -this.precision) / 2;
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `Number${this.inverse ? 'Not' : ''}CloseTo`;
+  }
+
+  override getExpectedType() {
+    return 'number';
+  }
+
+  override toAsymmetricMatcher(): string {
+    return [
+      this.toString(),
+      this.sample,
+      `(${this.precision} ${this.precision === 1 ? 'digit' : 'digits'})`,
+    ].join(' ');
+  }
+}
+
+const any = (expectedObject: unknown): Any => new Any(expectedObject);
+const anything = (): Anything => new Anything();
+const arrayContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample);
+const arrayNotContaining = (sample: Array<unknown>): ArrayContaining => new ArrayContaining(sample, true);
+const arrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample);
+const notArrayOf = (sample: unknown): ArrayOf => new ArrayOf(sample, true);
+const objectContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample);
+const objectNotContaining = (sample: Record<string, unknown>): ObjectContaining => new ObjectContaining(sample, true);
+const stringContaining = (expected: string): StringContaining => new StringContaining(expected);
+const stringNotContaining = (expected: string): StringContaining => new StringContaining(expected, true);
+const stringMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected);
+const stringNotMatching = (expected: string | RegExp): StringMatching => new StringMatching(expected, true);
+const closeTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision);
+const notCloseTo = (expected: number, precision?: number): CloseTo => new CloseTo(expected, precision, true);
+
+// -----------------------------------------------------------------------------
+// Print helpers (print.ts)
+// -----------------------------------------------------------------------------
+
+const printSubstring = (val: string): string => val.replace(/"|\\/g, '\\$&');
+
+const printReceivedStringContainExpectedSubstring = (
+  received: string,
+  start: number,
+  length: number,
+): string =>
+  RECEIVED_COLOR(
+      `"${printSubstring(received.slice(0, start))}${INVERTED_COLOR(
+          printSubstring(received.slice(start, start + length)),
+      )}${printSubstring(received.slice(start + length))}"`,
+  );
+
+const printReceivedStringContainExpectedResult = (
+  received: string,
+  result: RegExpExecArray | null,
+): string =>
+  result === null
+    ? printReceived(received)
+    : printReceivedStringContainExpectedSubstring(received, result.index, result[0].length);
+
+const printReceivedArrayContainExpectedItem = (
+  received: Array<unknown>,
+  index: number,
+): string =>
+  RECEIVED_COLOR(
+      `[${received
+          .map((item, i) => {
+            const stringified = stringify(item);
+            return i === index ? INVERTED_COLOR(stringified) : stringified;
+          })
+          .join(', ')}]`,
+  );
+
+const printCloseTo = (
+  receivedDiff: number,
+  expectedDiff: number,
+  precision: number,
+  isNot: boolean | undefined,
+): string => {
+  const receivedDiffString = stringify(receivedDiff);
+  const expectedDiffString = receivedDiffString.includes('e')
+    ? expectedDiff.toExponential(0)
+    : 0 <= precision && precision < 20
+      ? expectedDiff.toFixed(precision + 1)
+      : stringify(expectedDiff);
+
+  return (
+    `Expected precision:  ${isNot ? '    ' : ''}  ${stringify(precision)}\n` +
+    `Expected difference: ${isNot ? 'not ' : ''}< ${EXPECTED_COLOR(expectedDiffString)}\n` +
+    `Received difference: ${isNot ? '    ' : ''}  ${RECEIVED_COLOR(receivedDiffString)}`
+  );
+};
+
+const printConstructorName = (
+  label: string,
+  constructor: Function,
+  isNot: boolean,
+  isExpected: boolean,
+): string =>
+  typeof constructor.name === 'string'
+    ? constructor.name.length === 0
+      ? `${label} name is an empty string`
+      : `${label}: ${isNot ? (isExpected ? 'not ' : '    ') : ''}${
+        isExpected
+          ? EXPECTED_COLOR(constructor.name)
+          : RECEIVED_COLOR(constructor.name)
+      }`
+    : `${label} name is not a string`;
+
+const printExpectedConstructorName = (label: string, expected: Function): string =>
+  `${printConstructorName(label, expected, false, true)}\n`;
+
+const printExpectedConstructorNameNot = (label: string, expected: Function): string =>
+  `${printConstructorName(label, expected, true, true)}\n`;
+
+const printReceivedConstructorName = (label: string, received: Function): string =>
+  `${printConstructorName(label, received, false, false)}\n`;
+
+const printReceivedConstructorNameNot = (
+  label: string,
+  received: Function,
+  expected: Function,
+): string =>
+  typeof expected.name === 'string' &&
+  expected.name.length > 0 &&
+  typeof received.name === 'string' &&
+  received.name.length > 0
+    ? `${printConstructorName(label, received, true, false)} ${
+      Object.getPrototypeOf(received) === expected
+        ? 'extends'
+        : 'extends … extends'
+    } ${EXPECTED_COLOR(expected.name)}\n`
+    : `${printConstructorName(label, received, false, false)}\n`;
+
+// -----------------------------------------------------------------------------
+// Default matchers (matchers.ts)
+// -----------------------------------------------------------------------------
+
+const EXPECTED_LABEL = 'Expected';
+const RECEIVED_LABEL = 'Received';
+const EXPECTED_VALUE_LABEL = 'Expected value';
+const RECEIVED_VALUE_LABEL = 'Received value';
+
+const isExpand = (expand?: boolean): boolean => expand !== false;
+
+const toStrictEqualTesters = [
+  iterableEquality,
+  typeEquality,
+  sparseArrayEquality,
+  arrayBufferEquality,
+];
+
+type ContainIterable =
+  | Array<unknown>
+  | Set<unknown>
+  | NodeListOf<Node>
+  | DOMTokenList
+  | HTMLCollectionOf<any>;
+
+const matchers: MatchersObject = {
+  toBe(received: unknown, expected: unknown) {
+    const matcherName = 'toBe';
+    const options: MatcherHintOptions = {
+      comment: 'Object.is equality',
+      isNot: this.isNot,
+      promise: this.promise,
+    };
+
+    const pass = Object.is(received, expected);
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}`
+      : () => {
+        const expectedType = getType(expected);
+
+        let deepEqualityName = null;
+        if (expectedType !== 'map' && expectedType !== 'set') {
+          if (equals(received, expected, [...this.customTesters, ...toStrictEqualTesters], true))
+            deepEqualityName = 'toStrictEqual';
+          else if (equals(received, expected, [...this.customTesters, iterableEquality]))
+            deepEqualityName = 'toEqual';
+        }
+
+        return (
+          matcherHint(matcherName, undefined, undefined, options) +
+            '\n\n' +
+            (deepEqualityName === null
+              ? ''
+              : `${DIM_COLOR(
+                  `If it should pass with deep equality, replace "${matcherName}" with "${deepEqualityName}"`,
+              )}\n\n`) +
+            printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand))
+        );
+      };
+
+    return { actual: received, expected, message, name: matcherName, pass };
+  },
+
+  toBeCloseTo(received: number, expected: number, precision = 2) {
+    const matcherName = 'toBeCloseTo';
+    const secondArgument = arguments.length === 3 ? 'precision' : undefined;
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = {
+      isNot,
+      promise: this.promise,
+      secondArgument,
+      secondArgumentColor: (arg: string) => arg,
+    };
+
+    if (typeof expected !== 'number') {
+      throw new TypeError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${EXPECTED_COLOR('expected')} value must be a number`,
+              printWithType('Expected', expected, printExpected),
+          ),
+      );
+    }
+
+    if (typeof received !== 'number') {
+      throw new TypeError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must be a number`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    let pass = false;
+    let expectedDiff = 0;
+    let receivedDiff = 0;
+
+    if (received === Number.POSITIVE_INFINITY && expected === Number.POSITIVE_INFINITY) {
+      pass = true;
+    } else if (received === Number.NEGATIVE_INFINITY && expected === Number.NEGATIVE_INFINITY) {
+      pass = true;
+    } else {
+      expectedDiff = Math.pow(10, -precision) / 2;
+      receivedDiff = Math.abs(expected - received);
+      pass = receivedDiff < expectedDiff;
+    }
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}\n` +
+          (receivedDiff === 0
+            ? ''
+            : `Received:     ${printReceived(received)}\n` +
+              `\n${printCloseTo(receivedDiff, expectedDiff, precision, isNot)}`)
+      : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: ${printExpected(expected)}\n` +
+          `Received: ${printReceived(received)}\n` +
+          '\n' +
+          printCloseTo(receivedDiff, expectedDiff, precision, isNot);
+
+    return { message, pass };
+  },
+
+  toBeDefined(received: unknown, expected: void) {
+    const matcherName = 'toBeDefined';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = received !== void 0;
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeFalsy(received: unknown, expected: void) {
+    const matcherName = 'toBeFalsy';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = !received;
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeGreaterThan(received: number | bigint, expected: number | bigint) {
+    const matcherName = 'toBeGreaterThan';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { isNot, promise: this.promise };
+    ensureNumbers(received, expected, matcherName, options);
+
+    const pass = received > expected;
+    const message = () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      `Expected:${isNot ? ' not' : ''} > ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}   ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeGreaterThanOrEqual(received: number | bigint, expected: number | bigint) {
+    const matcherName = 'toBeGreaterThanOrEqual';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { isNot, promise: this.promise };
+    ensureNumbers(received, expected, matcherName, options);
+
+    const pass = received >= expected;
+    const message = () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      `Expected:${isNot ? ' not' : ''} >= ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}    ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeInstanceOf(received: any, expected: Function) {
+    const matcherName = 'toBeInstanceOf';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+
+    if (typeof expected !== 'function') {
+      throw new TypeError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${EXPECTED_COLOR('expected')} value must be a function`,
+              printWithType('Expected', expected, printExpected),
+          ),
+      );
+    }
+
+    const pass = received instanceof expected;
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          printExpectedConstructorNameNot('Expected constructor', expected) +
+          (typeof received.constructor === 'function' && received.constructor !== expected
+            ? printReceivedConstructorNameNot('Received constructor', received.constructor, expected)
+            : '')
+      : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          printExpectedConstructorName('Expected constructor', expected) +
+          (isPrimitive(received) || Object.getPrototypeOf(received) === null
+            ? `\nReceived value has no prototype\nReceived value: ${printReceived(received)}`
+            : typeof received.constructor === 'function'
+              ? printReceivedConstructorName('Received constructor', received.constructor)
+              : `\nReceived value: ${printReceived(received)}`);
+
+    return { message, pass };
+  },
+
+  toBeLessThan(received: number | bigint, expected: number | bigint) {
+    const matcherName = 'toBeLessThan';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { isNot, promise: this.promise };
+    ensureNumbers(received, expected, matcherName, options);
+
+    const pass = received < expected;
+    const message = () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      `Expected:${isNot ? ' not' : ''} < ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}   ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeLessThanOrEqual(received: number | bigint, expected: number | bigint) {
+    const matcherName = 'toBeLessThanOrEqual';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { isNot, promise: this.promise };
+    ensureNumbers(received, expected, matcherName, options);
+
+    const pass = received <= expected;
+    const message = () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      `Expected:${isNot ? ' not' : ''} <= ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}    ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeNaN(received: any, expected: void) {
+    const matcherName = 'toBeNaN';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = Number.isNaN(received);
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeNull(received: unknown, expected: void) {
+    const matcherName = 'toBeNull';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = received === null;
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeTruthy(received: unknown, expected: void) {
+    const matcherName = 'toBeTruthy';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = !!received;
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toBeUndefined(received: unknown, expected: void) {
+    const matcherName = 'toBeUndefined';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = received === void 0;
+    const message = () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return { message, pass };
+  },
+
+  toContain(received: ContainIterable | string, expected: unknown) {
+    const matcherName = 'toContain';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { comment: 'indexOf', isNot, promise: this.promise };
+
+    if (received === null || received === undefined) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must not be null nor undefined`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    if (typeof received === 'string') {
+      const wrongTypeErrorMessage = `${EXPECTED_COLOR('expected')} value must be a string if ${RECEIVED_COLOR('received')} value is a string`;
+
+      if (typeof expected !== 'string') {
+        throw new TypeError(
+            matcherErrorMessage(
+                matcherHint(matcherName, received, String(expected), options),
+                wrongTypeErrorMessage,
+                printWithType('Expected', expected, printExpected) +
+              '\n' +
+              printWithType('Received', received, printReceived),
+            ),
+        );
+      }
+
+      const index = received.indexOf(String(expected));
+      const pass = index !== -1;
+
+      const message = () => {
+        const labelExpected = `Expected ${typeof expected === 'string' ? 'substring' : 'value'}`;
+        const labelReceived = 'Received string';
+        const printLabel = getLabelPrinter(labelExpected, labelReceived);
+
+        return (
+          matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `${printLabel(labelExpected)}${isNot ? 'not ' : ''}${printExpected(expected)}\n` +
+          `${printLabel(labelReceived)}${isNot ? '    ' : ''}${
+            isNot
+              ? printReceivedStringContainExpectedSubstring(received, index, String(expected).length)
+              : printReceived(received)
+          }`
+        );
+      };
+
+      return { message, pass };
+    }
+
+    const indexable = [...received];
+    const index = indexable.indexOf(expected);
+    const pass = index !== -1;
+
+    const message = () => {
+      const labelExpected = 'Expected value';
+      const labelReceived = `Received ${getType(received)}`;
+      const printLabel = getLabelPrinter(labelExpected, labelReceived);
+
+      return (
+        matcherHint(matcherName, undefined, undefined, options) +
+        '\n\n' +
+        `${printLabel(labelExpected)}${isNot ? 'not ' : ''}${printExpected(expected)}\n` +
+        `${printLabel(labelReceived)}${isNot ? '    ' : ''}${
+          isNot && Array.isArray(received)
+            ? printReceivedArrayContainExpectedItem(received, index)
+            : printReceived(received)
+        }` +
+        (!isNot &&
+        indexable.some(item =>
+          equals(item, expected, [...this.customTesters, iterableEquality]),
+        )
+          ? `\n\n${SUGGEST_TO_CONTAIN_EQUAL}`
+          : '')
+      );
+    };
+
+    return { message, pass };
+  },
+
+  toContainEqual(received: ContainIterable, expected: unknown) {
+    const matcherName = 'toContainEqual';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { comment: 'deep equality', isNot, promise: this.promise };
+
+    if (received === null || received === undefined) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must not be null nor undefined`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    const index = [...received].findIndex(item =>
+      equals(item, expected, [...this.customTesters, iterableEquality]),
+    );
+    const pass = index !== -1;
+
+    const message = () => {
+      const labelExpected = 'Expected value';
+      const labelReceived = `Received ${getType(received)}`;
+      const printLabel = getLabelPrinter(labelExpected, labelReceived);
+
+      return (
+        matcherHint(matcherName, undefined, undefined, options) +
+        '\n\n' +
+        `${printLabel(labelExpected)}${isNot ? 'not ' : ''}${printExpected(expected)}\n` +
+        `${printLabel(labelReceived)}${isNot ? '    ' : ''}${
+          isNot && Array.isArray(received)
+            ? printReceivedArrayContainExpectedItem(received, index)
+            : printReceived(received)
+        }`
+      );
+    };
+
+    return { message, pass };
+  },
+
+  toEqual(received: unknown, expected: unknown) {
+    const matcherName = 'toEqual';
+    const options: MatcherHintOptions = { comment: 'deep equality', isNot: this.isNot, promise: this.promise };
+
+    const pass = equals(received, expected, [...this.customTesters, iterableEquality]);
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}\n` +
+          (stringify(expected) === stringify(received)
+            ? ''
+            : `Received:     ${printReceived(received)}`)
+      : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand));
+
+    return { actual: received, expected, message, name: matcherName, pass };
+  },
+
+  toHaveLength(received: any, expected: number) {
+    const matcherName = 'toHaveLength';
+    const isNot = this.isNot;
+    const options: MatcherHintOptions = { isNot, promise: this.promise };
+
+    if (typeof received?.length !== 'number') {
+      throw new TypeError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must have a length property whose value must be a number`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    ensureExpectedIsNonNegativeInteger(expected, matcherName, options);
+
+    const pass = received.length === expected;
+
+    const message = () => {
+      const labelExpected = 'Expected length';
+      const labelReceivedLength = 'Received length';
+      const labelReceivedValue = `Received ${getType(received)}`;
+      const printLabel = getLabelPrinter(labelExpected, labelReceivedLength, labelReceivedValue);
+
+      return (
+        matcherHint(matcherName, undefined, undefined, options) +
+        '\n\n' +
+        `${printLabel(labelExpected)}${isNot ? 'not ' : ''}${printExpected(expected)}\n` +
+        (isNot ? '' : `${printLabel(labelReceivedLength)}${printReceived(received.length)}\n`) +
+        `${printLabel(labelReceivedValue)}${isNot ? '    ' : ''}${printReceived(received)}`
+      );
+    };
+
+    return { message, pass };
+  },
+
+  toHaveProperty(received: object, expectedPath: string | Array<string>, expectedValue?: unknown) {
+    const matcherName = 'toHaveProperty';
+    const expectedArgument = 'path';
+    const hasValue = arguments.length === 3;
+    const options: MatcherHintOptions = {
+      isNot: this.isNot,
+      promise: this.promise,
+      secondArgument: hasValue ? 'value' : '',
+    };
+
+    if (received === null || received === undefined) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, expectedArgument, options),
+              `${RECEIVED_COLOR('received')} value must not be null nor undefined`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    const expectedPathType = getType(expectedPath);
+
+    if (expectedPathType !== 'string' && expectedPathType !== 'array') {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, expectedArgument, options),
+              `${EXPECTED_COLOR('expected')} path must be a string or array`,
+              printWithType('Expected', expectedPath, printExpected),
+          ),
+      );
+    }
+
+    const expectedPathLength =
+      typeof expectedPath === 'string' ? pathAsArray(expectedPath).length : expectedPath.length;
+
+    if (expectedPathType === 'array' && expectedPathLength === 0) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, expectedArgument, options),
+              `${EXPECTED_COLOR('expected')} path must not be an empty array`,
+              printWithType('Expected', expectedPath, printExpected),
+          ),
+      );
+    }
+
+    const result = getPath(received, expectedPath);
+    const { lastTraversedObject, endPropIsDefined, hasEndProp, value } = result;
+    const receivedPath = result.traversedPath;
+    const hasCompletePath = receivedPath.length === expectedPathLength;
+    const receivedValue = hasCompletePath ? result.value : lastTraversedObject;
+
+    const pass =
+      hasValue && endPropIsDefined
+        ? equals(value, expectedValue, [...this.customTesters, iterableEquality])
+        : Boolean(hasEndProp);
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, expectedArgument, options) +
+          '\n\n' +
+          (hasValue
+            ? `Expected path: ${printExpected(expectedPath)}\n\n` +
+              `Expected value: not ${printExpected(expectedValue)}${
+                stringify(expectedValue) === stringify(receivedValue)
+                  ? ''
+                  : `\nReceived value:     ${printReceived(receivedValue)}`
+              }`
+            : `Expected path: not ${printExpected(expectedPath)}\n\n` +
+              `Received value: ${printReceived(receivedValue)}`)
+      : () =>
+        matcherHint(matcherName, undefined, expectedArgument, options) +
+          '\n\n' +
+          `Expected path: ${printExpected(expectedPath)}\n` +
+          (hasCompletePath
+            ? `\n${printDiffOrStringify(
+                expectedValue,
+                receivedValue,
+                EXPECTED_VALUE_LABEL,
+                RECEIVED_VALUE_LABEL,
+                isExpand(this.expand),
+            )}`
+            : `Received path: ${printReceived(
+                expectedPathType === 'array' || receivedPath.length === 0
+                  ? receivedPath
+                  : receivedPath.join('.'),
+            )}\n\n${
+              hasValue ? `Expected value: ${printExpected(expectedValue)}\n` : ''
+            }Received value: ${printReceived(receivedValue)}`);
+
+    return { message, pass };
+  },
+
+  toMatch(received: string, expected: string | RegExp) {
+    const matcherName = 'toMatch';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+
+    if (typeof received !== 'string') {
+      throw new TypeError(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must be a string`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    if (!(typeof expected === 'string') && !(expected && typeof expected.test === 'function')) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${EXPECTED_COLOR('expected')} value must be a string or regular expression`,
+              printWithType('Expected', expected, printExpected),
+          ),
+      );
+    }
+
+    const pass =
+      typeof expected === 'string'
+        ? received.includes(expected)
+        : new RegExp(expected).test(received);
+
+    const message = pass
+      ? () =>
+        typeof expected === 'string'
+          ? matcherHint(matcherName, undefined, undefined, options) +
+              '\n\n' +
+              `Expected substring: not ${printExpected(expected)}\n` +
+              `Received string:        ${printReceivedStringContainExpectedSubstring(
+                  received,
+                  received.indexOf(expected),
+                  expected.length,
+              )}`
+          : matcherHint(matcherName, undefined, undefined, options) +
+              '\n\n' +
+              `Expected pattern: not ${printExpected(expected)}\n` +
+              `Received string:      ${printReceivedStringContainExpectedResult(
+                  received,
+                  typeof expected.exec === 'function' ? expected.exec(received) : null,
+              )}`
+      : () => {
+        const labelExpected = `Expected ${typeof expected === 'string' ? 'substring' : 'pattern'}`;
+        const labelReceived = 'Received string';
+        const printLabel = getLabelPrinter(labelExpected, labelReceived);
+
+        return (
+          matcherHint(matcherName, undefined, undefined, options) +
+            '\n\n' +
+            `${printLabel(labelExpected)}${printExpected(expected)}\n` +
+            `${printLabel(labelReceived)}${printReceived(received)}`
+        );
+      };
+
+    return { message, pass };
+  },
+
+  toMatchObject(received: object, expected: object) {
+    const matcherName = 'toMatchObject';
+    const options: MatcherHintOptions = { isNot: this.isNot, promise: this.promise };
+
+    if (typeof received !== 'object' || received === null) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${RECEIVED_COLOR('received')} value must be a non-null object`,
+              printWithType('Received', received, printReceived),
+          ),
+      );
+    }
+
+    if (typeof expected !== 'object' || expected === null) {
+      throw new Error(
+          matcherErrorMessage(
+              matcherHint(matcherName, undefined, undefined, options),
+              `${EXPECTED_COLOR('expected')} value must be a non-null object`,
+              printWithType('Expected', expected, printExpected),
+          ),
+      );
+    }
+
+    const pass = equals(received, expected, [...this.customTesters, iterableEquality, subsetEquality]);
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}` +
+          (stringify(expected) === stringify(received)
+            ? ''
+            : `\nReceived:     ${printReceived(received)}`)
+      : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          printDiffOrStringify(
+              expected,
+              getObjectSubset(received, expected, this.customTesters),
+              EXPECTED_LABEL,
+              RECEIVED_LABEL,
+              isExpand(this.expand),
+          );
+
+    return { message, pass };
+  },
+
+  toStrictEqual(received: unknown, expected: unknown) {
+    const matcherName = 'toStrictEqual';
+    const options: MatcherHintOptions = { comment: 'deep equality', isNot: this.isNot, promise: this.promise };
+
+    const pass = equals(received, expected, [...this.customTesters, ...toStrictEqualTesters], true);
+
+    const message = pass
+      ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}\n` +
+          (stringify(expected) === stringify(received)
+            ? ''
+            : `Received:     ${printReceived(received)}`)
+      : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+          '\n\n' +
+          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand));
+
+    return { actual: received, expected, message, name: matcherName, pass };
+  },
+};
+
+// -----------------------------------------------------------------------------
+// toThrow matcher (toThrowMatchers.ts)
+// -----------------------------------------------------------------------------
+
+const DID_NOT_THROW = 'Received function did not throw';
+
+type Thrown =
+  | { hasMessage: true; isError: true; message: string; value: Error }
+  | { hasMessage: boolean; isError: false; message: string; value: any };
+
+const getThrown = (e: any): Thrown => {
+  const hasMessage = e !== null && e !== undefined && typeof e.message === 'string';
+
+  if (hasMessage && typeof e.name === 'string' && typeof e.stack === 'string')
+    return { hasMessage, isError: true, message: e.message, value: e };
+
+  return {
+    hasMessage,
+    isError: false,
+    message: hasMessage ? e.message : String(e),
+    value: e,
+  };
+};
+
+const createThrowMatcher = (matcherName: string, fromPromise?: boolean): RawMatcherFn =>
+  function(this: MatcherContext, received: any, expected: any): ExpectationResult {
+    const options = { isNot: this.isNot, promise: this.promise };
+
+    let thrown: Thrown | null = null;
+
+    if (fromPromise && isError(received)) {
+      thrown = getThrown(received);
+    } else {
+      if (typeof received === 'function') {
+        try {
+          received();
+        } catch (error) {
+          thrown = getThrown(error);
+        }
+      } else if (!fromPromise) {
+        const placeholder = expected === undefined ? '' : 'expected';
+        throw new Error(
+            matcherErrorMessage(
+                matcherHint(matcherName, undefined, placeholder, options),
+                `${RECEIVED_COLOR('received')} value must be a function`,
+                printWithType('Received', received, printReceived),
+            ),
+        );
+      }
+    }
+
+    if (expected === undefined)
+      return toThrow(matcherName, options, thrown);
+    if (typeof expected === 'function')
+      return toThrowExpectedClass(matcherName, options, thrown, expected);
+    if (typeof expected === 'string')
+      return toThrowExpectedString(matcherName, options, thrown, expected);
+    if (expected !== null && typeof expected.test === 'function')
+      return toThrowExpectedRegExp(matcherName, options, thrown, expected);
+    if (expected !== null && typeof expected.asymmetricMatch === 'function')
+      return toThrowExpectedAsymmetric(matcherName, options, thrown, expected);
+    if (expected !== null && typeof expected === 'object')
+      return toThrowExpectedObject(matcherName, options, thrown, expected);
+    throw new Error(
+        matcherErrorMessage(
+            matcherHint(matcherName, undefined, undefined, options),
+            `${EXPECTED_COLOR('expected')} value must be a string or regular expression or class or error`,
+            printWithType('Expected', expected, printExpected),
+        ),
+    );
+  };
+
+const toThrowMatchers: MatchersObject = {
+  toThrow: createThrowMatcher('toThrow'),
+};
+
+const toThrowExpectedRegExp = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: RegExp,
+): SyncExpectationResult => {
+  const pass = thrown !== null && expected.test(thrown.message);
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected pattern: not ', expected) +
+      (thrown !== null && thrown.hasMessage
+        ? formatReceived('Received message:     ', thrown, 'message', expected) + formatStack(thrown)
+        : formatReceived('Received value:       ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected pattern: ', expected) +
+      (thrown === null
+        ? `\n${DID_NOT_THROW}`
+        : thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') + formatStack(thrown)
+          : formatReceived('Received value:   ', thrown, 'value'));
+
+  return { message, pass };
+};
+
+type AsymmetricMatcherExpected = { asymmetricMatch: (received: unknown) => boolean };
+
+const toThrowExpectedAsymmetric = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: AsymmetricMatcherExpected,
+): SyncExpectationResult => {
+  const pass = thrown !== null && expected.asymmetricMatch(thrown.value);
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected asymmetric matcher: not ', expected) +
+      '\n' +
+      (thrown !== null && thrown.hasMessage
+        ? formatReceived('Received name:    ', thrown, 'name') +
+          formatReceived('Received message: ', thrown, 'message') +
+          formatStack(thrown)
+        : formatReceived('Thrown value: ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected asymmetric matcher: ', expected) +
+      '\n' +
+      (thrown === null
+        ? DID_NOT_THROW
+        : thrown.hasMessage
+          ? formatReceived('Received name:    ', thrown, 'name') +
+            formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Thrown value: ', thrown, 'value'));
+
+  return { message, pass };
+};
+
+const toThrowExpectedObject = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: Error,
+): SyncExpectationResult => {
+  const expectedMessageAndCause = createMessageAndCause(expected);
+  const thrownMessageAndCause = thrown === null ? null : createMessageAndCause(thrown.value);
+  const isCompareErrorInstance = thrown?.isError && expected instanceof Error;
+  const isExpectedCustomErrorInstance = expected.constructor.name !== Error.name;
+
+  const pass =
+    thrown !== null &&
+    thrown.message === expected.message &&
+    thrownMessageAndCause === expectedMessageAndCause &&
+    (!isCompareErrorInstance || !isExpectedCustomErrorInstance || thrown.value instanceof expected.constructor);
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected(`Expected ${messageAndCause(expected)}: not `, expectedMessageAndCause) +
+      (thrown !== null && thrown.hasMessage
+        ? formatStack(thrown)
+        : formatReceived('Received value:       ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      (thrown === null
+        ? formatExpected(`Expected ${messageAndCause(expected)}: `, expectedMessageAndCause) +
+          '\n' +
+          DID_NOT_THROW
+        : thrown.hasMessage
+          ? printDiffOrStringify(
+              expectedMessageAndCause,
+              thrownMessageAndCause,
+              `Expected ${messageAndCause(expected)}`,
+              `Received ${messageAndCause(thrown.value)}`,
+              true,
+          ) +
+            '\n' +
+            formatStack(thrown)
+          : formatExpected(`Expected ${messageAndCause(expected)}: `, expectedMessageAndCause) +
+            formatReceived('Received value:   ', thrown, 'value'));
+
+  return { message, pass };
+};
+
+const toThrowExpectedClass = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: Function,
+): SyncExpectationResult => {
+  const pass = thrown !== null && thrown.value instanceof expected;
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      printExpectedConstructorNameNot('Expected constructor', expected) +
+      (thrown !== null &&
+      thrown.value !== null && thrown.value !== undefined &&
+      typeof thrown.value.constructor === 'function' &&
+      thrown.value.constructor !== expected
+        ? printReceivedConstructorNameNot('Received constructor', thrown.value.constructor, expected)
+        : '') +
+      '\n' +
+      (thrown !== null && thrown.hasMessage
+        ? formatReceived('Received message: ', thrown, 'message') + formatStack(thrown)
+        : formatReceived('Received value: ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      printExpectedConstructorName('Expected constructor', expected) +
+      (thrown === null
+        ? `\n${DID_NOT_THROW}`
+        : `${
+          thrown.value !== null && thrown.value !== undefined && typeof thrown.value.constructor === 'function'
+            ? printReceivedConstructorName('Received constructor', thrown.value.constructor)
+            : ''
+        }\n${
+          thrown.hasMessage
+            ? formatReceived('Received message: ', thrown, 'message') + formatStack(thrown)
+            : formatReceived('Received value: ', thrown, 'value')
+        }`);
+
+  return { message, pass };
+};
+
+const toThrowExpectedString = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: string,
+): SyncExpectationResult => {
+  const pass = thrown !== null && thrown.message.includes(expected);
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected substring: not ', expected) +
+      (thrown !== null && thrown.hasMessage
+        ? formatReceived('Received message:       ', thrown, 'message', expected) + formatStack(thrown)
+        : formatReceived('Received value:         ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, undefined, options) +
+      '\n\n' +
+      formatExpected('Expected substring: ', expected) +
+      (thrown === null
+        ? `\n${DID_NOT_THROW}`
+        : thrown.hasMessage
+          ? formatReceived('Received message:   ', thrown, 'message') + formatStack(thrown)
+          : formatReceived('Received value:     ', thrown, 'value'));
+
+  return { message, pass };
+};
+
+const toThrow = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+): SyncExpectationResult => {
+  const pass = thrown !== null;
+
+  const message = pass
+    ? () =>
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      (thrown !== null && thrown.hasMessage
+        ? formatReceived('Error name:    ', thrown, 'name') +
+          formatReceived('Error message: ', thrown, 'message') +
+          formatStack(thrown)
+        : formatReceived('Thrown value: ', thrown, 'value'))
+    : () =>
+      matcherHint(matcherName, undefined, '', options) + '\n\n' + DID_NOT_THROW;
+
+  return { message, pass };
+};
+
+const formatExpected = (label: string, expected: unknown) =>
+  `${label + printExpected(expected)}\n`;
+
+const formatReceived = (
+  label: string,
+  thrown: Thrown | null,
+  key: string,
+  expected?: string | RegExp,
+) => {
+  if (thrown === null)
+    return '';
+
+  if (key === 'message') {
+    const message = thrown.message;
+
+    if (typeof expected === 'string') {
+      const index = message.indexOf(expected);
+      if (index !== -1) {
+        return `${
+          label + printReceivedStringContainExpectedSubstring(message, index, expected.length)
+        }\n`;
+      }
+    } else if (expected instanceof RegExp) {
+      return `${
+        label +
+        printReceivedStringContainExpectedResult(
+            message,
+            typeof expected.exec === 'function' ? expected.exec(message) : null,
+        )
+      }\n`;
+    }
+
+    return `${label + printReceived(message)}\n`;
+  }
+
+  if (key === 'name')
+    return thrown.isError ? `${label + printReceived(thrown.value.name)}\n` : '';
+
+  if (key === 'value')
+    return thrown.isError ? '' : `${label + printReceived(thrown.value)}\n`;
+
+  return '';
+};
+
+const formatStack = (thrown: Thrown | null) => {
+  if (thrown === null || !thrown.isError)
+    return '';
+  const config = { rootDir: process.cwd(), testMatch: [] };
+  const options = { noStackTrace: false };
+  if (thrown.value instanceof AggregateError)
+    return formatExecError(thrown.value, config, options);
+  return formatStackTrace(
+      separateMessageFromStack(thrown.value.stack!).stack,
+      config,
+      options,
+  );
+};
+
+function createMessageAndCause(error: Error) {
+  if (error.cause) {
+    const seen = new WeakSet();
+    return JSON.stringify(buildSerializeError(error), (_, value) => {
+      if (isObject(value)) {
+        if (seen.has(value))
+          return;
+        seen.add(value);
+      }
+      if (typeof value === 'bigint' || value === undefined)
+        return String(value);
+      return value;
+    });
+  }
+
+  return error.message;
+}
+
+function buildSerializeError(error: { [key: string]: any }): any {
+  if (!isObject(error))
+    return error;
+
+  const result: { [key: string]: any } = {};
+  for (const name of Object.getOwnPropertyNames(error).sort()) {
+    if (['stack', 'fileName', 'lineNumber'].includes(name))
+      continue;
+    if (name === 'cause') {
+      result[name] = buildSerializeError(error['cause']);
+      continue;
+    }
+    result[name] = error[name];
+  }
+
+  return result;
+}
+
+function isObject(obj: unknown) {
+  return obj !== null && obj !== undefined && typeof obj === 'object';
+}
+
+function messageAndCause(error: Error) {
+  return error.cause === undefined ? 'message' : 'message and cause';
+}
+
+// -----------------------------------------------------------------------------
+// expect function (index.ts)
+// -----------------------------------------------------------------------------
+
+export class JestAssertionError extends Error {
+  matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
+}
+
+const getPromiseMatcher = (name: string) => {
+  if (name === 'toThrow')
+    return createThrowMatcher(name, true);
+  return null;
+};
+
+type AsymmetricMatchers = {
+  any(sample: unknown): AsymmetricMatcher<any>;
+  anything(): AsymmetricMatcher<any>;
+  arrayContaining(sample: Array<unknown>): AsymmetricMatcher<any>;
+  arrayOf(sample: unknown): AsymmetricMatcher<any>;
+  closeTo(sample: number, precision?: number): AsymmetricMatcher<any>;
+  objectContaining(sample: Record<string, unknown>): AsymmetricMatcher<any>;
+  stringContaining(sample: string): AsymmetricMatcher<any>;
+  stringMatching(sample: string | RegExp): AsymmetricMatcher<any>;
+};
+
+interface BaseExpect {
+  extend(matchers: MatchersObject): void;
+  getState(): MatcherState;
+  setState(state: Partial<MatcherState>): void;
+}
+
+export type Expect = (<T = unknown>(actual: T) => any) &
+  BaseExpect &
+  AsymmetricMatchers & {
+    not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
+  };
+
+export const expect: Expect = ((actual: any, ...rest: Array<any>) => {
+  if (rest.length > 0)
+    throw new Error('Expect takes at most one argument.');
+
+  const allMatchers = getMatchers();
+  const expectation: any = {
+    not: {},
+    rejects: { not: {} },
+    resolves: { not: {} },
+  };
+
+  const err = new JestAssertionError();
+
+  for (const name of Object.keys(allMatchers)) {
+    const matcher = allMatchers[name];
+    const promiseMatcher = getPromiseMatcher(name) || matcher;
+    expectation[name] = makeThrowingMatcher(matcher, false, '', actual);
+    expectation.not[name] = makeThrowingMatcher(matcher, true, '', actual);
+
+    expectation.resolves[name] = makeResolveMatcher(name, promiseMatcher, false, actual, err);
+    expectation.resolves.not[name] = makeResolveMatcher(name, promiseMatcher, true, actual, err);
+
+    expectation.rejects[name] = makeRejectMatcher(name, promiseMatcher, false, actual, err);
+    expectation.rejects.not[name] = makeRejectMatcher(name, promiseMatcher, true, actual, err);
+  }
+
+  return expectation;
+}) as Expect;
+
+const getMessage = (message?: () => string) =>
+  (message && message()) ||
+  RECEIVED_COLOR('No message was specified for this matcher.');
+
+const makeResolveMatcher =
+  (
+    matcherName: string,
+    matcher: RawMatcherFn,
+    isNot: boolean,
+    actual: Promise<any> | (() => Promise<any>),
+    outerErr: JestAssertionError,
+  ): PromiseMatcherFn =>
+    (...args: Array<any>) => {
+      const options = { isNot, promise: 'resolves' };
+
+      const actualWrapper: Promise<any> =
+        typeof actual === 'function' ? actual() : actual;
+
+      if (!isPromise(actualWrapper)) {
+        throw new JestAssertionError(
+            matcherErrorMessage(
+                matcherHint(matcherName, undefined, '', options),
+                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+                printWithType('Received', actual, printReceived),
+            ),
+        );
+      }
+
+      const innerErr = new JestAssertionError();
+
+      return actualWrapper.then(
+          result => makeThrowingMatcher(matcher, isNot, 'resolves', result, innerErr).apply(null, args),
+          error => {
+            outerErr.message =
+              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+          'Received promise rejected instead of resolved\n' +
+          `Rejected to value: ${printReceived(error)}`;
+            throw outerErr;
+          },
+      );
+    };
+
+const makeRejectMatcher =
+  (
+    matcherName: string,
+    matcher: RawMatcherFn,
+    isNot: boolean,
+    actual: Promise<any> | (() => Promise<any>),
+    outerErr: JestAssertionError,
+  ): PromiseMatcherFn =>
+    (...args: Array<any>) => {
+      const options = { isNot, promise: 'rejects' };
+
+      const actualWrapper: Promise<any> =
+        typeof actual === 'function' ? actual() : actual;
+
+      if (!isPromise(actualWrapper)) {
+        throw new JestAssertionError(
+            matcherErrorMessage(
+                matcherHint(matcherName, undefined, '', options),
+                `${RECEIVED_COLOR('received')} value must be a promise or a function returning a promise`,
+                printWithType('Received', actual, printReceived),
+            ),
+        );
+      }
+
+      const innerErr = new JestAssertionError();
+
+      return actualWrapper.then(
+          result => {
+            outerErr.message =
+              `${matcherHint(matcherName, undefined, '', options)}\n\n` +
+          'Received promise resolved instead of rejected\n' +
+          `Resolved to value: ${printReceived(result)}`;
+            throw outerErr;
+          },
+          error => makeThrowingMatcher(matcher, isNot, 'rejects', error, innerErr).apply(null, args),
+      );
+    };
+
+const makeThrowingMatcher = (
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  promise: string,
+  actual: any,
+  err?: JestAssertionError,
+): ThrowingMatcherFn =>
+  function throwingMatcher(this: void, ...args: Array<any>): any {
+    let throws = true;
+    const matcherUtilsThing: MatcherUtils = {
+      customTesters: [],
+      dontThrow: () => (throws = false),
+      equals,
+      utils,
+    };
+
+    const matcherContext: MatcherContext = {
+      ...getState<MatcherState>(),
+      ...matcherUtilsThing,
+      error: err,
+      isNot,
+      promise,
+    };
+
+    const processResult = (
+      result: SyncExpectationResult,
+      asyncError?: JestAssertionError,
+    ) => {
+      _validateResult(result);
+
+      if ((result.pass && isNot) || (!result.pass && !isNot)) {
+        const message = getMessage(result.message);
+        let error;
+
+        if (err) {
+          error = err;
+          error.message = message;
+        } else if (asyncError) {
+          error = asyncError;
+          error.message = message;
+        } else {
+          error = new JestAssertionError(message);
+
+          if (Error.captureStackTrace)
+            Error.captureStackTrace(error, throwingMatcher);
+        }
+        error.matcherResult = { ...result, message };
+
+        if (throws)
+          throw error;
+      }
+    };
+
+    const handleError = (error: Error) => {
+      if (
+        matcher[INTERNAL_MATCHER_FLAG] === true &&
+        !(error instanceof JestAssertionError) &&
+        error.name !== 'PrettyFormatPluginError' &&
+        Error.captureStackTrace
+      )
+        Error.captureStackTrace(error, throwingMatcher);
+      throw error;
+    };
+
+    let potentialResult: ExpectationResult;
+
+    try {
+      potentialResult =
+        matcher[INTERNAL_MATCHER_FLAG] === true
+          ? matcher.call(matcherContext, actual, ...args)
+          : (function __EXTERNAL_MATCHER_TRAP__() {
+            return matcher.call(matcherContext, actual, ...args);
+          })();
+
+      if (isPromise(potentialResult)) {
+        const asyncError = new JestAssertionError();
+        if (Error.captureStackTrace)
+          Error.captureStackTrace(asyncError, throwingMatcher);
+
+        return potentialResult
+            .then(aResult => processResult(aResult, asyncError))
+            .catch(handleError);
+      }
+      return processResult(potentialResult);
+    } catch (error: any) {
+      return handleError(error);
+    }
+  };
+
+expect.extend = (matchers: MatchersObject) => setMatchers(matchers, false, expect);
+
+expect.anything = anything;
+expect.any = any;
+
+expect.not = {
+  arrayContaining: arrayNotContaining,
+  arrayOf: notArrayOf,
+  closeTo: notCloseTo,
+  objectContaining: objectNotContaining,
+  stringContaining: stringNotContaining,
+  stringMatching: stringNotMatching,
+};
+
+expect.arrayContaining = arrayContaining;
+expect.arrayOf = arrayOf;
+expect.closeTo = closeTo;
+expect.objectContaining = objectContaining;
+expect.stringContaining = stringContaining;
+expect.stringMatching = stringMatching;
+
+const _validateResult = (result: any) => {
+  if (
+    typeof result !== 'object' ||
+    typeof result.pass !== 'boolean' ||
+    (result.message &&
+      typeof result.message !== 'string' &&
+      typeof result.message !== 'function')
+  ) {
+    throw new Error(
+        'Unexpected return from a matcher function.\n' +
+        'Matcher functions should ' +
+        'return an object in the following format:\n' +
+        '  {message?: string | function, pass: boolean}\n' +
+        `'${stringify(result)}' was returned`,
+    );
+  }
+};
+
+expect.getState = getState;
+expect.setState = setState;
+
+// Register built-in matchers.
+setMatchers(matchers, true, expect);
+setMatchers(toThrowMatchers, true, expect);
+
+export default expect;
+
+// #endregion

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -50,30 +50,29 @@ import type { MatcherHintOptions } from 'jest-matcher-utils';
 // Types
 // -----------------------------------------------------------------------------
 
-export type SyncExpectationResult = {
+type SyncExpectationResult = {
   pass: boolean;
   message(): string;
 };
 
-export type AsyncExpectationResult = Promise<SyncExpectationResult>;
+type AsyncExpectationResult = Promise<SyncExpectationResult>;
 
-export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
+type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
-export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
+type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
   (this: Context, actual: any, ...expected: Array<any>): ExpectationResult;
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
-export type MatchersObject = {
+type MatchersObject = {
   [name: string]: RawMatcherFn;
 };
 
-export type ThrowingMatcherFn = (...args: Array<any>) => any;
-export type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
+type ThrowingMatcherFn = (...args: Array<any>) => any;
+type PromiseMatcherFn = (...args: Array<any>) => Promise<any>;
 
-export interface MatcherUtils {
+interface MatcherUtils {
   customTesters: Array<Tester>;
-  dontThrow(): void;
   equals: EqualsFunction;
   utils: typeof matcherUtils & {
     iterableEquality: Tester;
@@ -81,18 +80,15 @@ export interface MatcherUtils {
   };
 }
 
-export interface MatcherState {
-  currentTestName?: string;
+interface MatcherState {
   error?: Error;
-  expand?: boolean;
   isNot?: boolean;
   promise?: string;
-  testPath?: string;
 }
 
-export type MatcherContext = MatcherUtils & Readonly<MatcherState>;
+type MatcherContext = MatcherUtils & Readonly<MatcherState>;
 
-export type AsymmetricMatcherInterface = {
+type AsymmetricMatcherInterface = {
   asymmetricMatch(other: unknown): boolean;
   toString(): string;
   getExpectedType?(): string;
@@ -144,30 +140,9 @@ function isPromise<T>(candidate: unknown): candidate is Promise<T> {
       && typeof (candidate as any).then === 'function';
 }
 
-const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
-export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
+const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
 
-if (!Object.prototype.hasOwnProperty.call(globalThis, JEST_MATCHERS_OBJECT)) {
-  const defaultState: MatcherState = {};
-  Object.defineProperty(globalThis, JEST_MATCHERS_OBJECT, {
-    value: {
-      matchers: Object.create(null),
-      state: defaultState,
-    },
-  });
-}
-
-export const getState = <State extends MatcherState = MatcherState>(): State =>
-  (globalThis as any)[JEST_MATCHERS_OBJECT].state;
-
-export const setState = <State extends MatcherState = MatcherState>(
-  state: Partial<State>,
-): void => {
-  Object.assign((globalThis as any)[JEST_MATCHERS_OBJECT].state, state);
-};
-
-const getMatchers = (): MatchersObject =>
-  (globalThis as any)[JEST_MATCHERS_OBJECT].matchers;
+const allMatchers: MatchersObject = Object.create(null);
 
 const setMatchers = (
   matchers: MatchersObject,
@@ -237,7 +212,7 @@ const setMatchers = (
     }
   }
 
-  Object.assign((globalThis as any)[JEST_MATCHERS_OBJECT].matchers, matchers);
+  Object.assign(allMatchers, matchers);
 };
 
 // -----------------------------------------------------------------------------
@@ -270,7 +245,7 @@ function hasProperty(obj: object | null, property: string | symbol): boolean {
   return hasProperty(Object.getPrototypeOf(obj), property);
 }
 
-export abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface {
+abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface {
   $$typeof = Symbol.for('jest.asymmetricMatcher');
 
   constructor(
@@ -281,8 +256,6 @@ export abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface
   protected getMatcherContext(): MatcherContext {
     return {
       customTesters: [],
-      dontThrow: () => {},
-      ...getState<MatcherState>(),
       equals,
       isNot: this.inverse,
       utils,
@@ -673,8 +646,6 @@ const RECEIVED_LABEL = 'Received';
 const EXPECTED_VALUE_LABEL = 'Expected value';
 const RECEIVED_VALUE_LABEL = 'Received value';
 
-const isExpand = (expand?: boolean): boolean => expand !== false;
-
 const toStrictEqualTesters = [
   iterableEquality,
   typeEquality,
@@ -724,7 +695,7 @@ const matchers: MatchersObject = {
               : `${DIM_COLOR(
                   `If it should pass with deep equality, replace "${matcherName}" with "${deepEqualityName}"`,
               )}\n\n`) +
-            printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand))
+            printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, false)
         );
       };
 
@@ -1121,7 +1092,7 @@ const matchers: MatchersObject = {
       : () =>
         matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand));
+          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, false);
 
     return { actual: received, expected, message, name: matcherName, pass };
   },
@@ -1242,7 +1213,7 @@ const matchers: MatchersObject = {
                 receivedValue,
                 EXPECTED_VALUE_LABEL,
                 RECEIVED_VALUE_LABEL,
-                isExpand(this.expand),
+                false,
             )}`
             : `Received path: ${printReceived(
                 expectedPathType === 'array' || receivedPath.length === 0
@@ -1360,7 +1331,7 @@ const matchers: MatchersObject = {
               getObjectSubset(received, expected, this.customTesters),
               EXPECTED_LABEL,
               RECEIVED_LABEL,
-              isExpand(this.expand),
+              false,
           );
 
     return { message, pass };
@@ -1383,7 +1354,7 @@ const matchers: MatchersObject = {
       : () =>
         matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, isExpand(this.expand));
+          printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, false);
 
     return { actual: received, expected, message, name: matcherName, pass };
   },
@@ -1778,7 +1749,7 @@ function messageAndCause(error: Error) {
 // expect function (index.ts)
 // -----------------------------------------------------------------------------
 
-export class JestAssertionError extends Error {
+class JestAssertionError extends Error {
   matcherResult?: Omit<SyncExpectationResult, 'message'> & { message: string };
 }
 
@@ -1801,11 +1772,9 @@ type AsymmetricMatchers = {
 
 interface BaseExpect {
   extend(matchers: MatchersObject): void;
-  getState(): MatcherState;
-  setState(state: Partial<MatcherState>): void;
 }
 
-export type Expect = (<T = unknown>(actual: T) => any) &
+type Expect = (<T = unknown>(actual: T) => any) &
   BaseExpect &
   AsymmetricMatchers & {
     not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
@@ -1815,7 +1784,6 @@ export const expect: Expect = ((actual: any, ...rest: Array<any>) => {
   if (rest.length > 0)
     throw new Error('Expect takes at most one argument.');
 
-  const allMatchers = getMatchers();
   const expectation: any = {
     not: {},
     rejects: { not: {} },
@@ -1928,17 +1896,10 @@ const makeThrowingMatcher = (
   err?: JestAssertionError,
 ): ThrowingMatcherFn =>
   function throwingMatcher(this: void, ...args: Array<any>): any {
-    let throws = true;
-    const matcherUtilsThing: MatcherUtils = {
+    const matcherContext: MatcherContext = {
       customTesters: [],
-      dontThrow: () => (throws = false),
       equals,
       utils,
-    };
-
-    const matcherContext: MatcherContext = {
-      ...getState<MatcherState>(),
-      ...matcherUtilsThing,
       error: err,
       isNot,
       promise,
@@ -1967,9 +1928,7 @@ const makeThrowingMatcher = (
             Error.captureStackTrace(error, throwingMatcher);
         }
         error.matcherResult = { ...result, message };
-
-        if (throws)
-          throw error;
+        throw error;
       }
     };
 
@@ -2048,13 +2007,8 @@ const _validateResult = (result: any) => {
   }
 };
 
-expect.getState = getState;
-expect.setState = setState;
-
 // Register built-in matchers.
 setMatchers(matchers, true, expect);
 setMatchers(toThrowMatchers, true, expect);
-
-export default expect;
 
 // #endregion

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -1354,6 +1354,7 @@ export const createThrowMatcher = (matcherName: string, fromPromise?: boolean): 
 
 export const toThrowMatchers: MatchersObject = {
   toThrow: createThrowMatcher('toThrow'),
+  toThrowError: createThrowMatcher('toThrowError'),
 };
 
 const toThrowExpectedRegExp = (

--- a/packages/playwright/src/matchers/expectLibrary.ts
+++ b/packages/playwright/src/matchers/expectLibrary.ts
@@ -185,6 +185,38 @@ export abstract class AsymmetricMatcher<T> implements AsymmetricMatcherInterface
   toAsymmetricMatcher?(): string;
 }
 
+export function buildCustomAsymmetricMatcher(matcherName: string, matcher: RawMatcherFn) {
+  class CustomMatcher extends AsymmetricMatcher<[unknown, ...Array<unknown>]> {
+    constructor(inverse: boolean = false, ...sample: [unknown, ...Array<unknown>]) {
+      super(sample, inverse);
+    }
+
+    asymmetricMatch(other: unknown) {
+      const { pass } = matcher.call(
+          (this as any).getMatcherContext(),
+          other,
+          ...this.sample,
+      ) as SyncExpectationResult;
+      return this.inverse ? !pass : pass;
+    }
+
+    toString() {
+      return `${this.inverse ? 'not.' : ''}${matcherName}`;
+    }
+
+    override getExpectedType() {
+      return 'any';
+    }
+
+    override toAsymmetricMatcher() {
+      return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
+    }
+  }
+  const positive = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(false, ...sample);
+  const inverse = (...sample: [unknown, ...Array<unknown>]) => new CustomMatcher(true, ...sample);
+  return { positive, inverse };
+}
+
 class Any extends AsymmetricMatcher<any> {
   constructor(sample: unknown) {
     if (sample === undefined) {
@@ -1349,11 +1381,6 @@ export const createThrowMatcher = (matcherName: string, fromPromise?: boolean): 
     );
   };
 
-export const toThrowMatchers: MatchersObject = {
-  toThrow: createThrowMatcher('toThrow'),
-  toThrowError: createThrowMatcher('toThrowError'),
-};
-
 const toThrowExpectedRegExp = (
   matcherName: string,
   options: MatcherHintOptions,
@@ -1662,12 +1689,6 @@ function isObject(obj: unknown) {
 function messageAndCause(error: Error) {
   return error.cause === undefined ? 'message' : 'message and cause';
 }
-
-export const getPromiseMatcher = (name: string) => {
-  if (name === 'toThrow')
-    return createThrowMatcher(name, true);
-  return null;
-};
 
 export const getMessage = (message?: () => string) =>
   (message && message()) ||

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -35,28 +35,17 @@ export type MatcherResultProperty = Omit<MatcherResult<unknown, unknown>, 'messa
   message: string;
 };
 
-type JestError = Error & {
-  matcherResult: MatcherResultProperty;
-};
-
 export class ExpectError extends Error {
   matcherResult: MatcherResultProperty;
 
-  constructor(jestError: JestError, customMessage: string, stackFrames: StackFrame[]) {
+  constructor(matcherResult: MatcherResultProperty, customMessage: string, stackFrames: StackFrame[]) {
     super('');
-    // Copy to erase the JestMatcherError constructor name from the console.log(error).
-    this.name = jestError.name;
-    this.message = jestError.message;
-    this.matcherResult = jestError.matcherResult;
-
+    this.message = matcherResult.message;
+    this.matcherResult = matcherResult;
     if (customMessage)
       this.message = customMessage + '\n\n' + this.message;
     this.stack = this.name + ': ' + this.message + '\n' + stringifyStackFrames(stackFrames).join('\n');
   }
-}
-
-export function isJestError(e: unknown): e is JestError {
-  return e instanceof Error && 'matcherResult' in e && !!e.matcherResult;
 }
 
 export function expectTypes(receiver: any, types: ('APIResponse' | 'Page' | 'Locator')[], matcherName: string) {

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -20,18 +20,23 @@ import { stringifyStackFrames } from '@isomorphic/stackTrace';
 
 import type { StackFrame } from '@protocol/channels';
 
-export type MatcherResult<E, A> = {
-  name: string;
+export type MatcherAttachment = { name: string; contentType: string; path?: string; body?: string | Buffer };
+
+export type MatcherResult<E = unknown, A = unknown> = {
+  name?: string;
   expected?: E;
   message: () => string;
   pass: boolean;
   actual?: A;
+  diff?: string;
   log?: string[];
   timeout?: number;
   suggestedRebaseline?: string;
+  attachments?: MatcherAttachment[];
 };
 
-export type MatcherResultProperty = Omit<MatcherResult<unknown, unknown>, 'message'> & {
+export type MatcherResultProperty = Omit<MatcherResult, 'message' | 'name'> & {
+  name: string;
   message: string;
 };
 

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -33,9 +33,11 @@ export type MatcherResult<E = unknown, A = unknown> = {
   timeout?: number;
   suggestedRebaseline?: string;
   attachments?: MatcherAttachment[];
+  softError?: Error | unknown;
+  shouldNotRetryTest?: boolean;
 };
 
-export type MatcherResultProperty = Omit<MatcherResult, 'message' | 'name'> & {
+export type MatcherResultProperty = Omit<MatcherResult, 'message' | 'name' | 'shouldNotRetryTest'> & {
   name: string;
   message: string;
 };

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -33,7 +33,7 @@ import { toHaveScreenshotStepTitle } from './toMatchSnapshot';
 import { expectConfig } from './expect';
 
 import type { ExpectMatcherState } from '../../types/test';
-import type { ExpectStepInfo, ExpectTestInfo } from './expect';
+import type { ExpectTestInfo } from './expect';
 import type { InternalMatcherUtils } from './matcherHint';
 import type { APIResponse, Locator, Frame, Page } from 'playwright-core';
 import type { FrameExpectParams } from 'playwright-core/lib/client/types';
@@ -41,7 +41,6 @@ import type { ExpectMatcherUtils } from '../../types/test';
 import type { URLPattern } from '@isomorphic/urlMatch';
 
 export type ExpectMatcherStateInternal = Omit<ExpectMatcherState, 'utils'> & {
-  _stepInfo?: ExpectStepInfo;
   utils: ExpectMatcherUtils & InternalMatcherUtils;
 };
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -150,10 +150,7 @@ export async function toMatchAriaSnapshot(
           const message = 'A snapshot is not provided, generating new baseline.';
           testInfo._failWithError(new Error(message), 'shouldNotRetry');
         }
-        // TODO: ideally, we should return "pass: true" here because this matcher passes
-        // when regenerating baselines. However, we can only access suggestedRebaseline in case
-        // of an error, so we fail here and workaround it in the expect implementation.
-        return { pass: false, message: () => '', name: 'toMatchAriaSnapshot', suggestedRebaseline };
+        return { pass: true, message: () => '', name: 'toMatchAriaSnapshot', suggestedRebaseline };
       }
     }
   }

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -137,18 +137,17 @@ export async function toMatchAriaSnapshot(
         const relativePath = path.relative(process.cwd(), expectedPath);
         if (updateSnapshots === 'missing') {
           const message = `A snapshot doesn't exist at ${relativePath}, writing actual.`;
-          testInfo._failWithError(new Error(message), 'shouldNotRetry');
-        } else {
-          const message = `A snapshot is generated at ${relativePath}.`;
-          /* eslint-disable no-console */
-          console.log(message);
+          return { pass: true, message: () => '', name: 'toMatchAriaSnapshot', softError: new Error(message), shouldNotRetryTest: true };
         }
+        const message = `A snapshot is generated at ${relativePath}.`;
+        /* eslint-disable no-console */
+        console.log(message);
         return { pass: true, message: () => '', name: 'toMatchAriaSnapshot' };
       } else {
         const suggestedRebaseline = `\`\n${escapeTemplateString(indent(typedReceived.regex, '{indent}  '))}\n{indent}\``;
         if (updateSnapshots === 'missing') {
           const message = 'A snapshot is not provided, generating new baseline.';
-          testInfo._failWithError(new Error(message), 'shouldNotRetry');
+          return { pass: true, message: () => '', name: 'toMatchAriaSnapshot', suggestedRebaseline, softError: new Error(message), shouldNotRetryTest: true };
         }
         return { pass: true, message: () => '', name: 'toMatchAriaSnapshot', suggestedRebaseline };
       }

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -26,16 +26,14 @@ import { addSuffixToFilePath } from '@utils/fileUtils';
 import { callLogText, expectTypes, formatMatcherMessage } from './matcherHint';
 import { expectConfig } from './expect';
 
-import type { MatcherResult } from './matcherHint';
+import type { MatcherAttachment, MatcherResult } from './matcherHint';
 import type { ExpectMatcherStateInternal } from './matchers';
-import type { ExpectTestInfo, ExpectStepInfo } from './expect';
+import type { ExpectTestInfo } from './expect';
 import type { Locator, Page } from 'playwright-core';
 import type { ExpectScreenshotOptions, Page as PageEx } from 'playwright-core/lib/client/page';
 import type { Comparator, ImageComparatorOptions } from '@utils/comparators';
 
 type NameOrSegments = string | string[];
-
-type ImageMatcherResult = MatcherResult<string, string> & { diff?: string };
 
 type ToHaveScreenshotConfigOptions = ImageComparatorOptions & {
   animations?: 'allow' | 'disabled';
@@ -151,8 +149,8 @@ class SnapshotHelper {
     this.kind = this.mimeType.startsWith('image/') ? 'Screenshot' : 'Snapshot';
   }
 
-  createMatcherResult(message: string, pass: boolean, log?: string[]): ImageMatcherResult {
-    const unfiltered: ImageMatcherResult = {
+  createMatcherResult(message: string, pass: boolean, log?: string[], attachments?: MatcherAttachment[]): MatcherResult<string, string> {
+    const unfiltered: MatcherResult<string, string> = {
       name: this.matcherName,
       expected: this.expectedPath,
       actual: this.actualPath,
@@ -160,23 +158,24 @@ class SnapshotHelper {
       pass,
       message: () => message,
       log,
+      attachments,
     };
-    return Object.fromEntries(Object.entries(unfiltered).filter(([_, v]) => v !== undefined)) as ImageMatcherResult;
+    return Object.fromEntries(Object.entries(unfiltered).filter(([_, v]) => v !== undefined)) as MatcherResult<string, string>;
   }
 
-  handleMissingNegated(): ImageMatcherResult {
+  handleMissingNegated(): MatcherResult<string, string> {
     const isWriteMissingMode = this.updateSnapshots !== 'none';
     const message = `A snapshot doesn't exist at ${this.expectedPath}${isWriteMissingMode ? ', matchers using ".not" won\'t write them automatically.' : '.'}`;
     // NOTE: 'isNot' matcher implies inversed value.
     return this.createMatcherResult(message, true);
   }
 
-  handleDifferentNegated(): ImageMatcherResult {
+  handleDifferentNegated(): MatcherResult<string, string> {
     // NOTE: 'isNot' matcher implies inversed value.
     return this.createMatcherResult('', false);
   }
 
-  handleMatchingNegated(): ImageMatcherResult {
+  handleMatchingNegated(): MatcherResult<string, string> {
     const message = [
       colors.red(`${this.kind} comparison failed:`),
       '',
@@ -186,24 +185,25 @@ class SnapshotHelper {
     return this.createMatcherResult(message, true);
   }
 
-  handleMissing(actual: Buffer | string, step: ExpectStepInfo | undefined): ImageMatcherResult {
+  handleMissing(actual: Buffer | string): MatcherResult<string, string> {
+    const attachments: MatcherAttachment[] = [];
     const isWriteMissingMode = this.updateSnapshots !== 'none';
     if (isWriteMissingMode)
       writeFileSync(this.expectedPath, actual);
-    step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
+    attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
     writeFileSync(this.actualPath, actual);
-    step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
+    attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
     const message = `A snapshot doesn't exist at ${this.expectedPath}${isWriteMissingMode ? ', writing actual.' : '.'}`;
     if (this.updateSnapshots === 'all' || this.updateSnapshots === 'changed') {
       /* eslint-disable no-console */
       console.log(message);
-      return this.createMatcherResult(message, true);
+      return this.createMatcherResult(message, true, undefined, attachments);
     }
     if (this.updateSnapshots === 'missing') {
       this.testInfo._failWithError(new Error(message), 'shouldNotRetry');
-      return this.createMatcherResult('', true);
+      return this.createMatcherResult('', true, undefined, attachments);
     }
-    return this.createMatcherResult(message, false);
+    return this.createMatcherResult(message, false, undefined, attachments);
   }
 
   handleDifferent(
@@ -213,30 +213,30 @@ class SnapshotHelper {
     diff: Buffer | string | undefined,
     header: string,
     diffError: string,
-    log: string[] | undefined,
-    step: ExpectStepInfo | undefined): ImageMatcherResult {
+    log: string[] | undefined): MatcherResult<string, string> {
     const output = [`${header}${indent(diffError, '  ')}`];
     if (this.name) {
       output.push('');
       output.push(`  Snapshot: ${this.name}`);
     }
+    const attachments: MatcherAttachment[] = [];
     if (expected !== undefined) {
       // Copy the expectation inside the `test-results/` folder for backwards compatibility,
       // so that one can upload `test-results/` directory and have all the data inside.
       writeFileSync(this.legacyExpectedPath, expected);
-      step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
+      attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-expected'), contentType: this.mimeType, path: this.expectedPath });
     }
     if (previous !== undefined) {
       writeFileSync(this.previousPath, previous);
-      step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-previous'), contentType: this.mimeType, path: this.previousPath });
+      attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-previous'), contentType: this.mimeType, path: this.previousPath });
     }
     if (actual !== undefined) {
       writeFileSync(this.actualPath, actual);
-      step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
+      attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-actual'), contentType: this.mimeType, path: this.actualPath });
     }
     if (diff !== undefined) {
       writeFileSync(this.diffPath, diff);
-      step?._attachToStep({ name: addSuffixToFilePath(this.attachmentBaseName, '-diff'), contentType: this.mimeType, path: this.diffPath });
+      attachments.push({ name: addSuffixToFilePath(this.attachmentBaseName, '-diff'), contentType: this.mimeType, path: this.diffPath });
     }
 
     if (log?.length)
@@ -244,10 +244,10 @@ class SnapshotHelper {
     else
       output.push('');
 
-    return this.createMatcherResult(output.join('\n'), false, log);
+    return this.createMatcherResult(output.join('\n'), false, log, attachments);
   }
 
-  handleMatching(): ImageMatcherResult {
+  handleMatching(): MatcherResult<string, string> {
     return this.createMatcherResult('', true);
   }
 }
@@ -280,7 +280,7 @@ export function toMatchSnapshot(
   }
 
   if (!fs.existsSync(helper.expectedPath))
-    return helper.handleMissing(received, this._stepInfo);
+    return helper.handleMissing(received);
 
   const expected = fs.readFileSync(helper.expectedPath);
 
@@ -308,7 +308,7 @@ export function toMatchSnapshot(
     return helper.handleMatching();
 
   const header = formatMatcherMessage(this.utils, { promise: this.promise, isNot: this.isNot, matcherName: 'toMatchSnapshot', receiver: isString(received) ? 'string' : 'Buffer', expectation: 'expected' });
-  return helper.handleDifferent(received, expected, undefined, result.diff, header, result.errorMessage, undefined, this._stepInfo);
+  return helper.handleDifferent(received, expected, undefined, result.diff, header, result.errorMessage, undefined);
 }
 
 export function toHaveScreenshotStepTitle(
@@ -393,11 +393,11 @@ export async function toHaveScreenshot(
       // This can be due to e.g. spinning animation, so we want to show it as a diff.
       if (errorMessage) {
         const header = formatMatcherMessage(this.utils, { promise: this.promise, isNot: this.isNot, matcherName: 'toHaveScreenshot', locator: locator?.toString(), expectation: 'expected', timeout, timedOut });
-        return helper.handleDifferent(actual, undefined, previous, diff, header, errorMessage, log, this._stepInfo);
+        return helper.handleDifferent(actual, undefined, previous, diff, header, errorMessage, log);
       }
 
       // We successfully generated new screenshot.
-      return helper.handleMissing(actual!, this._stepInfo);
+      return helper.handleMissing(actual!);
     }
 
     // General case:
@@ -429,11 +429,11 @@ export async function toHaveScreenshot(
         return writeFiles(actual);
       let header = formatMatcherMessage(this.utils, { promise: this.promise, isNot: this.isNot, matcherName: 'toHaveScreenshot', locator: locator?.toString(), expectation: 'expected', timeout, timedOut });
       header += '  Failed to re-generate expected.\n';
-      return helper.handleDifferent(actual, expectScreenshotOptions.expected, previous, diff, header, errorMessage, log, this._stepInfo);
+      return helper.handleDifferent(actual, expectScreenshotOptions.expected, previous, diff, header, errorMessage, log);
     }
 
     const header = formatMatcherMessage(this.utils, { promise: this.promise, isNot: this.isNot, matcherName: 'toHaveScreenshot', locator: locator?.toString(), expectation: 'expected', timeout, timedOut });
-    return helper.handleDifferent(actual, expectScreenshotOptions.expected, previous, diff, header, errorMessage, log, this._stepInfo);
+    return helper.handleDifferent(actual, expectScreenshotOptions.expected, previous, diff, header, errorMessage, log);
   } finally {
     await page.screencast.showOverlays();
   }

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -200,8 +200,11 @@ class SnapshotHelper {
       return this.createMatcherResult(message, true, undefined, attachments);
     }
     if (this.updateSnapshots === 'missing') {
-      this.testInfo._failWithError(new Error(message), 'shouldNotRetry');
-      return this.createMatcherResult('', true, undefined, attachments);
+      return {
+        ...this.createMatcherResult('', true, undefined, attachments),
+        softError: new Error(message),
+        shouldNotRetryTest: true,
+      };
     }
     return this.createMatcherResult(message, false, undefined, attachments);
   }

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -54,7 +54,7 @@ interface TestStepData {
 }
 
 export interface TestStepInternal extends TestStepData {
-  complete(result: { error?: Error | unknown, suggestedRebaseline?: string }): void;
+  complete(result: { error?: Error | unknown, suggestedRebaseline?: string, attachments?: TestInfo['attachments'] }): void;
   info: TestStepInfoImpl;
   attachmentIndices: number[];
   stepId: string;
@@ -318,6 +318,10 @@ export class TestInfoImpl implements TestInfo {
           return;
 
         step.endWallTime = Date.now();
+        if (result.attachments) {
+          for (const attachment of result.attachments)
+            this._attach(attachment, stepId);
+        }
         if (result.error) {
           if (typeof result.error === 'object' && !(result.error as any)?.[stepSymbol])
             (result.error as any)[stepSymbol] = step;
@@ -694,12 +698,8 @@ export class TestStepInfoImpl implements TestStepInfo {
     }
   }
 
-  _attachToStep(attachment: TestInfo['attachments'][0]): void {
-    this._testInfo._attach(attachment, this._stepId);
-  }
-
   async attach(name: string, options?: { body?: string | Buffer; contentType?: string; path?: string; }): Promise<void> {
-    this._attachToStep(await normalizeAndSaveAttachment(this._testInfo.outputPath(), name, options));
+    this._testInfo._attach(await normalizeAndSaveAttachment(this._testInfo.outputPath(), name, options), this._stepId);
   }
 
   get titlePath(): string[] {

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -54,7 +54,7 @@ interface TestStepData {
 }
 
 export interface TestStepInternal extends TestStepData {
-  complete(result: { error?: Error | unknown, suggestedRebaseline?: string, attachments?: TestInfo['attachments'] }): void;
+  complete(result: { error?: Error | unknown, softError?: Error | unknown, shouldNotRetryTest?: boolean, suggestedRebaseline?: string, attachments?: TestInfo['attachments'] }): void;
   info: TestStepInfoImpl;
   attachmentIndices: number[];
   stepId: string;
@@ -322,6 +322,10 @@ export class TestInfoImpl implements TestInfo {
           for (const attachment of result.attachments)
             this._attach(attachment, stepId);
         }
+        if (result.softError)
+          this._failWithError(result.softError);
+        if (result.shouldNotRetryTest)
+          this._hasNonRetriableError = true;
         if (result.error) {
           if (typeof result.error === 'object' && !(result.error as any)?.[stepSymbol])
             (result.error as any)[stepSymbol] = step;
@@ -407,9 +411,7 @@ export class TestInfoImpl implements TestInfo {
       this.status = 'interrupted';
   }
 
-  _failWithError(error: Error | unknown, shouldNotRetry?: 'shouldNotRetry') {
-    if (shouldNotRetry)
-      this._hasNonRetriableError = true;
+  _failWithError(error: Error | unknown) {
     if (this.status === 'passed' || this.status === 'skipped')
       this.status = error instanceof TimeoutManagerError ? 'timedOut' : 'failed';
     const serialized = testInfoError(error);

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -46,7 +46,6 @@ interface TestStepData {
   location?: Location;
   apiName?: string;
   params?: Record<string, any>;
-  infectParentStepsWithError?: boolean;
   box?: boolean;
   // steps with any defined group are hidden from the report
   // 'internal' steps are hidden from the trace
@@ -62,6 +61,7 @@ export interface TestStepInternal extends TestStepData {
   steps: TestStepInternal[];
   endWallTime?: number;
   error?: ipc.TestInfoErrorImpl;
+  infectParentStepsWithError?: boolean;
 }
 
 type SnapshotNames = {
@@ -322,10 +322,6 @@ export class TestInfoImpl implements TestInfo {
           for (const attachment of result.attachments)
             this._attach(attachment, stepId);
         }
-        if (result.softError)
-          this._failWithError(result.softError);
-        if (result.shouldNotRetryTest)
-          this._hasNonRetriableError = true;
         if (result.error) {
           if (typeof result.error === 'object' && !(result.error as any)?.[stepSymbol])
             (result.error as any)[stepSymbol] = step;
@@ -334,6 +330,12 @@ export class TestInfoImpl implements TestInfo {
             error.stack = `${error.message}\n${stringifyStackFrames(step.boxedStack).join('\n')}`;
           step.error = error;
         }
+        if (result.softError) {
+          step.infectParentStepsWithError = true;
+          this._failWithError(result.softError);
+        }
+        if (result.shouldNotRetryTest)
+          this._hasNonRetriableError = true;
 
         if (!step.error) {
           // Soft errors inside try/catch will make the test fail.

--- a/tests/installation/bundle-licenses.spec.ts
+++ b/tests/installation/bundle-licenses.spec.ts
@@ -25,7 +25,7 @@ const EXPECTED: Record<string, Record<string, number>> = {
     'lib/utilsBundle.js.LICENSE': 80,
   },
   'playwright': {
-    'lib/matchers/expect.js.LICENSE': 30,
+    'lib/matchers/expect.js.LICENSE': 20,
     'lib/transform/esmLoader.js.LICENSE': 10,
     'lib/transform/babelBundle.js.LICENSE': 65,
   },

--- a/tests/page/expect-builtins.spec.ts
+++ b/tests/page/expect-builtins.spec.ts
@@ -1,0 +1,922 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ * Modifications copyright (c) Microsoft Corporation.
+ *
+ * This source code is licensed under the MIT license found here
+ * https://github.com/jestjs/jest/blob/v30.2.0/LICENSE
+ */
+
+// Adapted from jest/packages/expect/src/__tests__/matchers.test.js,
+// asymmetricMatchers.test.ts and toThrowMatchers.test.ts.
+
+import { test, expect } from './pageTest';
+
+test.describe('.toBe()', () => {
+  test('does not throw', () => {
+    expect('a').not.toBe('b');
+    expect('a').toBe('a');
+    expect(1).not.toBe(2);
+    expect(1).toBe(1);
+    expect(null).not.toBe(undefined);
+    expect(null).toBe(null);
+    expect(undefined).toBe(undefined);
+    expect(NaN).toBe(NaN);
+    expect(BigInt(1)).not.toBe(BigInt(2));
+    expect(BigInt(1)).not.toBe(1);
+    expect(BigInt(1)).toBe(BigInt(1));
+  });
+
+  for (const [i, [a, b]] of [
+    [1, 2],
+    [true, false],
+    [{}, {}],
+    [{ a: 1 }, { a: 1 }],
+    [{ a: 1 }, { a: 5 }],
+    [{ a: undefined, b: 2 }, { b: 2 }],
+    [new Date('2020-02-20'), new Date('2020-02-20')],
+    [/received/, /expected/],
+    [['abc'], ['cde']],
+    [[], []],
+    [null, undefined],
+    [-0, +0],
+  ].entries()) {
+    test(`fails for: ${JSON.stringify(a)} and ${JSON.stringify(b)} #${i}`, () => {
+      expect(() => expect(a).toBe(b)).toThrow();
+    });
+  }
+
+  for (const v of [false, 1, 'a', undefined, null, {}, []]) {
+    test(`fails for '${JSON.stringify(v)}' with '.not'`, () => {
+      expect(() => expect(v).not.toBe(v)).toThrow();
+    });
+  }
+
+  test('does not crash on circular references', () => {
+    const obj: any = {};
+    obj.circular = obj;
+    expect(() => expect(obj).toBe({})).toThrow();
+  });
+
+  test('matcherResult property contains matcher name, expected and actual values', () => {
+    const actual = { a: 1 };
+    const expected = { a: 2 };
+    try {
+      expect(actual).toBe(expected);
+    } catch (error) {
+      expect(error.matcherResult).toEqual(expect.objectContaining({
+        actual,
+        expected,
+        name: 'toBe',
+      }));
+    }
+  });
+});
+
+test.describe('.toStrictEqual()', () => {
+  class TestClassA {
+    a: number;
+    b: number;
+    constructor(a: number, b: number) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  class TestClassB {
+    a: number;
+    b: number;
+    constructor(a: number, b: number) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  test('does not ignore keys with undefined values', () => {
+    expect({ a: undefined, b: 2 }).not.toStrictEqual({ b: 2 });
+  });
+
+  test('does not ignore keys with undefined values inside an array', () => {
+    expect([{ a: undefined }]).not.toStrictEqual([{}]);
+  });
+
+  test('passes when comparing same type', () => {
+    expect({ test: new TestClassA(1, 2) }).toStrictEqual({ test: new TestClassA(1, 2) });
+  });
+
+  test('does not pass for different types', () => {
+    expect({ test: new TestClassA(1, 2) }).not.toStrictEqual({ test: new TestClassB(1, 2) });
+  });
+
+  test('passes for matching buffers', () => {
+    expect(Uint8Array.from([1]).buffer).toStrictEqual(Uint8Array.from([1]).buffer);
+    expect(Uint8Array.from([]).buffer).toStrictEqual(Uint8Array.from([]).buffer);
+    expect(Uint8Array.from([9, 3]).buffer).toStrictEqual(Uint8Array.from([9, 3]).buffer);
+  });
+
+  test('does not pass when ArrayBuffers are not equal', () => {
+    expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(Uint8Array.from([0, 0]).buffer);
+  });
+});
+
+test.describe('.toEqual()', () => {
+  for (const [a, b] of [
+    [true, false],
+    [1, 2],
+    [0, Number.MIN_VALUE],
+    [{ a: 1 }, { a: 2 }],
+    ['banana', 'apple'],
+    [null, undefined],
+    [[1], [2]],
+    [new Set([1, 2]), new Set()],
+    [new Set([1, 2]), new Set([1, 2, 3])],
+    [new Map([['a', 0]]), new Map([['b', 0]])],
+    [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 100])],
+    [{ a: 1, b: 2 }, expect.objectContaining({ a: 2 })],
+    [[1, 3], expect.arrayContaining([1, 2])],
+    ['abd', expect.stringContaining('bc')],
+    ['abd', expect.stringMatching(/bc/i)],
+    [undefined, expect.anything()],
+    [undefined, expect.any(Function)],
+  ].entries()) {
+    test(`{pass: false} expect().toEqual() #${a}`, () => {
+      expect(() => expect(b[0]).toEqual(b[1])).toThrow();
+      expect(b[0]).not.toEqual(b[1]);
+    });
+  }
+
+  for (const [a, b] of [
+    [true, true],
+    [1, 1],
+    [NaN, NaN],
+    ['abc', 'abc'],
+    [[1], [1]],
+    [{}, {}],
+    [{ a: 99 }, { a: 99 }],
+    [new Set(), new Set()],
+    [new Set([1, 2]), new Set([1, 2])],
+    [new Set([1, 2]), new Set([2, 1])],
+    [new Map(), new Map()],
+    [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 99])],
+    [{ a: 1, b: 2 }, expect.objectContaining({ a: 1 })],
+    [[1, 2, 3], expect.arrayContaining([2, 3])],
+    ['abcd', expect.stringContaining('bc')],
+    ['abcd', expect.stringMatching('bc')],
+    [true, expect.anything()],
+    [() => {}, expect.any(Function)],
+  ].entries()) {
+    test(`{pass: true} expect().toEqual() #${a}`, () => {
+      expect(b[0]).toEqual(b[1]);
+      expect(() => expect(b[0]).not.toEqual(b[1])).toThrow();
+    });
+  }
+
+  test('assertion error matcherResult property contains matcher name, expected and actual values', () => {
+    const actual = { a: 1 };
+    const expected = { a: 2 };
+    try {
+      expect(actual).toEqual(expected);
+    } catch (error) {
+      expect(error.matcherResult).toEqual(expect.objectContaining({
+        actual,
+        expected,
+        name: 'toEqual',
+      }));
+    }
+  });
+
+  test('symbol based keys in arrays are processed correctly', () => {
+    const mySymbol = Symbol('test');
+    const actual1: any[] = [];
+    actual1[mySymbol as any] = 3;
+    const actual2: any[] = [];
+    actual2[mySymbol as any] = 4;
+    const expected: any[] = [];
+    expected[mySymbol as any] = 3;
+
+    expect(actual1).toEqual(expected);
+    expect(actual2).not.toEqual(expected);
+  });
+
+  test('non-enumerable members should be skipped during equal', () => {
+    const actual: any = { x: 3 };
+    Object.defineProperty(actual, 'test', { enumerable: false, value: 5 });
+    expect(actual).toEqual({ x: 3 });
+  });
+
+  test('objectContaining sample can be used multiple times', () => {
+    const expected = expect.objectContaining({ b: 7 });
+    expect({ a: 1, b: 2 }).not.toEqual(expected);
+    expect({ a: 3, b: 7 }).toEqual(expected);
+  });
+
+  test.describe('cyclic object equality', () => {
+    test('properties with the same circularity are equal', () => {
+      const a: any = {};
+      a.x = a;
+      const b: any = {};
+      b.x = b;
+      expect(a).toEqual(b);
+      expect(b).toEqual(a);
+    });
+
+    test('properties with different circularity are not equal', () => {
+      const a: any = {};
+      a.x = { y: a };
+      const b: any = {};
+      const bx: any = {};
+      b.x = bx;
+      bx.y = bx;
+      expect(a).not.toEqual(b);
+      expect(b).not.toEqual(a);
+    });
+  });
+});
+
+test.describe('.toBeInstanceOf()', () => {
+  class A {}
+  class B {}
+  class C extends B {}
+  class E extends C {}
+
+  for (const [i, [a, b]] of ([
+    [new Map(), Map],
+    [[], Array],
+    [new A(), A],
+    [new C(), B],
+    [new E(), B],
+  ] as const).entries()) {
+    test(`passing instanceof #${i}`, () => {
+      expect(() => expect(a).not.toBeInstanceOf(b)).toThrow();
+      expect(a).toBeInstanceOf(b);
+    });
+  }
+
+  for (const [i, [a, b]] of ([
+    ['a', String],
+    [1, Number],
+    [true, Boolean],
+    [new A(), B],
+  ] as const).entries()) {
+    test(`failing instanceof #${i}`, () => {
+      expect(() => expect(a).toBeInstanceOf(b)).toThrow();
+      expect(a).not.toBeInstanceOf(b);
+    });
+  }
+
+  test('throws if constructor is not a function', () => {
+    expect(() => expect({}).toBeInstanceOf(4 as any)).toThrow();
+  });
+});
+
+test.describe('.toBeTruthy(), .toBeFalsy()', () => {
+  for (const v of [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity]) {
+    test(`'${String(v)}' is truthy`, () => {
+      expect(v).toBeTruthy();
+      expect(v).not.toBeFalsy();
+      expect(() => expect(v).not.toBeTruthy()).toThrow();
+      expect(() => expect(v).toBeFalsy()).toThrow();
+    });
+  }
+
+  for (const v of [false, null, NaN, 0, '', undefined]) {
+    test(`'${String(v)}' is falsy`, () => {
+      expect(v).toBeFalsy();
+      expect(v).not.toBeTruthy();
+      expect(() => expect(v).toBeTruthy()).toThrow();
+      expect(() => expect(v).not.toBeFalsy()).toThrow();
+    });
+  }
+});
+
+test.describe('.toBeNaN()', () => {
+  test('{pass: true}', () => {
+    for (const v of [NaN, Math.sqrt(-1), Infinity - Infinity, 0 / 0]) {
+      expect(v).toBeNaN();
+      expect(() => expect(v).not.toBeNaN()).toThrow();
+    }
+  });
+
+  test('throws', () => {
+    for (const v of [1, '', null, undefined, {}, [], 0.2, 0, Infinity, -Infinity]) {
+      expect(() => expect(v).toBeNaN()).toThrow();
+      expect(v).not.toBeNaN();
+    }
+  });
+});
+
+test.describe('.toBeNull()', () => {
+  for (const v of [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity]) {
+    test(`fails for '${String(v)}'`, () => {
+      expect(v).not.toBeNull();
+      expect(() => expect(v).toBeNull()).toThrow();
+    });
+  }
+
+  test('fails for null with .not', () => {
+    expect(() => expect(null).not.toBeNull()).toThrow();
+  });
+
+  test('pass for null', () => {
+    expect(null).toBeNull();
+  });
+});
+
+test.describe('.toBeDefined(), .toBeUndefined()', () => {
+  for (const v of [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity]) {
+    test(`'${String(v)}' is defined`, () => {
+      expect(v).toBeDefined();
+      expect(v).not.toBeUndefined();
+      expect(() => expect(v).not.toBeDefined()).toThrow();
+      expect(() => expect(v).toBeUndefined()).toThrow();
+    });
+  }
+
+  test('undefined is undefined', () => {
+    expect(undefined).toBeUndefined();
+    expect(undefined).not.toBeDefined();
+    expect(() => expect(undefined).toBeDefined()).toThrow();
+    expect(() => expect(undefined).not.toBeUndefined()).toThrow();
+  });
+});
+
+test.describe('.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual()', () => {
+  for (const [small, big] of [
+    [1, 2],
+    [-Infinity, Infinity],
+    [Number.MIN_VALUE, Number.MAX_VALUE],
+    [0.1, 0.2],
+  ] as const) {
+    test(`comparing ${small} and ${big}`, () => {
+      expect(small).toBeLessThan(big);
+      expect(big).not.toBeLessThan(small);
+      expect(big).toBeGreaterThan(small);
+      expect(small).not.toBeGreaterThan(big);
+      expect(small).toBeLessThanOrEqual(big);
+      expect(big).not.toBeLessThanOrEqual(small);
+      expect(big).toBeGreaterThanOrEqual(small);
+      expect(small).not.toBeGreaterThanOrEqual(big);
+
+      expect(() => expect(small).toBeGreaterThan(big)).toThrow();
+      expect(() => expect(small).not.toBeLessThan(big)).toThrow();
+      expect(() => expect(big).not.toBeGreaterThan(small)).toThrow();
+      expect(() => expect(big).toBeLessThan(small)).toThrow();
+      expect(() => expect(small).toBeGreaterThanOrEqual(big)).toThrow();
+      expect(() => expect(small).not.toBeLessThanOrEqual(big)).toThrow();
+      expect(() => expect(big).not.toBeGreaterThanOrEqual(small)).toThrow();
+      expect(() => expect(big).toBeLessThanOrEqual(small)).toThrow();
+    });
+  }
+
+  test('can compare BigInt to Numbers', () => {
+    const a = BigInt(2);
+    expect(a).toBeGreaterThan(1);
+    expect(a).toBeGreaterThanOrEqual(2);
+    expect(2).toBeLessThanOrEqual(a);
+    expect(a).toBeLessThan(3);
+    expect(a).toBeLessThanOrEqual(2);
+  });
+
+  for (const [n1, n2] of [
+    [1, 1],
+    [Number.MIN_VALUE, Number.MIN_VALUE],
+    [Infinity, Infinity],
+    [-Infinity, -Infinity],
+  ]) {
+    test(`equal numbers: [${n1}, ${n2}]`, () => {
+      expect(n1).toBeGreaterThanOrEqual(n2);
+      expect(n1).toBeLessThanOrEqual(n2);
+      expect(() => expect(n1).not.toBeGreaterThanOrEqual(n2)).toThrow();
+      expect(() => expect(n1).not.toBeLessThanOrEqual(n2)).toThrow();
+    });
+  }
+});
+
+test.describe('.toContain(), .toContainEqual()', () => {
+  const typedArray = new Int8Array(2);
+  typedArray[0] = 0;
+  typedArray[1] = 1;
+
+  test('iterable', () => {
+    const iterable = {
+      *[Symbol.iterator]() {
+        yield 1;
+        yield 2;
+        yield 3;
+      },
+    };
+    expect(iterable).toContain(2);
+    expect(iterable).toContainEqual(2);
+    expect(() => expect(iterable).not.toContain(1)).toThrow();
+    expect(() => expect(iterable).not.toContainEqual(1)).toThrow();
+  });
+
+  for (const [i, [list, v]] of ([
+    [[1, 2, 3, 4], 1],
+    [['a', 'b', 'c', 'd'], 'a'],
+    [[undefined, null], null],
+    [[undefined, null], undefined],
+    ['abcdef', 'abc'],
+    ['11112111', '2'],
+    [new Set(['abc', 'def']), 'abc'],
+    [typedArray, 1],
+  ] as const).entries()) {
+    test(`contains #${i}`, () => {
+      expect(list).toContain(v);
+      expect(() => expect(list).not.toContain(v)).toThrow();
+    });
+  }
+
+  for (const [i, [list, v]] of ([
+    [[1, 2, 3], 4],
+    [[null, undefined], 1],
+    [[{}, []], []],
+    [[{}, []], {}],
+  ] as const).entries()) {
+    test(`does not contain #${i}`, () => {
+      expect(list).not.toContain(v);
+      expect(() => expect(list).toContain(v)).toThrow();
+    });
+  }
+
+  test('error cases', () => {
+    expect(() => expect(null).toContain(1)).toThrow();
+  });
+
+  for (const [i, [list, v]] of ([
+    [[1, 2, 3, 4], 1],
+    [['a', 'b', 'c', 'd'], 'a'],
+    [[undefined, null], null],
+    [[{ a: 'b' }, { a: 'c' }], { a: 'b' }],
+    [new Set([1, 2, 3, 4]), 1],
+  ] as const).entries()) {
+    test(`contains a value equal #${i}`, () => {
+      expect(list).toContainEqual(v);
+      expect(() => expect(list).not.toContainEqual(v)).toThrow();
+    });
+  }
+
+  test('error cases for toContainEqual', () => {
+    expect(() => expect(null).toContainEqual(1)).toThrow();
+  });
+});
+
+test.describe('.toBeCloseTo', () => {
+  for (const [n1, n2] of [
+    [0, 0],
+    [0, 0.001],
+    [1.23, 1.229],
+    [1.23, 1.226],
+    [1.23, 1.234],
+    [Infinity, Infinity],
+    [-Infinity, -Infinity],
+  ]) {
+    test(`{pass: true} expect(${n1}).toBeCloseTo(${n2})`, () => {
+      expect(n1).toBeCloseTo(n2);
+      expect(() => expect(n1).not.toBeCloseTo(n2)).toThrow();
+    });
+  }
+
+  for (const [n1, n2] of [
+    [0, 0.01],
+    [1, 1.23],
+    [Infinity, -Infinity],
+    [Infinity, 1.23],
+    [-Infinity, -1.23],
+  ]) {
+    test(`{pass: false} expect(${n1}).toBeCloseTo(${n2})`, () => {
+      expect(n1).not.toBeCloseTo(n2);
+      expect(() => expect(n1).toBeCloseTo(n2)).toThrow();
+    });
+  }
+
+  for (const [n1, n2, p] of [
+    [0, 0.1, 0],
+    [0, 0.0001, 3],
+    [0, 0.000_004, 5],
+    [2.000_000_2, 2, 5],
+  ]) {
+    test(`{pass: true} expect(${n1}).toBeCloseTo(${n2}, ${p})`, () => {
+      expect(n1).toBeCloseTo(n2, p);
+      expect(() => expect(n1).not.toBeCloseTo(n2, p)).toThrow();
+    });
+  }
+});
+
+test.describe('.toMatch()', () => {
+  for (const [n1, n2] of [
+    ['foo', 'foo'],
+    ['Foo bar', /^foo/i],
+  ] as const) {
+    test(`{pass: true} expect(${n1}).toMatch(${n2})`, () => {
+      expect(n1).toMatch(n2);
+      expect(() => expect(n1).not.toMatch(n2)).toThrow();
+    });
+  }
+
+  for (const [n1, n2] of [
+    ['bar', 'foo'],
+    ['bar', /foo/],
+  ] as const) {
+    test(`throws: [${n1}, ${n2}]`, () => {
+      expect(() => expect(n1).toMatch(n2)).toThrow();
+    });
+  }
+
+  for (const [i, [n1, n2]] of ([
+    [1, 'foo'],
+    [{}, 'foo'],
+    [[], 'foo'],
+    [true, 'foo'],
+    [/foo/i, 'foo'],
+    [() => {}, 'foo'],
+    [undefined, 'foo'],
+  ] as const).entries()) {
+    test(`throws if non String actual value passed #${i}`, () => {
+      expect(() => expect(n1).toMatch(n2)).toThrow();
+    });
+  }
+
+  for (const [i, [n1, n2]] of ([
+    ['foo', 1],
+    ['foo', {}],
+    ['foo', []],
+    ['foo', true],
+    ['foo', () => {}],
+    ['foo', undefined],
+  ] as const).entries()) {
+    test(`throws if non String/RegExp expected value passed #${i}`, () => {
+      expect(() => expect(n1).toMatch(n2 as any)).toThrow();
+    });
+  }
+
+  test('escapes strings properly', () => {
+    expect('this?: throws').toMatch('this?: throws');
+  });
+
+  test('does not maintain RegExp state between calls', () => {
+    const regex = /f\d+/gi;
+    expect('f123').toMatch(regex);
+    expect('F456').toMatch(regex);
+    expect(regex.lastIndex).toBe(0);
+  });
+});
+
+test.describe('.toHaveLength', () => {
+  for (const [i, [received, length]] of ([
+    [[1, 2], 2],
+    [[], 0],
+    [['a', 'b'], 2],
+    ['abc', 3],
+    ['', 0],
+    [() => {}, 0],
+  ] as const).entries()) {
+    test(`{pass: true} toHaveLength(${length}) #${i}`, () => {
+      expect(received).toHaveLength(length);
+      expect(() => expect(received).not.toHaveLength(length)).toThrow();
+    });
+  }
+
+  for (const [i, [received, length]] of ([
+    [[1, 2], 3],
+    [[], 1],
+    [['a', 'b'], 99],
+    ['abc', 66],
+    ['', 1],
+  ] as const).entries()) {
+    test(`{pass: false} toHaveLength(${length}) #${i}`, () => {
+      expect(received).not.toHaveLength(length);
+      expect(() => expect(received).toHaveLength(length)).toThrow();
+    });
+  }
+
+  test('error cases', () => {
+    expect(() => expect({ a: 9 }).toHaveLength(1)).toThrow();
+    expect(() => expect(0).toHaveLength(1)).toThrow();
+    expect(() => expect(undefined).not.toHaveLength(1)).toThrow();
+  });
+});
+
+test.describe('.toHaveProperty()', () => {
+  for (const [i, [obj, keyPath, value]] of ([
+    [{ a: { b: { c: { d: 1 } } } }, 'a.b.c.d', 1],
+    [{ a: { b: { c: { d: 1 } } } }, ['a', 'b', 'c', 'd'], 1],
+    [{ 'a.b.c.d': 1 }, ['a.b.c.d'], 1],
+    [{ a: { b: [1, 2, 3] } }, ['a', 'b', 1], 2],
+    [{ a: { b: [1, 2, 3] } }, ['a', 'b', 1], expect.any(Number)],
+    [{ a: 0 }, 'a', 0],
+    [{ a: { b: undefined } }, 'a.b', undefined],
+    [{ a: { b: { c: 5 } } }, 'a.b', { c: 5 }],
+    [{ a: { b: [{ c: [{ d: 1 }] }] } }, 'a.b[0].c[0].d', 1],
+    [{ '': 1 }, '', 1],
+  ] as const).entries()) {
+    test(`{pass: true} toHaveProperty with value #${i}`, () => {
+      expect(obj).toHaveProperty(keyPath as any, value);
+      expect(() => expect(obj).not.toHaveProperty(keyPath as any, value)).toThrow();
+    });
+  }
+
+  for (const [i, [obj, keyPath, value]] of ([
+    [{ a: { b: { c: { d: 1 } } } }, 'a.b.ttt.d', 1],
+    [{ a: { b: { c: { d: 1 } } } }, 'a.b.c.d', 2],
+    [{ 'a.b.c.d': 1 }, 'a.b.c.d', 2],
+    [{ a: { b: { c: {} } } }, 'a.b.c.d', 1],
+    [{ a: 1 }, 'a.b.c.d', 5],
+    [{}, 'a', 'test'],
+    [{ a: { b: 3 } }, 'a.b', undefined],
+  ] as const).entries()) {
+    test(`{pass: false} toHaveProperty with value #${i}`, () => {
+      expect(() => expect(obj).toHaveProperty(keyPath, value)).toThrow();
+      expect(obj).not.toHaveProperty(keyPath, value);
+    });
+  }
+
+  for (const [i, [obj, keyPath]] of ([
+    [{ a: { b: { c: { d: 1 } } } }, 'a.b.c.d'],
+    [{ a: { b: { c: { d: 1 } } } }, ['a', 'b', 'c', 'd']],
+    [{ 'a.b.c.d': 1 }, ['a.b.c.d']],
+    [{ a: 0 }, 'a'],
+    [{ a: { b: undefined } }, 'a.b'],
+  ] as const).entries()) {
+    test(`{pass: true} toHaveProperty without value #${i}`, () => {
+      expect(obj).toHaveProperty(keyPath as any);
+      expect(() => expect(obj).not.toHaveProperty(keyPath as any)).toThrow();
+    });
+  }
+
+  for (const [i, [obj, keyPath]] of ([
+    [{ a: { b: { c: {} } } }, 'a.b.c.d'],
+    [{ a: 1 }, 'a.b.c.d'],
+    [{}, 'a'],
+  ] as const).entries()) {
+    test(`{pass: false} toHaveProperty without value #${i}`, () => {
+      expect(() => expect(obj).toHaveProperty(keyPath)).toThrow();
+      expect(obj).not.toHaveProperty(keyPath);
+    });
+  }
+
+  for (const [i, [obj, keyPath]] of ([
+    [null, 'a.b'],
+    [undefined, 'a'],
+    [{ a: { b: {} } }, undefined],
+    [{ a: { b: {} } }, null],
+    [{ a: { b: {} } }, 1],
+  ] as const).entries()) {
+    test(`{error} toHaveProperty #${i}`, () => {
+      expect(() => expect(obj).toHaveProperty(keyPath as any)).toThrow();
+    });
+  }
+});
+
+test.describe('.toMatchObject()', () => {
+  for (const [i, [a, b]] of ([
+    [{ a: 'b', c: 'd' }, { a: 'b' }],
+    [{ a: 'b', c: 'd' }, { a: 'b', c: 'd' }],
+    [{ a: 'b', t: { x: { r: 'r' }, z: 'z' } }, { a: 'b', t: { z: 'z' } }],
+    [{ a: [3, 4, 5], b: 'b' }, { a: [3, 4, 5] }],
+    [{ a: 1, c: 2 }, { a: expect.any(Number) }],
+    [new Set([1, 2]), new Set([1, 2])],
+    [new Date('2015-11-30'), new Date('2015-11-30')],
+    [{ a: null, b: 'b' }, { a: null }],
+    [{ a: undefined, b: 'b' }, { a: undefined }],
+    [[1, 2], [1, 2]],
+    [new Error('foo'), new Error('foo')],
+    [new Error('bar'), { message: 'bar' }],
+  ] as const).entries()) {
+    test(`{pass: true} toMatchObject #${i}`, () => {
+      expect(a).toMatchObject(b as any);
+      expect(() => expect(a).not.toMatchObject(b as any)).toThrow();
+    });
+  }
+
+  for (const [i, [a, b]] of ([
+    [{ a: 'b', c: 'd' }, { e: 'b' }],
+    [{ a: 'b', c: 'd' }, { a: 'b!', c: 'd' }],
+    [{ a: 'a', c: 'd' }, { a: expect.any(Number) }],
+    [{ a: [3, 4, 5], b: 'b' }, { a: [3, 4, 5, 6] }],
+    [[1, 2], [1, 3]],
+    [new Set([1, 2]), new Set([2])],
+    [new Error('foo'), new Error('bar')],
+  ] as const).entries()) {
+    test(`{pass: false} toMatchObject #${i}`, () => {
+      expect(a).not.toMatchObject(b as any);
+      expect(() => expect(a).toMatchObject(b as any)).toThrow();
+    });
+  }
+
+  for (const [i, [a, b]] of ([
+    [null, {}],
+    [4, {}],
+    ['44', {}],
+    [true, {}],
+    [undefined, {}],
+    [{}, null],
+    [{}, 4],
+  ] as const).entries()) {
+    test(`throws toMatchObject #${i}`, () => {
+      expect(() => expect(a).toMatchObject(b as any)).toThrow();
+    });
+  }
+
+  test('does not match properties up in the prototype chain', () => {
+    const a: any = {};
+    a.ref = a;
+    const b = Object.create(a);
+    b.other = 'child';
+    const matcher: any = { other: 'child' };
+    matcher.ref = matcher;
+    expect(b).not.toMatchObject(matcher);
+    expect(() => expect(b).toMatchObject(matcher)).toThrow();
+  });
+});
+
+test.describe('.toThrow()', () => {
+  class CustomError extends Error {}
+
+  test('to throw or not to throw', () => {
+    expect(() => {
+      throw new CustomError('apple');
+    }).toThrow();
+    expect(() => {}).not.toThrow();
+  });
+
+  test('substring passes', () => {
+    expect(() => {
+      throw new CustomError('apple');
+    }).toThrow('apple');
+    expect(() => {
+      throw new CustomError('banana');
+    }).not.toThrow('apple');
+    expect(() => {}).not.toThrow('apple');
+  });
+
+  test('substring fails when did not throw', () => {
+    expect(() => expect(() => {}).toThrow('apple')).toThrow();
+  });
+
+  test('substring fails when message did not match', () => {
+    expect(() => expect(() => {
+      throw new CustomError('apple');
+    }).toThrow('banana')).toThrow();
+  });
+
+  test('regexp passes', () => {
+    expect(() => {
+      throw new CustomError('apple');
+    }).toThrow(/apple/);
+    expect(() => {
+      throw new CustomError('banana');
+    }).not.toThrow(/apple/);
+    expect(() => {}).not.toThrow(/apple/);
+  });
+
+  test('regexp fails when did not throw', () => {
+    expect(() => expect(() => {}).toThrow(/apple/)).toThrow();
+  });
+
+  test('error class passes', () => {
+    class Err extends CustomError {}
+    class Err2 extends CustomError {}
+
+    expect(() => {
+      throw new Err('apple');
+    }).toThrow(Err);
+    expect(() => {
+      throw new Err('apple');
+    }).toThrow(CustomError);
+
+    expect(() => {
+      throw new Err('apple');
+    }).not.toThrow(Err2);
+  });
+
+  test('object with message passes', () => {
+    expect(() => {
+      throw new CustomError('apple');
+    }).toThrow({ message: 'apple' });
+    expect(() => {
+      throw new CustomError('banana');
+    }).not.toThrow({ message: 'apple' });
+  });
+
+  test('properly escapes strings when matching against errors', () => {
+    expect(() => {
+      throw new TypeError('"this"? throws.');
+    }).toThrow('"this"? throws.');
+  });
+
+  test('error message and cause properties', () => {
+    const errorCause = new Error('cause');
+    const error = new Error('message', { cause: errorCause });
+    expect(() => {
+      throw error;
+    }).toThrow({ message: 'message', cause: errorCause });
+  });
+});
+
+test.describe('asymmetric matchers', () => {
+  test('Any matches primitives', () => {
+    expect('jest').toEqual(expect.any(String));
+    expect(1).toEqual(expect.any(Number));
+    expect(() => {}).toEqual(expect.any(Function));
+    expect(true).toEqual(expect.any(Boolean));
+    expect({}).toEqual(expect.any(Object));
+    expect([]).toEqual(expect.any(Array));
+  });
+
+  test('Any throws when called with empty constructor', () => {
+    expect(() => (expect.any as any)()).toThrow(
+        'any() expects to be passed a constructor function. Please pass one or use anything() to match any object.');
+  });
+
+  test('Anything matches any type', () => {
+    expect('jest').toEqual(expect.anything());
+    expect(1).toEqual(expect.anything());
+    expect(() => {}).toEqual(expect.anything());
+    expect(true).toEqual(expect.anything());
+    expect({}).toEqual(expect.anything());
+    expect([]).toEqual(expect.anything());
+  });
+
+  test('Anything does not match null and undefined', () => {
+    expect(null).not.toEqual(expect.anything());
+    expect(undefined).not.toEqual(expect.anything());
+  });
+
+  test('ArrayContaining matches', () => {
+    expect(['foo']).toEqual(expect.arrayContaining(['foo']));
+    expect(['foo', 'bar']).toEqual(expect.arrayContaining(['foo']));
+  });
+
+  test('ArrayContaining does not match', () => {
+    expect(['bar']).not.toEqual(expect.arrayContaining(['foo']));
+  });
+
+  test('ObjectContaining matches', () => {
+    expect({ foo: 'foo', jest: 'jest' }).toEqual(expect.objectContaining({ foo: 'foo' }));
+    expect({ foo: undefined }).toEqual(expect.objectContaining({ foo: undefined }));
+  });
+
+  test('ObjectContaining does not match', () => {
+    expect({ bar: 'bar' }).not.toEqual(expect.objectContaining({ foo: 'foo' }));
+    expect({ foo: 'foox' }).not.toEqual(expect.objectContaining({ foo: 'foo' }));
+    expect({}).not.toEqual(expect.objectContaining({ foo: undefined }));
+  });
+
+  test('ObjectContaining throws for non-objects', () => {
+    expect(() => expect({}).toEqual(expect.objectContaining(1337 as any))).toThrow(
+        "You must provide an object to ObjectContaining, not 'number'.");
+  });
+
+  test('StringContaining matches string against string', () => {
+    expect('queen*').toEqual(expect.stringContaining('en*'));
+    expect('queue').not.toEqual(expect.stringContaining('en*'));
+  });
+
+  test('StringMatching matches string against regexp', () => {
+    expect('queen').toEqual(expect.stringMatching(/en/));
+    expect('queue').not.toEqual(expect.stringMatching(/en/));
+  });
+
+  test('StringMatching matches string against string', () => {
+    expect('queen').toEqual(expect.stringMatching('en'));
+    expect('queue').not.toEqual(expect.stringMatching('en'));
+  });
+
+  test('closeTo matches', () => {
+    expect(0).toEqual(expect.closeTo(0));
+    expect(0.001).toEqual(expect.closeTo(0));
+    expect(1.229).toEqual(expect.closeTo(1.23));
+    expect(Infinity).toEqual(expect.closeTo(Infinity));
+  });
+
+  test('closeTo does not match', () => {
+    expect(0.01).not.toEqual(expect.closeTo(0));
+    expect(1.23).not.toEqual(expect.closeTo(1));
+    expect(Infinity).not.toEqual(expect.closeTo(-Infinity));
+  });
+
+  test('closeTo with precision', () => {
+    expect(0.1).toEqual(expect.closeTo(0, 0));
+    expect(0.0001).toEqual(expect.closeTo(0, 3));
+    expect(0.000_004).toEqual(expect.closeTo(0, 5));
+  });
+
+  test('closeTo throws if expected is not number', () => {
+    expect(() => (expect.closeTo as any)('a')).toThrow('Expected is not a Number');
+  });
+
+  test('arrayOf matches', () => {
+    expect([1]).toEqual(expect.arrayOf(1));
+    expect([1, 1, 1]).toEqual(expect.arrayOf(1));
+    expect([{ a: 1 }, { a: 1 }]).toEqual(expect.arrayOf({ a: 1 }));
+    expect(['a', 'b', 'c']).toEqual(expect.arrayOf(expect.any(String)));
+  });
+
+  test('arrayOf does not match', () => {
+    expect([2]).not.toEqual(expect.arrayOf(1));
+    expect([1, 2]).not.toEqual(expect.arrayOf(1));
+    expect('not an array').not.toEqual(expect.arrayOf(1));
+    expect({}).not.toEqual(expect.arrayOf(1));
+    expect([1, 2]).not.toEqual(expect.arrayOf(expect.any(String)));
+  });
+});

--- a/tests/page/expect-matcher-result.spec.ts
+++ b/tests/page/expect-matcher-result.spec.ts
@@ -308,6 +308,7 @@ test('toHaveScreenshot should populate matcherResult', async ({ page, server, is
   e.matcherResult.message = stripAnsi(e.matcherResult.message);
 
   expect.soft(e.matcherResult).toEqual({
+    attachments: [expect.any(Object), expect.any(Object), expect.any(Object)],
     actual: expect.stringContaining('screenshot-sanity-actual'),
     expected: expect.stringContaining('screenshot-sanity-'),
     diff: expect.stringContaining('screenshot-sanity-diff'),

--- a/tests/playwright-test/expect-poll.spec.ts
+++ b/tests/playwright-test/expect-poll.spec.ts
@@ -279,3 +279,29 @@ test('should show custom message', {
   expect(result.output).toContain('Expected: 2');
   expect(result.output).toContain('Received: 1');
 });
+
+test('should swallow matcher errors and predicate errors', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should poll async predicate', async () => {
+        let i = 0;
+        await test.expect.poll(async () => {
+          if (++i === 2)
+            return 'some foo text';
+          return undefined;
+        }).toContain('foo');
+      });
+      test('should poll async predicate with not', async () => {
+        let i = 0;
+        await test.expect.poll(async () => {
+          if (++i === 2)
+            return 'some bar text';
+          return undefined;
+        }).not.toContain('foo');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -412,72 +412,18 @@ test('should return void/Promise when appropriate', async ({ runTSC }) => {
   expect(result.exitCode).toBe(0);
 });
 
-test.describe('helpful expect errors', () => {
-  test('top-level', async ({ runInlineTest }) => {
-    const result = await runInlineTest({
-      'a.spec.ts': `
-        import { test, expect } from '@playwright/test';
-        test('explodes', () => {
-          expect(1).nope();
-        });
-      `
-    });
-
-    expect(result.output).toContain(`expect: Property 'nope' not found.`);
+test('bare expect call should not throw', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('explodes', () => {
+        expect('');
+      });
+    `
   });
 
-  test('soft', async ({ runInlineTest }) => {
-    const result = await runInlineTest({
-      'a.spec.ts': `
-        import { test, expect } from '@playwright/test';
-        test('explodes', () => {
-          expect.soft(1).nope();
-        });
-      `
-    });
-
-    expect(result.output).toContain(`expect: Property 'nope' not found.`);
-  });
-
-  test('poll', async ({ runInlineTest }) => {
-    const result = await runInlineTest({
-      'a.spec.ts': `
-        import { test, expect } from '@playwright/test';
-        test('explodes', () => {
-          expect.poll(() => {}).nope();
-        });
-      `
-    });
-
-    expect(result.output).toContain(`expect: Property 'nope' not found.`);
-  });
-
-  test('not', async ({ runInlineTest }) => {
-    const result = await runInlineTest({
-      'a.spec.ts': `
-        import { test, expect } from '@playwright/test';
-        test('explodes', () => {
-          expect(1).not.nope();
-        });
-      `
-    });
-
-    expect(result.output).toContain(`expect: Property 'nope' not found.`);
-  });
-
-  test('bare', async ({ runInlineTest }) => {
-    const result = await runInlineTest({
-      'a.spec.ts': `
-        import { test, expect } from '@playwright/test';
-        test('explodes', () => {
-          expect('');
-        });
-      `
-    });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.passed).toBe(1);
-  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
 });
 
 test('should reasonably work in global setup', async ({ runInlineTest }) => {

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -16,6 +16,7 @@
 
 import { config as loadEnv } from 'dotenv';
 loadEnv({ path: path.join(__dirname, '..', '..', '.env') });
+process.env.PWTEST_UNDER_TEST = '1';
 
 import { defineConfig, type ReporterDescription } from './stable-test-runner';
 import * as path from 'path';

--- a/tests/playwright-test/ui-mode-fixtures.ts
+++ b/tests/playwright-test/ui-mode-fixtures.ts
@@ -102,7 +102,6 @@ export const test = base
             command: ['node', cliEntrypoint, 'test', (options.useWeb ? '--ui-host=127.0.0.1' : '--ui'), '--workers=1', ...(options.additionalArgs || [])],
             env: inheritAndCleanEnv({
               ...env,
-              PWTEST_UNDER_TEST: '1',
               PWTEST_CACHE_DIR: cacheDir,
               PWTEST_HEADED_FOR_TEST: headless ? '0' : '1',
               PWTEST_PRINT_WS_ENDPOINT: '1',


### PR DESCRIPTION
## Summary
- Vendor the jest `expect` library (v30.2.0) into `packages/playwright/src/matchers/expectLibrary.ts`, adapted and trimmed to Playwright's needs.
- Simplify surrounding glue: `expect.ts` rewritten on top of the vendored library, no more proxies, global variables, smaller interface into the test runner, etc.
- Shaves ~200k from the expect bundle.