### PR TITLE
chore: brush up cli tests

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/channelSessions.ts
+++ b/packages/playwright-core/src/tools/cli-client/channelSessions.ts
@@ -26,7 +26,7 @@ export type ChannelSession = {
 };
 
 export async function listChannelSessions(): Promise<ChannelSession[]> {
-  if (process.env.PLAYWRIGHT_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST)
+  if (process.env.PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST)
     return [];
   const result: ChannelSession[] = [];
   for (const [channel, dirs] of channelToUserDataDir) {

--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -218,7 +218,7 @@ export class TextOutput implements Output {
   }
 
   show(_session: string, pid: number | undefined): void {
-    if (process.env.PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST)
+    if (process.env.PWTEST_PRINT_DASHBOARD_PID_FOR_TEST)
       console.log(`### Dashboard opened with pid ${pid}.`);
   }
 

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -269,7 +269,7 @@ const daemonProcessPatterns = ['run-mcp-server', 'run-cli-server', 'cli-daemon',
 
 async function killAllDaemons(): Promise<number[]> {
   const platform = os.platform();
-  const pidFilterEnv = process.env.PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST;
+  const pidFilterEnv = process.env.PWTEST_KILL_ALL_PID_FILTER_FOR_TEST;
   const pidFilter = pidFilterEnv ? new Set(pidFilterEnv.split(',').map(p => parseInt(p, 10)).filter(n => !isNaN(n))) : undefined;
   const killed: number[] = [];
 

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -205,7 +205,7 @@ async function launchApp(appName: string) {
 }
 
 export async function syncLocalStorageWithSettings(page: api.Page, appName: string) {
-  const settingsFile = process.env.PLAYWRIGHT_DASHBOARD_SETTINGS_FILE_FOR_TEST ?? path.join(registryDirectory, '.settings', `${appName}.json`);
+  const settingsFile = process.env.PWTEST_DASHBOARD_SETTINGS_FILE ?? path.join(registryDirectory, '.settings', `${appName}.json`);
 
   await page.exposeBinding('_saveSerializedSettings', (_, settings) => {
     fs.mkdirSync(path.dirname(settingsFile), { recursive: true });

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -168,7 +168,7 @@ async function launchApp(appName: string) {
   const context = await playwright.chromium.launchPersistentContext('', {
     ignoreDefaultArgs: ['--enable-automation'],
     channel,
-    headless: !!process.env.PW_DASHBOARD_APP_BIND_TITLE,
+    headless: !!process.env.PWTEST_DASHBOARD_APP_BIND_TITLE,
     args: [
       '--app=data:text/html,',
       '--test-type=',
@@ -177,8 +177,8 @@ async function launchApp(appName: string) {
     ],
     viewport: null,
   });
-  if (process.env.PW_DASHBOARD_APP_BIND_TITLE)
-    await context.browser()?.bind(process.env.PW_DASHBOARD_APP_BIND_TITLE, { workspaceDir: process.cwd() });
+  if (process.env.PWTEST_DASHBOARD_APP_BIND_TITLE)
+    await context.browser()?.bind(process.env.PWTEST_DASHBOARD_APP_BIND_TITLE, { workspaceDir: process.cwd() });
 
   const [page] = context.pages();
   // Chromium on macOS opens a new tab when clicking on the dock icon.

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -160,13 +160,11 @@ test('video-chapter', async ({ cli, server }) => {
   await cli('video-stop');
 });
 
-test('pick', async ({ cdpServer, cli, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('pick', async ({ boundBrowser, cli }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   const scriptReady = page.waitForEvent('console', msg => msg.text() === 'Recorder script ready for test');
@@ -181,13 +179,11 @@ test('pick', async ({ cdpServer, cli, server }) => {
   expect(output).toContain(`locator: getByRole('button', { name: 'Submit' })`);
 });
 
-test('pick activates dashboard session', async ({ cdpServer, cli, server, startDashboardServer }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('pick activates dashboard session', async ({ boundBrowser, cli, startDashboardServer }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   const dashboard = await startDashboardServer();
@@ -216,13 +212,11 @@ test('generate-locator', async ({ cli, server }) => {
   expect(output).toContain(`getByRole('button', { name: 'Submit' })`);
 });
 
-test('highlight', async ({ cdpServer, cli, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('highlight', async ({ boundBrowser, cli }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   const { output } = await cli('highlight', 'e2');
@@ -235,13 +229,11 @@ test('highlight', async ({ cdpServer, cli, server }) => {
   expect(await highlight.boundingBox()).toEqual(await page.getByRole('button', { name: 'Submit' }).boundingBox());
 });
 
-test('highlight --hide', async ({ cdpServer, cli, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('highlight --hide', async ({ boundBrowser, cli }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   await cli('highlight', 'e2');
@@ -252,13 +244,11 @@ test('highlight --hide', async ({ cdpServer, cli, server }) => {
   await expect(page.locator('x-pw-highlight')).toHaveCount(0);
 });
 
-test('highlight --hide all', async ({ cdpServer, cli, server }) => {
-  server.setContent('/', `<button>Submit</button><a href="#">Go</a>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('highlight --hide all', async ({ boundBrowser, cli }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button><a href="#">Go</a>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   await cli('highlight', 'e2');
@@ -270,13 +260,11 @@ test('highlight --hide all', async ({ cdpServer, cli, server }) => {
   await expect(page.locator('x-pw-highlight')).toHaveCount(0);
 });
 
-test('highlight --style', async ({ cdpServer, cli, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('highlight --style', async ({ boundBrowser, cli, mcpBrowser }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  await cli('attach', `--cdp=${cdpServer.endpoint}`);
+  await cli('attach', 'default');
   await cli('snapshot');
 
   await cli('highlight', 'e2', '--style=outline: 3px solid rgb(255, 0, 0); background-color: rgba(0, 255, 0, 0.25)');
@@ -286,7 +274,10 @@ test('highlight --style', async ({ cdpServer, cli, server }) => {
   expect(await highlight.evaluate((el: HTMLElement) => ({
     outline: el.style.outline,
     backgroundColor: el.style.backgroundColor,
-  }))).toEqual({
+  }))).toEqual(mcpBrowser === 'webkit' ? {
+    outline: '3px solid rgb(255, 0, 0)',
+    backgroundColor: 'rgba(0, 255, 0, 0.25)',
+  } : {
     outline: 'rgb(255, 0, 0) solid 3px',
     backgroundColor: 'rgba(0, 255, 0, 0.25)',
   });

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -97,8 +97,8 @@ export const test = baseTest.extend<{
       await fs.promises.rm(path.join(daemonDir, dir), { recursive: true, force: true }).catch(() => {});
   },
   boundBrowser: async ({ mcpBrowser, playwright }, use) => {
-    const browserName = mcpBrowser === 'chrome' ? 'chromium' : mcpBrowser;
-    const channel = mcpBrowser === 'chrome' ? 'chrome' : undefined;
+    const browserName = (mcpBrowser === 'chrome' || mcpBrowser === 'msedge') ? 'chromium' : mcpBrowser;
+    const channel = (mcpBrowser === 'chrome' || mcpBrowser === 'msedge') ? mcpBrowser : undefined;
     const browser = await playwright[browserName].launch({ channel, headless: true });
     for (const [name, value] of Object.entries(cliEnv()))
       process.env[name] = value;

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -113,7 +113,7 @@ export const test = baseTest.extend<{
 function cliEnv() {
   return {
     PLAYWRIGHT_SERVER_REGISTRY: test.info().outputPath('registry'),
-    PLAYWRIGHT_DASHBOARD_SETTINGS_FILE_FOR_TEST: test.info().outputPath('dashboard.settings.json'),
+    PWTEST_DASHBOARD_SETTINGS_FILE: test.info().outputPath('dashboard.settings.json'),
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
     PLAYWRIGHT_SOCKETS_DIR: path.join(os.tmpdir(), 'ds' + String(test.info().workerIndex)),
     PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST: '1',

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -27,6 +27,7 @@ import type { CommonFixtures } from '../config/commonFixtures';
 
 export { expect } from './fixtures';
 export const test = baseTest.extend<{
+  boundBrowser: Browser,
   cliEnv: Record<string, string>,
   startDashboardServer: (options?: { cwd?: string, session?: string }) => Promise<Page>,
   connectToDashboard: (bindTitle: string) => Promise<Browser>;
@@ -37,7 +38,8 @@ export const test = baseTest.extend<{
     inlineSnapshot?: string,
     snapshot?: string,
     attachments?: { name: string, data: Buffer | null }[],
-    pid?: number,
+    daemonPid?: number,
+    dashboardPid?: number,
   }>;
 }>({
   cliEnv: async ({}, use) => {
@@ -70,27 +72,41 @@ export const test = baseTest.extend<{
     });
     await cli('show', '--kill');
   },
+
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
-    const sessions: { name: string, pid: number }[] = [];
     await fs.promises.mkdir(test.info().outputPath('.playwright'), { recursive: true });
-    const pids: number[] = [];
+    const allPids: number[] = [];
 
     await use(async (...args: string[]) => {
       const cliArgs = args.filter(arg => typeof arg === 'string');
       const cliOptions = args.findLast(arg => typeof arg === 'object') || {};
-      const result = await runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless }, sessions);
-      if (result.pid !== undefined)
-        pids.push(result.pid);
+      const result = await runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless });
+      if (result.daemonPid)
+        allPids.push(result.daemonPid);
+      if (result.dashboardPid)
+        allPids.push(result.dashboardPid);
       return result;
     });
 
-    for (const pid of pids)
+    for (const pid of allPids)
       killProcessGroup(pid);
 
     const daemonDir = path.join(test.info().outputDir, 'daemon');
     const userDataDirs = await fs.promises.readdir(daemonDir).catch(() => []);
     for (const dir of userDataDirs.filter(f => f.startsWith('ud-')))
       await fs.promises.rm(path.join(daemonDir, dir), { recursive: true, force: true }).catch(() => {});
+  },
+  boundBrowser: async ({ mcpBrowser, playwright }, use) => {
+    const browserName = mcpBrowser === 'chrome' ? 'chromium' : mcpBrowser;
+    const channel = mcpBrowser === 'chrome' ? 'chrome' : undefined;
+    const browser = await playwright[browserName].launch({ channel, headless: true });
+    for (const [name, value] of Object.entries(cliEnv()))
+      process.env[name] = value;
+    await browser.bind('default');
+    await use(browser);
+    for (const name of Object.keys(cliEnv()))
+      delete process.env[name];
+    await browser.close();
   },
 });
 
@@ -100,11 +116,11 @@ function cliEnv() {
     PLAYWRIGHT_DASHBOARD_SETTINGS_FILE_FOR_TEST: test.info().outputPath('dashboard.settings.json'),
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
     PLAYWRIGHT_SOCKETS_DIR: path.join(os.tmpdir(), 'ds' + String(test.info().workerIndex)),
-    PLAYWRIGHT_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST: '1',
+    PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST: '1',
   };
 }
 
-async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string, env?: Record<string, string> }, options: { mcpBrowser: string, mcpHeadless: boolean }, sessions: { name: string, pid: number }[]) {
+async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string, env?: Record<string, string>, bindTitle?: string }, options: { mcpBrowser: string, mcpHeadless: boolean }) {
   const stepTitle = `cli ${args.join(' ')}`;
   return await test.step(stepTitle, async () => {
     const testInfo = test.info();
@@ -115,7 +131,8 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
         ...cliEnv(),
         PLAYWRIGHT_MCP_BROWSER: options.mcpBrowser,
         PLAYWRIGHT_MCP_HEADLESS: String(options.mcpHeadless),
-        PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST: '1',
+        PWTEST_PRINT_DASHBOARD_PID_FOR_TEST: '1',
+        PWTEST_DASHBOARD_APP_BIND_TITLE: cliOptions.bindTitle,
         ...cliOptions.env,
       }),
     });
@@ -130,12 +147,10 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
     const attachments = loadAttachments(cli.stdout);
 
     const browserMatches = cli.stdout.includes('### Browser') ? cli.stdout.match(/Browser `(.+)` opened with pid (\d+)\./) : undefined;
-    const [, sessionName, browserPid] = browserMatches ?? [];
-    if (sessionName && browserPid)
-      sessions.push({ name: sessionName, pid: +browserPid });
+    const [, , daemonPid] = browserMatches ?? [];
     const dashboardMatches = cli.stdout.includes('### Dashboard') ? cli.stdout.match(/Dashboard opened with pid (\d+)\./) : undefined;
     const dashboardPid = dashboardMatches?.[1];
-    const pid = browserPid ?? dashboardPid;
+
     return {
       exitCode: await cli.exitCode,
       output: cli.stdout.trim(),
@@ -143,7 +158,8 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
       snapshot,
       inlineSnapshot,
       attachments,
-      pid: pid ? +pid : undefined,
+      daemonPid: daemonPid ? +daemonPid : undefined,
+      dashboardPid: dashboardPid ? +dashboardPid : undefined,
     };
   });
 }

--- a/tests/mcp/cli-json.spec.ts
+++ b/tests/mcp/cli-json.spec.ts
@@ -68,7 +68,7 @@ test('delete-data returns not-deleted when there is no session', async ({ cli })
 });
 
 test('kill-all returns zero killed when filter matches nothing', async ({ cli }) => {
-  const { output } = await cli('--json', 'kill-all', { env: { PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST: '0' } });
+  const { output } = await cli('--json', 'kill-all', { env: { PWTEST_KILL_ALL_PID_FILTER_FOR_TEST: '0' } });
   expect(JSON.parse(output)).toEqual({ killed: 0, pids: [] });
 });
 

--- a/tests/mcp/cli-killall.spec.ts
+++ b/tests/mcp/cli-killall.spec.ts
@@ -26,29 +26,29 @@ function isAlive(pid: number): boolean {
 }
 
 test('kill-all kills only filtered pid', async ({ cli, server }) => {
-  const { pid } = await cli('open', server.HELLO_WORLD);
-  expect(pid).toBeDefined();
-  expect(isAlive(pid!)).toBe(true);
+  const { daemonPid } = await cli('open', server.HELLO_WORLD);
+  expect(daemonPid).toBeDefined();
+  expect(isAlive(daemonPid)).toBe(true);
 
   const { output } = await cli('kill-all', {
-    env: { PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST: String(pid) },
+    env: { PWTEST_KILL_ALL_PID_FILTER_FOR_TEST: String(daemonPid) },
   });
-  expect(output).toContain(`Killed daemon process ${pid}`);
+  expect(output).toContain(`Killed daemon process ${daemonPid}`);
   expect(output).toContain('Killed 1 daemon process.');
 
-  await expect.poll(() => isAlive(pid!)).toBe(false);
+  await expect.poll(() => isAlive(daemonPid)).toBe(false);
 });
 
 test('kill-all kills filtered dashboard pid', async ({ cli }) => {
-  const { pid } = await cli('show', { env: { PLAYWRIGHT_PRINT_DASHBOARD_PID_FOR_TEST: '1' } });
-  expect(pid).toBeDefined();
-  await expect.poll(() => isAlive(pid!)).toBe(true);
+  const { dashboardPid } = await cli('show');
+  expect(dashboardPid).toBeDefined();
+  await expect.poll(() => isAlive(dashboardPid)).toBe(true);
 
   const { output } = await cli('kill-all', {
-    env: { PLAYWRIGHT_KILL_ALL_PID_FILTER_FOR_TEST: String(pid) },
+    env: { PWTEST_KILL_ALL_PID_FILTER_FOR_TEST: String(dashboardPid) },
   });
-  expect(output).toContain(`Killed daemon process ${pid}`);
+  expect(output).toContain(`Killed daemon process ${dashboardPid}`);
   expect(output).toContain('Killed 1 daemon process.');
 
-  await expect.poll(() => isAlive(pid!)).toBe(false);
+  await expect.poll(() => isAlive(dashboardPid)).toBe(false);
 });

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -240,7 +240,7 @@ test('list --all lists sessions from all workspaces', async ({ cli, server }, te
   expect(sessionFilesAfterClose).toContain('session2.session');
   expect(sessionFilesAfterClose).toContain('session3.session');
 
-  killProcessGroup(session3.pid);
+  killProcessGroup(session3.daemonPid);
 
   const { output: listOne } = await cli('list', '--all', { cwd: workspace2 });
   expect(listOne).not.toContain('workspace1');

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -94,16 +94,16 @@ function isAlive(pid: number): boolean {
 
 test('daemon show: closing page exits the process', async ({ cli, connectToDashboard }) => {
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  const { exitCode, pid } = await cli('show', { env: { PW_DASHBOARD_APP_BIND_TITLE: bindTitle } });
+  const { exitCode, dashboardPid } = await cli('show', { bindTitle });
   expect(exitCode).toBe(0);
-  expect(pid).toBeDefined();
-  expect(isAlive(pid!)).toBe(true);
+  expect(dashboardPid).toBeDefined();
+  expect(isAlive(dashboardPid)).toBe(true);
 
   const browser = await connectToDashboard(bindTitle);
   const page = browser.contexts()[0].pages()[0];
   await page.close();
 
-  await expect(() => expect(isAlive(pid!)).toBe(false)).toPass();
+  await expect(() => expect(isAlive(dashboardPid)).toBe(false)).toPass();
 });
 
 async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page, text: string) {
@@ -135,7 +135,7 @@ function verifyAnnotateOutput(output: string, expectedText: string, outputDir: s
 test('should capture annotations via show --annotate', async ({ connectToDashboard, cli, server }) => {
   await cli('open', server.EMPTY_PAGE);
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  await cli('show', { env: { PW_DASHBOARD_APP_BIND_TITLE: bindTitle } });
+  await cli('show', { bindTitle });
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
@@ -157,7 +157,7 @@ test('should start dashboard and annotate when no dashboard is running', async (
   await cli('open', server.EMPTY_PAGE);
 
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  const annotatePromise = cli('show', '--annotate', { env: { PW_DASHBOARD_APP_BIND_TITLE: bindTitle } });
+  const annotatePromise = cli('show', '--annotate', { bindTitle });
   let done = false;
   void annotatePromise.finally(() => { done = true; });
 

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -74,7 +74,8 @@ test('should show current workspace sessions first', async ({ cli, server, start
   });
 });
 
-test('should activate session when show is called with -s', async ({ cli, server, startDashboardServer }) => {
+test('should activate session when show is called with -s', async ({ cli, server, startDashboardServer, mcpBrowser }) => {
+  test.fixme(mcpBrowser === 'firefox', 'race condition gonna be fixed through https://github.com/microsoft/playwright/pull/40315');
   await cli('-s=sessA', 'open', server.EMPTY_PAGE);
   await cli('-s=sessB', 'open', server.EMPTY_PAGE);
 

--- a/tests/mcp/devtools.spec.ts
+++ b/tests/mcp/devtools.spec.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { test, expect } from './fixtures';
+import { test, expect } from './cli-fixtures';
 
 test.use({ mcpCaps: ['devtools'] });
 
-test('browser_pick_locator', async ({ cdpServer, startClient, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('browser_pick_locator', async ({ boundBrowser, startClient }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  const { client } = await startClient({ args: [`--endpoint=default`] });
   await client.callTool({ name: 'browser_snapshot' });
 
   const scriptReady = page.waitForEvent('console', msg => msg.text() === 'Recorder script ready for test');
@@ -39,13 +37,11 @@ test('browser_pick_locator', async ({ cdpServer, startClient, server }) => {
   });
 });
 
-test('browser_highlight', async ({ cdpServer, startClient, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('browser_highlight', async ({ boundBrowser, startClient }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  const { client } = await startClient({ args: [`--endpoint=default`] });
   await client.callTool({ name: 'browser_snapshot' });
 
   expect(await client.callTool({
@@ -62,13 +58,11 @@ test('browser_highlight', async ({ cdpServer, startClient, server }) => {
   expect(await highlight.boundingBox()).toEqual(await page.getByRole('button', { name: 'Submit' }).boundingBox());
 });
 
-test('browser_highlight with style', async ({ cdpServer, startClient, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('browser_highlight with style', async ({ boundBrowser, startClient, mcpBrowser }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  const { client } = await startClient({ args: [`--endpoint=default`] });
   await client.callTool({ name: 'browser_snapshot' });
 
   expect(await client.callTool({
@@ -87,19 +81,20 @@ test('browser_highlight with style', async ({ cdpServer, startClient, server }) 
   expect(await highlight.evaluate((el: HTMLElement) => ({
     outline: el.style.outline,
     backgroundColor: el.style.backgroundColor,
-  }))).toEqual({
+  }))).toEqual(mcpBrowser === 'webkit' ? {
+    outline: '3px solid rgb(255, 0, 0)',
+    backgroundColor: 'rgba(0, 255, 0, 0.25)',
+  } : {
     outline: 'rgb(255, 0, 0) solid 3px',
     backgroundColor: 'rgba(0, 255, 0, 0.25)',
   });
 });
 
-test('browser_hide_highlight', async ({ cdpServer, startClient, server }) => {
-  server.setContent('/', `<button>Submit</button>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('browser_hide_highlight', async ({ boundBrowser, startClient }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
 
-  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  const { client } = await startClient({ args: [`--endpoint=default`] });
   await client.callTool({ name: 'browser_snapshot' });
 
   await client.callTool({
@@ -117,13 +112,11 @@ test('browser_hide_highlight', async ({ cdpServer, startClient, server }) => {
   await expect(page.locator('x-pw-highlight')).toHaveCount(0);
 });
 
-test('browser_hide_highlight all', async ({ cdpServer, startClient, server }) => {
-  server.setContent('/', `<button>Submit</button><a href="#">Go</a>`, 'text/html');
-  const browserContext = await cdpServer.start();
-  const [page] = browserContext.pages();
-  await page.goto(server.PREFIX);
+test('browser_hide_highlight all', async ({ boundBrowser, startClient }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button><a href="#">Go</a>`);
 
-  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  const { client } = await startClient({ args: [`--endpoint=default`] });
   await client.callTool({ name: 'browser_snapshot' });
 
   await client.callTool({ name: 'browser_highlight', arguments: { element: 'Submit button', target: 'e2' } });


### PR DESCRIPTION
- Fix `boundBrowser` fixture to handle `msedge` → `chromium` mapping (matches existing `chrome` handling)
- Fixes 11 msedge test failures in `devtools.spec.ts` and `cli-devtools.spec.ts`

Supersedes #40323