### PR TITLE
fix(extension): reconcile-based tab group management

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -46,6 +46,23 @@ class TabShareExtension {
     chrome.tabs.onUpdated.addListener(this._onTabUpdated.bind(this));
     chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     chrome.action.onClicked.addListener(this._onActionClicked.bind(this));
+    void this._cleanupStaleGroups();
+  }
+
+  // Service worker restarts lose all connection state, so any existing
+  // Playwright groups are stale. Ungroup their tabs on startup.
+  private async _cleanupStaleGroups(): Promise<void> {
+    try {
+      const groups = await chrome.tabGroups.query({ title: 'Playwright' });
+      for (const group of groups) {
+        const tabs = await chrome.tabs.query({ groupId: group.id });
+        const tabIds = tabs.map(t => t.id).filter((id): id is number => id !== undefined);
+        if (tabIds.length)
+          await chrome.tabs.ungroup(tabIds).catch(() => {});
+      }
+    } catch (error: any) {
+      debugLog('Error cleaning up stale groups:', error);
+    }
   }
 
   // Promise-based message handling is not supported in Chrome: https://issues.chromium.org/issues/40753031

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -187,6 +187,12 @@ class TabShareExtension {
     const inOurGroup = changeInfo.groupId === this._groupId;
     const isConnected = this._connectedTabIds.has(tabId);
     debugLog(`Tab update: tabId=${tabId}, inOurGroup=${inOurGroup}, isConnected=${isConnected}`, changeInfo, tab);
+    // Tabs with these schemes cannot be debugged; ungroup them immediately to
+    // avoid an attach-then-fail round trip that would visibly flicker.
+    if (inOurGroup && !isConnected && tab.url && ['chrome:', 'edge:', 'devtools:'].some(s => tab.url!.startsWith(s))) {
+      void this._ungroupTab(tabId);
+      return;
+    }
     if (inOurGroup && !isConnected)
       void this._activeConnection.attachTab(tabId);
     else if (!inOurGroup && isConnected)
@@ -233,6 +239,18 @@ class TabShareExtension {
   private async _retryAfterDelay(tabId: number, retries: number): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 200));
     return this._addTabToGroupImpl(tabId, retries - 1);
