### PR TITLE
feat(dashboard): modal annotate and record modes

### DIFF
--- a/packages/dashboard/src/annotations.css
+++ b/packages/dashboard/src/annotations.css
@@ -27,27 +27,6 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  box-shadow: inset 0 0 0 1px rgb(var(--annotate-blue) / 0.72), inset 0 0 26px rgb(var(--annotate-blue) / 0.28);
-}
-
-.annotation-toolbar {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  display: inline-flex;
-  gap: 6px;
-  padding: 6px;
-  background: var(--color-canvas-overlay);
-  border: 1px solid var(--color-border-muted);
-  border-radius: 999px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  z-index: 20;
-  cursor: default;
-}
-
-:root.dark-mode .annotation-toolbar {
-  border-color: var(--color-border-default);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
 }
 
 :root.dark-mode .annotate-action-btn {
@@ -77,16 +56,6 @@
 .annotate-action-btn:disabled {
   opacity: 0.5;
   cursor: default;
-}
-
-.annotate-action-btn.primary {
-  background: rgb(var(--annotate-blue));
-  color: #fff;
-  border-color: transparent;
-}
-
-.annotate-action-btn.primary:hover:not(:disabled) {
-  background: rgb(var(--annotate-blue) / 0.85);
 }
 
 .annotate-action-btn.danger {

--- a/packages/dashboard/src/annotations.tsx
+++ b/packages/dashboard/src/annotations.tsx
@@ -142,14 +142,71 @@ export async function saveAnnotationAsDownload(blob: Blob): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
-export const Annotations: React.FC<{
+export async function buildAnnotatedImage(
+  img: HTMLImageElement,
+  viewportWidth: number,
+  viewportHeight: number,
+  annotations: Annotation[],
+): Promise<Blob | null> {
+  if (!img.naturalWidth || !img.naturalHeight || !viewportWidth || !viewportHeight)
+    return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx)
+    return null;
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  const sx = canvas.width / viewportWidth;
+  const sy = canvas.height / viewportHeight;
+  const blue = 'rgb(54, 116, 209)';
+  const fontSize = Math.max(11, Math.round(14 * sy));
+  ctx.font = `500 ${fontSize}px -apple-system, system-ui, sans-serif`;
+  ctx.textBaseline = 'middle';
+  for (const a of annotations) {
+    const x = a.x * sx;
+    const y = a.y * sy;
+    const w = a.width * sx;
+    const h = a.height * sy;
+    ctx.fillStyle = 'rgba(54, 116, 209, 0.12)';
+    ctx.fillRect(x, y, w, h);
+    ctx.lineWidth = Math.max(2, Math.round(2 * sy));
+    ctx.strokeStyle = blue;
+    ctx.strokeRect(x, y, w, h);
+    if (a.text) {
+      const padX = Math.max(4, Math.round(6 * sy));
+      const padY = Math.max(2, Math.round(3 * sy));
+      const metrics = ctx.measureText(a.text);
+      const labelW = metrics.width + padX * 2;
+      const labelH = fontSize + padY * 2;
+      const labelX = x - ctx.lineWidth / 2;
+      const labelY = y - labelH;
+      ctx.fillStyle = blue;
+      ctx.fillRect(labelX, labelY, labelW, labelH);
+      ctx.fillStyle = '#fff';
+      ctx.fillText(a.text, labelX + padX, labelY + labelH / 2);
+    }
+  }
+  return await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/png'));
+}
+
+export type AnnotationsHandle = {
+  clear(): void;
+  submit(): Promise<void>;
+  save(): Promise<void>;
+};
+
+type AnnotationsProps = {
   active: boolean;
   displayRef: React.RefObject<HTMLImageElement | null>;
   screenRef: React.RefObject<HTMLDivElement | null>;
   viewportWidth: number;
   viewportHeight: number;
   onSubmit: (blob: Blob, annotations: Annotation[]) => Promise<void> | void;
-}> = ({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit }) => {
+  onAnnotationsChange?: (count: number) => void;
+};
+
+export const Annotations = React.forwardRef<AnnotationsHandle, AnnotationsProps>(({ active, displayRef, screenRef, viewportWidth, viewportHeight, onSubmit, onAnnotationsChange }, ref) => {
   const [annotations, setAnnotations] = React.useState<Annotation[]>([]);
   const [draft, setDraft] = React.useState<{ startX: number; startY: number; x: number; y: number } | null>(null);
   const [selection, setSelection] = React.useState<Selection>(null);
@@ -313,55 +370,38 @@ export const Annotations: React.FC<{
     }
   }
 
-  async function submitAnnotations() {
-    const img = displayRef.current;
-    if (!img || !img.naturalWidth || !img.naturalHeight || !viewportWidth || !viewportHeight)
-      return;
-    const canvas = document.createElement('canvas');
-    canvas.width = img.naturalWidth;
-    canvas.height = img.naturalHeight;
-    const ctx = canvas.getContext('2d');
-    if (!ctx)
-      return;
-    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-    const sx = canvas.width / viewportWidth;
-    const sy = canvas.height / viewportHeight;
-    const blue = 'rgb(54, 116, 209)';
-    const fontSize = Math.max(11, Math.round(14 * sy));
-    ctx.font = `500 ${fontSize}px -apple-system, system-ui, sans-serif`;
-    ctx.textBaseline = 'middle';
-    for (const a of annotations) {
-      const x = a.x * sx;
-      const y = a.y * sy;
-      const w = a.width * sx;
-      const h = a.height * sy;
-      ctx.fillStyle = 'rgba(54, 116, 209, 0.12)';
-      ctx.fillRect(x, y, w, h);
-      ctx.lineWidth = Math.max(2, Math.round(2 * sy));
-      ctx.strokeStyle = blue;
-      ctx.strokeRect(x, y, w, h);
-      if (a.text) {
-        const padX = Math.max(4, Math.round(6 * sy));
-        const padY = Math.max(2, Math.round(3 * sy));
-        const metrics = ctx.measureText(a.text);
-        const labelW = metrics.width + padX * 2;
-        const labelH = fontSize + padY * 2;
-        const labelX = x - ctx.lineWidth / 2;
-        const labelY = y - labelH;
-        ctx.fillStyle = blue;
-        ctx.fillRect(labelX, labelY, labelW, labelH);
-        ctx.fillStyle = '#fff';
-        ctx.fillText(a.text, labelX + padX, labelY + labelH / 2);
-      }
-    }
-    const blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, 'image/png'));
-    if (!blob)
-      return;
-    await onSubmit(blob, annotations);
-    setAnnotations([]);
-    setSelection(null);
-    setDraft(null);
-  }
+  React.useEffect(() => {
+    onAnnotationsChange?.(annotations.length);
+  }, [annotations.length, onAnnotationsChange]);
+
+  React.useImperativeHandle(ref, () => ({
+    clear: () => {
+      setAnnotations([]);
+      setDraft(null);
+      setSelection(null);
+    },
+    submit: async () => {
+      const img = displayRef.current;
+      if (!img)
+        return;
+      const blob = await buildAnnotatedImage(img, viewportWidth, viewportHeight, annotations);
+      if (!blob)
+        return;
+      await onSubmit(blob, annotations);
+      setAnnotations([]);
+      setSelection(null);
+      setDraft(null);
+    },
+    save: async () => {
+      const img = displayRef.current;
+      if (!img)
+        return;
+      const blob = await buildAnnotatedImage(img, viewportWidth, viewportHeight, annotations);
+      if (!blob)
+        return;
+      await saveAnnotationAsDownload(blob);
+    },
+  }), [displayRef, viewportWidth, viewportHeight, annotations, onSubmit]);
 
   if (!active)
     return null;
@@ -386,25 +426,6 @@ export const Annotations: React.FC<{
       onKeyDown={onLayerKeyDown}
       onContextMenu={e => e.preventDefault()}
     >
-      <div className='annotation-toolbar' onMouseDown={e => e.stopPropagation()}>
-        <button
-          className='annotate-action-btn'
-          onClick={() => { setAnnotations([]); setDraft(null); setSelection(null); }}
-          disabled={annotations.length === 0}
-          title='Remove all annotations'
-        >
-          Clear
-        </button>
-        <button
-          className='annotate-action-btn primary'
-          onClick={submitAnnotations}
-          disabled={annotations.length === 0}
-          title='Submit annotation'
-        >
-          Submit
-        </button>
-      </div>
-
       {annotations.map(a => {
         const style = mapRect(a);
         if (!style)
@@ -495,13 +516,13 @@ export const Annotations: React.FC<{
                   layerRef.current?.focus();
                 }}
               >
-                Delete
+                Discard
               </button>
               <button
                 className='annotate-action-btn'
                 onClick={closeEditor}
               >
-                Done
+                Add
               </button>
             </div>
           </div>
@@ -510,4 +531,5 @@ export const Annotations: React.FC<{
 
     </div>
   );
-};
+});
+Annotations.displayName = 'Annotations';

--- a/packages/dashboard/src/dashboard.css
+++ b/packages/dashboard/src/dashboard.css
@@ -17,11 +17,35 @@
 .dashboard-view {
   --interactive-orange: 238 134 12;
   --annotate-blue: 54 116 209;
+  --recording-red: 239 68 68;
   display: flex;
   flex-direction: column;
   height: 100%;
   width: 100%;
   overflow: hidden;
+  position: relative;
+}
+
+.dashboard-view.annotate::after,
+.dashboard-view.recording::after {
+  position: absolute;
+  inset: 0;
+  content: '';
+  border-radius: 8px;
+  pointer-events: none;
+}
+
+.dashboard-view.annotate::after {
+  box-shadow: inset 0 0 0 1px rgb(var(--annotate-blue) / 0.72), inset 0 0 8px rgb(var(--annotate-blue) / 0.28);
+}
+
+.dashboard-view.recording::after {
+  box-shadow: inset 0 0 0 1px rgb(var(--recording-red) / 0.72), inset 0 0 8px rgb(var(--recording-red) / 0.28);
+}
+
+.dashboard-view.annotate .toolbar,
+.dashboard-view.recording .toolbar {
+  background: none !important;
 }
 
 /* -- Mode toggle buttons (interactive / annotate) -- */
@@ -214,6 +238,34 @@
   flex: 1;
   min-height: 0;
   width: 100%;
+}
+
+.annotate-view, .recording-view {
+  position: relative;
+  width: calc(100% - 16px);
+  height: calc(100% - 16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.annotate-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+  box-shadow: 0 0 0 1px var(--color-border-muted), 0 0 8px var(--color-border-muted);
+}
+
+.recording-video {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  background: #000;
+  box-shadow: 0 0 0 1px var(--color-border-muted), 0 0 8px var(--color-border-muted);
 }
 
 .display {

--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -17,17 +17,24 @@
 import React from 'react';
 import './dashboard.css';
 import { DashboardClientContext } from './dashboardContext';
-import { ChevronLeftIcon, ChevronRightIcon, ReloadIcon } from './icons';
-import { Annotations, getImageLayout, clientToViewport, saveAnnotationAsDownload } from './annotations';
+import { ChevronLeftIcon, ChevronRightIcon, DownloadIcon, LockIcon, LockOpenIcon, ReloadIcon, ScreenshotRegionIcon } from './icons';
+import { Annotations, getImageLayout, clientToViewport } from './annotations';
 
-import type { Annotation } from './annotations';
-import { ToolbarButton } from '@web/components/toolbarButton';
+import type { Annotation, AnnotationsHandle } from './annotations';
+import { ToolbarButton, ToolbarSeparator } from '@web/components/toolbarButton';
 import { useMeasureForRef } from '@web/uiUtils';
 
 import type { Tab, DashboardChannelEvents } from './dashboardChannel';
 
 const BUTTONS = ['left', 'middle', 'right'] as const;
 type Mode = 'readonly' | 'interactive' | 'annotate';
+
+// Recording mode is a separate, mode-replacing overlay similar to annotate.
+// While null, the normal toolbar is shown. When non-null, the recording
+// toolbar replaces it.
+type RecordingState =
+  | { phase: 'recording' }
+  | { phase: 'stopped'; blob: Blob; url: string };
 
 type DashboardState = {
   // Server-driven session state.
@@ -49,7 +56,7 @@ type DashboardState = {
   annotateInitiator: 'cli' | 'user' | null;
   // Interaction mode and ephemeral UI flags.
   mode: Mode;
-  recording: boolean;
+  recording: RecordingState | null;
 };
 
 type DashboardAction =
@@ -61,7 +68,9 @@ type DashboardAction =
   // User events
   | { type: 'toggleInteractive' }
   | { type: 'toggleAnnotate' }
-  | { type: 'setRecording'; recording: boolean }
+  | { type: 'startRecording' }
+  | { type: 'stoppedRecording'; blob: Blob; url: string }
+  | { type: 'exitRecording' }
   | { type: 'submitAnnotation' }
   | { type: 'setUrl'; url: string };
 
@@ -73,7 +82,7 @@ const initialDashboardState: DashboardState = {
   cliAnnotatePending: false,
   annotateInitiator: null,
   mode: 'readonly',
-  recording: false,
+  recording: null,
 };
 
 function dashboardReducer(state: DashboardState, action: DashboardAction): DashboardState {
@@ -101,7 +110,7 @@ function dashboardReducer(state: DashboardState, action: DashboardAction): Dashb
         tabs: action.tabs,
         url,
         mode,
-        recording: false,
+        recording: null,
         liveFrame: undefined,
         annotateFrame: undefined,
         cliAnnotatePending: wasAnnotateActive,
@@ -175,8 +184,12 @@ function dashboardReducer(state: DashboardState, action: DashboardAction): Dashb
         annotateInitiator: initiator,
       };
     }
-    case 'setRecording':
-      return { ...state, recording: action.recording };
+    case 'startRecording':
+      return { ...state, recording: { phase: 'recording' } };
+    case 'stoppedRecording':
+      return { ...state, recording: { phase: 'stopped', blob: action.blob, url: action.url } };
+    case 'exitRecording':
+      return { ...state, recording: null };
     case 'submitAnnotation':
       return {
         ...state,
@@ -230,30 +243,33 @@ export const Dashboard: React.FC = () => {
   const { tabs, url, mode, recording, liveFrame, annotateFrame, annotateInitiator } = state;
   const interactive = mode === 'interactive';
   const annotating = mode === 'annotate';
-  // While annotating, the on-screen image is the frozen snapshot so the
-  // user can draw on a stable picture even as the page keeps moving.
-  const frame = annotating ? annotateFrame : liveFrame;
 
-  const [screenshotIcon, setScreenshotIcon] = React.useState<'device-camera' | 'clippy'>('device-camera');
   const [flashTick, setFlashTick] = React.useState(0);
+  const [annotationCount, setAnnotationCount] = React.useState(0);
 
   const displayRef = React.useRef<HTMLImageElement>(null);
   const screenRef = React.useRef<HTMLDivElement>(null);
+  const annotateViewRef = React.useRef<HTMLDivElement>(null);
   const toolbarRef = React.useRef<HTMLDivElement>(null);
   const viewportMainRef = React.useRef<HTMLDivElement>(null);
   const browserChromeRef = React.useRef<HTMLDivElement>(null);
   const interactiveBtnRef = React.useRef<HTMLButtonElement>(null);
+  const annotationsRef = React.useRef<AnnotationsHandle>(null);
   const moveThrottleRef = React.useRef(0);
 
-  const aspect = frame && frame.viewportWidth && frame.viewportHeight
-    ? frame.viewportWidth / frame.viewportHeight
+  const aspect = liveFrame && liveFrame.viewportWidth && liveFrame.viewportHeight
+    ? liveFrame.viewportWidth / liveFrame.viewportHeight
     : null;
 
   const [viewportRect] = useMeasureForRef(viewportMainRef);
 
+  // Active recording hides the browser chrome so the viewport matches what's
+  // being captured (mirroring annotate mode's chrome-less frame).
+  const showBrowserChrome = recording?.phase !== 'recording';
+
   const windowStyle = React.useMemo<React.CSSProperties | undefined>(() => {
     const OUTER_MARGIN = 24;
-    const chromeHeight = browserChromeRef.current?.offsetHeight ?? 40;
+    const chromeHeight = showBrowserChrome ? (browserChromeRef.current?.offsetHeight ?? 40) : 0;
     const availW = viewportRect.width - OUTER_MARGIN;
     const availH = viewportRect.height - OUTER_MARGIN;
     if (availW <= 0 || availH <= 0)
@@ -268,10 +284,10 @@ export const Dashboard: React.FC = () => {
       w = h * aspect;
     }
     return { width: w, height: h + chromeHeight };
-  }, [viewportRect, aspect]);
+  }, [viewportRect, aspect, showBrowserChrome]);
 
   React.useEffect(() => {
-    if (flashTick === 0 || interactive)
+    if (flashTick === 0)
       return;
     const btn = interactiveBtnRef.current;
     if (!btn)
@@ -285,13 +301,16 @@ export const Dashboard: React.FC = () => {
       clearTimeout(timer);
       btn.classList.remove('flash');
     };
-  }, [flashTick, interactive]);
+  }, [flashTick]);
+
+  React.useEffect(() => {
+    if (interactive)
+      interactiveBtnRef.current?.classList.remove('flash');
+  }, [interactive]);
 
   const onSubmitAnnotations = React.useCallback(async (blob: Blob, annotations: Annotation[]) => {
-    if (!client || annotateInitiator !== 'cli') {
-      await saveAnnotationAsDownload(blob);
+    if (!client)
       return;
-    }
     const dataUrl = await new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
@@ -304,11 +323,61 @@ export const Dashboard: React.FC = () => {
       annotations: annotations.map(a => ({ x: a.x, y: a.y, width: a.width, height: a.height, text: a.text })),
     });
     dispatch({ type: 'submitAnnotation' });
-  }, [client, annotateInitiator]);
+  }, [client]);
 
   function flashInteractiveHint() {
     setFlashTick(tick => tick + 1);
   }
