### PR TITLE
fix(cli): prefix bare filenames with ./ in printed links

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -68,8 +68,13 @@ export class Response {
     this._raw = this._json || (options?.raw ?? false);
   }
 
-  private _computRelativeTo(fileName: string): string {
-    return path.relative(this._clientWorkspace, fileName);
+  private _computeRelativeTo(fileName: string): string {
+    const rel = path.relative(this._clientWorkspace, fileName);
+    // Prefix bare filenames with `./` so they're not mistaken for living in
+    // the auto-named `.playwright-cli/` artifact directory.
+    if (path.dirname(rel) === '.' && !rel.startsWith('.'))
+      return './' + rel;
+    return rel;
   }
 
   async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
@@ -78,7 +83,7 @@ export class Response {
       fileName = await this.resolveClientFilename(template.suggestedFilename);
     else
       fileName = await this._context.outputFile(template, { origin: 'llm' });
-    const relativeName = this._computRelativeTo(fileName);
+    const relativeName = this._computeRelativeTo(fileName);
     const printableLink = `- [${title}](${relativeName})`;
     return { fileName, relativeName, printableLink };
   }
@@ -113,7 +118,7 @@ export class Response {
   }
 
   addFileLink(title: string, fileName: string) {
-    const relativeName = this._computRelativeTo(fileName);
+    const relativeName = this._computeRelativeTo(fileName);
     this.addTextResult(`- [${title}](${relativeName})`);
   }
 
@@ -272,7 +277,7 @@ export class Response {
         if (event.type === 'download-start')
           text.push(`- Downloading file ${event.download.download.suggestedFilename()} ...`);
         else if (event.type === 'download-finish')
-          text.push(`- Downloaded file ${event.download.download.suggestedFilename()} to "${this._computRelativeTo(event.download.outputFile)}"`);
+          text.push(`- Downloaded file ${event.download.download.suggestedFilename()} to "${this._computeRelativeTo(event.download.outputFile)}"`);
       }
     }
     if (text.length)
@@ -281,7 +286,7 @@ export class Response {
     const pausedDetails = this._context.debugger().pausedDetails();
     if (pausedDetails) {
       addSection('Paused', [
-        `- ${pausedDetails.title} at ${this._computRelativeTo(pausedDetails.location.file)}${pausedDetails.location.line ? ':' + pausedDetails.location.line : ''}`,
+        `- ${pausedDetails.title} at ${this._computeRelativeTo(pausedDetails.location.file)}${pausedDetails.location.line ? ':' + pausedDetails.location.line : ''}`,
         '- Use any tools to explore and interact, resume by calling resume/step-over/pause-at',
       ]);
     }

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -149,7 +149,7 @@ test('video-start-stop', async ({ cli, server }) => {
   const { output: tabCloseOutput } = await cli('tab-close');
   expect(tabCloseOutput).toContain(`0: (current) [](${server.EMPTY_PAGE})`);
   const { output: videoStopOutput } = await cli('video-stop');
-  expect(videoStopOutput).toContain(`### Result\n- [Video](video.webm)\n- [Video](video-1.webm)`);
+  expect(videoStopOutput).toContain(`### Result\n- [Video](./video.webm)\n- [Video](./video-1.webm)`);
 });
 
 test('video-chapter', async ({ cli, server }) => {

--- a/tests/mcp/cli-save-as.spec.ts
+++ b/tests/mcp/cli-save-as.spec.ts
@@ -41,7 +41,7 @@ test('screenshot --full-page', async ({ cli, server, mcpBrowser }) => {
 test('screenshot --filename', async ({ cli, server, mcpBrowser }) => {
   await cli('open', server.HELLO_WORLD);
   const { output, attachments } = await cli('screenshot', '--filename=screenshot.png');
-  expect(output).toContain('[Screenshot of viewport](screenshot.png)');
+  expect(output).toContain('[Screenshot of viewport](./screenshot.png)');
   expect(attachments[0].name).toEqual('Screenshot of viewport');
   expect(attachments[0].data).toEqual(expect.any(Buffer));
 });
@@ -58,7 +58,7 @@ test('pdf --filename', async ({ cli, server, mcpBrowser }) => {
   test.skip(mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'PDF is only supported in Chromium and Chrome');
   await cli('open', server.HELLO_WORLD);
   const { output, attachments } = await cli('pdf', '--filename=pdf.pdf');
-  expect(output).toContain('[Page as pdf](pdf.pdf)');
+  expect(output).toContain('[Page as pdf](./pdf.pdf)');
   expect(attachments[0].name).toEqual('Page as pdf');
   expect(attachments[0].data).toEqual(expect.any(Buffer));
 });

--- a/tests/mcp/roots.spec.ts
+++ b/tests/mcp/roots.spec.ts
@@ -125,6 +125,6 @@ test('should return relative paths when root is specified', async ({ startClient
     name: 'browser_take_screenshot',
     arguments: { filename: 'screenshot.png' },
   })).toHaveResponse({
-    result: expect.stringContaining(`[Screenshot of viewport](screenshot.png)`),
+    result: expect.stringContaining(`[Screenshot of viewport](./screenshot.png)`),
   });
 });


### PR DESCRIPTION
## Summary
- A user-supplied `--filename=foo.yml` printed as `[Snapshot](foo.yml)` was ambiguous — my agent mistook it for living under the auto-named `.playwright-cli/` artifact directory and then did `cat .playwright-cli/foo.yml`, which failed.
- Now bare filenames in the client's CWD are printed as `./foo.yml`, in both the markdown link and the emitted Playwright code.
- Drive-by: fix `_computRelativeTo` typo.