### PR TITLE
docs(cli): document run-code syntax constraints

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/references/running-code.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/running-code.md
@@ -11,6 +11,16 @@ playwright-cli run-code "async page => {
 }"
 ```
 
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
 ## Geolocation
 
 ```bash


### PR DESCRIPTION
## Summary
- Document that `run-code` evaluates a single function expression wrapped in `(...)`.
- Call out that `export default` / `import` / `require` are unsupported (the CLI uses bare `vm.runInContext`, no module/transpile support).
- Document the previously-undocumented `--filename=` form in this file.

My copilot tried running `--filename=script.mjs` and tried using import/export. It recovered, but I think it's better not make the requirements clear before the agent spends tokens writing a script that won't work.