+
+  const onStartRecording = React.useCallback(async () => {
+    if (!client)
+      return;
+    await client.startRecording();
+    dispatch({ type: 'startRecording' });
+  }, [client]);
+
+  const onStopRecording = React.useCallback(async () => {
+    if (!client)
+      return;
+    const { streamId } = await client.stopRecording();
+    const chunks: Blob[] = [];
+    while (true) {
+      const { data, eof } = await client.readStream({ streamId });
+      if (data)
+        chunks.push(base64ToBlob(data, 'video/webm'));
+      if (eof)
+        break;
+    }
+    const blob = new Blob(chunks, { type: 'video/webm' });
+    const url = URL.createObjectURL(blob);
+    dispatch({ type: 'stoppedRecording', blob, url });
+  }, [client]);
+
+  const onSaveRecording = React.useCallback(async () => {
+    if (state.recording?.phase !== 'stopped')
+      return;
+    const writable = await pickSaveWritable(`playwright-recording-${Date.now()}.webm`, 'WebM Video', 'video/webm', '.webm');
+    if (!writable)
+      return;
+    await writable.write(state.recording.blob);
+    await writable.close();
+  }, [state.recording]);
+
+  const onExitRecording = React.useCallback(async () => {
+    if (state.recording?.phase === 'recording' && client) {
+      // Drain the stream without persisting; keeps the server clean.
+      const { streamId } = await client.stopRecording();
+      while (true) {
+        const { eof } = await client.readStream({ streamId });
+        if (eof)
+          break;
+      }
+    }
+    if (state.recording?.phase === 'stopped')
+      URL.revokeObjectURL(state.recording.url);
+    dispatch({ type: 'exitRecording' });
+  }, [state.recording, client]);
+
 
   React.useEffect(() => {
     if (!client)
@@ -348,8 +417,8 @@ export const Dashboard: React.FC = () => {
   const ready = !!client && !!selectedTab;
 
   function imgCoords(e: React.MouseEvent): { x: number; y: number } {
-    const vw = frame?.viewportWidth ?? 0;
-    const vh = frame?.viewportHeight ?? 0;
+    const vw = liveFrame?.viewportWidth ?? 0;
+    const vh = liveFrame?.viewportHeight ?? 0;
     if (!vw || !vh)
       return { x: 0, y: 0 };
     const layout = getImageLayout(displayRef.current);
@@ -436,177 +505,234 @@ export const Dashboard: React.FC = () => {
     overlayText = 'Select a session';
 
   return (
-    <div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '')}>
+    <div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '') + (recording ? ' recording' : '')}>
       {/* Toolbar */}
       <div ref={toolbarRef} className='toolbar'>
-        <ToolbarButton
-          ref={interactiveBtnRef}
-          className='mode-toggle mode-interactive'
-          title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
-          icon='person'
-          toggled={interactive}
-          disabled={!ready}
-          onClick={() => {
-            dispatch({ type: 'toggleInteractive' });
-          }}
-        />
-        <ToolbarButton
-          className='mode-toggle mode-annotate'
-          title={annotating ? 'Disable annotation mode' : 'Enable annotation mode'}
-          icon='comment-draft'
-          toggled={annotating}
-          disabled={!ready || !frame}
-          onClick={() => {
-            dispatch({ type: 'toggleAnnotate' });
-          }}
-        />
-        <div className='toolbar-right'>
-          <ToolbarButton
-            className='recording'
-            title={recording ? 'Stop recording' : 'Record video'}
-            icon='record'
-            toggled={recording}
-            style={{ color: recording ? 'var(--color-scale-red-5)' : undefined }}
-            disabled={!ready}
-            onClick={async () => {
-              if (!client)
-                return;
-              if (recording) {
-                const writable = await pickSaveWritable(`playwright-recording-${Date.now()}.webm`, 'WebM Video', 'video/webm', '.webm');
-                if (!writable)
-                  return;
-                dispatch({ type: 'setRecording', recording: false });
-                const { streamId } = await client.stopRecording();
-                while (true) {
-                  const { data, eof } = await client.readStream({ streamId });
-                  if (eof)
-                    break;
-                  await writable.write(base64ToBlob(data, 'video/webm'));
+        {annotating ? (
+          <>
+            {annotateInitiator === 'cli' && (
+              <>
+                <ToolbarButton
+                  className='annotate-toolbar-btn'
+                  title='Submit annotation'
+                  icon='check'
+                  disabled={annotationCount === 0}
+                  onClick={() => annotationsRef.current?.submit()}
+                />
+                <ToolbarSeparator />
+              </>
+            )}
+            <ToolbarButton
+              className='annotate-toolbar-btn'
+              title='Save annotated image'
+              onClick={() => annotationsRef.current?.save()}
+            >
+              <DownloadIcon />
+            </ToolbarButton>
+            <ToolbarButton
+              className='annotate-toolbar-btn'
+              title='Clear annotations'
+              icon='circle-slash'
+              disabled={annotationCount === 0}
+              onClick={() => annotationsRef.current?.clear()}
+            />
+            <div className='toolbar-right'>
+              <ToolbarButton
+                className='annotate-toolbar-btn'
+                title='Close annotation mode'
+                icon='close'
+                onClick={() => dispatch({ type: 'toggleAnnotate' })}
+              />
+            </div>
+          </>
+        ) : recording ? (
+          <>
+            <ToolbarButton
+              className='recording'
+              title={recording.phase === 'recording' ? 'Stop recording' : 'Start new recording'}
+              icon='record'
+              toggled={recording.phase === 'recording'}
+              style={{ color: recording.phase === 'recording' ? 'var(--color-scale-red-5)' : undefined }}
+              onClick={async () => {
+                if (recording.phase === 'recording') {
+                  await onStopRecording();
+                } else {
+                  URL.revokeObjectURL(recording.url);
+                  await onStartRecording();
                 }
-                await writable.close();
-              } else {
-                await client.startRecording();
-                dispatch({ type: 'setRecording', recording: true });
-              }
-            }}>
-            {recording && <span className='recording-label'>Recording...</span>}
-          </ToolbarButton>
-          <ToolbarButton
-            className='screenshot'
-            title='Save screenshot'
-            icon={screenshotIcon}
-            disabled={!ready}
-            onClick={async () => {
-              if (!client)
-                return;
-              const writable = await pickSaveWritable(`playwright-screenshot-${Date.now()}.png`, 'PNG Image', 'image/png', '.png');
-              if (!writable)
-                return;
-              const data = await client.screenshot();
-              await writable.write(base64ToBlob(data, 'image/png'));
-              await writable.close();
-              setScreenshotIcon('clippy');
-              setTimeout(() => setScreenshotIcon('device-camera'), 3000);
-            }}
-          />
-        </div>
+              }}>
+              {recording.phase === 'recording' && <span className='recording-label'>Recording...</span>}
+            </ToolbarButton>
+            <ToolbarButton
+              title='Save recording'
+              disabled={recording.phase !== 'stopped'}
+              onClick={onSaveRecording}
+            >
+              <DownloadIcon />
+            </ToolbarButton>
+            <div className='toolbar-right'>
+              <ToolbarButton
+                title='Close'
+                icon='close'
+                onClick={onExitRecording}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <ToolbarButton
+              ref={interactiveBtnRef}
+              className='mode-toggle mode-interactive'
+              title={interactive ? 'Disable interactive mode' : 'Enable interactive mode'}
+              toggled={interactive}
+              disabled={!ready}
+              onClick={() => {
+                dispatch({ type: 'toggleInteractive' });
+              }}
+            >
+              {interactive ? <LockOpenIcon /> : <LockIcon />}
+            </ToolbarButton>
+            <ToolbarSeparator />
+            <ToolbarButton
+              className='mode-toggle mode-annotate'
+              title='Enable annotation mode'
+              disabled={!ready || !liveFrame}
+              onClick={() => {
+                dispatch({ type: 'toggleAnnotate' });
+              }}
+            >
+              <ScreenshotRegionIcon />
+            </ToolbarButton>
+            <ToolbarButton
+              title='Record video'
+              icon='record'
+              disabled={!ready}
+              onClick={onStartRecording}
+            />
+          </>
+        )}
       </div>
 
       {/* Viewport */}
       <div className='viewport-wrapper'>
         <div ref={viewportMainRef} className='viewport-main'>
-          <div className='browser-window' style={windowStyle}>
-            <div ref={browserChromeRef} className='browser-chrome'>
-              <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                client?.back();
-              }}>
-                <ChevronLeftIcon />
-              </button>
-              <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                client?.forward();
-              }}>
-                <ChevronRightIcon />
-              </button>
-              <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
-                if (!interactive) {
-                  flashInteractiveHint();
-                  return;
-                }
-                client?.reload();
-              }}>
-                <ReloadIcon />
-              </button>
-              <div className='omnibox-wrap'>
-                <input
-                  id='omnibox'
-                  className='omnibox'
-                  type='text'
-                  placeholder='Search or enter URL'
-                  spellCheck={false}
-                  autoComplete='off'
-                  value={url}
-                  onChange={e => {
-                    if (!interactive)
-                      return;
-                    dispatch({ type: 'setUrl', url: e.target.value });
-                  }}
-                  onKeyDown={e => {
-                    if (!interactive)
-                      return;
-                    onOmniboxKeyDown(e);
-                  }}
-                  onFocus={e => {
-                    if (!interactive) {
-                      flashInteractiveHint();
-                      e.target.blur();
-                      return;
-                    }
-                    e.target.select();
-                  }}
-                  aria-disabled={!interactive || undefined}
-                  readOnly={!interactive}
-                />
-              </div>
-            </div>
-            <div
-              ref={screenRef}
-              className='screen'
-              tabIndex={0}
-              style={{ display: frame ? '' : 'none' }}
-              onMouseDown={onScreenMouseDown}
-              onMouseUp={onScreenMouseUp}
-              onMouseMove={onScreenMouseMove}
-              onWheel={onScreenWheel}
-              onKeyDown={onScreenKeyDown}
-              onKeyUp={onScreenKeyUp}
-              onContextMenu={e => e.preventDefault()}
-            >
+          {annotating && annotateFrame ? (
+            <div ref={annotateViewRef} className='annotate-view'>
               <img
                 ref={displayRef}
                 id='display'
-                className='display'
-                alt='screencast'
-                src={frame ? 'data:image/jpeg;base64,' + frame.data : undefined}
+                className='annotate-image'
+                alt='annotation'
+                src={'data:image/jpeg;base64,' + annotateFrame.data}
               />
               <Annotations
-                active={annotating}
+                ref={annotationsRef}
+                active={true}
                 displayRef={displayRef}
-                screenRef={screenRef}
-                viewportWidth={frame?.viewportWidth ?? 0}
-                viewportHeight={frame?.viewportHeight ?? 0}
+                screenRef={annotateViewRef}
+                viewportWidth={annotateFrame.viewportWidth ?? 0}
+                viewportHeight={annotateFrame.viewportHeight ?? 0}
                 onSubmit={onSubmitAnnotations}
+                onAnnotationsChange={setAnnotationCount}
               />
             </div>
-            {overlayText && <div className={'screen-overlay' + (frame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
-          </div>
+          ) : recording?.phase === 'stopped' ? (
+            <div className='recording-view'>
+              <video
+                className='recording-video'
+                src={recording.url}
+                controls
+                autoPlay
+              />
+            </div>
+          ) : (
+            <div className='browser-window' style={windowStyle}>
+              {showBrowserChrome && (
+                <div ref={browserChromeRef} className='browser-chrome'>
+                  <button className='nav-btn' title='Back' aria-disabled={!interactive || undefined} onClick={() => {
+                    if (!interactive) {
+                      flashInteractiveHint();
+                      return;
+                    }
+                    client?.back();
+                  }}>
+                    <ChevronLeftIcon />
+                  </button>
+                  <button className='nav-btn' title='Forward' aria-disabled={!interactive || undefined} onClick={() => {
+                    if (!interactive) {
+                      flashInteractiveHint();
+                      return;
+                    }
+                    client?.forward();
+                  }}>
+                    <ChevronRightIcon />
+                  </button>
+                  <button className='nav-btn' title='Reload' aria-disabled={!interactive || undefined} onClick={() => {
+                    if (!interactive) {
+                      flashInteractiveHint();
+                      return;
+                    }
+                    client?.reload();
+                  }}>
+                    <ReloadIcon />
+                  </button>
+                  <div className='omnibox-wrap'>
+                    <input
+                      id='omnibox'
+                      className='omnibox'
+                      type='text'
+                      placeholder='Search or enter URL'
+                      spellCheck={false}
+                      autoComplete='off'
+                      value={url}
+                      onChange={e => {
+                        if (!interactive)
+                          return;
+                        dispatch({ type: 'setUrl', url: e.target.value });
+                      }}
+                      onKeyDown={e => {
+                        if (!interactive)
+                          return;
+                        onOmniboxKeyDown(e);
+                      }}
+                      onFocus={e => {
+                        if (!interactive) {
+                          flashInteractiveHint();
+                          e.target.blur();
+                          return;
+                        }
+                        e.target.select();
+                      }}
+                      aria-disabled={!interactive || undefined}
+                      readOnly={!interactive}
+                    />
+                  </div>
+                </div>
+              )}
+              <div
+                ref={screenRef}
+                className='screen'
+                tabIndex={0}
+                style={{ display: liveFrame ? '' : 'none' }}
+                onMouseDown={onScreenMouseDown}
+                onMouseUp={onScreenMouseUp}
+                onMouseMove={onScreenMouseMove}
+                onWheel={onScreenWheel}
+                onKeyDown={onScreenKeyDown}
+                onKeyUp={onScreenKeyUp}
+                onContextMenu={e => e.preventDefault()}
+              >
+                <img
+                  ref={displayRef}
+                  id='display'
+                  className='display'
+                  alt='screencast'
+                  src={liveFrame ? 'data:image/jpeg;base64,' + liveFrame.data : undefined}
+                />
+              </div>
+              {overlayText && <div className={'screen-overlay' + (liveFrame ? ' has-frame' : '')}><span>{overlayText}</span></div>}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/dashboard/src/icons.tsx
+++ b/packages/dashboard/src/icons.tsx
@@ -89,6 +89,30 @@ export const PlusIcon: React.FC = () => (
   </svg>
 );
 
+export const LockIcon: React.FC = () => (
+  <svg width='20' height='20' viewBox='0 -960 960 960' style={{ fill: 'currentColor' }} aria-hidden='true'>
+    <path d='M240-80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h40v-80q0-83 58.5-141.5T480-920q83 0 141.5 58.5T680-720v80h40q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Zm0-80h480v-400H240v400Zm296.5-143.5Q560-327 560-360t-23.5-56.5Q513-440 480-440t-56.5 23.5Q400-393 400-360t23.5 56.5Q447-280 480-280t56.5-23.5ZM360-640h240v-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80ZM240-160v-400 400Z'/>
+  </svg>
+);
+
+export const LockOpenIcon: React.FC = () => (
+  <svg width='20' height='20' viewBox='0 -960 960 960' style={{ fill: 'currentColor' }} aria-hidden='true'>
+    <path d='M240-160h480v-400H240v400Zm296.5-143.5Q560-327 560-360t-23.5-56.5Q513-440 480-440t-56.5 23.5Q400-393 400-360t23.5 56.5Q447-280 480-280t56.5-23.5ZM240-160v-400 400Zm0 80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h280v-80q0-83 58.5-141.5T720-920q83 0 141.5 58.5T920-720h-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80h120q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Z'/>
+  </svg>
+);
+
+export const ScreenshotRegionIcon: React.FC = () => (
+  <svg width='20' height='20' viewBox='0 -960 960 960' style={{ fill: 'currentColor' }} aria-hidden='true'>
+    <path d='M680-80v-120H560v-80h120v-120h80v120h120v80H760v120h-80ZM200-200v-200h80v120h120v80H200Zm0-360v-200h200v80H280v120h-80Zm480 0v-120H560v-80h200v200h-80Z'/>
+  </svg>
+);
+
+export const DownloadIcon: React.FC = () => (
+  <svg width='20' height='20' viewBox='0 -960 960 960' style={{ fill: 'currentColor' }} aria-hidden='true'>
+    <path d='M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z'/>
+  </svg>
+);
+
 export const ReloadIcon: React.FC = () => (
   <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
     <polyline points='23 4 23 10 17 10'/>

--- a/packages/dashboard/src/settingsView.css
+++ b/packages/dashboard/src/settingsView.css
@@ -21,22 +21,13 @@
 .settings-gear-btn {
   width: 28px;
   height: 28px;
-  border-radius: 6px;
+  justify-content: center;
 }
 
 .settings-gear-btn svg {
   width: 16px;
   height: 16px;
   fill: currentColor;
-}
-
-.settings-gear-btn:hover {
-  background: var(--color-neutral-subtle);
-}
-
-.settings-gear-btn.open {
-  background: var(--color-neutral-muted);
-  color: var(--color-fg-default);
 }
 
 .settings-popup {

--- a/packages/dashboard/src/settingsView.tsx
+++ b/packages/dashboard/src/settingsView.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import './settingsView.css';
 import { kThemeOptions, type Theme, useThemeSetting } from '@web/theme';
+import { ToolbarButton } from '@web/components/toolbarButton';
 import { GearIcon } from './icons';
 
 export const SettingsButton: React.FC = () => {
@@ -45,13 +46,14 @@ export const SettingsButton: React.FC = () => {
 
   return (
     <div ref={containerRef} className='settings-button-container'>
-      <button
-        className={'settings-gear-btn' + (open ? ' open' : '')}
+      <ToolbarButton
+        className='settings-gear-btn'
         title='Settings'
+        toggled={open}
         onClick={() => setOpen(!open)}
       >
         <GearIcon />
-      </button>
+      </ToolbarButton>
       {open && (
         <div className='settings-popup'>
           <div className='setting-row'>

--- a/packages/web/src/components/DEPS.list
+++ b/packages/web/src/components/DEPS.list
@@ -1,6 +1,7 @@
 [*]
 ../theme.ts
 ../third_party/vscode/codicon.css
+../third_party/vscode/colors.css
 ../uiUtils.ts
 ../ansi2html.ts
 ../shared

--- a/packages/web/src/components/toolbarButton.css
+++ b/packages/web/src/components/toolbarButton.css
@@ -25,6 +25,7 @@
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  border-radius: 4px;
 }
 
 .toolbar-button:disabled {

--- a/packages/web/src/components/toolbarButton.tsx
+++ b/packages/web/src/components/toolbarButton.tsx
@@ -14,6 +14,7 @@
   limitations under the License.
 */
 
+import '../third_party/vscode/colors.css';
 import './toolbarButton.css';
 import '../third_party/vscode/codicon.css';
 import * as React from 'react';

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -145,7 +145,7 @@ async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page
   await dashboard.mouse.up();
   await dashboard.locator('.annotation-textarea').fill(text);
   await dashboard.locator('.annotation-textarea').press('Enter');
-  await dashboard.locator('.annotate-action-btn.primary').click();
+  await dashboard.getByRole('button', { name: 'Submit annotation' }).click();
 }
 
 function verifyAnnotateOutput(output: string, expectedText: string, outputDir: string) {
@@ -199,39 +199,6 @@ test('should start dashboard and annotate when no dashboard is running', async (
   expect(done).toBe(true);
   expect(exitCode).toBe(0);
   verifyAnnotateOutput(output, 'hi', test.info().outputDir);
-});
-
-test('should keep CLI annotate engaged across mode switches', async ({ connectToDashboard, cli, server }) => {
-  await cli('open', server.EMPTY_PAGE);
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  await cli('show', { bindTitle });
-  const browser = await connectToDashboard(bindTitle);
-
-  const dashboard = browser.contexts()[0].pages()[0];
-  await dashboard.locator('.sidebar-tab').first().click();
-
-  const annotatePromise = cli('show', '--annotate');
-  let done = false;
-  void annotatePromise.finally(() => { done = true; });
-
-  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
-
-  await dashboard.locator('.mode-toggle.mode-interactive').click();
-  await expect(dashboard.locator('div.dashboard-view')).toHaveClass(/interactive/);
-  await expect(dashboard.locator('div.dashboard-view')).not.toHaveClass(/annotate/);
-
-  const box = await dashboard.locator('img#display').boundingBox();
-  await dashboard.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
-
-  await dashboard.locator('.mode-toggle.mode-annotate').click();
-  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
-
-  await drawAndSubmitAnnotation(dashboard, 'round-trip');
-
-  const { output, exitCode } = await annotatePromise;
-  expect(done).toBe(true);
-  expect(exitCode).toBe(0);
-  verifyAnnotateOutput(output, 'round-trip', test.info().outputDir);
 });
 
 test('should enter annotate mode on fresh dashboard.tsx mount with -s --annotate', async ({ connectToDashboard, cli, server }) => {
@@ -376,22 +343,7 @@ async function installSaveFilePickerMock(page: import('playwright-core').Page): 
   };
 }
 
-test('screenshot writes PNG bytes to the chosen file', async ({ cli, server, page, startDashboardServer }) => {
-  await cli('open', server.EMPTY_PAGE);
-  const awaitBytes = await installSaveFilePickerMock(page);
-
-  const dashboard = await startDashboardServer();
-  await dashboard.locator('.sidebar-tab').first().click();
-  await expect(dashboard.locator('img#display')).toBeVisible();
-  await expect(dashboard.locator('.screenshot')).toBeEnabled();
-
-  await dashboard.locator('.screenshot').click();
-
-  const bytes = await awaitBytes();
-  expect(bytes.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
-});
-
-test('stop recording streams WebM bytes to the chosen file', async ({ cli, server, page, startDashboardServer }) => {
+test('save recording streams WebM bytes to the chosen file', async ({ cli, server, page, startDashboardServer }) => {
   await cli('open', server.EMPTY_PAGE);
   const awaitBytes = await installSaveFilePickerMock(page);
 
@@ -399,11 +351,15 @@ test('stop recording streams WebM bytes to the chosen file', async ({ cli, serve
   await dashboard.locator('.sidebar-tab').first().click();
   await expect(dashboard.locator('img#display')).toBeVisible();
 
-  const recordBtn = dashboard.locator('.recording');
-  await expect(recordBtn).toBeEnabled();
-  await recordBtn.click();
+  // Enter recording mode from the normal toolbar.
+  await dashboard.getByRole('button', { name: 'Record video' }).click();
   await expect(dashboard.locator('.recording-label')).toBeVisible();
-  await recordBtn.click();
+
+  // Click the toggled record button again to transition to the 'stopped' phase.
+  await dashboard.getByRole('button', { name: 'Stop recording' }).click();
+
+  // Save the recording.
+  await dashboard.getByRole('button', { name: 'Save recording' }).click();
 
   const bytes = await awaitBytes();
   // WebM files start with the EBML magic bytes.


### PR DESCRIPTION
## Summary
- Annotation mode is now a distinct modal view: the main toolbar is replaced with Clear / Submit (CLI only) / Save / Close actions, and the viewport renders just the frozen screenshot (no browser chrome) inside a blue glow frame.
- Recording mode follows the same pattern: Record / Save / Close toolbar, red glow, chrome-less live screencast while recording, and a native `<video controls>` playback view once stopped.
- Settings gear now uses the shared `ToolbarButton`; hover/toggled/disabled styles consolidated in dashboard `common.css` so every toolbar button picks them up.
- Icon refresh: lock / lock-open for interactive, screenshot-region for annotate, Material download for Save.
- Standalone screenshot button removed (covered by annotate + Save). Tests updated to role-based locators.