### PR TITLE
feat(cli): list browsers attachable via extension in `list --all`

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/channelSessions.ts
+++ b/packages/playwright-core/src/tools/cli-client/channelSessions.ts
@@ -30,6 +30,8 @@ export type ChannelSession = {
 // and the hardcoded url in packages/playwright-core/src/tools/mcp/cdpRelay.ts.
 const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
+export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-mcp-bridge/${playwrightExtensionId}`;
+
 export async function listChannelSessions(): Promise<ChannelSession[]> {
   if (process.env.PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST)
     return [];

--- a/packages/playwright-core/src/tools/cli-client/channelSessions.ts
+++ b/packages/playwright-core/src/tools/cli-client/channelSessions.ts
@@ -55,10 +55,6 @@ async function hasPlaywrightExtension(userDataDir: string): Promise<boolean> {
   return await pathExists(path.join(userDataDir, 'Default', 'Extensions', playwrightExtensionId));
 }
 
-export function remoteDebuggingHint(channel: string): string {
-  return `to enable, launch ${channel}, navigate to chrome://inspect/#remote-debugging and check "Allow remote debugging for this browser instance"`;
-}
-
 async function pathExists(p: string): Promise<boolean> {
   try {
     await fs.promises.access(p);

--- a/packages/playwright-core/src/tools/cli-client/channelSessions.ts
+++ b/packages/playwright-core/src/tools/cli-client/channelSessions.ts
@@ -23,7 +23,12 @@ export type ChannelSession = {
   channel: string;
   userDataDir: string;
   endpoint?: string;
+  extensionInstalled: boolean;
 };
+
+// Keep in sync with the id declared via "key" in packages/extension/manifest.json
+// and the hardcoded url in packages/playwright-core/src/tools/mcp/cdpRelay.ts.
+const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
 export async function listChannelSessions(): Promise<ChannelSession[]> {
   if (process.env.PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST)
@@ -35,10 +40,17 @@ export async function listChannelSessions(): Promise<ChannelSession[]> {
       continue;
     if (!await pathExists(userDataDir))
       continue;
-    const endpoint = await readEndpoint(userDataDir);
-    result.push({ channel, userDataDir, endpoint });
+    const [endpoint, extensionInstalled] = await Promise.all([
+      readEndpoint(userDataDir),
+      hasPlaywrightExtension(userDataDir),
+    ]);
+    result.push({ channel, userDataDir, endpoint, extensionInstalled });
   }
   return result;
+}
+
+async function hasPlaywrightExtension(userDataDir: string): Promise<boolean> {
+  return await pathExists(path.join(userDataDir, 'Default', 'Extensions', playwrightExtensionId));
 }
 
 export function remoteDebuggingHint(channel: string): string {

--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -368,9 +368,11 @@ function renderChannelSession(session: ChannelSession): string {
     lines.push(`  - attach (extension): \`playwright-cli attach --extension=${session.channel}\``);
   else
     lines.push(`  - attach (extension): install at ${playwrightExtensionInstallUrl}`);
-  if (session.endpoint)
+  if (session.endpoint) {
     lines.push(`  - attach (remote debugging): \`playwright-cli attach --cdp=${session.channel}\``);
-  else
-    lines.push(`  - attach (remote debugging): enable at chrome://inspect/#remote-debugging`);
+  } else {
+    const inspectScheme = session.channel.startsWith('msedge') ? 'edge' : 'chrome';
+    lines.push(`  - attach (remote debugging): enable at ${inspectScheme}://inspect/#remote-debugging`);
+  }
   return lines.join('\n');
 }

--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -19,7 +19,7 @@
 
 import path from 'path';
 
-import { remoteDebuggingHint } from './channelSessions';
+import { playwrightExtensionInstallUrl, remoteDebuggingHint } from './channelSessions';
 
 import type { ChannelSession } from './channelSessions';
 import type { BrowserStatus } from '../../serverRegistry';
@@ -158,17 +158,9 @@ export class TextOutput implements Output {
     if (!count)
       console.log('  (no browsers)');
 
-    const extensionChannels = channelSessions?.filter(s => s.extensionInstalled) ?? [];
-    if (extensionChannels.length) {
-      console.log('');
-      console.log('### Browsers available to attach via extension');
-      for (const session of extensionChannels)
-        console.log(renderExtensionChannel(session));
-    }
-
     if (channelSessions?.length) {
       console.log('');
-      console.log('### Browsers available to attach via CDP');
+      console.log('### Discovered browsers');
       for (const session of channelSessions)
         console.log(renderChannelSession(session));
     }
@@ -372,19 +364,19 @@ function renderServer(server: BrowserStatus): string {
 function renderChannelSession(session: ChannelSession): string {
   const lines = [`- ${session.channel}:`];
   lines.push(`  - data-dir: ${session.userDataDir}`);
+  if (session.extensionInstalled) {
+    lines.push(`  - extension: installed`);
+    lines.push(`  - run \`playwright-cli attach --extension=${session.channel}\` to attach`);
+  } else {
+    lines.push(`  - extension: not installed`);
+    lines.push(`  - install the Playwright MCP Bridge extension: ${playwrightExtensionInstallUrl}`);
+  }
   if (session.endpoint) {
-    lines.push(`  - endpoint: ${session.endpoint}`);
+    lines.push(`  - remote debugging: ${session.endpoint}`);
     lines.push(`  - run \`playwright-cli attach --cdp=${session.channel}\` to attach`);
   } else {
-    lines.push(`  - status: remote debugging not enabled`);
+    lines.push(`  - remote debugging: not enabled`);
     lines.push(`  - ${remoteDebuggingHint(session.channel)}`);
   }
-  return lines.join('\n');
-}
-
-function renderExtensionChannel(session: ChannelSession): string {
-  const lines = [`- ${session.channel}:`];
-  lines.push(`  - data-dir: ${session.userDataDir}`);
-  lines.push(`  - run \`playwright-cli attach --extension=${session.channel}\` to attach`);
   return lines.join('\n');
 }

--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -158,6 +158,14 @@ export class TextOutput implements Output {
     if (!count)
       console.log('  (no browsers)');
 
+    const extensionChannels = channelSessions?.filter(s => s.extensionInstalled) ?? [];
+    if (extensionChannels.length) {
+      console.log('');
+      console.log('### Browsers available to attach via extension');
+      for (const session of extensionChannels)
+        console.log(renderExtensionChannel(session));
+    }
+
     if (channelSessions?.length) {
       console.log('');
       console.log('### Browsers available to attach via CDP');
@@ -371,5 +379,12 @@ function renderChannelSession(session: ChannelSession): string {
     lines.push(`  - status: remote debugging not enabled`);
     lines.push(`  - ${remoteDebuggingHint(session.channel)}`);
   }
+  return lines.join('\n');
+}
+
+function renderExtensionChannel(session: ChannelSession): string {
+  const lines = [`- ${session.channel}:`];
+  lines.push(`  - data-dir: ${session.userDataDir}`);
+  lines.push(`  - run \`playwright-cli attach --extension=${session.channel}\` to attach`);
   return lines.join('\n');
 }

--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -19,7 +19,7 @@
 
 import path from 'path';
 
-import { playwrightExtensionInstallUrl, remoteDebuggingHint } from './channelSessions';
+import { playwrightExtensionInstallUrl } from './channelSessions';
 
 import type { ChannelSession } from './channelSessions';
 import type { BrowserStatus } from '../../serverRegistry';
@@ -160,7 +160,7 @@ export class TextOutput implements Output {
 
     if (channelSessions?.length) {
       console.log('');
-      console.log('### Discovered browsers');
+      console.log('### Browsers available to attach via CDP');
       for (const session of channelSessions)
         console.log(renderChannelSession(session));
     }
@@ -364,19 +364,13 @@ function renderServer(server: BrowserStatus): string {
 function renderChannelSession(session: ChannelSession): string {
   const lines = [`- ${session.channel}:`];
   lines.push(`  - data-dir: ${session.userDataDir}`);
-  if (session.extensionInstalled) {
-    lines.push(`  - extension: installed`);
-    lines.push(`  - run \`playwright-cli attach --extension=${session.channel}\` to attach`);
-  } else {
-    lines.push(`  - extension: not installed`);
-    lines.push(`  - install the Playwright MCP Bridge extension: ${playwrightExtensionInstallUrl}`);
-  }
-  if (session.endpoint) {
-    lines.push(`  - remote debugging: ${session.endpoint}`);
-    lines.push(`  - run \`playwright-cli attach --cdp=${session.channel}\` to attach`);
-  } else {
-    lines.push(`  - remote debugging: not enabled`);
-    lines.push(`  - ${remoteDebuggingHint(session.channel)}`);
-  }
+  if (session.extensionInstalled)
+    lines.push(`  - attach (extension): \`playwright-cli attach --extension=${session.channel}\``);
+  else
+    lines.push(`  - attach (extension): install at ${playwrightExtensionInstallUrl}`);
+  if (session.endpoint)
+    lines.push(`  - attach (remote debugging): \`playwright-cli attach --cdp=${session.channel}\``);
+  else
+    lines.push(`  - attach (remote debugging): enable at chrome://inspect/#remote-debugging`);
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- `playwright-cli list --all` now detects browsers whose default profile has the Playwright MCP extension installed and prints them in a new **"Browsers available to attach via extension"** section with a ready-to-copy `playwright-cli attach --extension=<channel>` command.
- Detection piggy-backs on the existing channel scan: we additionally check `<userDataDir>/Default/Extensions/<extensionId>`. Endpoint and extension checks now run in parallel per channel.