### PR TITLE
fix(dashboard): ensure tabs arrive before frame on session switch

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -39,7 +39,7 @@ declare const __PW_DASHBOARD_HMR__: boolean;
 
 type DashboardServer = {
   url: string;
-  reveal: (options: DashboardOptions) => void;
+  reveal: (options: DashboardOptions) => Promise<void>;
   triggerAnnotate: () => void;
   registerAnnotateWaiter: (socket: net.Socket) => void;
 };
@@ -67,9 +67,9 @@ async function startDashboardServer(options: DashboardOptions): Promise<Dashboar
   httpServer.createWebSocket(() => {
     let connection: DashboardConnection;
     // eslint-disable-next-line prefer-const
-    connection = new DashboardConnection(() => connections.delete(connection), () => {
+    connection = new DashboardConnection(() => connections.delete(connection), async () => {
       if (currentReveal.sessionName)
-        connection.revealSession(currentReveal.sessionName, currentReveal.workspaceDir);
+        await connection.revealSession(currentReveal.sessionName, currentReveal.workspaceDir);
       if (pendingAnnotate) {
         pendingAnnotate = false;
         connection.emitAnnotate();
@@ -89,12 +89,11 @@ async function startDashboardServer(options: DashboardOptions): Promise<Dashboar
     attachDashboardStaticServer(httpServer, dashboardDir);
   await httpServer.start({ port: options.port, host: options.host });
 
-  const reveal = (next: DashboardOptions) => {
+  const reveal = async (next: DashboardOptions) => {
     currentReveal = next;
     if (!next.sessionName)
       return;
-    for (const connection of connections)
-      connection.revealSession(next.sessionName, next.workspaceDir);
+    await Promise.all([...connections].map(c => c.revealSession(next.sessionName!, next.workspaceDir)));
   };
 
   const triggerAnnotate = () => {
@@ -339,10 +338,10 @@ export async function openDashboardApp() {
         socket.end();
         return;
       }
-      void statePromise.then(({ page, server: dashboard }) => {
+      void statePromise.then(async ({ page, server: dashboard }) => {
         if (parsed.annotate) {
           page?.bringToFront().catch(() => {});
-          dashboard.reveal(parsed);
+          await dashboard.reveal(parsed);
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
         } else if (parsed.kill) {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -113,7 +113,7 @@ export class DashboardConnection implements Transport {
   private _onAnnotationSubmit?: (base64Png: string, annotations: AnnotationData[]) => void;
   private _serverRegistryDispose?: () => void;
   private _pushSessionsScheduled = false;
-  private _pushTabsScheduled = false;
+  private _pushTabsPromise: Promise<void> | null = null;
   private _visible = true;
   private _pendingReveal: { sessionName: string; workspaceDir?: string } | undefined;
 
@@ -214,9 +214,9 @@ export class DashboardConnection implements Transport {
     await this._attachedPage?.setScreencastActive(params.visible);
   }
 
-  revealSession(sessionName: string, workspaceDir?: string) {
+  async revealSession(sessionName: string, workspaceDir?: string) {
     this._pendingReveal = { sessionName, workspaceDir };
-    void this._tryRevealPending();
+    await this._tryRevealPending();
   }
 
   private async _tryRevealPending() {
@@ -233,7 +233,6 @@ export class DashboardConnection implements Transport {
       return;
     this._pendingReveal = undefined;
     await this._switchAttachedTo(page);
-    this._pushTabs();
   }
 
   async submitAnnotation(params: { data: string; annotations: AnnotationData[] }) {
@@ -293,19 +292,19 @@ export class DashboardConnection implements Transport {
     this.sendEvent?.('cancelAnnotate', {});
   }
 
-  _pushTabs() {
-    if (this._pushTabsScheduled)
-      return;
-    this._pushTabsScheduled = true;
-    queueMicrotask(async () => {
-      this._pushTabsScheduled = false;
-      try {
-        const tabs = await this._aggregateTabs();
-        this.emitTabs(tabs);
-      } catch {
-        // best-effort
-      }
-    });
+  _pushTabs(): Promise<void> {
+    if (!this._pushTabsPromise) {
+      this._pushTabsPromise = new Promise<void>(resolve => queueMicrotask(async () => {
+        this._pushTabsPromise = null;
+        try {
+          const tabs = await this._aggregateTabs();
+          this.emitTabs(tabs);
+        } finally {
+          resolve();
+        }
+      }));
+    }
+    return this._pushTabsPromise;
   }
 
   private async _aggregateTabs(): Promise<Tab[]> {
@@ -341,6 +340,11 @@ export class DashboardConnection implements Transport {
     }
     const attached = new AttachedPage(this, slot, page);
     this._attachedPage = attached;
+    // Push tabs before starting the screencast so that the client sees
+    // the page change (tabs event) before the first frame arrives for
+    // the new page. Without this, the client may receive a frame for
+    // the new page while still thinking the old page is selected.
+    await this._pushTabs();
     try {
       await attached.init();
     } catch (e) {


### PR DESCRIPTION
When `show --annotate` switches sessions, the server now emits the tabs update before starting the screencast for the new page. This prevents the client from freezing the annotate overlay on a stale frame from the previous session.

Also awaits `revealSession()` before `triggerAnnotate()` so the annotate event is sent after the session switch completes.