### PR TITLE
feat(fixtures): add tag option to propagate tags to tests

### DIFF
--- a/docs/src/test-api/class-testinfo.md
+++ b/docs/src/test-api/class-testinfo.md
@@ -215,7 +215,7 @@ Test function as passed to `test(title, testFunction)`.
 * since: v1.43
 - type: <[Array]<[string]>>
 
-Tags that apply to the test. Learn more about [tags](../test-annotations.md#tag-tests).
+Tags that apply to the test. Includes tags declared directly on the test or its enclosing describe blocks, tags extracted from the test title, and tags inherited from fixtures used by the test. Learn more about [tags](../test-annotations.md#tag-tests).
 
 :::note
 Any changes made to this list while the test is running will not be visible to test reporters.

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -779,6 +779,46 @@ export const test = base.extend({
 });
 ```
 
+## Fixture tags
+
+You can attach tags to a fixture so that every test using that fixture automatically inherits those tags. This lets you categorize tests through the fixtures they rely on rather than annotating each test individually.
+
+```js
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  apiFixture: [async ({}, use) => {
+    // ...
+    await use();
+  }, { tag: '@api' }],
+});
+```
+
+```js title="example.spec.ts"
+import { test } from './my-test';
+
+// Automatically tagged with '@api' because the fixture carries it.
+test('my test', async ({ apiFixture }) => {
+  // ...
+});
+```
+
+Tags propagate **transitively**: if fixture `A` depends on fixture `B` and `B` carries a tag, any test using `A` will also inherit that tag.
+
+You can specify multiple tags as an array:
+
+```js
+export const test = base.extend({
+  myFixture: [async ({}, use) => {
+    await use();
+  }, { tag: ['@smoke', '@regression'] }],
+});
+```
+
+[Automatic fixtures](#automatic-fixtures) propagate their tags to every test in the suite, even tests that don't explicitly list the fixture.
+
+Tags from fixtures are combined with tags declared directly on the test. Duplicate tags are deduplicated. All fixture tags must start with `@`. Fixture-inherited tags are visible in [`property: TestInfo.tags`] at runtime. Learn more about [tagging tests](./test-annotations.md#tag-tests).
+
 ## Adding global beforeEach/afterEach hooks
 
 [`method: Test.beforeEach`] and [`method: Test.afterEach`] hooks run before/after each test declared in the same file and same [`method: Test.describe`] block (if any). If you want to declare hooks that run before/after each test globally, you can declare them as auto fixtures like this:

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -25,7 +25,7 @@ import type { Location } from '../../types/testReporter';
 export type FixtureScope = 'test' | 'worker';
 type FixtureAuto = boolean | 'all-hooks-included';
 const kScopeOrder: FixtureScope[] = ['test', 'worker'];
-type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' };
+type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self', tag?: string | string[] };
 type FixtureTuple = [ value: any, options: FixtureOptions ];
 export type FixtureRegistration = {
   // Fixture registration location.
@@ -53,6 +53,8 @@ export type FixtureRegistration = {
   optionOverride?: boolean;
   // Do not generate the step for this fixture, consider it internal.
   box?: boolean | 'self';
+  // Tags to be inherited by tests that use this fixture, directly or transitively.
+  tag?: string[];
 };
 export type LoadError = {
   message: string;
@@ -113,8 +115,10 @@ export class FixturePool {
     for (const entry of Object.entries(fixtures)) {
       const name = entry[0];
       let value = entry[1];
-      let options: { auto: FixtureAuto, scope: FixtureScope, option: boolean, timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
+      let options: { auto: FixtureAuto, scope: FixtureScope, option: boolean, timeout: number | undefined, customTitle?: string, box?: boolean | 'self', tag?: string[] } | undefined;
       if (isFixtureTuple(value)) {
+        const rawTag = value[1].tag;
+        const tag: string[] | undefined = rawTag ? ([] as string[]).concat(rawTag) : undefined;
         options = {
           auto: value[1].auto ?? false,
           scope: value[1].scope || 'test',
@@ -122,6 +126,7 @@ export class FixturePool {
           timeout: value[1].timeout,
           customTitle: value[1].title,
           box: value[1].box,
+          tag,
         };
         value = value[0];
       }
@@ -139,7 +144,7 @@ export class FixturePool {
         }
       } else if (previous) {
         // Note: deliberately not inheriting "options.box" so that fixture override is visible by default.
-        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle };
+        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle, tag: previous.tag };
       } else if (!options) {
         options = { auto: false, scope: 'test', option: false, timeout: undefined };
       }
@@ -162,8 +167,12 @@ export class FixturePool {
         fn = original.fn;
       }
 
+      for (const tag of options.tag ?? []) {
+        if (!tag.startsWith('@'))
+          this._addLoadError(`Fixture "${name}" tag "${tag}" must start with "@".`, location);
+      }
       const deps = fixtureParameterNames(fn, location, e => this._onLoadError(e));
-      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: options.option, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
+      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: options.option, timeout: options.timeout, customTitle: options.customTitle, box: options.box, tag: options.tag, deps, super: previous, optionOverride: isOptionsOverride };
       registrationId(registration);
       this._registrations.set(name, registration);
     }
@@ -252,6 +261,31 @@ export class FixturePool {
 
   autoFixtures() {
     return [...this._registrations.values()].filter(r => r.auto !== false);
+  }
+
+  tagsForTest(directParams: string[]): string[] {
+    const tags = new Set<string>();
+    const visited = new Set<string>();
+
+    const collect = (name: string) => {
+      if (visited.has(name))
+        return;
+      visited.add(name);
+      const registration = this._registrations.get(name);
+      if (!registration)
+        return;
+      for (const tag of registration.tag ?? [])
+        tags.add(tag);
+      for (const dep of registration.deps)
+        collect(dep);
+    };
+
+    for (const registration of this.autoFixtures())
+      collect(registration.name);
+    for (const name of directParams)
+      collect(name);
+
+    return [...tags];
   }
 
   private _addLoadError(message: string, location: Location) {

--- a/packages/playwright/src/common/poolBuilder.ts
+++ b/packages/playwright/src/common/poolBuilder.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FixturePool } from './fixtures';
+import { FixturePool, fixtureParameterNames } from './fixtures';
 import { formatLocation } from '../util';
 
 import type { FullProjectInternal } from './config';
@@ -48,6 +48,11 @@ export class PoolBuilder {
         test._poolDigest = pool.digest;
       if (this._type === 'worker')
         test._pool = pool;
+      const directParams = fixtureParameterNames(test.fn, test.location, e => this._handleLoadError(e, testErrors));
+      for (const tag of pool.tagsForTest(directParams)) {
+        if (!test._tags.includes(tag))
+          test._tags.push(tag);
+      }
     });
   }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2604,7 +2604,9 @@ export interface TestInfo {
   status?: "passed"|"failed"|"timedOut"|"skipped"|"interrupted";
 
   /**
-   * Tags that apply to the test. Learn more about [tags](https://playwright.dev/docs/test-annotations#tag-tests).
+   * Tags that apply to the test. Includes tags declared directly on the test or its enclosing describe blocks, tags
+   * extracted from the test title, and tags inherited from fixtures used by the test. Learn more about
+   * [tags](https://playwright.dev/docs/test-annotations#tag-tests).
    *
    * **NOTE** Any changes made to this list while the test is running will not be visible to test reporters.
    *

--- a/tests/playwright-test/fixture-tags.spec.ts
+++ b/tests/playwright-test/fixture-tags.spec.ts
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+const tagsReporter = String.raw`
+  export default class Reporter {
+    onBegin(config, suite) {
+      const visit = suite => {
+        for (const t of suite.tests || [])
+          console.log('\n%%title=' + t.title + ', tags=' + t.tags.join(','));
+        for (const child of suite.suites || [])
+          visit(child);
+      };
+      visit(suite);
+    }
+    onError(error) { console.log(error); }
+  }
+`;
+
+test('direct fixture usage inherits tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('value'); }, { tag: '@smoke' }],
+      });
+      test('uses fixture', async ({ myFixture }) => {});
+      test('no fixture', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=uses fixture, tags=@smoke',
+    'title=no fixture, tags=',
+  ]);
+});
+
+test('transitive fixture usage inherits tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        baseFixture: [async ({}, use) => { await use('base'); }, { tag: '@smoke' }],
+        childFixture: async ({ baseFixture }, use) => { await use(baseFixture + '-child'); },
+      });
+      test('uses child', async ({ childFixture }) => {});
+      test('uses base directly', async ({ baseFixture }) => {});
+      test('uses neither', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=uses child, tags=@smoke',
+    'title=uses base directly, tags=@smoke',
+    'title=uses neither, tags=',
+  ]);
+});
+
+test('auto fixture propagates tag to all tests', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        autoFixture: [async ({}, use) => { await use(); }, { auto: true, tag: '@auto' }],
+      });
+      test('test one', async ({}) => {});
+      test('test two', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test one, tags=@auto',
+    'title=test two, tags=@auto',
+  ]);
+});
+
+test('worker-scoped fixture propagates tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        workerFixture: [async ({}, use) => { await use('w'); }, { scope: 'worker', tag: '@perf' }],
+      });
+      test('uses worker fixture', async ({ workerFixture }) => {});
+      test('no worker fixture', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=uses worker fixture, tags=@perf',
+    'title=no worker fixture, tags=',
+  ]);
+});
+
+test('multiple tags on one fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('x'); }, { tag: ['@smoke', '@regression'] }],
+      });
+      test('test', async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test, tags=@smoke,@regression',
+  ]);
+});
+
+test('tags from multiple fixtures are combined', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        fixtureA: [async ({}, use) => { await use('a'); }, { tag: '@featureA' }],
+        fixtureB: [async ({}, use) => { await use('b'); }, { tag: '@featureB' }],
+      });
+      test('uses both', async ({ fixtureA, fixtureB }) => {});
+      test('uses only A', async ({ fixtureA }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=uses both, tags=@featureA,@featureB',
+    'title=uses only A, tags=@featureA',
+  ]);
+});
+
+test('fixture tag and test tag are both present', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('x'); }, { tag: '@smoke' }],
+      });
+      test('tagged test', { tag: '@critical' }, async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=tagged test, tags=@critical,@smoke',
+  ]);
+});
+
+test('fixture tag is deduplicated when test already has same tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('x'); }, { tag: '@smoke' }],
+      });
+      test('test', { tag: '@smoke' }, async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test, tags=@smoke',
+  ]);
+});
+
+test('fixture tag is visible in testInfo.tags', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('x'); }, { tag: '@smoke' }],
+      });
+      test('test', async ({ myFixture }, testInfo) => {
+        expect(testInfo.tags).toContain('@smoke');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('--grep filters by fixture-inherited tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': String.raw`
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        smokeFixture: [async ({}, use) => { await use('x'); }, { tag: '@smoke' }],
+      });
+      test('smoke test', async ({ smokeFixture }) => { console.log('\n%% smoke'); });
+      test('other test', async ({}) => { console.log('\n%% other'); });
+    `,
+  }, { grep: '@smoke' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual(['smoke']);
+});
+
+test('fixture tags are resolved statically and available for filtering before fixture evaluation', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': String.raw`
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        apiFixture: [async ({}, use) => {
+          console.log('\n%% apiFixture evaluated');
+          await use('api');
+        }, { tag: '@api' }],
+      });
+      test('api test', async ({ apiFixture }) => { console.log('\n%% api test ran'); });
+      test('unit test', async ({}) => { console.log('\n%% unit test ran'); });
+    `,
+  }, { grep: '@api' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  // Fixture was evaluated (because the matching test used it), but only for the
+  // matching test — proving the tag was known before execution for filtering.
+  expect(result.outputLines).toEqual(['apiFixture evaluated', 'api test ran']);
+});
+
+test('grep-invert excludes tests by fixture tag without evaluating the fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': String.raw`
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        slowFixture: [async ({}, use) => {
+          console.log('\n%% slowFixture evaluated');
+          await use('slow');
+        }, { tag: '@slow' }],
+      });
+      test('slow test', async ({ slowFixture }) => { console.log('\n%% slow test ran'); });
+      test('fast test', async ({}) => { console.log('\n%% fast test ran'); });
+    `,
+  }, { 'grep-invert': '@slow' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  // The slow fixture was never evaluated because its test was filtered out
+  // BEFORE execution — proving tags are resolved statically, not at runtime.
+  expect(result.outputLines).toEqual(['fast test ran']);
+});
+
+test('fixture tag must start with @', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        myFixture: [async ({}, use) => { await use('x'); }, { tag: 'smoke' }],
+      });
+      test('test', async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Fixture "myFixture" tag "smoke" must start with "@".`);
+});
+
+test('function-only fixture override inherits tag from original', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const base2 = base.extend({
+        myFixture: [async ({}, use) => { await use('original'); }, { tag: '@smoke' }],
+      });
+      const test = base2.extend({
+        myFixture: async ({}, use) => { await use('overridden'); },
+      });
+      test('test', async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test, tags=@smoke',
+  ]);
+});
+
+test('tuple fixture override without tag clears inherited tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const base2 = base.extend({
+        myFixture: [async ({}, use) => { await use('original'); }, { tag: '@smoke' }],
+      });
+      const test = base2.extend({
+        myFixture: [async ({}, use) => { await use('overridden'); }, {}],
+      });
+      test('test', async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test, tags=',
+  ]);
+});
+
+test('tuple fixture override can set a new tag', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': tagsReporter,
+    'playwright.config.ts': `module.exports = { reporter: './reporter' };`,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const base2 = base.extend({
+        myFixture: [async ({}, use) => { await use('original'); }, { tag: '@smoke' }],
+      });
+      const test = base2.extend({
+        myFixture: [async ({}, use) => { await use('overridden'); }, { tag: '@regression' }],
+      });
+      test('test', async ({ myFixture }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test, tags=@regression',
+  ]);
+});


### PR DESCRIPTION
Fixtures can now declare tags via the { tag: '@name' } option. Tags are resolved statically during pool building and inherited by every test that uses the fixture (directly or transitively), including via auto fixtures. Fixture-inherited tags are available for --grep filtering and visible in testInfo.tags at runtime.

References https://github.com/microsoft/playwright/issues/40272