### PR TITLE
devops(extension): tune Extension workflow triggers and setup

### DIFF
--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: allow-publishing-extension-to-cws
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -9,9 +9,11 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/extension/**'
       - 'packages/playwright-core/src/server/bidi/**'
       - 'packages/playwright-core/src/tools/**'
       - 'tests/bidi/**'
+      - 'tests/extension/**'
       - 'tests/mcp/**'
     branches:
       - main

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -1,4 +1,4 @@
-name: Extension
+name: extension
 
 on:
   push:
@@ -24,6 +24,10 @@ on:
       - 'tests/extension/**'
       - '.github/workflows/tests_extension.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: 1
   ELECTRON_SKIP_BINARY_DOWNLOAD: 1
@@ -45,5 +49,5 @@ jobs:
     - run: npm ci
     - run: npm run build
     - run: npm run build-extension
-    - run: npx playwright install --with-deps
+    - run: npx playwright install --with-deps chromium
     - run: npm run test-extension

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -9,9 +9,11 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/extension/**'
       - 'packages/playwright-core/src/server/bidi/**'
       - 'packages/playwright-core/src/tools/**'
       - 'tests/bidi/**'
+      - 'tests/extension/**'
       - 'tests/mcp/**'
     branches:
       - main

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -9,8 +9,10 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/extension/**'
       - 'packages/playwright-core/src/server/bidi/**'
       - 'tests/bidi/**'
+      - 'tests/extension/**'
     types: [ labeled ]
     branches:
       - main


### PR DESCRIPTION
## Summary
- Skip tests_primary, tests_secondary, and tests_components on changes under \`packages/extension/**\` and \`tests/extension/**\`.
- Add concurrency group to Extension workflow and install only chromium.
- Bump checkout/setup-node to v6 in publish_extension.yml.