### PR TITLE
feat(extension): rehaul status page header

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -28,7 +28,7 @@ type PageMessage = {
   type: 'connectToTab';
   tabId?: number;
   windowId?: number;
-  mcpRelayUrl: string;
+  clientName?: string;
 } | {
   type: 'getConnectionStatus';
 } | {
@@ -39,6 +39,7 @@ type PageMessage = {
 
 class PlaywrightExtension {
   private _activeGroup: ConnectedTabGroup | undefined;
+  private _activeClientName: string | undefined;
   private _pendingConnections = new PendingConnections();
   // Service worker restarts lose all connection state, so any existing
   // Playwright groups are stale. Connections wait on this before reconciling.
@@ -66,13 +67,14 @@ class PlaywrightExtension {
       case 'connectToTab':
         const tabId = message.tabId || sender.tab?.id!;
         const windowId = message.windowId || sender.tab?.windowId!;
-        this._connectTab(sender.tab!.id!, tabId, windowId).then(
+        this._connectTab(sender.tab!.id!, tabId, windowId, message.clientName).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true; // Return true to indicate that the response will be sent asynchronously
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabIds: this._activeGroup?.connectedTabIds() ?? []
+          connectedTabIds: this._activeGroup?.connectedTabIds() ?? [],
+          clientName: this._activeClientName,
         });
         return false;
       case 'disconnect':
@@ -91,7 +93,7 @@ class PlaywrightExtension {
     }
   }
 
-  private async _connectTab(selectorTabId: number, tabId: number, windowId: number): Promise<void> {
+  private async _connectTab(selectorTabId: number, tabId: number, windowId: number, clientName: string | undefined): Promise<void> {
     try {
       await this._cleanupPromise;
       this._disconnect('Another connection is requested');
@@ -102,10 +104,13 @@ class PlaywrightExtension {
 
       const group = new ConnectedTabGroup(pending.connection, tabId);
       group.onclose = () => {
-        if (this._activeGroup === group)
+        if (this._activeGroup === group) {
           this._activeGroup = undefined;
+          this._activeClientName = undefined;
+        }
       };
       this._activeGroup = group;
+      this._activeClientName = clientName;
 
       await Promise.all([
         chrome.tabs.update(tabId, { active: true }),
@@ -137,6 +142,7 @@ class PlaywrightExtension {
   private _disconnect(reason: string) {
     this._activeGroup?.close(reason);
     this._activeGroup = undefined;
+    this._activeClientName = undefined;
   }
 }
 

--- a/packages/extension/src/ui/connect.css
+++ b/packages/extension/src/ui/connect.css
@@ -140,6 +140,21 @@ body {
   border-color: #c73836;
 }
 
+/* Connection header */
+.connection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px;
+  margin-bottom: 16px;
+}
+
+.client-info {
+  font-size: 14px;
+  color: #1f2328;
+}
+
 /* Tab selection */
 .tab-section-title {
   padding-left: 12px;

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -141,9 +141,9 @@ const ConnectApp: React.FC = () => {
     try {
       const response = await chrome.runtime.sendMessage({
         type: 'connectToTab',
-        mcpRelayUrl,
         tabId: tab?.id,
         windowId: tab?.windowId,
+        clientName: clientInfo,
       });
 
       if (response?.success) {

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -23,13 +23,14 @@ import { AuthTokenSection } from './authToken';
 
 const StatusApp: React.FC = () => {
   const [connectedTabs, setConnectedTabs] = useState<TabInfo[]>([]);
+  const [clientName, setClientName] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     void loadStatus();
   }, []);
 
   const loadStatus = async () => {
-    const { connectedTabIds } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+    const { connectedTabIds, clientName } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
     const tabs: TabInfo[] = [];
     for (const tabId of (connectedTabIds as number[] ?? [])) {
       try {
@@ -46,6 +47,7 @@ const StatusApp: React.FC = () => {
       }
     }
     setConnectedTabs(tabs);
+    setClientName(clientName);
   };
 
   const openTab = async (tabId: number) => {
@@ -63,19 +65,22 @@ const StatusApp: React.FC = () => {
       <div className='content-wrapper'>
         {connectedTabs.length > 0 ? (
           <div>
+            <div className='connection-header'>
+              <div className='client-info'>
+                Connected to <strong>"{clientName || 'unknown'}"</strong>
+              </div>
+              <Button variant='primary' onClick={disconnect}>
+                Disconnect
+              </Button>
+            </div>
             <div className='tab-section-title'>
-              {connectedTabs.length === 1 ? 'Page connected to Playwright client:' : 'Pages connected to Playwright client:'}
+              {connectedTabs.length === 1 ? 'Accessible page:' : 'Accessible pages:'}
             </div>
             <div>
-              {connectedTabs.map((tab, index) => (
+              {connectedTabs.map(tab => (
                 <TabItem
                   key={tab.id}
                   tab={tab}
-                  button={index === 0 ? (
-                    <Button variant='primary' onClick={disconnect}>
-                      Disconnect
-                    </Button>
-                  ) : undefined}
                   onClick={() => openTab(tab.id)}
                 />
               ))}
@@ -83,7 +88,7 @@ const StatusApp: React.FC = () => {
           </div>
         ) : (
           <div className='status-banner'>
-            No clients are currently connected.
+            No clients are currently connected. You can connect from the Playwright CLI or MCP server by passing the --extension flag.
           </div>
         )}
         <AuthTokenSection />


### PR DESCRIPTION
## Summary
- Show the connected client's name with the Disconnect button in a header row above the tab list (previously the button was attached to the first tab item).
- Plumb the client name from the connect page through the background to the status page via `getConnectionStatus`.
- Update the empty state to tell the user how to connect (pass \`--extension\` to the Playwright CLI or MCP server).