### PR TITLE
chore: enable one-var lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,7 @@ export const baseRules = {
   "new-parens": 2,
   "arrow-parens": [2, "as-needed"],
   "prefer-const": 2,
+  "one-var": [2, "never"],
   "quote-props": [2, "consistent"],
   "nonblock-statement-body-position": [2, "below"],
 

--- a/packages/isomorphic/cssTokenizer.ts
+++ b/packages/isomorphic/cssTokenizer.ts
@@ -489,7 +489,9 @@ export function tokenize(str1: string): CSSTokenInterface[] {
         repr += stringFromCode(code);
       }
     }
-    const c1 = next(1), c2 = next(2), c3 = next(3);
+    const c1 = next(1);
+    const c2 = next(2);
+    const c3 = next(3);
     if ((c1 === 0x45 || c1 === 0x65) && digit(c2)) {
       consume();
       repr += stringFromCode(code);

--- a/packages/isomorphic/imageUtils.ts
+++ b/packages/isomorphic/imageUtils.ts
@@ -57,7 +57,8 @@ export function scaleImageToSize(image: ImageData, size: { width: number; height
 
   // Catmull–Rom weights
   const weights = (t: number, o: Float32Array) => {
-    const t2 = t * t, t3 = t2 * t;
+    const t2 = t * t;
+    const t3 = t2 * t;
     o[0] = -0.5 * t + 1.0 * t2 - 0.5 * t3;
     o[1] = 1.0 - 2.5 * t2 + 1.5 * t3;
     o[2] = 0.5 * t + 2.0 * t2 - 1.5 * t3;
@@ -112,14 +113,26 @@ export function scaleImageToSize(image: ImageData, size: { width: number; height
 
   for (let y = 0; y < h2; y++) {
     const yb = y * 4;
-    const rb0 = yRow[yb + 0], rb1 = yRow[yb + 1], rb2 = yRow[yb + 2], rb3 = yRow[yb + 3];
-    const wy0 = yW[yb + 0], wy1 = yW[yb + 1], wy2 = yW[yb + 2], wy3 = yW[yb + 3];
+    const rb0 = yRow[yb + 0];
+    const rb1 = yRow[yb + 1];
+    const rb2 = yRow[yb + 2];
+    const rb3 = yRow[yb + 3];
+    const wy0 = yW[yb + 0];
+    const wy1 = yW[yb + 1];
+    const wy2 = yW[yb + 2];
+    const wy3 = yW[yb + 3];
     const dstBase = y * dstRowStride;
 
     for (let x = 0; x < w2; x++) {
       const xb = x * 4;
-      const xo0 = xOff[xb + 0], xo1 = xOff[xb + 1], xo2 = xOff[xb + 2], xo3 = xOff[xb + 3];
-      const wx0 = xW[xb + 0], wx1 = xW[xb + 1], wx2 = xW[xb + 2], wx3 = xW[xb + 3];
+      const xo0 = xOff[xb + 0];
+      const xo1 = xOff[xb + 1];
+      const xo2 = xOff[xb + 2];
+      const xo3 = xOff[xb + 3];
+      const wx0 = xW[xb + 0];
+      const wx1 = xW[xb + 1];
+      const wx2 = xW[xb + 2];
+      const wx3 = xW[xb + 3];
       const di = dstBase + (x << 2);
 
       // unrolled RGBA

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -987,7 +987,10 @@ function roundPoint(point: types.Point): types.Point {
 }
 
 function quadToRect(quad: types.Quad): types.Rect {
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
   for (const point of quad) {
     minX = Math.min(minX, point.x);
     minY = Math.min(minY, point.y);

--- a/packages/trace-viewer/src/ui/playbackControl.tsx
+++ b/packages/trace-viewer/src/ui/playbackControl.tsx
@@ -87,7 +87,8 @@ export function usePlayback(
   const scrubberRef = React.useRef<HTMLDivElement>(null);
 
   const actionIndexAtTime = React.useCallback((t: number): number => {
-    let lo = 0, hi = actions.length - 1;
+    let lo = 0;
+    let hi = actions.length - 1;
     while (lo < hi) {
       const mid = (lo + hi + 1) >> 1;
       if (actions[mid].startTime <= t)

--- a/packages/utils/image_tools/compare.ts
+++ b/packages/utils/image_tools/compare.ts
@@ -61,7 +61,9 @@ export function compare(actual: Buffer, expected: Buffer, diff: Buffer|null, wid
     drawPixel(width, diff, x - paddingSize, y - paddingSize, value, value, value);
   } : noop;
 
-  let fastR, fastG, fastB;
+  let fastR;
+  let fastG;
+  let fastB;
 
   let diffCount = 0;
   for (let y = paddingSize; y < r1.height - paddingSize; ++y){

--- a/tests/config/testserver/index.ts
+++ b/tests/config/testserver/index.ts
@@ -196,7 +196,8 @@ export class TestServer {
     let promise = this._requestSubscribers.get(path);
     if (promise)
       return promise;
-    let fulfill, reject;
+    let fulfill;
+    let reject;
     promise = new Promise((f, r) => {
       fulfill = f;
       reject = r;

--- a/tests/image_tools/unit.spec.ts
+++ b/tests/image_tools/unit.spec.ts
@@ -45,7 +45,8 @@ test('colorDeltaE94 should work', async () => {
 });
 
 test('fast stats and naive computation should match', async () => {
-  const N = 13, M = 17;
+  const N = 13;
+  const M = 17;
   const png1 = randomPNG(N, M, 239);
   const png2 = randomPNG(N, M, 261);
   const [r1] = ImageChannel.intoRGB(png1.width, png1.height, png1.data);

--- a/tests/page/page-history.spec.ts
+++ b/tests/page/page-history.spec.ts
@@ -279,7 +279,8 @@ it('regression test for issue 20791', async ({ page, server }) => {
 });
 
 it('should reload proper page', async ({ page, server }) => {
-  let mainRequest = 0, popupRequest = 0;
+  let mainRequest = 0;
+  let popupRequest = 0;
   server.setRoute('/main.html', (req, res) => {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
     res.end(`<!doctype html><h1>main: ${++mainRequest}</h1>`);

--- a/tests/page/page-mouse.spec.ts
+++ b/tests/page/page-mouse.spec.ts
@@ -322,7 +322,8 @@ it('should dispatch mouse move after context menu was opened', async ({ page, br
       window.addEventListener('contextmenu', x, false);
     });
   });
-  const CX = 100, CY = 100;
+  const CX = 100;
+  const CY = 100;
   await page.mouse.move(CX, CY);
   await page.mouse.down({ button: 'right' });
   await page.evaluate(() => window['contextMenuPromise']);

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -32,7 +32,8 @@ async function networkIdleTest(frame: Frame, server: TestServer, action: () => P
     ]);
   };
 
-  let responseA, responseB;
+  let responseA;
+  let responseB;
   // Hold on to a bunch of requests without answering.
   server.setRoute('/fetch-request-a.js', (req, res) => responseA = res);
   const firstFetchResourceRequested = waitForRequest('/fetch-request-a.js');

--- a/tests/playwright-test/golden.spec.ts
+++ b/tests/playwright-test/golden.spec.ts
@@ -537,7 +537,8 @@ test('should compare binary', async ({ runInlineTest }) => {
 });
 
 test('should respect maxDiffPixels option', async ({ runInlineTest }) => {
-  const width = 20, height = 20;
+  const width = 20;
+  const height = 20;
   const BAD_PIXELS = 120;
   const image1 = createWhiteImage(width, height);
   const image2 = paintBlackPixels(image1, BAD_PIXELS);
@@ -589,7 +590,8 @@ test('should respect maxDiffPixels option', async ({ runInlineTest }) => {
 });
 
 test('should respect maxDiffPixelRatio option', async ({ runInlineTest }) => {
-  const width = 20, height = 20;
+  const width = 20;
+  const height = 20;
   const BAD_RATIO = 0.25;
   const BAD_PIXELS = Math.floor(width * height * BAD_RATIO);
   const image1 = createWhiteImage(width, height);


### PR DESCRIPTION
Disallow `const a = 1, b = 2;` form in favor of one declaration per statement (matches existing review feedback patterns).

10 pre-existing violations fixed.