### PR TITLE
feat(extension): close connect tab after selecting a different tab

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -111,6 +111,9 @@ class PlaywrightExtension {
         chrome.tabs.update(tabId, { active: true }),
         chrome.windows.update(windowId, { focused: true }),
       ]);
+
+      if (tabId !== selectorTabId)
+        await chrome.tabs.remove(selectorTabId).catch(() => {});
     } catch (error: any) {
       debugLog(`Failed to connect tab ${tabId}:`, error.message);
       throw error;

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -93,10 +93,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
           ],
         });
 
-        // for manifest v3:
-        let [serviceWorker] = browserContext.serviceWorkers();
-        if (!serviceWorker)
-          serviceWorker = await browserContext.waitForEvent('serviceworker');
+        // MV3 service workers start lazily; wait for the extension's
+        // background to be ready so tests can reach `chrome.*` via it.
+        if (!browserContext.serviceWorkers().length)
+          await browserContext.waitForEvent('serviceworker');
 
         return browserContext;
       }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -188,8 +188,6 @@ test(`snapshot of an existing page`, async ({ browserWithExtension, startClient,
   expect(await navigateResponse).toHaveResponse({
     inlineSnapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
-
-  expect(browserContext.pages()).toHaveLength(4);
 });
 
 test(`extension not installed timeout`, async ({ startExtensionClient, server }) => {

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -40,7 +40,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   await navigatePromise;
 });
 
-test('connected tab is in green Playwright group, connect page is not', async ({ browserWithExtension, startClient, server }) => {
+test('connected tab is in green Playwright group, connect page is closed', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 
   const page = await browserContext.newPage();
@@ -54,14 +54,20 @@ test('connected tab is in green Playwright group, connect page is not', async ({
 
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
+  const connectClosePromise = connectPage.waitForEvent('close');
 
   await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
+  // The connect page tab is closed since the user selected a different tab.
+  await connectClosePromise;
+
+  const [sw] = browserContext.serviceWorkers();
+
   // Connected tab should be in the Playwright group.
   await expect.poll(async () => {
-    return connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
       if (!connectedTab || connectedTab.groupId === -1)
         return null;
@@ -69,14 +75,6 @@ test('connected tab is in green Playwright group, connect page is not', async ({
       return { color: g.color, title: g.title };
     });
   }).toEqual({ color: 'green', title: 'Playwright' });
-
-  // Connect page itself should not be in any group.
-  const connectGroupId = await connectPage.evaluate(async () => {
-    const chrome = (window as any).chrome;
-    const connectTab = await chrome.tabs.getCurrent();
-    return connectTab?.groupId ?? -1;
-  });
-  expect(connectGroupId).toBe(-1);
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server, protocolVersion }) => {
@@ -104,18 +102,20 @@ test('tab added to group gets auto-attached', async ({ browserWithExtension, sta
   await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
+  const [sw] = browserContext.serviceWorkers();
+
   // Wait for the connected tab to be added to the group.
   await expect.poll(async () => {
-    return connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
       return connectedTab?.groupId ?? -1;
     });
   }).toBeGreaterThan(-1);
 
   // Drag the extra tab into the Playwright group — this should auto-attach it.
-  await connectPage.evaluate(async (targetUrl: string) => {
-    const chrome = (window as any).chrome;
+  await sw.evaluate(async (targetUrl: string) => {
+    const chrome = (globalThis as any).chrome;
     const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
     const [extra] = await chrome.tabs.query({ url: targetUrl });
     await chrome.tabs.group({ groupId: connectedTab.groupId, tabIds: [extra.id] });
@@ -147,42 +147,44 @@ test('chrome:// tab dragged into group is automatically ungrouped', async ({ bro
   await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
+  const [sw] = browserContext.serviceWorkers();
+
   // Wait for the connected tab to be added to the group.
   await expect.poll(async () => {
-    return connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
       return connectedTab?.groupId ?? -1;
     });
   }).toBeGreaterThan(-1);
 
   // Open a chrome:// tab.
-  const chromeTabId = await connectPage.evaluate(async () => {
-    const chrome = (window as any).chrome;
+  const chromeTabId = await sw.evaluate(async () => {
+    const chrome = (globalThis as any).chrome;
     const tab = await chrome.tabs.create({ url: 'chrome://version/', active: false });
     return tab.id as number;
   });
 
   // Wait for the chrome:// URL to actually load so tab.url is set.
   await expect.poll(async () => {
-    return connectPage.evaluate(async (id: number) => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async (id: number) => {
+      const chrome = (globalThis as any).chrome;
       const tab = await chrome.tabs.get(id);
       return tab.url || '';
     }, chromeTabId);
   }).toContain('chrome://version');
 
   // Drag the chrome:// tab into the Playwright group.
-  await connectPage.evaluate(async (id: number) => {
-    const chrome = (window as any).chrome;
+  await sw.evaluate(async (id: number) => {
+    const chrome = (globalThis as any).chrome;
     const [connectedTab] = await chrome.tabs.query({ title: 'Title' });
     await chrome.tabs.group({ groupId: connectedTab.groupId, tabIds: [id] });
   }, chromeTabId);
 
   // The chrome:// tab should be automatically removed from the group.
   await expect.poll(async () => {
-    return connectPage.evaluate(async (id: number) => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async (id: number) => {
+      const chrome = (globalThis as any).chrome;
       const tab = await chrome.tabs.get(id);
       return tab.groupId;
     }, chromeTabId);
@@ -213,10 +215,12 @@ test('tab removed from group gets auto-detached', async ({ browserWithExtension,
   // Create a second tab via the client — it will be attached and added to the group.
   await client.callTool({ name: 'browser_tabs', arguments: { action: 'new', url: server.PREFIX + '/second' } });
 
+  const [sw] = browserContext.serviceWorkers();
+
   // The second tab is attached (has the connected badge).
   await expect.poll(async () => {
-    return connectPage.evaluate(async (targetUrl: string) => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async (targetUrl: string) => {
+      const chrome = (globalThis as any).chrome;
       const [t] = await chrome.tabs.query({ url: targetUrl });
       if (!t?.id)
         return '';
@@ -225,16 +229,16 @@ test('tab removed from group gets auto-detached', async ({ browserWithExtension,
   }).toBe('✓');
 
   // Ungroup the second tab — this should auto-detach it.
-  await connectPage.evaluate(async (targetUrl: string) => {
-    const chrome = (window as any).chrome;
+  await sw.evaluate(async (targetUrl: string) => {
+    const chrome = (globalThis as any).chrome;
     const [second] = await chrome.tabs.query({ url: targetUrl });
     await chrome.tabs.ungroup([second.id]);
   }, server.PREFIX + '/second');
 
   // The badge should be cleared, indicating the tab was detached.
   await expect.poll(async () => {
-    return connectPage.evaluate(async (targetUrl: string) => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async (targetUrl: string) => {
+      const chrome = (globalThis as any).chrome;
       const [t] = await chrome.tabs.query({ url: targetUrl });
       if (!t?.id)
         return '';
@@ -261,11 +265,13 @@ test('connected tab is removed from group on disconnect', async ({ browserWithEx
   await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
   await navigatePromise;
 
+  const [sw] = browserContext.serviceWorkers();
+
   await client.close();
 
   await expect.poll(async () => {
-    return connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       const [tab] = await chrome.tabs.query({ title: 'Title' });
       return tab?.groupId ?? -1;
     });
@@ -287,17 +293,18 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
     const connectPage = await connectPagePromise;
     await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
     await navigatePromise;
-    return { client, connectPage };
+    return { client };
   };
 
   // First connection.
   const first = await connect();
+  const [sw] = browserContext.serviceWorkers();
   await first.client.close();
 
   // Wait for the tab to be ungrouped after disconnect.
   await expect.poll(async () => {
-    return first.connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       if (!chrome?.tabs)
         return null;
       const [tab] = await chrome.tabs.query({ title: 'Title' });
@@ -306,12 +313,12 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
   }).toBe(-1);
 
   // Second connection.
-  const second = await connect();
+  await connect();
 
   // The tab must end up in a green Playwright group again.
   await expect.poll(async () => {
-    return second.connectPage.evaluate(async () => {
-      const chrome = (window as any).chrome;
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
       if (!chrome?.tabs)
         return null;
       const [tab] = await chrome.tabs.query({ title: 'Title' });


### PR DESCRIPTION
## Summary
- Close the connect page tab after `Allow & select` when the user picked a different tab — it no longer lingers after a successful connection.
- Migrate post-connect `chrome.*` queries in extension tests from the (now-closed) connect page to the extension service worker.