### PR TITLE
chore(dashboard): remove browser_pick_locator remnants

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -68,13 +68,6 @@ await context.CloseAsync();
 
 This event is not emitted.
 
-## event: BrowserContext.pickLocator
-* since: v1.60
-- argument: <[Page]>
-
-Emitted when a client calls [`method: Page.pickLocator`] on a page in this context. The event is dispatched to all
-clients connected to the context, including the one that initiated the call.
-
 ## property: BrowserContext.clock
 * since: v1.45
 - type: <[Clock]>

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import './dashboard.css';
 import { DashboardClientContext } from './dashboardContext';
-import { asLocator } from '@isomorphic/locatorGenerators';
 import { ChevronLeftIcon, ChevronRightIcon, ReloadIcon } from './icons';
 import { Annotations, getImageLayout, clientToViewport, saveAnnotationAsDownload } from './annotations';
 
@@ -50,7 +49,6 @@ type DashboardState = {
   annotateInitiator: 'cli' | 'user' | null;
   // Interaction mode and ephemeral UI flags.
   mode: Mode;
-  picking: boolean;
   recording: boolean;
 };
 
@@ -60,12 +58,9 @@ type DashboardAction =
   | { type: 'frame'; frame: DashboardChannelEvents['frame'] }
   | { type: 'cliAnnotate' }
   | { type: 'cliCancelAnnotate' }
-  | { type: 'pickLocator' }
-  | { type: 'elementPicked' }
   // User events
   | { type: 'toggleInteractive' }
   | { type: 'toggleAnnotate' }
-  | { type: 'cancelPicking' }
   | { type: 'setRecording'; recording: boolean }
   | { type: 'submitAnnotation' }
   | { type: 'setUrl'; url: string };
@@ -78,7 +73,6 @@ const initialDashboardState: DashboardState = {
   cliAnnotatePending: false,
   annotateInitiator: null,
   mode: 'readonly',
-  picking: false,
   recording: false,
 };
 
@@ -107,7 +101,6 @@ function dashboardReducer(state: DashboardState, action: DashboardAction): Dashb
         tabs: action.tabs,
         url,
         mode,
-        picking: false,
         recording: false,
         liveFrame: undefined,
         annotateFrame: undefined,
@@ -155,13 +148,9 @@ function dashboardReducer(state: DashboardState, action: DashboardAction): Dashb
         annotateInitiator: null,
       };
     }
-    case 'pickLocator':
-      return { ...state, mode: 'interactive', picking: true };
-    case 'elementPicked':
-      return { ...state, picking: false };
     case 'toggleInteractive': {
       const next: Mode = state.mode === 'interactive' ? 'readonly' : 'interactive';
-      return { ...state, mode: next, picking: false };
+      return { ...state, mode: next };
     }
     case 'toggleAnnotate': {
       if (state.mode === 'annotate') {
@@ -184,11 +173,8 @@ function dashboardReducer(state: DashboardState, action: DashboardAction): Dashb
         annotateFrame: state.liveFrame,
         cliAnnotatePending: false,
         annotateInitiator: initiator,
-        picking: false,
       };
     }
-    case 'cancelPicking':
-      return { ...state, picking: false };
     case 'setRecording':
       return { ...state, recording: action.recording };
     case 'submitAnnotation':
