### PR TITLE
fix(doclint): fall back to browsers.json when a browser cannot launch

### DIFF
--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -308,12 +308,25 @@ function writeAssumeNoop(name, content, dirtyFiles) {
 
 async function getBrowserVersions() {
   const names = ['chromium', 'firefox', 'webkit'];
-  const browsers = await Promise.all(names.map(name => playwright[name].launch()));
+  const settled = await Promise.allSettled(names.map(name =>
+    playwright[name].launch().then(async browser => {
+      const version = browser.version();
+      await browser.close();
+      return version;
+    })
+  ));
+  const browsersJSONPath = path.join(PROJECT_DIR, 'packages/playwright-core/browsers.json');
+  const browsersJSON = JSON.parse(fs.readFileSync(browsersJSONPath, 'utf8'));
   const result = {};
   for (let i = 0; i < names.length; i++) {
-    result[names[i]] = browsers[i].version();
+    if (settled[i].status === 'fulfilled') {
+      result[names[i]] = settled[i].value;
+    } else {
+      const entry = browsersJSON.browsers.find(b => b.name === names[i]);
+      result[names[i]] = entry?.browserVersion ?? 'unknown';
+      console.warn(`WARNING: Could not launch ${names[i]}, using browsers.json fallback: ${result[names[i]]}`); // eslint-disable-line no-console
+    }
   }
-  await Promise.all(browsers.map(browser => browser.close()));
   return result;
 }
 


### PR DESCRIPTION
## Summary

- `getBrowserVersions` used `Promise.all`, causing `npm run doc` (and therefore `npm run flint`) to abort entirely if any single browser failed to launch
- Common trigger: WebKit requires `libgstreamer-plugins-bad1.0-0`, which is absent on many developer Linux setups and CI images where only Chromium is needed
- Changed to `Promise.allSettled`; browsers that cannot launch fall back to their existing `browserVersion` from `browsers.json` with a warning — this is safe because WebKit's version is already hardcoded in `browsers.json` rather than reported dynamically by the browser build (see #15702)

Fixes: https://github.com/microsoft/playwright/issues/40317