### PR TITLE
chore: rebrand extension UI strings

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,8 +1,8 @@
-# Playwright MCP Chrome Extension
+# Playwright Chrome Extension
 
 ## Introduction
 
-The Playwright MCP Chrome Extension allows you to connect to pages in your existing browser and leverage the state of your default user profile. This means the AI assistant can interact with websites where you're already logged in, using your existing cookies, sessions, and browser state, providing a seamless experience without requiring separate authentication or setup.
+The Playwright Chrome Extension allows you to connect to pages in your existing browser and leverage the state of your default user profile. This means the AI assistant can interact with websites where you're already logged in, using your existing cookies, sessions, and browser state, providing a seamless experience without requiring separate authentication or setup.
 
 ## Prerequisites
 

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -50,7 +50,7 @@ const ConnectApp: React.FC = () => {
       try {
         const host = new URL(relayUrl).hostname;
         if (host !== '127.0.0.1' && host !== '[::1]') {
-          handleReject(`MCP extension only allows loopback connections (127.0.0.1 or [::1]). Received host: ${host}`);
+          handleReject(`Playwright extension only allows loopback connections (127.0.0.1 or [::1]). Received host: ${host}`);
           return;
         }
       } catch (e) {
@@ -238,7 +238,7 @@ const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensio
   const chromeWebStoreUrl = 'https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm';
   return (
     <div>
-      Playwright MCP version trying to connect requires newer extension version (current version: {extensionVersion}).{' '}
+      Playwright client trying to connect requires newer extension version (current version: {extensionVersion}).{' '}
       Update <a href={chromeWebStoreUrl} target='_blank' rel='noopener noreferrer'>Playwright Extension</a> from the Chrome Web Store to the latest version.{' '}
       See <a href={readmeUrl} target='_blank' rel='noopener noreferrer'>installation instructions</a> for more details.
     </div>

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -83,7 +83,7 @@ const StatusApp: React.FC = () => {
           </div>
         ) : (
           <div className='status-banner'>
-            No MCP clients are currently connected.
+            No clients are currently connected.
           </div>
         )}
         <AuthTokenSection />

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -73,8 +73,10 @@ export function decorateProgram(program: Command) {
           const message = process.env.PWDEBUGIMPL ? (error as Error).stack || (error as Error).message : (error as Error).message;
           console.log(`### Error\n${message}`);
           console.log('<EOF>');
-          // The cli-client never destroys our stdout pipe on the error path,
-          // so the libuv handle would keep the daemon alive forever.
+          // Hygiene cleanup in createExtensionBrowser releases the http server
+          // and websocket connections, but the chrome subprocess + WS lifecycle
+          // leave behind libuv state we can't reach from JS, so the event loop
+          // would otherwise stay alive for ~5 seconds.
           // eslint-disable-next-line no-restricted-properties
           process.exit(1);
         }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -245,7 +245,7 @@ test(`extension needs update`, async ({ startExtensionClient, server }) => {
   });
 
   const confirmationPage = await confirmationPagePromise;
-  await expect(confirmationPage.locator('.status-banner')).toContainText(`Playwright MCP version trying to connect requires newer extension version`);
+  await expect(confirmationPage.locator('.status-banner')).toContainText(`Playwright client trying to connect requires newer extension version`);
 
   expect(await navigateResponse).toHaveResponse({
     error: expect.stringContaining('Extension connection timeout.'),


### PR DESCRIPTION
## Summary
- Drop "MCP" from user-facing extension strings (README, connect page, status page) and update matching test assertion.
- Expand the cli-daemon `process.exit(1)` comment to explain why hygiene cleanup isn't enough to drain the event loop.