### PR TITLE
fix(dashboard): align omnibox scheme detection with Chrome

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -57,7 +57,9 @@ function smartUrl(input: string): string {
   const isLocalhost = /^localhost(:\d+)?$/i.test(host);
   const hasPort = /:\d+$/.test(host);
   const isIp = /^\d{1,3}(\.\d{1,3}){3}(:\d+)?$/.test(host);
-  if (hasDot || isLocalhost || hasPort || isIp)
+  if (isLocalhost || isIp || (hasPort && !hasDot))
+    return 'http://' + value;
+  if (hasDot || hasPort)
     return 'https://' + value;
   return 'https://' + host + '.com' + value.slice(host.length);
 }


### PR DESCRIPTION
## Summary
- `smartUrl` now prefixes `http://` for localhost, IP literals, and single-label hosts with an explicit port; `https://` is reserved for dotted hostnames.
- Previously every parsed host got `https://`, which broke navigation to typical local dev servers (e.g. `localhost:3000`).