### PR TITLE
fix(step): fixed truncating error stack traces with Promise.all

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -275,7 +275,8 @@ export class TestTypeImpl {
     const testInfo = currentTestInfo();
     if (!testInfo)
       throw new Error(`test.step() can only be called from a test`);
-    await testInfo._onUserStepBegin?.(title);
+    if (testInfo._onUserStepBegin)
+      await testInfo._onUserStepBegin?.(title);
     const step = testInfo._addStep({ category: 'test.step', title, location: options.location, box: options.box });
     return await currentZone().with('stepZone', step).run(async () => {
       try {
@@ -299,7 +300,8 @@ export class TestTypeImpl {
         step.complete({ error });
         throw error;
       } finally {
-        await testInfo._onUserStepEnd?.();
+        if (testInfo._onUserStepEnd)
+          await testInfo._onUserStepEnd?.();
       }
     });
   }

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1826,3 +1826,45 @@ fixture   |  Fixture "context"
 pw:api    |    Close context
 `);
 });
+
+test('should return all called files inside stack trace', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': stepIndentReporter,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: [['./reporter']],
+      };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test'
+      import { foo } from './b.model';
+
+      test('has title', async ({ page }) => {
+        await test.step('multiple check', async () => {
+          await Promise.all([
+            foo(page),
+            foo(page),
+          ])
+        })
+      });
+    `,
+    'b.model.ts': `
+        import test, { expect, Page } from "@playwright/test";
+
+        export const foo = async (page: Page) => {
+            await test.step('Check color', async () => {
+                await Promise.all([
+                    await test.step('check1', async () => expect(page.locator('body')).toHaveCSS('color', 'fffffff', { timeout: 50 })),
+                    await test.step('check2', async () => expect(page.locator('body')).toHaveCSS('color', 'fffffff', { timeout: 50 })),
+              ])
+            }); 
+        }
+    `,
+  }, { reporter: '', workers: 1 });
+
+  const message = result.results[0].errors[0].message;
+
+  expect(message).toMatch(new RegExp(`a.test.ts:6:20`));
+  expect(message).toMatch(new RegExp(`a.test.ts:8:16`));
+  expect(message).toMatch(new RegExp(`at foo (.*?)\/b\.model\.ts:5:24`));
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/40141

# Summary
Fix that was described by @pavelfeldman https://github.com/microsoft/playwright/issues/40141#issuecomment-4229935470 to save all stack trace of errors, when using `Promise.all` inside POM
Fix by conditionally calls `_onUserStepBegin` and `_onUserStepEnd`

Add test for that fix
