### PR TITLE
fix(browser_console_messages): fix zod .default().describe() schema order

### DIFF
--- a/packages/playwright-core/src/tools/backend/console.ts
+++ b/packages/playwright-core/src/tools/backend/console.ts
@@ -24,7 +24,7 @@ const console = defineTabTool({
     title: 'Get console messages',
     description: 'Returns all console messages',
     inputSchema: z.object({
-      level: z.enum(['error', 'warning', 'info', 'debug']).default('info').describe('Level of the console messages to return. Each level includes the messages of more severe levels. Defaults to "info".'),
+      level: z.enum(['error', 'warning', 'info', 'debug']).describe('Level of the console messages to return. Each level includes the messages of more severe levels. Defaults to "info".').default('info'),
       all: z.boolean().optional().describe('Return all console messages since the beginning of the session, not just since the last navigation. Defaults to false.'),
       filename: z.string().optional().describe('Filename to save the console messages to. If not provided, messages are returned as text.'),
     }),


### PR DESCRIPTION
## Summary
- Reorder zod chained calls: change `.default('info').describe(...)` to `.describe(...).default('info')` for the level parameter in console.ts

## Why
Issue #1429: Gemini calls browser_console_messages and receives "parameters.level schema didn't specify the schema type field". When `.default()` appears before `.describe()` in zod chaining, zodToJSONSchema drops the description, causing schema validation failure.

## Validation
- [x] Single line change in packages/playwright-core/src/tools/backend/console.ts
- [x] TypeScript compilation check passed