### PR TITLE
feat(extension): hide chrome-extension:// tabs from the selector

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -122,7 +122,7 @@ class PlaywrightExtension {
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
     const tabs = await chrome.tabs.query({});
-    return tabs.filter(tab => !isNonDebuggableUrl(tab.url));
+    return tabs.filter(tab => !isNonDebuggableUrl(tab.url) && !tab.url?.startsWith('chrome-extension:'));
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -16,7 +16,6 @@
 
 import crypto from 'crypto';
 import fs from 'fs';
-import net from 'net';
 import path from 'path';
 
 import { playwright } from '../../inprocess';

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test as base, expect, extensionId, clickAllow } from './extension-fixtures';
+import { test as base, expect, extensionId } from './extension-fixtures';
 
 import type { CliResult } from './extension-fixtures';
 import type { Page } from 'playwright';
@@ -72,7 +72,7 @@ test('daemon exits when user closes the connect tab', async ({ startAttach }) =>
 
 test('attach <url> --extension', async ({ startAttach, cli, server }) => {
   const { confirmationPage, cliPromise } = await startAttach();
-  await clickAllow(confirmationPage);
+  await confirmationPage.getByRole('button', { name: 'Allow', exact: true }).click();
 
   {
     const { output } = await cliPromise;

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test as base, expect, extensionId } from './extension-fixtures';
+import { test as base, expect, extensionId, clickAllowAndSelect } from './extension-fixtures';
 
 import type { CliResult } from './extension-fixtures';
 import type { Page } from 'playwright';
@@ -72,7 +72,7 @@ test('daemon exits when user closes the connect tab', async ({ startAttach }) =>
 
 test('attach <url> --extension', async ({ startAttach, cli, server }) => {
   const { confirmationPage, cliPromise } = await startAttach();
-  await confirmationPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(confirmationPage, 'Welcome');
 
   {
     const { output } = await cliPromise;

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test as base, expect, extensionId, clickAllowAndSelect } from './extension-fixtures';
+import { test as base, expect, extensionId, clickAllow } from './extension-fixtures';
 
 import type { CliResult } from './extension-fixtures';
 import type { Page } from 'playwright';
@@ -72,7 +72,7 @@ test('daemon exits when user closes the connect tab', async ({ startAttach }) =>
 
 test('attach <url> --extension', async ({ startAttach, cli, server }) => {
   const { confirmationPage, cliPromise } = await startAttach();
-  await clickAllowAndSelect(confirmationPage, 'Welcome');
+  await clickAllow(confirmationPage);
 
   {
     const { output } = await cliPromise;

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -224,12 +224,6 @@ export async function clickAllowAndSelect(connectPage: Page, tabTitle: RegExp | 
   });
 }
 
-// Accepts the connection without selecting a different tab, so the connect
-// page itself becomes the connected tab.
-export async function clickAllow(connectPage: Page): Promise<void> {
-  await connectPage.getByRole('button', { name: 'Allow', exact: true }).click();
-}
-
 export async function connectAndNavigate(
   browserContext: BrowserContext,
   client: Client,
@@ -240,6 +234,6 @@ export async function connectAndNavigate(
   );
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
   const selectorPage = await confirmationPagePromise;
-  await clickAllow(selectorPage);
+  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
   return await navigatePromise;
 }

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -224,17 +224,22 @@ export async function clickAllowAndSelect(connectPage: Page, tabTitle: RegExp | 
   });
 }
 
+// Accepts the connection without selecting a different tab, so the connect
+// page itself becomes the connected tab.
+export async function clickAllow(connectPage: Page): Promise<void> {
+  await connectPage.getByRole('button', { name: 'Allow', exact: true }).click();
+}
+
 export async function connectAndNavigate(
   browserContext: BrowserContext,
   client: Client,
   url: string,
-  tabTitle: RegExp | string = 'Welcome',
 ): Promise<Awaited<ReturnType<Client['callTool']>>> {
   const confirmationPagePromise = browserContext.waitForEvent('page', page =>
     page.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
   );
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
   const selectorPage = await confirmationPagePromise;
-  await clickAllowAndSelect(selectorPage, tabTitle);
+  await clickAllow(selectorPage);
   return await navigatePromise;
 }

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -20,9 +20,10 @@ import path from 'path';
 import { chromium } from 'playwright';
 import { spawn } from 'child_process';
 import { test as base, expect } from '../mcp/fixtures';
+import { kTargetClosedErrorMessage } from '../config/errors';
 
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { BrowserContext } from 'playwright';
+import type { BrowserContext, Page } from 'playwright';
 import type { StartClient } from '../mcp/fixtures';
 
 export type BrowserWithExtension = {
@@ -213,6 +214,16 @@ export async function startWithExtensionFlag(browserWithExtension: BrowserWithEx
   return client;
 }
 
+// The connect page closes itself once a different tab is selected, which races
+// with the click — the request reaches the background while the page is being
+// torn down. Swallow the resulting "Target closed" error.
+export async function clickAllowAndSelect(connectPage: Page, tabTitle: RegExp | string): Promise<void> {
+  await connectPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Allow & select' }).click().catch(e => {
+    if (!e?.message?.includes(kTargetClosedErrorMessage))
+      throw e;
+  });
+}
+
 export async function connectAndNavigate(
   browserContext: BrowserContext,
   client: Client,
@@ -224,6 +235,6 @@ export async function connectAndNavigate(
   );
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(selectorPage, tabTitle);
   return await navigatePromise;
 }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { test, testWithOldExtensionVersion, expect, extensionId, clickAllow, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
@@ -30,7 +30,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllowAndSelect(selectorPage, 'Welcome');
+  await clickAllow(selectorPage);
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -104,7 +104,7 @@ test(`browser_run_code can evaluate in a web worker`, async ({ startExtensionCli
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllowAndSelect(selectorPage, 'Welcome');
+  await clickAllow(selectorPage);
 
   await navigateResponse;
 
@@ -222,7 +222,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllowAndSelect(selectorPage, 'Welcome');
+  await clickAllow(selectorPage);
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test, testWithOldExtensionVersion, expect, extensionId, clickAllow, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
@@ -30,7 +30,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllow(selectorPage);
+  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -104,7 +104,7 @@ test(`browser_run_code can evaluate in a web worker`, async ({ startExtensionCli
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllow(selectorPage);
+  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
 
   await navigateResponse;
 
@@ -222,7 +222,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   });
 
   const selectorPage = await confirmationPagePromise;
-  await clickAllow(selectorPage);
+  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test, testWithOldExtensionVersion, expect, extensionId, startWithExtensionFlag } from './extension-fixtures';
+import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
@@ -30,7 +30,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -104,7 +104,7 @@ test(`browser_run_code can evaluate in a web worker`, async ({ startExtensionCli
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   await navigateResponse;
 
@@ -183,7 +183,7 @@ test(`snapshot of an existing page`, async ({ browserWithExtension, startClient,
   const selectorPage = await confirmationPagePromise;
   expect(browserContext.pages()).toHaveLength(4);
 
-  await selectorPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(selectorPage, 'Title');
 
   expect(await navigateResponse).toHaveResponse({
     inlineSnapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -222,7 +222,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { test, expect, extensionId, clickAllow, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test('connect page hides chrome-extension:// tabs from the selector', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
@@ -55,7 +55,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   });
   expect(groupId).toBe(-1);
 
-  await clickAllowAndSelect(connectPage, 'Welcome');
+  await clickAllow(connectPage);
   await navigatePromise;
 });
 

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect, extensionId, clickAllow, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { test, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test('connect page hides chrome-extension:// tabs from the selector', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
@@ -55,7 +55,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   });
   expect(groupId).toBe(-1);
 
-  await clickAllow(connectPage);
+  await connectPage.getByRole('button', { name: 'Allow', exact: true }).click();
   await navigatePromise;
 });
 

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -16,6 +16,25 @@
 
 import { test, expect, extensionId, startWithExtensionFlag } from './extension-fixtures';
 
+test('connect page hides chrome-extension:// tabs from the selector', async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+
+  const extraExtensionPage = await browserContext.newPage();
+  await extraExtensionPage.goto(`chrome-extension://${extensionId}/status.html`);
+
+  const client = await startWithExtensionFlag(browserWithExtension, startClient);
+
+  const connectPagePromise = browserContext.waitForEvent('page', p =>
+    p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+  );
+  client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } }).catch(() => {});
+
+  const connectPage = await connectPagePromise;
+  await expect(connectPage.locator('.tab-item').first()).toBeVisible();
+
+  await expect(connectPage.locator('.tab-item', { hasText: 'chrome-extension://' })).toHaveCount(0);
+});
+
 test('connect page is not in group before selection', async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
 

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect, extensionId, startWithExtensionFlag } from './extension-fixtures';
+import { test, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
 test('connect page hides chrome-extension:// tabs from the selector', async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
@@ -55,7 +55,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   });
   expect(groupId).toBe(-1);
 
-  await connectPage.locator('.tab-item', { hasText: 'Welcome' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Welcome');
   await navigatePromise;
 });
 
@@ -75,7 +75,7 @@ test('connected tab is in green Playwright group, connect page is closed', async
   const connectPage = await connectPagePromise;
   const connectClosePromise = connectPage.waitForEvent('close');
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Title');
   await navigatePromise;
 
   // The connect page tab is closed since the user selected a different tab.
@@ -118,7 +118,7 @@ test('tab added to group gets auto-attached', async ({ browserWithExtension, sta
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Title');
   await navigatePromise;
 
   const [sw] = browserContext.serviceWorkers();
@@ -163,7 +163,7 @@ test('chrome:// tab dragged into group is automatically ungrouped', async ({ bro
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Title');
   await navigatePromise;
 
   const [sw] = browserContext.serviceWorkers();
@@ -228,7 +228,7 @@ test('tab removed from group gets auto-detached', async ({ browserWithExtension,
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Title');
   await navigatePromise;
 
   // Create a second tab via the client — it will be attached and added to the group.
@@ -281,7 +281,7 @@ test('connected tab is removed from group on disconnect', async ({ browserWithEx
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
   const connectPage = await connectPagePromise;
 
-  await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+  await clickAllowAndSelect(connectPage, 'Title');
   await navigatePromise;
 
   const [sw] = browserContext.serviceWorkers();
@@ -310,7 +310,7 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
     );
     const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
     const connectPage = await connectPagePromise;
-    await connectPage.locator('.tab-item', { hasText: 'Title' }).getByRole('button', { name: 'Allow & select' }).click();
+    await clickAllowAndSelect(connectPage, 'Title');
     await navigatePromise;
     return { client };
   };


### PR DESCRIPTION
## Summary
- Filter out `chrome-extension://` tabs from the connect dialog's tab list so the user doesn't see the extension's own pages (including the connect page itself) as connectable targets.
- Drag-into-group behavior is unchanged — those tabs are still debuggable if someone deliberately adds them to the Playwright group.