@@ -241,7 +227,7 @@ function smartUrl(input: string): string {
 export const Dashboard: React.FC = () => {
   const client = React.useContext(DashboardClientContext);
   const [state, dispatch] = React.useReducer(dashboardReducer, initialDashboardState);
-  const { tabs, url, mode, picking, recording, liveFrame, annotateFrame, annotateInitiator } = state;
+  const { tabs, url, mode, recording, liveFrame, annotateFrame, annotateInitiator } = state;
   const interactive = mode === 'interactive';
   const annotating = mode === 'annotate';
   // While annotating, the on-screen image is the frozen snapshot so the
@@ -344,25 +330,15 @@ export const Dashboard: React.FC = () => {
         window.resizeTo(targetW, targetH);
       }
     };
-    const onElementPicked = (params: DashboardChannelEvents['elementPicked']) => {
-      const locator = asLocator('javascript', params.selector);
-      navigator.clipboard?.writeText(locator).catch(() => {});
-      dispatch({ type: 'elementPicked' });
-    };
-    const onPickLocator = () => dispatch({ type: 'pickLocator' });
     const onAnnotate = () => dispatch({ type: 'cliAnnotate' });
     const onCancelAnnotate = () => dispatch({ type: 'cliCancelAnnotate' });
     client.on('tabs', onTabs);
     client.on('frame', onFrame);
-    client.on('elementPicked', onElementPicked);
-    client.on('pickLocator', onPickLocator);
     client.on('annotate', onAnnotate);
     client.on('cancelAnnotate', onCancelAnnotate);
     return () => {
       client.off('tabs', onTabs);
       client.off('frame', onFrame);
-      client.off('elementPicked', onElementPicked);
-      client.off('pickLocator', onPickLocator);
       client.off('annotate', onAnnotate);
       client.off('cancelAnnotate', onCancelAnnotate);
     };
@@ -431,12 +407,6 @@ export const Dashboard: React.FC = () => {
   function onScreenKeyDown(e: React.KeyboardEvent) {
     if (annotating)
       return;
-    if (picking && e.key === 'Escape') {
-      e.preventDefault();
-      client?.cancelPickLocator();
-      dispatch({ type: 'cancelPicking' });
-      return;
-    }
     if (!interactive || !client)
       return;
     e.preventDefault();
@@ -477,7 +447,6 @@ export const Dashboard: React.FC = () => {
           toggled={interactive}
           disabled={!ready}
           onClick={() => {
-            client?.cancelPickLocator();
             dispatch({ type: 'toggleInteractive' });
           }}
         />
@@ -488,7 +457,6 @@ export const Dashboard: React.FC = () => {
           toggled={annotating}
           disabled={!ready || !frame}
           onClick={() => {
-            client?.cancelPickLocator();
             dispatch({ type: 'toggleAnnotate' });
           }}
         />

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -34,8 +34,6 @@ export type DashboardChannelEvents = {
   sessions: { sessions: SessionStatus[]; clientInfo: ClientInfo };
   tabs: { tabs: Tab[] };
   frame: { data: string; viewportWidth: number; viewportHeight: number };
-  elementPicked: { selector: string; ariaSnapshot?: string };
-  pickLocator: {};
   annotate: {};
   cancelAnnotate: {};
 };
@@ -61,8 +59,6 @@ export interface DashboardChannel {
   wheel(params: { deltaX: number; deltaY: number }): Promise<void>;
   keydown(params: { key: string }): Promise<void>;
   keyup(params: { key: string }): Promise<void>;
-  pickLocator(): Promise<void>;
-  cancelPickLocator(): Promise<void>;
   startRecording(): Promise<void>;
   stopRecording(): Promise<{ streamId: string }>;
   readStream(params: { streamId: string }): Promise<{ data: string; eof: boolean }>;

--- a/packages/dashboard/src/icons.tsx
+++ b/packages/dashboard/src/icons.tsx
@@ -96,12 +96,6 @@ export const ReloadIcon: React.FC = () => (
   </svg>
 );
 
-export const PickLocatorIcon: React.FC = () => (
-  <svg viewBox='0 0 48 48' fill='currentColor'>
-    <path d='M18 42h-7.5c-3 0-4.5-1.5-4.5-4.5v-27C6 7.5 7.5 6 10.5 6h27C42 6 42 10.404 42 10.5V18h-3V9H9v30h9v3Zm27-15-9 6 9 9-3 3-9-9-6 9-6-24 24 6Z'/>
-  </svg>
-);
-
 export const InspectorPanelIcon: React.FC = () => (
   <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
     <rect x='3' y='3' width='18' height='18' rx='2'/>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -8368,13 +8368,6 @@ export interface BrowserContext {
   on(event: 'pageload', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  on(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8480,11 +8473,6 @@ export interface BrowserContext {
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
   once(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
-  once(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
@@ -8646,13 +8634,6 @@ export interface BrowserContext {
   addListener(event: 'pageload', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  addListener(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8762,11 +8743,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'request', listener: (request: Request) => any): this;
 
   /**
@@ -8848,11 +8824,6 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   off(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
-  off(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -9012,13 +8983,6 @@ export interface BrowserContext {
    * page.
    */
   prependListener(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  prependListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
@@ -9852,13 +9816,6 @@ export interface BrowserContext {
    * page.
    */
   waitForEvent(event: 'pageload', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
-
-  /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  waitForEvent(event: 'picklocator', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -149,7 +149,6 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
           dialog.dismiss().catch(() => {});
       }
     });
-    this._channel.on('pickLocator', ({ page }) => this.emit(Events.BrowserContext.PickLocator, Page.from(page)));
     this._channel.on('request', ({ request, page }) => this._onRequest(network.Request.from(request), Page.fromNullable(page)));
     this._channel.on('requestFailed', ({ request, failureText, responseEndTiming, page }) => this._onRequestFailed(network.Request.from(request), responseEndTiming, failureText, Page.fromNullable(page)));
     this._channel.on('requestFinished', params => this._onRequestFinished(params));

--- a/packages/playwright-core/src/client/events.ts
+++ b/packages/playwright-core/src/client/events.ts
@@ -40,7 +40,6 @@ export const Events = {
   },
 
   BrowserContext: {
-    PickLocator: 'picklocator',
     Console: 'console',
     Close: 'close',
     Dialog: 'dialog',

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -939,9 +939,6 @@ scheme.BrowserContextInitializer = tObject({
 scheme.BrowserContextBindingCallEvent = tObject({
   binding: tChannel(['BindingCall']),
 });
-scheme.BrowserContextPickLocatorEvent = tObject({
-  page: tChannel(['Page']),
-});
 scheme.BrowserContextConsoleEvent = tObject({
   type: tString,
   text: tString,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -45,7 +45,6 @@ import type * as types from './types';
 import type * as channels from '@protocol/channels';
 
 const BrowserContextEvent = {
-  PickLocator: 'picklocator',
   Console: 'console',
   Close: 'close',
   Page: 'page',
@@ -66,7 +65,6 @@ const BrowserContextEvent = {
 } as const;
 
 export type BrowserContextEventMap = {
-  [BrowserContextEvent.PickLocator]: [page: Page];
   [BrowserContextEvent.Console]: [message: ConsoleMessage];
   [BrowserContextEvent.Close]: [];
   [BrowserContextEvent.Page]: [page: Page];

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -105,9 +105,6 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     this.addObjectListener(BrowserContext.Events.Page, page => {
       this._dispatchEvent('page', { page: PageDispatcher.from(this, page) });
     });
-    this.addObjectListener(BrowserContext.Events.PickLocator, page => {
-      this._dispatchEvent('pickLocator', { page: PageDispatcher.from(this, page) });
-    });
     this.addObjectListener(BrowserContext.Events.Close, () => {
       this._dispatchEvent('close');
       this._dispose();

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -274,7 +274,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async pickLocator(progress: Progress, page: Page): Promise<string> {
-    page.emitOnContext(BrowserContext.Events.PickLocator, page);
     if (this._mode !== 'none')
       await progress.race(this.setMode('none'));
 

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -65,26 +65,6 @@ const resume = defineTool({
   },
 });
 
-const pickLocator = defineTabTool({
-  capability: 'devtools',
-  schema: {
-    name: 'browser_pick_locator',
-    title: 'Pick element locator',
-    description: 'Wait for the user to pick an element in the browser and return its ref and locator.',
-    inputSchema: z.object({}),
-    type: 'readOnly',
-  },
-
-  handle: async (tab, params, response) => {
-    const locator = await tab.page.pickLocator();
-    // Regenerate aria refs so the picked element has an aria ref we can read below.
-    await tab.page.ariaSnapshot({ mode: 'ai' });
-    const ref = await locator.ariaRef();
-    const resolved = await locator.normalize();
-    response.addTextResult(`ref: ${ref ?? '(none)'}\nlocator: ${resolved.toString()}`);
-  },
-});
-
 const highlight = defineTabTool({
   capability: 'devtools',
   schema: {
@@ -128,4 +108,4 @@ const hideHighlight = defineTabTool({
   },
 });
 
-export default [resume, pickLocator, highlight, hideHighlight];
+export default [resume, highlight, hideHighlight];

--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -159,8 +159,8 @@ playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 
-# wait for the user to pick an element in the browser, print its ref and locator
-playwright-cli pick
+# launch the dashboard with annotation prompt to ask the user for input
+playwright-cli show --annotate
 
 # generate a Playwright locator for an element from its ref or selector
 playwright-cli generate-locator e5 --raw

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -32,7 +32,6 @@ import type { BrowserDescriptor, BrowserStatus } from '../../serverRegistry';
 
 type BrowserTrackerCallbacks = {
   onTabsChanged: () => void;
-  onPickLocator: (page: api.Page) => void;
   onContextClosed: (context: api.BrowserContext) => void;
 };
 
@@ -87,9 +86,6 @@ class BrowserTracker {
       eventsHelper.addEventListener(context, 'framenavigated', (frame: api.Frame) => {
         if (frame === frame.page().mainFrame())
           this._callbacks.onTabsChanged();
-      }),
-      eventsHelper.addEventListener(context, 'picklocator', (page: api.Page) => {
-        this._callbacks.onPickLocator(page);
       }),
       eventsHelper.addEventListener(context, 'close', () => {
         const ls = this._contextListeners.get(context);
@@ -289,14 +285,6 @@ export class DashboardConnection implements Transport {
     this.sendEvent?.('frame', { data, viewportWidth, viewportHeight });
   }
 
-  emitElementPicked(selector: string, ariaSnapshot?: string) {
-    this.sendEvent?.('elementPicked', { selector, ariaSnapshot });
-  }
-
-  emitPickLocator() {
-    this.sendEvent?.('pickLocator', {});
-  }
-
   emitAnnotate() {
     this.sendEvent?.('annotate', {});
   }
@@ -421,7 +409,6 @@ export class DashboardConnection implements Transport {
         continue;
       const slot = await BrowserTracker.create(status, {
         onTabsChanged: () => this._pushTabs(),
-        onPickLocator: page => { this._onPickLocator(page).catch(() => {}); },
         onContextClosed: context => {
           if (this._attachedPage?.page.context() === context) {
             this._attachedPage.dispose();
@@ -449,11 +436,6 @@ export class DashboardConnection implements Transport {
   private _findPage(params: { browser: string; context: string; page: string }): api.Page | undefined {
     const context = this._findContext(params);
     return context?.pages().find(p => pageId(p) === params.page);
-  }
-
-  private async _onPickLocator(page: api.Page) {
-    await this._switchAttachedTo(page);
-    this.emitPickLocator();
   }
 }
 
@@ -554,15 +536,6 @@ class AttachedPage {
 
   async keyup(params: { key: string }) {
     await this._page.keyboard.up(params.key);
-  }
-
-  async pickLocator() {
-    const locator = await this._page.pickLocator();
-    this._owner.emitElementPicked(locator.toString(), await locator.ariaSnapshot());
-  }
-
-  async cancelPickLocator() {
-    await this._page.cancelPickLocator();
   }
 
   async startRecording() {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -8368,13 +8368,6 @@ export interface BrowserContext {
   on(event: 'pageload', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  on(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8480,11 +8473,6 @@ export interface BrowserContext {
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
    */
   once(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
-   */
-  once(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Adds an event listener that will be automatically removed after it is triggered once. See `addListener` for more information about this event.
@@ -8646,13 +8634,6 @@ export interface BrowserContext {
   addListener(event: 'pageload', listener: (page: Page) => any): this;
 
   /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  addListener(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
    * only listen for requests from a particular page, use
    * [page.on('request')](https://playwright.dev/docs/api/class-page#page-event-request).
@@ -8762,11 +8743,6 @@ export interface BrowserContext {
   /**
    * Removes an event listener added by `on` or `addListener`.
    */
-  removeListener(event: 'picklocator', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
   removeListener(event: 'request', listener: (request: Request) => any): this;
 
   /**
@@ -8848,11 +8824,6 @@ export interface BrowserContext {
    * Removes an event listener added by `on` or `addListener`.
    */
   off(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Removes an event listener added by `on` or `addListener`.
-   */
-  off(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Removes an event listener added by `on` or `addListener`.
@@ -9012,13 +8983,6 @@ export interface BrowserContext {
    * page.
    */
   prependListener(event: 'pageload', listener: (page: Page) => any): this;
-
-  /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  prependListener(event: 'picklocator', listener: (page: Page) => any): this;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To
@@ -9852,13 +9816,6 @@ export interface BrowserContext {
    * page.
    */
   waitForEvent(event: 'pageload', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
-
-  /**
-   * Emitted when a client calls [page.pickLocator()](https://playwright.dev/docs/api/class-page#page-pick-locator) on a
-   * page in this context. The event is dispatched to all clients connected to the context, including the one that
-   * initiated the call.
-   */
-  waitForEvent(event: 'picklocator', optionsOrPredicate?: { predicate?: (page: Page) => boolean | Promise<boolean>, timeout?: number } | ((page: Page) => boolean | Promise<boolean>)): Promise<Page>;
 
   /**
    * Emitted when a request is issued from any pages created through this context. The [request] object is read-only. To

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1642,7 +1642,6 @@ export type BrowserContextInitializer = {
 };
 export interface BrowserContextEventTarget {
   on(event: 'bindingCall', callback: (params: BrowserContextBindingCallEvent) => void): this;
-  on(event: 'pickLocator', callback: (params: BrowserContextPickLocatorEvent) => void): this;
   on(event: 'console', callback: (params: BrowserContextConsoleEvent) => void): this;
   on(event: 'close', callback: (params: BrowserContextCloseEvent) => void): this;
   on(event: 'dialog', callback: (params: BrowserContextDialogEvent) => void): this;
@@ -1695,9 +1694,6 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, EventT
 }
 export type BrowserContextBindingCallEvent = {
   binding: BindingCallChannel,
-};
-export type BrowserContextPickLocatorEvent = {
-  page: PageChannel,
 };
 export type BrowserContextConsoleEvent = {
   type: string,
@@ -2074,7 +2070,6 @@ export type BrowserContextClockSetSystemTimeResult = void;
 
 export interface BrowserContextEvents {
   'bindingCall': BrowserContextBindingCallEvent;
-  'pickLocator': BrowserContextPickLocatorEvent;
   'console': BrowserContextConsoleEvent;
   'close': BrowserContextCloseEvent;
   'dialog': BrowserContextDialogEvent;

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -1516,10 +1516,6 @@ BrowserContext:
       parameters:
         binding: BindingCall
 
-    pickLocator:
-      parameters:
-        page: Page
-
     console:
       parameters:
         $mixin: ConsoleMessage

--- a/tests/mcp/devtools.spec.ts
+++ b/tests/mcp/devtools.spec.ts
@@ -18,25 +18,6 @@ import { test, expect } from './cli-fixtures';
 
 test.use({ mcpCaps: ['devtools'] });
 
-test('browser_pick_locator', async ({ boundBrowser, startClient }) => {
-  const page = await boundBrowser.newPage();
-  await page.setContent(`<button>Submit</button>`);
-
-  const { client } = await startClient({ args: [`--endpoint=default`] });
-  await client.callTool({ name: 'browser_snapshot' });
-
-  const scriptReady = page.waitForEvent('console', msg => msg.text() === 'Recorder script ready for test');
-  const pickPromise = client.callTool({ name: 'browser_pick_locator' });
-  await scriptReady;
-
-  const box = await page.getByRole('button', { name: 'Submit' }).boundingBox();
-  await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
-
-  expect(await pickPromise).toHaveResponse({
-    result: `ref: e2\nlocator: getByRole('button', { name: 'Submit' })`,
-  });
-});
-
 test('browser_highlight', async ({ boundBrowser, startClient }) => {
   const page = await boundBrowser.newPage();
   await page.setContent(`<button>Submit</button>`);


### PR DESCRIPTION
## Summary
- Remove the `browser_pick_locator` MCP tool and its test
- Remove the `BrowserContext.pickLocator` event end-to-end (protocol, server/client, dispatcher, recorder emit, docs)
- Remove dead `pickLocator`/`elementPicked` plumbing from the dashboard (controller, channel, frontend, icon)
- `Page.pickLocator()` / `Page.cancelPickLocator()` public API is preserved