### PR TITLE
test(mcp): tear down daemons spawned via cli --json in fixture teardown

### DIFF
--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -159,7 +159,7 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
     const attachments = loadAttachments(cli.stdout);
 
     const browserMatches = cli.stdout.includes('### Browser') ? cli.stdout.match(/Browser `(.+)` opened with pid (\d+)\./) : undefined;
-    const [, , daemonPid] = browserMatches ?? [];
+    const daemonPid = browserMatches?.[2] ?? parseJsonPid(cli.stdout);
     const dashboardMatches = cli.stdout.includes('### Dashboard') ? cli.stdout.match(/Dashboard opened with pid (\d+)\./) : undefined;
     const dashboardPid = dashboardMatches?.[1];
 
@@ -174,6 +174,13 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
       dashboardPid: dashboardPid ? +dashboardPid : undefined,
     };
   });
+}
+
+function parseJsonPid(stdout: string) {
+  try {
+    return JSON.parse(stdout).pid;
+  } catch {
+  }
 }
 
 function loadAttachments(output: string) {


### PR DESCRIPTION
## Summary
- The MCP `cli` test fixture extracts the daemon pid from the text-mode marker `### Browser \`X\` opened with pid N.` to reap it in teardown. Tests using `cli('--json', 'open', ...)` (added in #40284) get no such marker, so the daemon survives the test as an orphan process — visible in CI as "Terminate orphan process" entries at the end of MCP jobs (example: https://github.com/microsoft/playwright/actions/runs/24770691947/job/72476069241#step:7:2).
- Fall back to parsing the `--json` envelope's `pid` field so the teardown loop works regardless of output mode.
