### PR TITLE
fix(electron): ignore internal Node.js contexts

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -166,6 +166,11 @@ export class Chromium extends BrowserType {
       const session = connection.rootSession;
       const worker = new Worker(this, '', () => transport.closeAndWait());
       session.on('Runtime.executionContextCreated', event => {
+        const isDefault = event.context.auxData?.isDefault as boolean | undefined;
+        if (isDefault === false) {
+          // Node.js sometimes creates internal contexts we are not interested in.
+          return;
+        }
         worker.workerScriptLoaded();
         worker.createExecutionContext(new CRExecutionContext(session, event.context));
       });


### PR DESCRIPTION
To avoid confusing the actual main context with internal contexts that cannot be exposed through the API anyway.

Fixes the failing `electron/electron-app.spec.ts:93` test on windows electron bot.