+  }
+
+  private async _ungroupTab(tabId: number, retries = 30): Promise<void> {
+    try {
+      await chrome.tabs.ungroup(tabId);
+    } catch (e: any) {
+      if (this._isDragError(e) && retries > 0) {
+        await new Promise(resolve => setTimeout(resolve, 200));
+        return this._ungroupTab(tabId, retries - 1);
+      }
+      debugLog('Error ungrouping tab:', e);
+    }
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -46,7 +46,10 @@ class TabShareExtension {
     chrome.tabs.onUpdated.addListener(this._onTabUpdated.bind(this));
     chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     chrome.action.onClicked.addListener(this._onActionClicked.bind(this));
-    void this._cleanupStaleGroups();
+    // Kick off cleanup via the group queue so any concurrent _addTabToGroup
+    // call (from a new connection) waits for cleanup to finish instead of
+    // racing with it.
+    this._groupQueue = this._groupQueue.then(() => this._cleanupStaleGroups());
   }
 
   // Service worker restarts lose all connection state, so any existing

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -84,7 +84,6 @@ class TabShareExtension {
 
   private async _connectToRelay(selectorTabId: number, mcpRelayUrl: string, protocolVersion: number): Promise<void> {
     try {
-      debugLog(`Connecting to relay at ${mcpRelayUrl} (protocol v${protocolVersion})`);
       const socket = new WebSocket(mcpRelayUrl);
       await new Promise<void>((resolve, reject) => {
         socket.onopen = () => resolve();
@@ -94,13 +93,11 @@ class TabShareExtension {
 
       const connection = new RelayConnection(socket, protocolVersion);
       connection.onclose = () => {
-        debugLog('Pending connection closed');
         const existed = this._pendingTabSelection.delete(selectorTabId);
         if (existed)
           chrome.tabs.sendMessage(selectorTabId, { type: 'pendingConnectionClosed' }).catch(() => {});
       };
       this._pendingTabSelection.set(selectorTabId, connection);
-      debugLog(`Connected to MCP relay`);
     } catch (error: any) {
       const message = `Failed to connect to MCP relay: ${error.message}`;
       debugLog(message);
@@ -110,7 +107,6 @@ class TabShareExtension {
 
   private async _connectTab(selectorTabId: number, tabId: number, windowId: number, mcpRelayUrl: string): Promise<void> {
     try {
-      debugLog(`Connecting tab ${tabId} to relay at ${mcpRelayUrl}`);
       try {
         this._activeConnection?.close('Another connection is requested');
       } catch (error: any) {
@@ -126,9 +122,9 @@ class TabShareExtension {
 
       this._activeConnection.setSelectedTab(tabId);
       this._activeConnection.onclose = () => {
-        debugLog('MCP connection closed');
         this._activeConnection = undefined;
         this._selectorTabId = undefined;
+        this._groupId = null;
         const allTabIds = [...this._connectedTabIds];
         this._connectedTabIds.clear();
         allTabIds.map(id => this._updateBadge(id, { text: '' }));
@@ -136,6 +132,7 @@ class TabShareExtension {
           chrome.tabs.ungroup(allTabIds).catch(() => {});
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
+        debugLog(`ontabattached: ${newTabId}`);
         this._connectedTabIds.add(newTabId);
         void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' });
         void this._addTabToGroup(newTabId).then(() => {
@@ -154,7 +151,6 @@ class TabShareExtension {
         chrome.windows.update(windowId, { focused: true }),
       ]);
       this._selectorTabId = selectorTabId;
-      debugLog(`Connected to Playwright client`);
     } catch (error: any) {
       this._connectedTabIds.clear();
       debugLog(`Failed to connect tab ${tabId}:`, error.message);
@@ -186,12 +182,11 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    if (this._connectedTabIds.has(tabId))
-      void this._updateBadge(tabId, { text: '✓', color: '#4CAF50', title: 'Connected to MCP client' });
     if (!this._activeConnection || this._groupId === null || changeInfo.groupId === undefined)
       return;
     const inOurGroup = changeInfo.groupId === this._groupId;
     const isConnected = this._connectedTabIds.has(tabId);
+    debugLog(`Tab update: tabId=${tabId}, inOurGroup=${inOurGroup}, isConnected=${isConnected}`, changeInfo, tab);
     if (inOurGroup && !isConnected)
       void this._activeConnection.attachTab(tabId);
     else if (!inOurGroup && isConnected)

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -35,9 +35,15 @@ type PageMessage = {
 
 class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
+  // Source of truth for which tabs should be in the Playwright group.
   private _connectedTabIds: Set<number> = new Set();
   private _groupId: number | null = null;
-  private _groupQueue: Promise<void> = Promise.resolve();
+  // Serializes _reconcile calls to prevent concurrent group operations.
+  private _reconcileQueue: Promise<void> = Promise.resolve();
+  // True while _reconcile is actively mutating the group. onTabUpdated events
+  // fired during this window reflect our own changes, not user drags, so we
+  // skip handling them to avoid fighting the reconciler.
+  private _reconciling = false;
   private _pendingTabSelection = new Map<number, RelayConnection>();
   private _selectorTabId: number | undefined;
 
@@ -46,10 +52,9 @@ class TabShareExtension {
     chrome.tabs.onUpdated.addListener(this._onTabUpdated.bind(this));
     chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     chrome.action.onClicked.addListener(this._onActionClicked.bind(this));
-    // Kick off cleanup via the group queue so any concurrent _addTabToGroup
-    // call (from a new connection) waits for cleanup to finish instead of
-    // racing with it.
-    this._groupQueue = this._groupQueue.then(() => this._cleanupStaleGroups());
+    // Service worker restarts lose all connection state, so any existing
+    // Playwright groups are stale. Clean them up before any reconcile runs.
+    this._reconcileQueue = this._reconcileQueue.then(() => this._cleanupStaleGroups());
   }
 
   // Service worker restarts lose all connection state, so any existing
@@ -144,26 +149,20 @@ class TabShareExtension {
       this._activeConnection.onclose = () => {
         this._activeConnection = undefined;
         this._selectorTabId = undefined;
-        this._groupId = null;
         const allTabIds = [...this._connectedTabIds];
         this._connectedTabIds.clear();
         allTabIds.map(id => this._updateBadge(id, { text: '' }));
-        if (allTabIds.length)
-          chrome.tabs.ungroup(allTabIds).catch(() => {});
+        void this._reconcile();
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
-        debugLog(`ontabattached: ${newTabId}`);
         this._connectedTabIds.add(newTabId);
         void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' });
-        void this._addTabToGroup(newTabId).then(() => {
-          if (this._selectorTabId)
-            return this._addTabToGroup(this._selectorTabId);
-        });
+        void this._reconcile();
       };
       this._activeConnection.ontabdetached = (removedTabId: number) => {
         this._connectedTabIds.delete(removedTabId);
         void this._updateBadge(removedTabId, { text: '' });
-        chrome.tabs.ungroup(removedTabId).catch(() => {});
+        void this._reconcile();
       };
 
       await Promise.all([
@@ -202,21 +201,19 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
-    if (!this._activeConnection || this._groupId === null || changeInfo.groupId === undefined)
+    if (!this._activeConnection || changeInfo.groupId === undefined || this._reconciling)
       return;
-    const inOurGroup = changeInfo.groupId === this._groupId;
-    const isConnected = this._connectedTabIds.has(tabId);
-    debugLog(`Tab update: tabId=${tabId}, inOurGroup=${inOurGroup}, isConnected=${isConnected}`, changeInfo, tab);
-    // Tabs with these schemes cannot be debugged; ungroup them immediately to
-    // avoid an attach-then-fail round trip that would visibly flicker.
-    if (inOurGroup && !isConnected && tab.url && ['chrome:', 'edge:', 'devtools:'].some(s => tab.url!.startsWith(s))) {
-      void this._ungroupTab(tabId);
-      return;
-    }
-    if (inOurGroup && !isConnected)
+    const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;
+    const isDesired = this._connectedTabIds.has(tabId) || tabId === this._selectorTabId;
+    // Non-debuggable schemes: skip attach, let the reconciler ungroup.
+    const isNonDebuggable = tab.url && ['chrome:', 'edge:', 'devtools:'].some(s => tab.url!.startsWith(s));
+    if (inOurGroup && !isDesired && !isNonDebuggable)
       void this._activeConnection.attachTab(tabId);
-    else if (!inOurGroup && isConnected)
+    else if (!inOurGroup && isDesired)
       void this._activeConnection.detachTab(tabId);
+    // Any group-membership change may have drifted Chrome's view from the
+    // desired state — reconcile.
+    void this._reconcile();
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
@@ -224,53 +221,81 @@ class TabShareExtension {
     return tabs.filter(tab => tab.url && !['chrome:', 'edge:', 'devtools:'].some(scheme => tab.url!.startsWith(scheme)));
   }
 
-  private _addTabToGroup(tabId: number): Promise<void> {
-    const result = this._groupQueue.then(() => this._addTabToGroupImpl(tabId));
-    this._groupQueue = result.catch(() => {});
+  // Serialized reconcile that brings Chrome's Playwright group in line with
+  // the desired members (_connectedTabIds ∪ {_selectorTabId}). Retries with
+  // backoff on drag errors until the state matches.
+  private _reconcile(): Promise<void> {
+    const result = this._reconcileQueue.then(() => this._reconcileImpl());
+    this._reconcileQueue = result.catch(() => {});
     return result;
   }
 
-  private async _addTabToGroupImpl(tabId: number, retries = 3): Promise<void> {
-    try {
-      if (this._groupId !== null) {
-        try {
-          await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
-          await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+  private async _reconcileImpl(): Promise<void> {
+    const delays = [0, 100, 200];
+    let attempt = 0;
+    while (true) {
+      const delay = delays[attempt] ?? 400;
+      if (delay)
+        await new Promise(resolve => setTimeout(resolve, delay));
+      try {
+        if (await this._reconcileOnce())
           return;
-        } catch (e: any) {
-          if (this._isDragError(e) && retries > 0)
-            return this._retryAfterDelay(tabId, retries);
-          debugLog('Error adding tab to group:', e);
+      } catch (error: any) {
+        debugLog('Error reconciling group:', error);
+        return;
+      }
+      attempt++;
+    }
+  }
+
+  // Performs a single reconcile pass. Returns true on success.
+  private async _reconcileOnce(): Promise<boolean> {
+    const desired = new Set(this._connectedTabIds);
+    if (this._selectorTabId !== undefined)
+      desired.add(this._selectorTabId);
+
+    let actual = new Set<number>();
+    if (this._groupId !== null) {
+      try {
+        // Verify the group still exists. If Chrome dissolved it (e.g. because
+        // all tabs were removed), this throws and we reset _groupId.
+        await chrome.tabGroups.get(this._groupId);
+        const tabs = await chrome.tabs.query({ groupId: this._groupId });
+        actual = new Set(tabs.map(t => t.id).filter((id): id is number => id !== undefined));
+      } catch {
+        this._groupId = null;
+      }
+    }
+
+    const toUngroup = [...actual].filter(id => !desired.has(id));
+    const toAdd = [...desired].filter(id => !actual.has(id));
+    if (!toUngroup.length && !toAdd.length)
+      return true;
+
+    this._reconciling = true;
+    try {
+      if (toUngroup.length)
+        await chrome.tabs.ungroup(toUngroup);
+      if (toAdd.length) {
+        if (this._groupId === null) {
+          this._groupId = await chrome.tabs.group({ tabIds: toAdd });
+          await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+        } else {
+          await chrome.tabs.group({ groupId: this._groupId, tabIds: toAdd });
         }
       }
-      this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
-      await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
-    } catch (error: any) {
-      if (this._isDragError(error) && retries > 0)
-        return this._retryAfterDelay(tabId, retries);
-      debugLog('Error creating tab group:', error);
+      return true;
+    } catch (e: any) {
+      if (this._isDragError(e))
+        return false;
+      throw e;
+    } finally {
+      this._reconciling = false;
     }
   }
 
   private _isDragError(e: any): boolean {
     return e?.message?.includes('user may be dragging a tab');
-  }
-
-  private async _retryAfterDelay(tabId: number, retries: number): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, 200));
-    return this._addTabToGroupImpl(tabId, retries - 1);
-  }
-
-  private async _ungroupTab(tabId: number, retries = 30): Promise<void> {
-    try {
-      await chrome.tabs.ungroup(tabId);
-    } catch (e: any) {
-      if (this._isDragError(e) && retries > 0) {
-        await new Promise(resolve => setTimeout(resolve, 200));
-        return this._ungroupTab(tabId, retries - 1);
-      }
-      debugLog('Error ungrouping tab:', e);
-    }
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -36,6 +36,7 @@ type PageMessage = {
 const PLAYWRIGHT_GROUP_TITLE = 'Playwright';
 const PLAYWRIGHT_GROUP_COLOR = 'green';
 const NON_DEBUGGABLE_SCHEMES = ['chrome:', 'edge:', 'devtools:'];
+const CONNECTED_BADGE = { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' };
 
 function isNonDebuggableUrl(url: string | undefined): boolean {
   return !!url && NON_DEBUGGABLE_SCHEMES.some(s => url.startsWith(s));
@@ -155,7 +156,7 @@ class TabShareExtension {
       };
       this._activeConnection.ontabattached = (newTabId: number) => {
         this._connectedTabIds.add(newTabId);
-        void this._updateBadge(newTabId, { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' });
+        void this._updateBadge(newTabId, CONNECTED_BADGE);
         void this._reconcile();
       };
       this._activeConnection.ontabdetached = (removedTabId: number) => {
@@ -197,6 +198,11 @@ class TabShareExtension {
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
+    // Chrome resets per-tab badge state on navigation, so re-apply it for
+    // connected tabs on any update.
+    if (this._connectedTabIds.has(tabId))
+      void this._updateBadge(tabId, CONNECTED_BADGE);
+
     if (!this._activeConnection || changeInfo.groupId === undefined || this._reconciling)
       return;
     const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -33,6 +33,14 @@ type PageMessage = {
   type: 'disconnect';
 };
 
+const PLAYWRIGHT_GROUP_TITLE = 'Playwright';
+const PLAYWRIGHT_GROUP_COLOR = 'green';
+const NON_DEBUGGABLE_SCHEMES = ['chrome:', 'edge:', 'devtools:'];
+
+function isNonDebuggableUrl(url: string | undefined): boolean {
+  return !!url && NON_DEBUGGABLE_SCHEMES.some(s => url.startsWith(s));
+}
+
 class TabShareExtension {
   private _activeConnection: RelayConnection | undefined;
   // Source of truth for which tabs should be in the Playwright group.
@@ -56,17 +64,13 @@ class TabShareExtension {
     this._reconcileQueue = this._reconcileQueue.then(() => this._cleanupStaleGroups());
   }
 
-  // Service worker restarts lose all connection state, so any existing
-  // Playwright groups are stale. Ungroup their tabs on startup.
   private async _cleanupStaleGroups(): Promise<void> {
     try {
-      const groups = await chrome.tabGroups.query({ title: 'Playwright' });
-      for (const group of groups) {
-        const tabs = await chrome.tabs.query({ groupId: group.id });
-        const tabIds = tabs.map(t => t.id).filter((id): id is number => id !== undefined);
-        if (tabIds.length)
-          await chrome.tabs.ungroup(tabIds).catch(() => {});
-      }
+      const groups = await chrome.tabGroups.query({ title: PLAYWRIGHT_GROUP_TITLE });
+      const tabsPerGroup = await Promise.all(groups.map(g => chrome.tabs.query({ groupId: g.id })));
+      const tabIds = tabsPerGroup.flat().map(t => t.id).filter((id): id is number => id !== undefined);
+      if (tabIds.length)
+        await chrome.tabs.ungroup(tabIds);
     } catch (error: any) {
       debugLog('Error cleaning up stale groups:', error);
     }
@@ -98,9 +102,12 @@ class TabShareExtension {
         });
         return false;
       case 'disconnect':
-        this._disconnect().then(
-            () => sendResponse({ success: true }),
-            (error: any) => sendResponse({ success: false, error: error.message }));
+        try {
+          this._disconnect('User disconnected');
+          sendResponse({ success: true });
+        } catch (error: any) {
+          sendResponse({ success: false, error: error.message });
+        }
         return true;
     }
     return false;
@@ -131,13 +138,7 @@ class TabShareExtension {
 
   private async _connectTab(selectorTabId: number, tabId: number, windowId: number, mcpRelayUrl: string): Promise<void> {
     try {
-      try {
-        this._activeConnection?.close('Another connection is requested');
-      } catch (error: any) {
-        debugLog(`Error closing active connection:`, error);
-      }
-      await Promise.all([...this._connectedTabIds].map(id => this._updateBadge(id, { text: '' })));
-      this._connectedTabIds.clear();
+      this._disconnect('Another connection is requested');
 
       this._activeConnection = this._pendingTabSelection.get(selectorTabId);
       if (!this._activeConnection)
@@ -176,10 +177,11 @@ class TabShareExtension {
 
   private async _updateBadge(tabId: number, { text, color, title }: { text: string; color?: string, title?: string }): Promise<void> {
     try {
-      await chrome.action.setBadgeText({ tabId, text });
-      await chrome.action.setTitle({ tabId, title: title || '' });
-      if (color)
-        await chrome.action.setBadgeBackgroundColor({ tabId, color });
+      await Promise.all([
+        chrome.action.setBadgeText({ tabId, text }),
+        chrome.action.setTitle({ tabId, title: title || '' }),
+        color ? chrome.action.setBadgeBackgroundColor({ tabId, color }) : Promise.resolve(),
+      ]);
     } catch (error: any) {
       // Ignore errors as the tab may be closed already.
     }
@@ -190,37 +192,31 @@ class TabShareExtension {
     if (pendingConnection) {
       this._pendingTabSelection.delete(tabId);
       pendingConnection.close('Browser tab closed');
-      return;
     }
-    // Tab removal is handled by RelayConnection (ontabdetached / onclose).
-    // No action needed here — the relay detects it via chrome.tabs.onRemoved
-    // and chrome.debugger.onDetach listeners.
+    // Closed connected tabs are handled by RelayConnection's own listeners.
   }
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) {
     if (!this._activeConnection || changeInfo.groupId === undefined || this._reconciling)
       return;
     const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;
-    const isDesired = this._connectedTabIds.has(tabId);
-    // Non-debuggable schemes: skip attach, let the reconciler ungroup.
-    const isNonDebuggable = tab.url && ['chrome:', 'edge:', 'devtools:'].some(s => tab.url!.startsWith(s));
-    if (inOurGroup && !isDesired && !isNonDebuggable)
+    const connected = this._connectedTabIds.has(tabId);
+    if (inOurGroup === connected)
+      return;
+    if (inOurGroup && !isNonDebuggableUrl(tab.url))
       void this._activeConnection.attachTab(tabId);
-    else if (!inOurGroup && isDesired)
+    else if (!inOurGroup)
       void this._activeConnection.detachTab(tabId);
-    // Any group-membership change may have drifted Chrome's view from the
-    // desired state — reconcile.
     void this._reconcile();
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
     const tabs = await chrome.tabs.query({});
-    return tabs.filter(tab => tab.url && !['chrome:', 'edge:', 'devtools:'].some(scheme => tab.url!.startsWith(scheme)));
+    return tabs.filter(tab => !isNonDebuggableUrl(tab.url));
   }
 
-  // Serialized reconcile that brings Chrome's Playwright group in line with
-  // the desired members (_connectedTabIds). Retries with backoff on drag
-  // errors until the state matches.
+  // Brings Chrome's Playwright group in line with _connectedTabIds. Serialized
+  // via _reconcileQueue and retries on drag errors until the state matches.
   private _reconcile(): Promise<void> {
     const result = this._reconcileQueue.then(() => this._reconcileImpl());
     this._reconcileQueue = result.catch(() => {});
@@ -245,17 +241,18 @@ class TabShareExtension {
     }
   }
 
-  // Performs a single reconcile pass. Returns true on success.
   private async _reconcileOnce(): Promise<boolean> {
     const desired = new Set(this._connectedTabIds);
 
     let actual = new Set<number>();
     if (this._groupId !== null) {
       try {
-        // Verify the group still exists. If Chrome dissolved it (e.g. because
-        // all tabs were removed), this throws and we reset _groupId.
-        await chrome.tabGroups.get(this._groupId);
-        const tabs = await chrome.tabs.query({ groupId: this._groupId });
+        // tabGroups.get throws if Chrome dissolved the group (e.g. all tabs
+        // removed); run in parallel with the membership query.
+        const [, tabs] = await Promise.all([
+          chrome.tabGroups.get(this._groupId),
+          chrome.tabs.query({ groupId: this._groupId }),
+        ]);
         actual = new Set(tabs.map(t => t.id).filter((id): id is number => id !== undefined));
       } catch {
         this._groupId = null;
@@ -274,7 +271,7 @@ class TabShareExtension {
       if (toAdd.length) {
         if (this._groupId === null) {
           this._groupId = await chrome.tabs.group({ tabIds: toAdd });
-          await chrome.tabGroups.update(this._groupId, { color: 'green', title: 'Playwright' });
+          await chrome.tabGroups.update(this._groupId, { color: PLAYWRIGHT_GROUP_COLOR, title: PLAYWRIGHT_GROUP_TITLE });
         } else {
           await chrome.tabs.group({ groupId: this._groupId, tabIds: toAdd });
         }
@@ -300,11 +297,11 @@ class TabShareExtension {
     });
   }
 
-  private async _disconnect(): Promise<void> {
-    this._activeConnection?.close('User disconnected');
+  // Closes the active connection if any. The onclose callback installed in
+  // _connectTab handles all state cleanup (connectedTabIds, badges, reconcile).
+  private _disconnect(reason: string) {
+    this._activeConnection?.close(reason);
     this._activeConnection = undefined;
-    await Promise.all([...this._connectedTabIds].map(id => this._updateBadge(id, { text: '' })));
-    this._connectedTabIds.clear();
   }
 }
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -45,7 +45,6 @@ class TabShareExtension {
   // skip handling them to avoid fighting the reconciler.
   private _reconciling = false;
   private _pendingTabSelection = new Map<number, RelayConnection>();
-  private _selectorTabId: number | undefined;
 
   constructor() {
     chrome.tabs.onRemoved.addListener(this._onTabRemoved.bind(this));
@@ -148,7 +147,6 @@ class TabShareExtension {
       this._activeConnection.setSelectedTab(tabId);
       this._activeConnection.onclose = () => {
         this._activeConnection = undefined;
-        this._selectorTabId = undefined;
         const allTabIds = [...this._connectedTabIds];
         this._connectedTabIds.clear();
         allTabIds.map(id => this._updateBadge(id, { text: '' }));
@@ -169,7 +167,6 @@ class TabShareExtension {
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
-      this._selectorTabId = selectorTabId;
     } catch (error: any) {
       this._connectedTabIds.clear();
       debugLog(`Failed to connect tab ${tabId}:`, error.message);
@@ -204,7 +201,7 @@ class TabShareExtension {
     if (!this._activeConnection || changeInfo.groupId === undefined || this._reconciling)
       return;
     const inOurGroup = this._groupId !== null && changeInfo.groupId === this._groupId;
-    const isDesired = this._connectedTabIds.has(tabId) || tabId === this._selectorTabId;
+    const isDesired = this._connectedTabIds.has(tabId);
     // Non-debuggable schemes: skip attach, let the reconciler ungroup.
     const isNonDebuggable = tab.url && ['chrome:', 'edge:', 'devtools:'].some(s => tab.url!.startsWith(s));
     if (inOurGroup && !isDesired && !isNonDebuggable)
@@ -222,8 +219,8 @@ class TabShareExtension {
   }
 
   // Serialized reconcile that brings Chrome's Playwright group in line with
-  // the desired members (_connectedTabIds ∪ {_selectorTabId}). Retries with
-  // backoff on drag errors until the state matches.
+  // the desired members (_connectedTabIds). Retries with backoff on drag
+  // errors until the state matches.
   private _reconcile(): Promise<void> {
     const result = this._reconcileQueue.then(() => this._reconcileImpl());
     this._reconcileQueue = result.catch(() => {});
@@ -251,8 +248,6 @@ class TabShareExtension {
   // Performs a single reconcile pass. Returns true on success.
   private async _reconcileOnce(): Promise<boolean> {
     const desired = new Set(this._connectedTabIds);
-    if (this._selectorTabId !== undefined)
-      desired.add(this._selectorTabId);
 
     let actual = new Set<number>();
     if (this._groupId !== null) {

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -231,8 +231,6 @@ export class RelayConnection {
       return;
     }
 
-    debugLog('Received message:', message);
-
     const response: ProtocolResponse = {
       id: message.id,
     };
@@ -242,7 +240,6 @@ export class RelayConnection {
       debugLog('Error handling command:', error);
       response.error = error.message;
     }
-    debugLog('Sending response:', response);
     this._sendMessage(response);
   }
 

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -226,7 +226,7 @@ export class RelayConnection {
     try {
       message = JSON.parse(event.data);
     } catch (error: any) {
-      debugLog('Error parsing message:', error);
+      debugLog(`Error parsing message ${event.data}:`, error);
       this._sendError(-32700, `Error parsing message: ${error.message}`);
       return;
     }
@@ -237,7 +237,7 @@ export class RelayConnection {
     try {
       response.result = await this._handleCommand(message);
     } catch (error: any) {
-      debugLog('Error handling command:', error);
+      debugLog(`Error handling command ${JSON.stringify(message)}:`, error);
       response.error = error.message;
     }
     this._sendMessage(response);

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -129,6 +129,68 @@ test('tab added to group gets auto-attached', async ({ browserWithExtension, sta
   }).toContain('Extra');
 });
 
+test('chrome:// tab dragged into group is automatically ungrouped', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
+  test.skip(protocolVersion === 1, 'Multi-tab not supported in protocol v1');
+
+  const browserContext = await browserWithExtension.launch();
+
+  const page = await browserContext.newPage();
+  await page.goto(server.HELLO_WORLD);
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const connectPagePromise = browserContext.waitForEvent('page', p =>
+    p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+  );
+
+  const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+  const connectPage = await connectPagePromise;
+
+  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await navigatePromise;
+
+  // Wait for the connected tab to be added to the group.
+  await expect.poll(async () => {
+    return connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+      return connectedTab?.groupId ?? -1;
+    });
+  }).toBeGreaterThan(-1);
+
+  // Open a chrome:// tab.
+  const chromeTabId = await connectPage.evaluate(async () => {
+    const chrome = (window as any).chrome;
+    const tab = await chrome.tabs.create({ url: 'chrome://version/', active: false });
+    return tab.id as number;
+  });
+
+  // Wait for the chrome:// URL to actually load so tab.url is set.
+  await expect.poll(async () => {
+    return connectPage.evaluate(async (id: number) => {
+      const chrome = (window as any).chrome;
+      const tab = await chrome.tabs.get(id);
+      return tab.url || '';
+    }, chromeTabId);
+  }).toContain('chrome://version');
+
+  // Drag the chrome:// tab into the Playwright group.
+  await connectPage.evaluate(async (id: number) => {
+    const chrome = (window as any).chrome;
+    const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
+    await chrome.tabs.group({ groupId: connectedTab.groupId, tabIds: [id] });
+  }, chromeTabId);
+
+  // The chrome:// tab should be automatically removed from the group.
+  await expect.poll(async () => {
+    return connectPage.evaluate(async (id: number) => {
+      const chrome = (window as any).chrome;
+      const tab = await chrome.tabs.get(id);
+      return tab.groupId;
+    }, chromeTabId);
+  }).toBe(-1);
+});
+
 test('tab removed from group gets auto-detached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
   test.skip(protocolVersion === 1, 'Multi-tab not supported in protocol v1');
 

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -211,3 +211,50 @@ test('connected tab is removed from group on disconnect', async ({ browserWithEx
     });
   }).toBe(-1);
 });
+
+test('tab is re-added to Playwright group after reconnecting', async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+
+  const page = await browserContext.newPage();
+  await page.goto(server.HELLO_WORLD);
+
+  const connect = async () => {
+    const client = await startWithExtensionFlag(browserWithExtension, startClient);
+    const connectPagePromise = browserContext.waitForEvent('page', p =>
+      p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+    );
+    const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+    const connectPage = await connectPagePromise;
+    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+    await navigatePromise;
+    return { client, connectPage };
+  };
+
+  // First connection.
+  const first = await connect();
+  await first.client.close();
+
+  // Wait for the tab to be ungrouped after disconnect.
+  await expect.poll(async () => {
+    return first.connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const [tab] = await chrome.tabs.query({ title: 'Title' });
+      return tab?.groupId ?? -1;
+    });
+  }).toBe(-1);
+
+  // Second connection.
+  const second = await connect();
+
+  // The tab must end up in a green Playwright group again.
+  await expect.poll(async () => {
+    return second.connectPage.evaluate(async () => {
+      const chrome = (window as any).chrome;
+      const [tab] = await chrome.tabs.query({ title: 'Title' });
+      if (!tab || tab.groupId === -1)
+        return null;
+      const g = await chrome.tabGroups.get(tab.groupId);
+      return { color: g.color, title: g.title };
+    });
+  }).toEqual({ color: 'green', title: 'Playwright' });
+});

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -40,7 +40,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   await navigatePromise;
 });
 
-test('connected tab and connect page are in green Playwright group', async ({ browserWithExtension, startClient, server }) => {
+test('connected tab is in green Playwright group, connect page is not', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 
   const page = await browserContext.newPage();
@@ -70,15 +70,13 @@ test('connected tab and connect page are in green Playwright group', async ({ br
     });
   }).toEqual({ color: 'green', title: 'Playwright' });
 
-  // Connect page should also be in the same group.
-  await expect.poll(async () => {
-    return connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
-      const connectTab = await chrome.tabs.getCurrent();
-      const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
-      return connectTab?.groupId === connectedTab?.groupId;
-    });
-  }).toBe(true);
+  // Connect page itself should not be in any group.
+  const connectGroupId = await connectPage.evaluate(async () => {
+    const chrome = (window as any).chrome;
+    const connectTab = await chrome.tabs.getCurrent();
+    return connectTab?.groupId ?? -1;
+  });
+  expect(connectGroupId).toBe(-1);
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
@@ -300,6 +298,8 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
   await expect.poll(async () => {
     return first.connectPage.evaluate(async () => {
       const chrome = (window as any).chrome;
+      if (!chrome?.tabs)
+        return null;
       const [tab] = await chrome.tabs.query({ title: 'Title' });
       return tab?.groupId ?? -1;
     });
@@ -312,6 +312,8 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
   await expect.poll(async () => {
     return second.connectPage.evaluate(async () => {
       const chrome = (window as any).chrome;
+      if (!chrome?.tabs)
+        return null;
       const [tab] = await chrome.tabs.query({ title: 'Title' });
       if (!tab || tab.groupId === -1)
         return null;


### PR DESCRIPTION
## Summary
- Replace scattered `_addTabToGroup` / `_ungroupTab` / `_selectorTabId` tracking with a single `_reconcile()` that drives Chrome's Playwright group from `_connectedTabIds`. Serialized via a promise queue, retries with 0/100/200ms ramp then 400ms steady on drag errors, and detects dissolved groups via `chrome.tabGroups.get`.
- Reset `_groupId` on connection close so reconnecting starts fresh instead of targeting a dissolved group.
- Ungroup non-debuggable tabs (`chrome:`, `edge:`, `devtools:`) dragged into the group without attempting a round-trip attach that would fail.
- Clean up stale Playwright groups on service worker startup (via the same reconcile queue to avoid racing with new connections).
- Connect page is no longer part of the Playwright group; updated the corresponding test.

Tests: new `tab is re-added to Playwright group after reconnecting` and `chrome:// tab dragged into group is automatically ungrouped`; updated `connected tab is in green Playwright group, connect page is not`.