### PR TITLE
feat(extension): rehaul connect page and fix tab group management

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -38,6 +38,7 @@ class TabShareExtension {
   private _connectedTabIds: Set<number> = new Set();
   private _groupId: number | null = null;
   private _pendingTabSelection = new Map<number, RelayConnection>();
+  private _selectorTabId: number | undefined;
 
   constructor() {
     chrome.tabs.onRemoved.addListener(this._onTabRemoved.bind(this));
@@ -126,15 +127,19 @@ class TabShareExtension {
       this._activeConnection.onclose = () => {
         debugLog('MCP connection closed');
         this._activeConnection = undefined;
+        this._selectorTabId = undefined;
         const allTabIds = [...this._connectedTabIds];
         this._connectedTabIds.clear();
         allTabIds.map(id => this._updateBadge(id, { text: '' }));
-        chrome.tabs.ungroup(allTabIds).catch(() => {});
+        chrome.tabs.ungroup([...allTabIds, selectorTabId]).catch(() => {});
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
         this._connectedTabIds.add(newTabId);
         void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' });
-        void this._addTabToGroup(newTabId);
+        void this._addTabToGroup(newTabId).then(() => {
+          if (this._selectorTabId)
+            return this._addTabToGroup(this._selectorTabId);
+        });
       };
       this._activeConnection.ontabdetached = (removedTabId: number) => {
         this._connectedTabIds.delete(removedTabId);
@@ -146,6 +151,7 @@ class TabShareExtension {
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
+      this._selectorTabId = selectorTabId;
       debugLog(`Connected to Playwright client`);
     } catch (error: any) {
       this._connectedTabIds.clear();
@@ -182,6 +188,9 @@ class TabShareExtension {
       void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
 
     if (!this._activeConnection || changeInfo.groupId === undefined)
+      return;
+    // Ignore the selector tab — it is in the group for visual association only.
+    if (tabId === this._selectorTabId)
       return;
     // Ignore the extension's own UI tabs (connect/status pages) — those get added
     // to the group for visual grouping, not because they should be controlled.

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -37,6 +37,7 @@ class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
   private _connectedTabIds: Set<number> = new Set();
   private _groupId: number | null = null;
+  private _groupQueue: Promise<void> = Promise.resolve();
   private _pendingTabSelection = new Map<number, RelayConnection>();
   private _selectorTabId: number | undefined;
 
@@ -131,7 +132,8 @@ class TabShareExtension {
         const allTabIds = [...this._connectedTabIds];
         this._connectedTabIds.clear();
         allTabIds.map(id => this._updateBadge(id, { text: '' }));
-        chrome.tabs.ungroup([...allTabIds, selectorTabId]).catch(() => {});
+        if (allTabIds.length)
+          chrome.tabs.ungroup(allTabIds).catch(() => {});
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
         this._connectedTabIds.add(newTabId);
@@ -187,20 +189,17 @@ class TabShareExtension {
     if (this._connectedTabIds.has(tabId))
       void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
 
-    if (!this._activeConnection || changeInfo.groupId === undefined)
+    if (!this._activeConnection || this._groupId === null || changeInfo.groupId === undefined)
       return;
-    // Ignore the selector tab — it is in the group for visual association only.
-    if (tabId === this._selectorTabId)
+    // Ignore extension UI tabs other than the selector tab — status pages etc.
+    // should not be auto-attached.
+    if (tabId !== this._selectorTabId && tab.url?.startsWith(chrome.runtime.getURL('')))
       return;
-    // Ignore the extension's own UI tabs (connect/status pages) — those get added
-    // to the group for visual grouping, not because they should be controlled.
-    if (tab.url?.startsWith(chrome.runtime.getURL('')))
-      return;
-    const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;
+    const inOurGroup = changeInfo.groupId === this._groupId;
     const isConnected = this._connectedTabIds.has(tabId);
     if (inOurGroup && !isConnected)
       void this._activeConnection.attachTab(tabId);
-    else if (this._groupId !== null && !inOurGroup && isConnected)
+    else if (!inOurGroup && isConnected)
       void this._activeConnection.detachTab(tabId);
   }
 
@@ -209,22 +208,26 @@ class TabShareExtension {
     return tabs.filter(tab => tab.url && !['chrome:', 'edge:', 'devtools:'].some(scheme => tab.url!.startsWith(scheme)));
   }
 
-  private async _addTabToGroup(tabId: number): Promise<void> {
-    try {
-      if (this._groupId !== null) {
-        try {
-          await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
-          await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
-          return;
-        } catch {
-          this._groupId = null;
+  private _addTabToGroup(tabId: number): Promise<void> {
+    const result = this._groupQueue.then(async () => {
+      try {
+        if (this._groupId !== null) {
+          try {
+            await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
+            await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+            return;
+          } catch {
+            this._groupId = null;
+          }
         }
+        this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
+        await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+      } catch (error: any) {
+        debugLog('Error adding tab to group:', error);
       }
-      this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
-      await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
-    } catch (error: any) {
-      debugLog('Error adding tab to group:', error);
-    }
+    });
+    this._groupQueue = result.catch(() => {});
+    return result;
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -191,7 +191,7 @@ class TabShareExtension {
     const isConnected = this._connectedTabIds.has(tabId);
     if (inOurGroup && !isConnected)
       void this._activeConnection.attachTab(tabId);
-    else if (!inOurGroup && isConnected)
+    else if (this._groupId !== null && !inOurGroup && isConnected)
       void this._activeConnection.detachTab(tabId);
   }
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -186,14 +186,9 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    if (this._connectedTabIds.has(tabId))
-      void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
-
+    // if (this._connectedTabIds.has(tabId))
+    //   void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
     if (!this._activeConnection || this._groupId === null || changeInfo.groupId === undefined)
-      return;
-    // Ignore extension UI tabs other than the selector tab — status pages etc.
-    // should not be auto-attached.
-    if (tabId !== this._selectorTabId && tab.url?.startsWith(chrome.runtime.getURL('')))
       return;
     const inOurGroup = changeInfo.groupId === this._groupId;
     const isConnected = this._connectedTabIds.has(tabId);
@@ -209,25 +204,40 @@ class TabShareExtension {
   }
 
   private _addTabToGroup(tabId: number): Promise<void> {
-    const result = this._groupQueue.then(async () => {
-      try {
-        if (this._groupId !== null) {
-          try {
-            await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
-            await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
-            return;
-          } catch {
-            this._groupId = null;
-          }
-        }
-        this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
-        await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
-      } catch (error: any) {
-        debugLog('Error adding tab to group:', error);
-      }
-    });
+    const result = this._groupQueue.then(() => this._addTabToGroupImpl(tabId));
     this._groupQueue = result.catch(() => {});
     return result;
+  }
+
+  private async _addTabToGroupImpl(tabId: number, retries = 3): Promise<void> {
+    try {
+      if (this._groupId !== null) {
+        try {
+          await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
+          await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+          return;
+        } catch (e: any) {
+          if (this._isDragError(e) && retries > 0)
+            return this._retryAfterDelay(tabId, retries);
+          debugLog('Error adding tab to group:', e);
+        }
+      }
+      this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
+      await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+    } catch (error: any) {
+      if (this._isDragError(error) && retries > 0)
+        return this._retryAfterDelay(tabId, retries);
+      debugLog('Error creating tab group:', error);
+    }
+  }
+
+  private _isDragError(e: any): boolean {
+    return e?.message?.includes('user may be dragging a tab');
+  }
+
+  private async _retryAfterDelay(tabId: number, retries: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return this._addTabToGroupImpl(tabId, retries - 1);
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -186,8 +186,8 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    // if (this._connectedTabIds.has(tabId))
-    //   void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
+    if (this._connectedTabIds.has(tabId))
+      void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
     if (!this._activeConnection || this._groupId === null || changeInfo.groupId === undefined)
       return;
     const inOurGroup = changeInfo.groupId === this._groupId;

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -94,13 +94,10 @@ class TabShareExtension {
       connection.onclose = () => {
         debugLog('Pending connection closed');
         const existed = this._pendingTabSelection.delete(selectorTabId);
-        if (existed) {
+        if (existed)
           chrome.tabs.sendMessage(selectorTabId, { type: 'pendingConnectionClosed' }).catch(() => {});
-          chrome.tabs.ungroup(selectorTabId).catch(() => {});
-        }
       };
       this._pendingTabSelection.set(selectorTabId, connection);
-      await this._addTabToGroup(selectorTabId);
       debugLog(`Connected to MCP relay`);
     } catch (error: any) {
       const message = `Failed to connect to MCP relay: ${error.message}`;

--- a/packages/extension/src/ui/connect.css
+++ b/packages/extension/src/ui/connect.css
@@ -41,7 +41,6 @@ body {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
-  padding-right: 12px;
 }
 
 .status-banner {
@@ -74,7 +73,7 @@ body {
 
 /* Warning banner */
 .warning-banner {
-  margin: 0 12px 16px 12px;
+  margin: 0 0 16px 0;
   padding: 12px;
   background-color: #fff8e1;
   border: 1px solid #f0c674;
@@ -90,10 +89,9 @@ body {
 
 /* Buttons */
 .button-container {
-  margin-bottom: 16px;
   display: flex;
   justify-content: flex-end;
-  padding-right: 12px;
+  gap: 8px;
 }
 
 .button {
@@ -107,7 +105,6 @@ body {
   align-items: center;
   justify-content: center;
   text-decoration: none;
-  margin-right: 8px;
   min-width: 90px;
 }
 
@@ -155,7 +152,7 @@ body {
 .tab-item {
   display: flex;
   align-items: center;
-  padding: 12px;
+  padding: 12px 0 12px 12px;
   margin-bottom: 8px;
   background-color: #ffffff;
   cursor: pointer;
@@ -224,7 +221,7 @@ body {
 /* Auth token section */
 .auth-token-section {
   margin: 16px 0;
-  padding: 16px;
+  padding: 12px;
   background-color: #f6f8fa;
   border-radius: 6px;
 }

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -144,8 +144,6 @@ const ConnectApp: React.FC = () => {
       });
 
       if (response?.success) {
-        if (tab)
-          window.close();
         setStatus({ type: 'connected', message: `"${clientInfo}" connected.` });
       } else {
         setStatus({

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -144,6 +144,8 @@ const ConnectApp: React.FC = () => {
       });
 
       if (response?.success) {
+        if (tab)
+          window.close();
         setStatus({ type: 'connected', message: `"${clientInfo}" connected.` });
       } else {
         setStatus({

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -36,7 +36,6 @@ const ConnectApp: React.FC = () => {
   const [showTabList, setShowTabList] = useState(true);
   const [clientInfo, setClientInfo] = useState('unknown');
   const [mcpRelayUrl, setMcpRelayUrl] = useState('');
-  const [newTab, setNewTab] = useState<boolean>(false);
 
   useEffect(() => {
     const runAsync = async () => {
@@ -104,12 +103,10 @@ const ConnectApp: React.FC = () => {
       await connectToMCPRelay(relayUrl, requestedVersion);
 
       // If this is a browser_navigate command, hide the tab list and show simple allow/reject
-      if (params.get('newTab') === 'true') {
-        setNewTab(true);
+      if (params.get('newTab') === 'true')
         setShowTabList(false);
-      } else {
+      else
         await loadTabs();
-      }
     };
     void runAsync();
   }, []);
@@ -183,20 +180,12 @@ const ConnectApp: React.FC = () => {
             <StatusBanner status={status} />
             {showButtons && (
               <div className='button-container'>
-                {newTab ? (
-                  <>
-                    <Button variant='primary' onClick={() => handleConnectToTab()}>
-                      Allow
-                    </Button>
-                    <Button variant='reject' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
-                      Reject
-                    </Button>
-                  </>
-                ) : (
-                  <Button variant='reject' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
-                    Reject
-                  </Button>
-                )}
+                <Button variant='primary' onClick={() => handleConnectToTab()}>
+                  Allow
+                </Button>
+                <Button variant='reject' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
+                  Reject
+                </Button>
               </div>
             )}
           </div>
@@ -218,7 +207,8 @@ const ConnectApp: React.FC = () => {
         {showTabList && (
           <div>
             <div className='tab-section-title'>
-              Select the default tab for this connection:
+              You can drag tabs into the Playwright group later to make them accessible to the client.
+              Optionally, select a tab to allow and immediately switch to it:
             </div>
             <div>
               {tabs.map(tab => (
@@ -227,7 +217,7 @@ const ConnectApp: React.FC = () => {
                   tab={tab}
                   button={
                     <Button variant='primary' onClick={() => handleConnectToTab(tab)}>
-                      Connect
+                      Allow &amp; select
                     </Button>
                   }
                 />

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -39,7 +39,7 @@ test('attach <url> --extension', async ({ browserWithExtension, cli, server }, t
   const confirmationPage = await confirmationPagePromise;
 
   // Click the Connect button
-  await confirmationPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Connect' }).click();
+  await confirmationPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
 
   {
     // Wait for the CLI command to complete

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -222,6 +222,6 @@ export async function connectAndNavigate(
   );
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Connect' }).click();
+  await selectorPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Allow & select' }).click();
   return await navigatePromise;
 }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -30,7 +30,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Connect' }).click();
+  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -104,7 +104,7 @@ test(`browser_run_code can evaluate in a web worker`, async ({ startExtensionCli
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Connect' }).click();
+  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
 
   await navigateResponse;
 
@@ -183,7 +183,7 @@ test(`snapshot of an existing page`, async ({ browserWithExtension, startClient,
   const selectorPage = await confirmationPagePromise;
   expect(browserContext.pages()).toHaveLength(4);
 
-  await selectorPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+  await selectorPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
 
   expect(await navigateResponse).toHaveResponse({
     inlineSnapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -224,7 +224,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Connect' }).click();
+  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect, extensionId, startWithExtensionFlag } from './extension-fixtures';
 
-test('connect page is not added to Playwright group', async ({ startExtensionClient, server }) => {
+test('connect page is not in group before selection', async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
 
   const connectPagePromise = browserContext.waitForEvent('page', page =>
@@ -34,14 +34,13 @@ test('connect page is not added to Playwright group', async ({ startExtensionCli
     const tab = await chrome.tabs.getCurrent();
     return tab?.groupId ?? -1;
   });
-
   expect(groupId).toBe(-1);
 
   await connectPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 });
 
-test('connected tab is added to green Playwright group', async ({ browserWithExtension, startClient, server }) => {
+test('connected tab and connect page are in green Playwright group', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 
   const page = await browserContext.newPage();
@@ -59,6 +58,7 @@ test('connected tab is added to green Playwright group', async ({ browserWithExt
   await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
+  // Connected tab should be in the Playwright group.
   await expect.poll(async () => {
     return connectPage.evaluate(async () => {
       const chrome = (window as any).chrome;
@@ -69,6 +69,16 @@ test('connected tab is added to green Playwright group', async ({ browserWithExt
       return { color: g.color, title: g.title };
     });
   }).toEqual({ color: 'green', title: 'Playwright' });
+
+  // Connect page should also be in the same group.
+  await expect.poll(async () => {
+    return connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const connectTab = await chrome.tabs.getCurrent();
+      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+      return connectTab?.groupId === connectedTab?.groupId;
+    });
+  }).toBe(true);
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect, extensionId, startWithExtensionFlag } from './extension-fixtures';
 
-test('connect page is added to green Playwright group on relay connect', async ({ startExtensionClient, server }) => {
+test('connect page is not added to Playwright group', async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
 
   const connectPagePromise = browserContext.waitForEvent('page', page =>
@@ -26,26 +26,22 @@ test('connect page is added to green Playwright group on relay connect', async (
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  // Wait for the tab list to appear — this means connectToMCPRelay was processed
-  // by the background and _addTabToGroup has been called.
+  // Wait for the tab list to appear — this means connectToMCPRelay was processed.
   await expect(connectPage.locator('.tab-item').first()).toBeVisible();
 
-  const group = await connectPage.evaluate(async () => {
+  const groupId = await connectPage.evaluate(async () => {
     const chrome = (window as any).chrome;
     const tab = await chrome.tabs.getCurrent();
-    if (!tab || tab.groupId === -1)
-      return null;
-    const g = await chrome.tabGroups.get(tab.groupId);
-    return { color: g.color, title: g.title };
+    return tab?.groupId ?? -1;
   });
 
-  expect(group).toEqual({ color: 'green', title: 'Playwright' });
+  expect(groupId).toBe(-1);
 
-  await connectPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Connect' }).click();
+  await connectPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 });
 
-test('connected tab is added to same Playwright group', async ({ browserWithExtension, startClient, server }) => {
+test('connected tab is added to green Playwright group', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 
   const page = await browserContext.newPage();
@@ -60,21 +56,19 @@ test('connected tab is added to same Playwright group', async ({ browserWithExte
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
-  const { connectGroupId, connectedGroupId } = await connectPage.evaluate(async () => {
-    const chrome = (window as any).chrome;
-    const connectTab = await chrome.tabs.getCurrent();
-    const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
-    return {
-      connectGroupId: connectTab?.groupId,
-      connectedGroupId: connectedTab?.groupId,
-    };
-  });
-
-  expect(connectGroupId).not.toBe(-1);
-  expect(connectedGroupId).toBe(connectGroupId);
+  await expect.poll(async () => {
+    return connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+      if (!connectedTab || connectedTab.groupId === -1)
+        return null;
+      const g = await chrome.tabGroups.get(connectedTab.groupId);
+      return { color: g.color, title: g.title };
+    });
+  }).toEqual({ color: 'green', title: 'Playwright' });
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
@@ -99,15 +93,24 @@ test('tab added to group gets auto-attached', async ({ browserWithExtension, sta
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
+
+  // Wait for the connected tab to be added to the group.
+  await expect.poll(async () => {
+    return connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+      return connectedTab?.groupId ?? -1;
+    });
+  }).toBeGreaterThan(-1);
 
   // Drag the extra tab into the Playwright group — this should auto-attach it.
   await connectPage.evaluate(async (targetUrl: string) => {
     const chrome = (window as any).chrome;
-    const connectTab = await chrome.tabs.getCurrent();
+    const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
     const [extra] = await chrome.tabs.query({ url: targetUrl });
-    await chrome.tabs.group({ groupId: connectTab.groupId, tabIds: [extra.id] });
+    await chrome.tabs.group({ groupId: connectedTab.groupId, tabIds: [extra.id] });
   }, server.PREFIX + '/extra');
 
   await expect.poll(async () => {
@@ -134,7 +137,7 @@ test('tab removed from group gets auto-detached', async ({ browserWithExtension,
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
   // Create a second tab via the client — it will be attached and added to the group.
@@ -185,7 +188,7 @@ test('connected tab is removed from group on disconnect', async ({ browserWithEx
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Connect' }).click();
+  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
   await client.close();


### PR DESCRIPTION
## Summary
- Redesign the connect page: "Allow" button alongside "Reject" for connecting without pre-selecting a tab; per-tab buttons renamed to "Allow & select"; added hint that tabs can be dragged into the Playwright group later.
- Align left/right boundaries of all sections on the connect page.
- The selector (connect) tab is now treated like any connected tab — fully attached to the client once the user approves, and added to the Playwright group.
- Simplify `_onTabUpdated` to drive attach/detach purely from group membership changes, unifying treatment of the selector tab and user-dragged tabs.
- Fix race conditions in tab group management:
  - Serialize `_addTabToGroup` via a promise queue to prevent concurrent calls from creating duplicate groups.
  - Retry group operations when Chrome rejects them mid-drag (`user may be dragging a tab`).
  - Guard `chrome.tabs.ungroup` against empty arrays.

<img width="672" height="718" alt="image" src="https://github.com/user-attachments/assets/2a959064-0598-4385-8590-3b53062d43bd" />
