### PR TITLE
feat(dashboard): snap annotation to element under cursor while Shift held

### DIFF
--- a/packages/dashboard/src/annotations.css
+++ b/packages/dashboard/src/annotations.css
@@ -125,6 +125,13 @@
   pointer-events: none;
 }
 
+.annotation-rect.snap-preview {
+  border-style: dashed;
+  border-color: rgb(var(--annotate-blue));
+  background: rgb(var(--annotate-blue) / 0.08);
+  pointer-events: none;
+}
+
 .annotation-handle {
   position: absolute;
   width: 10px;

--- a/packages/dashboard/src/annotations.tsx
+++ b/packages/dashboard/src/annotations.tsx
@@ -149,7 +149,7 @@ export const Annotations: React.FC<{
   viewportWidth: number;
   viewportHeight: number;
   onSubmit: (blob: Blob, annotations: Annotation[]) => Promise<void> | void;
-  inspectAt: (params: { x: number; y: number }) => Promise<{ bbox: Rect; locator: string } | null>;
+  inspectAt: (params: { x: number; y: number }) => Promise<{ box: Rect; locator: string } | null>;
 }> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit, inspectAt }) => {
   const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
   const [draft, setDraft] = React.useState<{ startX: number; startY: number; x: number; y: number } | null>(null);
@@ -204,7 +204,7 @@ export const Annotations: React.FC<{
     inspectInFlightRef.current = true;
     void inspectAt(vp).then(result => {
       if (seq === inspectSeqRef.current)
-        setSnapPreview(result ? { rect: result.bbox, locator: result.locator } : null);
+        setSnapPreview(result ? { rect: result.box, locator: result.locator } : null);
     }).catch(() => {
       if (seq === inspectSeqRef.current)
         setSnapPreview(null);

--- a/packages/dashboard/src/annotations.tsx
+++ b/packages/dashboard/src/annotations.tsx
@@ -149,7 +149,8 @@ export const Annotations: React.FC<{
   viewportWidth: number;
   viewportHeight: number;
   onSubmit: (blob: Blob, annotations: Annotation[]) => Promise<void> | void;
-}> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit }) => {
+  inspectAt: (params: { x: number; y: number }) => Promise<{ bbox: Rect; locator: string } | null>;
+}> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit, inspectAt }) => {
   const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
   const [draft, setDraft] = React.useState<{ startX: number; startY: number; x: number; y: number } | null>(null);
   const [selection, setSelection] = React.useState<Selection>(null);
@@ -157,6 +158,12 @@ export const Annotations: React.FC<{
   const [, setTick] = React.useState(0);
   const forceRender = React.useCallback(() => setTick(t => t + 1), []);
   const layerRef = React.useRef<HTMLDivElement>(null);
+  const [shiftHeld, setShiftHeld] = React.useState(false);
+  const [snapPreview, setSnapPreview] = React.useState<{ rect: Rect; locator: string } | null>(null);
+  const lastCursorRef = React.useRef<{ x: number; y: number } | null>(null);
+  const inspectSeqRef = React.useRef(0);
+  const inspectInFlightRef = React.useRef(false);
+  const pendingInspectRef = React.useRef<{ x: number; y: number } | null>(null);
 
   const selectedId = selection?.id ?? null;
   const editingId = selection?.editing ? selection.id : null;
@@ -180,7 +187,68 @@ export const Annotations: React.FC<{
       layerRef.current?.focus();
     else
       setSelection(null);
+    if (!active) {
+      setShiftHeld(false);
+      setSnapPreview(null);
+      lastCursorRef.current = null;
+      pendingInspectRef.current = null;
+    }
   }, [active]);
+
+  const runInspect = React.useCallback((vp: { x: number; y: number }) => {
+    if (inspectInFlightRef.current) {
+      pendingInspectRef.current = vp;
+      return;
+    }
+    const seq = ++inspectSeqRef.current;
+    inspectInFlightRef.current = true;
+    void inspectAt(vp).then(result => {
+      if (seq === inspectSeqRef.current)
+        setSnapPreview(result ? { rect: result.bbox, locator: result.locator } : null);
+    }).catch(() => {
+      if (seq === inspectSeqRef.current)
+        setSnapPreview(null);
+    }).finally(() => {
+      inspectInFlightRef.current = false;
+      const next = pendingInspectRef.current;
+      pendingInspectRef.current = null;
+      if (next)
+        runInspect(next);
+    });
+  }, [inspectAt]);
+
+  React.useEffect(() => {
+    if (!active)
+      return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift' && !shiftHeld) {
+        setShiftHeld(true);
+        const last = lastCursorRef.current;
+        if (last)
+          runInspect(last);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShiftHeld(false);
+        setSnapPreview(null);
+        pendingInspectRef.current = null;
+        inspectSeqRef.current++;
+      }
+    };
+    const onBlur = () => {
+      setShiftHeld(false);
+      setSnapPreview(null);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, [active, shiftHeld, runInspect]);
 
   React.useEffect(() => {
     if (!drag)
@@ -230,6 +298,16 @@ export const Annotations: React.FC<{
     const vp = imgCoords(e);
     if (!vp)
       return;
+    if (shiftHeld && snapPreview) {
+      e.preventDefault();
+      const id = newAnnotationId();
+      const { rect, locator } = snapPreview;
+      setAnnotations(prev => [...prev, { id, ...rect, text: locator }]);
+      setSelection({ id, editing: false });
+      return;
+    }
+    if (shiftHeld)
+      return;
     const hit = hitTestAnnotation(vp.x, vp.y);
     e.preventDefault();
     if (hit) {
@@ -242,9 +320,16 @@ export const Annotations: React.FC<{
   }
 
   function onLayerMouseMove(e: React.MouseEvent) {
+    const vp = imgCoords(e);
+    if (vp)
+      lastCursorRef.current = vp;
+    if (shiftHeld) {
+      if (vp)
+        runInspect(vp);
+      return;
+    }
     if (drag || !draft)
       return;
-    const vp = imgCoords(e);
     if (!vp)
       return;
     if (draft.x === vp.x && draft.y === vp.y)
@@ -448,6 +533,11 @@ export const Annotations: React.FC<{
       {draft && (() => {
         const style = mapRect(normalizeRect(draft));
         return style ? <div className='annotation-rect draft' style={style} /> : null;
+      })()}
+
+      {shiftHeld && snapPreview && (() => {
+        const style = mapRect(snapPreview.rect);
+        return style ? <div className='annotation-rect snap-preview' style={style} /> : null;
       })()}
 
       {editingAnnotation && (() => {

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -635,6 +635,7 @@ export const Dashboard: React.FC = () => {
                 viewportWidth={frame?.viewportWidth ?? 0}
                 viewportHeight={frame?.viewportHeight ?? 0}
                 onSubmit={onSubmitAnnotations}
+                inspectAt={async params => await client?.inspectAt(params) ?? null}
               />
             </div>
             {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -68,6 +68,7 @@ export interface DashboardChannel {
   readStream(params: { streamId: string }): Promise<{ data: string; eof: boolean }>;
   screenshot(): Promise<string>;
   submitAnnotation(params: { data: string; annotations: AnnotationData[] }): Promise<void>;
+  inspectAt(params: { x: number; y: number }): Promise<{ bbox: { x: number; y: number; width: number; height: number }; locator: string } | null>;
 
   on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;
   off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -68,7 +68,7 @@ export interface DashboardChannel {
   readStream(params: { streamId: string }): Promise<{ data: string; eof: boolean }>;
   screenshot(): Promise<string>;
   submitAnnotation(params: { data: string; annotations: AnnotationData[] }): Promise<void>;
-  inspectAt(params: { x: number; y: number }): Promise<{ bbox: { x: number; y: number; width: number; height: number }; locator: string } | null>;
+  inspectAt(params: { x: number; y: number }): Promise<{ box: { x: number; y: number; width: number; height: number }; locator: string } | null>;
 
   on<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;
   off<K extends keyof DashboardChannelEvents>(event: K, listener: (params: DashboardChannelEvents[K]) => void): void;

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -590,11 +590,10 @@ class AttachedPage {
     return buffer.toString('base64');
   }
 
-  async inspectAt(params: { x: number; y: number }): Promise<{ bbox: { x: number; y: number; width: number; height: number }; locator: string } | null> {
-    const allSelectors: string[] = [];
+  async inspectAt(params: { x: number; y: number }): Promise<{ box: { x: number; y: number; width: number; height: number }; locator: string } | null> {
     let frame = this._page.mainFrame();
-    let cx = params.x, cy = params.y;
-    let offsetX = 0, offsetY = 0;
+    let offsetX = 0;
+    let offsetY = 0;
 
     for (let depth = 0; depth < 10; depth++) {
       const result = await frame.evaluate(({ x, y }) => {
@@ -611,49 +610,103 @@ class AttachedPage {
           return 'xpath=/' + parts.join('/');
         };
 
+        // Shadow-piercing hit test, mirroring the workarounds in InjectedScript.expectHitTarget.
+        const parentElementOrShadowHost = (e: Element) => {
+          if (e.parentElement)
+            return e.parentElement;
+          if (e.parentNode && e.parentNode.nodeType === 11 /* DOCUMENT_FRAGMENT_NODE */ && (e.parentNode as ShadowRoot).host)
+            return (e.parentNode as ShadowRoot).host;
+          return undefined;
+        };
+        const deepElementFromPoint = (root: Document | ShadowRoot, hx: number, hy: number): Element | null => {
+          const elements = root.elementsFromPoint(hx, hy);
+          const single = root.elementFromPoint(hx, hy);
+          if (single && elements[0] && parentElementOrShadowHost(single) === elements[0]) {
+            // Workaround a case where elementsFromPoint misses the inner-most element with display:contents.
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=1342092
+            const style = single.ownerDocument.defaultView?.getComputedStyle(single);
+            if (style?.display === 'contents')
+              elements.unshift(single);
+          }
+          if (elements[0] && elements[0].shadowRoot === root && elements[1] === single) {
+            // Workaround webkit bug where first two elements are swapped:
+            // <host> / #shadow root / <target> -> elementsFromPoint produces [<host>, <target>] instead of [<target>, <host>].
+            elements.shift();
+          }
+          let el: Element | undefined = elements[0];
+          while (el && el.shadowRoot) {
+            const inner = deepElementFromPoint(el.shadowRoot, hx, hy);
+            if (!inner || inner === el)
+              break;
+            el = inner;
+          }
+          return el ?? null;
+        };
+
+        // Mirrors InjectedScript.describeIFrameStyle: the iframe's content origin sits at
+        // (border-left + padding-left, border-top + padding-top) inside its border-box.
+        const iframeBorderOf = (iframe: Element) => {
+          const s = iframe.ownerDocument.defaultView?.getComputedStyle(iframe);
+          if (!s)
+            return { left: 0, top: 0 };
+          return {
+            left: parseInt(s.borderLeftWidth || '0', 10) + parseInt(s.paddingLeft || '0', 10),
+            top: parseInt(s.borderTopWidth || '0', 10) + parseInt(s.paddingTop || '0', 10),
+          };
+        };
+
         const selectors: string[] = [];
-        let doc: Document = document;
-        let lx = x, ly = y, ox = 0, oy = 0;
+        let doc = document;
+        let lx = x;
+        let ly = y;
+        let ox = 0;
+        let oy = 0;
         while (true) {
-          const el = doc.elementFromPoint(lx, ly);
+          const el = deepElementFromPoint(doc, lx, ly);
           if (!el)
             return null;
           selectors.push(xpath(el));
           const r = el.getBoundingClientRect();
-          const bbox = { x: r.x + ox, y: r.y + oy, width: r.width, height: r.height };
-          if (el.tagName !== 'IFRAME' && el.tagName !== 'FRAME')
-            return { selectors, bbox, isFrame: false };
+          if (el.tagName !== 'IFRAME' && el.tagName !== 'FRAME') {
+            const box = { x: r.x + ox, y: r.y + oy, width: r.width, height: r.height };
+            return { selectors, isFrame: false as const, box };
+          }
+          const border = iframeBorderOf(el);
           let childDoc: Document | null = null;
           try { childDoc = (el as HTMLIFrameElement).contentDocument; } catch { /* cross-origin */ }
-          if (!childDoc)
-            return { selectors, bbox, isFrame: true };
-          ox += r.x; oy += r.y;
-          lx -= r.x; ly -= r.y;
+          if (!childDoc) {
+            // Cross-origin: bail. Outer code descends via Frame API and resumes inside the child frame.
+            return { selectors, isFrame: true as const, nextX: lx - r.x - border.left, nextY: ly - r.y - border.top };
+          }
+          // Same-origin: keep walking inside this evaluate.
+          ox += r.x + border.left;
+          oy += r.y + border.top;
+          lx -= r.x + border.left;
+          ly -= r.y + border.top;
           doc = childDoc;
         }
-      }, { x: cx, y: cy });
+      }, { x: params.x - offsetX, y: params.y - offsetY });
 
       if (!result)
         return null;
 
-      allSelectors.push(...result.selectors);
-      const bbox = { x: result.bbox.x + offsetX, y: result.bbox.y + offsetY, width: result.bbox.width, height: result.bbox.height };
+      const locator = frame.locator(result.selectors.join(' >> internal:control=enter-frame >> '));
 
       if (!result.isFrame) {
-        const normalized = await this._page.locator(allSelectors.join(' >> internal:control=enter-frame >> ')).normalize();
-        return { bbox, locator: normalized.toString() };
+        const normalized = await locator.normalize();
+        const box = { x: result.box.x + offsetX, y: result.box.y + offsetY, width: result.box.width, height: result.box.height };
+        return { box, locator: normalized.toString() };
       }
 
-      // Cross-origin boundary: descend via Playwright's Frame API. Use the full chain emitted in this evaluate
-      // (may include same-origin iframe hops between this frame and the cross-origin iframe).
-      const iframeHandle = await frame.locator(result.selectors.join(' >> internal:control=enter-frame >> ')).elementHandle();
-      const childFrame = await iframeHandle?.contentFrame();
-      await iframeHandle?.dispose();
+      // Cross-origin boundary: descend via Playwright's Frame API and continue inspection inside the child frame.
+      const handle = await locator.elementHandle();
+      const childFrame = await handle?.contentFrame();
+      await handle?.dispose();
       if (!childFrame)
         return null;
       frame = childFrame;
-      offsetX = bbox.x; offsetY = bbox.y;
-      cx -= result.bbox.x; cy -= result.bbox.y;
+      offsetX = params.x - result.nextX;
+      offsetY = params.y - result.nextY;
     }
     return null;
   }

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -591,46 +591,71 @@ class AttachedPage {
   }
 
   async inspectAt(params: { x: number; y: number }): Promise<{ bbox: { x: number; y: number; width: number; height: number }; locator: string } | null> {
-    const result = await this._page.evaluate(({ x, y }) => {
-      const el = document.elementFromPoint(x, y);
-      if (!el)
+    const allSelectors: string[] = [];
+    let frame = this._page.mainFrame();
+    let cx = params.x, cy = params.y;
+    let offsetX = 0, offsetY = 0;
+
+    for (let depth = 0; depth < 10; depth++) {
+      const result = await frame.evaluate(({ x, y }) => {
+        const xpath = (el: Element) => {
+          const parts: string[] = [];
+          for (let c: Element | null = el; c; c = c.parentElement) {
+            let i = 1;
+            for (let s = c.previousElementSibling; s; s = s.previousElementSibling) {
+              if (s.tagName === c.tagName)
+                i++;
+            }
+            parts.unshift(`${c.tagName.toLowerCase()}[${i}]`);
+          }
+          return 'xpath=/' + parts.join('/');
+        };
+
+        const selectors: string[] = [];
+        let doc: Document = document;
+        let lx = x, ly = y, ox = 0, oy = 0;
+        while (true) {
+          const el = doc.elementFromPoint(lx, ly);
+          if (!el)
+            return null;
+          selectors.push(xpath(el));
+          const r = el.getBoundingClientRect();
+          const bbox = { x: r.x + ox, y: r.y + oy, width: r.width, height: r.height };
+          if (el.tagName !== 'IFRAME' && el.tagName !== 'FRAME')
+            return { selectors, bbox, isFrame: false };
+          let childDoc: Document | null = null;
+          try { childDoc = (el as HTMLIFrameElement).contentDocument; } catch { /* cross-origin */ }
+          if (!childDoc)
+            return { selectors, bbox, isFrame: true };
+          ox += r.x; oy += r.y;
+          lx -= r.x; ly -= r.y;
+          doc = childDoc;
+        }
+      }, { x: cx, y: cy });
+
+      if (!result)
         return null;
-      const r = el.getBoundingClientRect();
-      const cssEscape = (s: string) => (window.CSS && window.CSS.escape) ? window.CSS.escape(s) : s;
-      const tokenFor = (node: Element): string => {
-        let token = node.tagName.toLowerCase();
-        if (node.id) {
-          token += '#' + cssEscape(node.id);
-          return token;
-        }
-        const classes = (node.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean).slice(0, 2);
-        for (const c of classes)
-          token += '.' + cssEscape(c);
-        const parent = node.parentElement;
-        if (parent) {
-          const sameTag = Array.from(parent.children).filter(c => c.tagName === node.tagName);
-          if (sameTag.length > 1)
-            token += `:nth-of-type(${sameTag.indexOf(node) + 1})`;
-        }
-        return token;
-      };
-      const parts: string[] = [];
-      let current: Element | null = el;
-      while (current && current !== document.documentElement) {
-        parts.unshift(tokenFor(current));
-        if (current.id)
-          break;
-        current = current.parentElement;
+
+      allSelectors.push(...result.selectors);
+      const bbox = { x: result.bbox.x + offsetX, y: result.bbox.y + offsetY, width: result.bbox.width, height: result.bbox.height };
+
+      if (!result.isFrame) {
+        const normalized = await this._page.locator(allSelectors.join(' >> internal:control=enter-frame >> ')).normalize();
+        return { bbox, locator: normalized.toString() };
       }
-      return {
-        bbox: { x: r.x, y: r.y, width: r.width, height: r.height },
-        selector: parts.join(' > '),
-      };
-    }, params);
-    if (!result)
-      return null;
-    const normalized = await this._page.locator('css=' + result.selector).normalize();
-    return { bbox: result.bbox, locator: normalized.toString() };
+
+      // Cross-origin boundary: descend via Playwright's Frame API. Use the full chain emitted in this evaluate
+      // (may include same-origin iframe hops between this frame and the cross-origin iframe).
+      const iframeHandle = await frame.locator(result.selectors.join(' >> internal:control=enter-frame >> ')).elementHandle();
+      const childFrame = await iframeHandle?.contentFrame();
+      await iframeHandle?.dispose();
+      if (!childFrame)
+        return null;
+      frame = childFrame;
+      offsetX = bbox.x; offsetY = bbox.y;
+      cx -= result.bbox.x; cy -= result.bbox.y;
+    }
+    return null;
   }
 
   private async _startScreencast(page: api.Page) {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -590,6 +590,49 @@ class AttachedPage {
     return buffer.toString('base64');
   }
 
+  async inspectAt(params: { x: number; y: number }): Promise<{ bbox: { x: number; y: number; width: number; height: number }; locator: string } | null> {
+    const result = await this._page.evaluate(({ x, y }) => {
+      const el = document.elementFromPoint(x, y);
+      if (!el)
+        return null;
+      const r = el.getBoundingClientRect();
+      const cssEscape = (s: string) => (window.CSS && window.CSS.escape) ? window.CSS.escape(s) : s;
+      const tokenFor = (node: Element): string => {
+        let token = node.tagName.toLowerCase();
+        if (node.id) {
+          token += '#' + cssEscape(node.id);
+          return token;
+        }
+        const classes = (node.getAttribute('class') || '').trim().split(/\s+/).filter(Boolean).slice(0, 2);
+        for (const c of classes)
+          token += '.' + cssEscape(c);
+        const parent = node.parentElement;
+        if (parent) {
+          const sameTag = Array.from(parent.children).filter(c => c.tagName === node.tagName);
+          if (sameTag.length > 1)
+            token += `:nth-of-type(${sameTag.indexOf(node) + 1})`;
+        }
+        return token;
+      };
+      const parts: string[] = [];
+      let current: Element | null = el;
+      while (current && current !== document.documentElement) {
+        parts.unshift(tokenFor(current));
+        if (current.id)
+          break;
+        current = current.parentElement;
+      }
+      return {
+        bbox: { x: r.x, y: r.y, width: r.width, height: r.height },
+        selector: parts.join(' > '),
+      };
+    }, params);
+    if (!result)
+      return null;
+    const normalized = await this._page.locator('css=' + result.selector).normalize();
+    return { bbox: result.bbox, locator: normalized.toString() };
+  }
+
   private async _startScreencast(page: api.Page) {
     await page.screencast.start({
       onFrame: ({ data }: { data: Buffer }) => {

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -309,6 +309,43 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   expect(exitCode).toBe(0);
 });
 
+test('should snap annotation to underlying element while Shift held', async ({ connectToDashboard, cli, server }) => {
+  server.setContent('/snap', `<!doctype html><html><head><style>html,body{margin:0;height:100vh;background:#fff}#target{position:absolute;left:200px;top:150px;width:400px;height:200px;background:#36c;color:#fff;font-size:24px}</style></head><body><button id='target'>Submit Order</button></body></html>`, 'text/html');
+
+  await cli('open', server.PREFIX + '/snap');
+  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
+  await cli('show', { bindTitle });
+  const browser = await connectToDashboard(bindTitle);
+  const dashboard = browser.contexts()[0].pages()[0];
+
+  await dashboard.locator('.sidebar-tab').first().click();
+  await expect(dashboard.locator('#display')).toBeVisible();
+
+  await dashboard.locator('.mode-toggle.mode-annotate').click();
+  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
+
+  const box = await dashboard.locator('img#display').boundingBox();
+  // Underlying page viewport is 1280x800; the target sits at (200,150)-(600,350).
+  // Center is (400, 250) in page coords.
+  const centerX = box!.x + box!.width * (400 / 1280);
+  const centerY = box!.y + box!.height * (250 / 800);
+
+  await dashboard.mouse.move(centerX, centerY);
+  await dashboard.keyboard.down('Shift');
+  await dashboard.mouse.move(centerX + 1, centerY + 1);
+  await expect(dashboard.locator('.annotation-rect.snap-preview')).toBeVisible();
+
+  await dashboard.mouse.down();
+  await dashboard.mouse.up();
+  await dashboard.keyboard.up('Shift');
+
+  await expect(dashboard.locator('.annotation-rect.snap-preview')).toHaveCount(0);
+  const committed = dashboard.locator('.annotation-rect:not(.draft):not(.snap-preview)');
+  await expect(committed).toHaveCount(1);
+  await expect(committed.locator('.annotation-label')).toHaveText(`getByRole('button', { name: 'Submit Order' })`);
+});
+
+
 test('should disengage annotate mode when --annotate client disconnects', async ({ connectToDashboard, cli, childProcess, cliEnv, mcpBrowser, mcpHeadless, server }) => {
   await cli('open', server.EMPTY_PAGE);
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -310,7 +310,9 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
 });
 
 test('should snap annotation to underlying element while Shift held', async ({ connectToDashboard, cli, server }) => {
-  server.setContent('/snap', `<!doctype html><html><head><style>html,body{margin:0;height:100vh;background:#fff}#target{position:absolute;left:200px;top:150px;width:400px;height:200px;background:#36c;color:#fff;font-size:24px}</style></head><body><button id='target'>Submit Order</button></body></html>`, 'text/html');
+  server.setContent('/snap-child', `<!doctype html><html><head><style>html,body{margin:0;background:#fff}#target{position:absolute;left:50px;top:50px;width:300px;height:150px;background:#36c;color:#fff;font-size:24px}</style></head><body><button id='target'>Submit Order</button></body></html>`, 'text/html');
+  server.setContent('/snap-mid', `<!doctype html><html><head><style>html,body{margin:0;background:#fff}iframe{position:absolute;left:50px;top:50px;width:500px;height:300px;border:0}</style></head><body><iframe src='${server.CROSS_PROCESS_PREFIX}/snap-child'></iframe></body></html>`, 'text/html');
+  server.setContent('/snap', `<!doctype html><html><head><style>html,body{margin:0;height:100vh;background:#fff}iframe{position:absolute;left:100px;top:50px;width:700px;height:400px;border:0}</style></head><body><iframe src='/snap-mid'></iframe></body></html>`, 'text/html');
 
   await cli('open', server.PREFIX + '/snap');
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
@@ -325,10 +327,10 @@ test('should snap annotation to underlying element while Shift held', async ({ c
   await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
 
   const box = await dashboard.locator('img#display').boundingBox();
-  // Underlying page viewport is 1280x800; the target sits at (200,150)-(600,350).
-  // Center is (400, 250) in page coords.
+  // Underlying page viewport is 1280x800. Same-origin iframe at (100,50). Cross-origin iframe at (50,50)
+  // inside it. Button at (50,50) size (300,150) → center at inner (200,125) → page coords (400, 275).
   const centerX = box!.x + box!.width * (400 / 1280);
-  const centerY = box!.y + box!.height * (250 / 800);
+  const centerY = box!.y + box!.height * (275 / 800);
 
   await dashboard.mouse.move(centerX, centerY);
   await dashboard.keyboard.down('Shift');
@@ -342,7 +344,7 @@ test('should snap annotation to underlying element while Shift held', async ({ c
   await expect(dashboard.locator('.annotation-rect.snap-preview')).toHaveCount(0);
   const committed = dashboard.locator('.annotation-rect:not(.draft):not(.snap-preview)');
   await expect(committed).toHaveCount(1);
-  await expect(committed.locator('.annotation-label')).toHaveText(`getByRole('button', { name: 'Submit Order' })`);
+  await expect(committed.locator('.annotation-label')).toHaveText(`locator('iframe').contentFrame().locator('iframe').contentFrame().getByRole('button', { name: 'Submit Order' })`);
 });
 
 


### PR DESCRIPTION
## Summary
- Hold Shift in annotate mode to snap a preview rect onto the bounding box of the element under the cursor; click commits an annotation pre-filled with a normalized Playwright locator.
- Hybrid resolver in `inspectAt`: a single page-side `evaluate` walks down via `contentDocument` for same-origin iframes, and only crosses cross-origin frame boundaries via the Frame API. Works for arbitrary nesting (e.g. main → same-origin iframe → cross-origin iframe).

https://github.com/user-attachments/assets/eb2584bc-dfb9-4319-a838-01bacffab455

