### PR TITLE
feat(browser): browser.on(context)

### DIFF
--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -72,6 +72,12 @@ await page.GotoAsync("https://www.bing.com");
 await browser.CloseAsync();
 ```
 
+## event: Browser.context
+* since: v1.60
+- argument: <[BrowserContext]>
+
+Emitted when a new browser context is created.
+
 ## event: Browser.disconnected
 * since: v1.8
 - argument: <[Browser]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -9975,6 +9975,11 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
+   * Emitted when a new browser context is created.
+   */
+  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9985,7 +9990,17 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new browser context is created.
+   */
+  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9998,12 +10013,27 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new browser context is created.
+   */
+  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -105,11 +105,11 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   private _didCreateContext(context: BrowserContext) {
     context._browser = this;
     this._contexts.add(context);
-    this.emit(Events.Browser.Context, context);
     // Note: when connecting to a browser, initial contexts arrive before `browserType` is set,
     // and will be configured later in `_connectToBrowserType`.
     if (this._browserType)
       this._setupBrowserContext(context);
+    this.emit(Events.Browser.Context, context);
   }
 
   private _setupBrowserContext(context: BrowserContext) {

--- a/packages/playwright-core/src/client/browser.ts
+++ b/packages/playwright-core/src/client/browser.ts
@@ -105,6 +105,7 @@ export class Browser extends ChannelOwner<channels.BrowserChannel> implements ap
   private _didCreateContext(context: BrowserContext) {
     context._browser = this;
     this._contexts.add(context);
+    this.emit(Events.Browser.Context, context);
     // Note: when connecting to a browser, initial contexts arrive before `browserType` is set,
     // and will be configured later in `_connectToBrowserType`.
     if (this._browserType)

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -31,6 +31,7 @@ export const Events = {
   },
 
   Browser: {
+    Context: 'context',
     Disconnected: 'disconnected'
   },
 

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -41,6 +41,7 @@ class BrowserTracker {
   readonly browser: api.Browser;
   private _callbacks: BrowserTrackerCallbacks;
   private _contextListeners = new Map<api.BrowserContext, Disposable[]>();
+  private _browserListeners: Disposable[] = [];
 
   static async create(descriptor: BrowserDescriptor, callbacks: BrowserTrackerCallbacks): Promise<BrowserTracker | undefined> {
     try {
@@ -48,6 +49,9 @@ class BrowserTracker {
       const slot = new BrowserTracker(descriptor, browser, callbacks);
       for (const context of browser.contexts())
         slot._wireContext(context);
+      slot._browserListeners.push(eventsHelper.addEventListener(browser, 'context', (context: api.BrowserContext) => {
+        slot._wireContext(context);
+      }));
       return slot;
     } catch {
       return undefined;
@@ -65,6 +69,8 @@ class BrowserTracker {
   }
 
   dispose() {
+    this._browserListeners.forEach(d => d.dispose());
+    this._browserListeners = [];
     for (const listeners of this._contextListeners.values())
       listeners.forEach(d => d.dispose());
     this._contextListeners.clear();

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -9975,6 +9975,11 @@ export interface Browser {
     behavior?: 'wait'|'ignoreErrors'|'default'
   }): Promise<void>;
   /**
+   * Emitted when a new browser context is created.
+   */
+  on(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
    * following:
    * - Browser application is closed or crashed.
@@ -9985,7 +9990,17 @@ export interface Browser {
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
+  once(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
+   */
   once(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new browser context is created.
+   */
+  addListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the
@@ -9998,12 +10013,27 @@ export interface Browser {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  removeListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   removeListener(event: 'disconnected', listener: (browser: Browser) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
+  off(event: 'context', listener: (browserContext: BrowserContext) => any): this;
+
+  /**
+   * Removes an event listener added by `on` or `addListener`.
+   */
   off(event: 'disconnected', listener: (browser: Browser) => any): this;
+
+  /**
+   * Emitted when a new browser context is created.
+   */
+  prependListener(event: 'context', listener: (browserContext: BrowserContext) => any): this;
 
   /**
    * Emitted when Browser gets disconnected from the browser application. This might happen because of one of the

--- a/tests/library/browser.spec.ts
+++ b/tests/library/browser.spec.ts
@@ -63,6 +63,13 @@ test('should dispatch page.on(close) upon browser.close and reject evaluate', as
   expect(error.message).toContain(kTargetClosedErrorMessage);
 });
 
+test('should fire context event on newContext', async ({ browser }) => {
+  const events = [];
+  browser.on('context', ctx => events.push(ctx));
+  const context = await browser.newContext();
+  expect(events).toEqual([context]);
+});
+
 test('newContext should not leave a context upon failure', async ({ browser, toImpl }) => {
   const error = await browser.newContext({
     __testHookBeforeSetStorageState: () => Promise.reject(new Error('Oh my')),

--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -16,7 +16,7 @@
 
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { expect, playwrightTest } from '../config/browserTest';
-import type { Browser, BrowserServer, ConnectOptions, Page } from 'playwright-core';
+import type { Browser, BrowserContext, BrowserServer, ConnectOptions, Page } from 'playwright-core';
 
 type ExtraFixtures = {
   remoteServer: BrowserServer;
@@ -91,6 +91,19 @@ test('should connect two clients', async ({ connect, remoteServer, server }) => 
 
   await expect(pageB1).toHaveURL(server.EMPTY_PAGE);
   await expect(pageB2).toHaveURL(server.PREFIX + '/frames/frame.html');
+});
+
+test('should fire context event on remote newContext', async ({ connect, remoteServer }) => {
+  const browserA = await connect(remoteServer.wsEndpoint());
+  const events: BrowserContext[] = [];
+  browserA.on('context', ctx => events.push(ctx));
+
+  const browserB = await connect(remoteServer.wsEndpoint());
+  const contextB = await browserB.newContext();
+
+  await expect.poll(() => events).toHaveLength(1);
+  expect(browserA.contexts()).toEqual([events[0]]);
+  expect(events[0]).not.toBe(contextB);
 });
 
 test('should have separate default timeouts', async ({ twoPages }) => {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -91,10 +91,22 @@ export const test = baseTest.extend<{
     for (const pid of allPids)
       killProcessGroup(pid);
 
-    const daemonDir = path.join(test.info().outputDir, 'daemon');
-    const userDataDirs = await fs.promises.readdir(daemonDir).catch(() => []);
-    for (const dir of userDataDirs.filter(f => f.startsWith('ud-')))
-      await fs.promises.rm(path.join(daemonDir, dir), { recursive: true, force: true }).catch(() => {});
+    const daemonDir = test.info().outputPath('daemon');
+    for (const dir of await fs.promises.readdir(daemonDir).catch<string[]>(() => [])) {
+      if (dir.startsWith('ud-')) {
+        await fs.promises.rm(path.join(daemonDir, dir), { recursive: true, force: true }).catch(() => {});
+        continue;
+      }
+      const workspacePath = path.join(daemonDir, dir);
+      for (const entry of await fs.promises.readdir(workspacePath).catch<string[]>(() => [])) {
+        if (!entry.endsWith('.err'))
+          continue;
+        const errPath = path.join(workspacePath, entry);
+        if ((await fs.promises.stat(errPath)).size === 0)
+          continue;
+        await test.info().attach(entry, { path: errPath, contentType: 'text/plain' });
+      }
+    }
   },
   boundBrowser: async ({ mcpBrowser, playwright }, use) => {
     const browserName = (mcpBrowser === 'chrome' || mcpBrowser === 'msedge') ? 'chromium' : mcpBrowser;

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -55,12 +55,14 @@ test('should show one row per context for a single browser', async ({ boundBrows
   const contextA = await boundBrowser.newContext();
   const pageA = await contextA.newPage();
   await pageA.goto(server.EMPTY_PAGE);
-  const contextB = await boundBrowser.newContext();
-  const pageB = await contextB.newPage();
-  await pageB.goto(server.EMPTY_PAGE);
 
   const dashboard = await startDashboardServer();
   const chips = dashboard.locator('.session-chip');
+  await expect(chips).toHaveCount(1);
+
+  const contextB = await boundBrowser.newContext();
+  const pageB = await contextB.newPage();
+  await pageB.goto(server.EMPTY_PAGE);
   await expect(chips).toHaveCount(2);
 });
 
@@ -97,8 +99,7 @@ test('should show current workspace sessions first', async ({ cli, server, start
   });
 });
 
-test('should activate session when show is called with -s', async ({ cli, server, startDashboardServer, mcpBrowser }) => {
-  test.fixme(mcpBrowser === 'firefox', 'race condition gonna be fixed through https://github.com/microsoft/playwright/pull/40315');
+test('should activate session when show is called with -s', async ({ cli, server, startDashboardServer }) => {
   await cli('-s=sessA', 'open', server.EMPTY_PAGE);
   await cli('-s=sessB', 'open', server.EMPTY_PAGE);
 


### PR DESCRIPTION
## Summary
- Add a public `browser.on('context', ...)` event, fired when a new context becomes visible via `browser.contexts()`.
