### PR TITLE
fix(screencast): deliver cached last frame to additional clients

### DIFF
--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -42,6 +42,7 @@ export class Screencast implements InstrumentationListener {
   private _clients = new Set<ScreencastClient>();
   private _actions: ActionOptions | undefined;
   private _size: types.Size | undefined;
+  private _lastFrame: types.ScreencastFrame | undefined;
 
   constructor(page: Page) {
     this.page = page;
@@ -73,9 +74,20 @@ export class Screencast implements InstrumentationListener {
   }
 
   addClient(client: ScreencastClient): { size: types.Size } {
+    const isFirst = this._clients.size === 0;
     this._clients.add(client);
-    if (this._clients.size === 1)
+    if (isFirst) {
       this._startScreencast(client.size, client.quality);
+    } else if (this._lastFrame) {
+      // Deliver the cached last frame to the new client so it does not have
+      // to wait for the next browser repaint. setTimeout(0) ensures the caller
+      // of addClient() finishes before the frame is dispatched.
+      const frame = this._lastFrame;
+      setTimeout(() => {
+        if (this._clients.has(client))
+          void client.onFrame(frame);
+      }, 0);
+    }
     return { size: this._size! };
   }
 
@@ -112,10 +124,12 @@ export class Screencast implements InstrumentationListener {
   }
 
   private _stopScreencast() {
+    this._lastFrame = undefined;
     this.page.delegate.stopScreencast();
   }
 
   onScreencastFrame(frame: types.ScreencastFrame, ack?: () => void) {
+    this._lastFrame = frame;
     const asyncResults: Promise<void>[] = [];
     for (const client of this._clients) {
       const result = client.onFrame(frame);

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -574,8 +574,6 @@ class AttachedPage {
       size: { width: 1280, height: 800 },
       ...(this._recordingPath ? { path: this._recordingPath } : {}),
     });
-    // TODO: this is necessary to trigger a first frame - should this be in screencast.start() implementation?
-    await page.screenshot().catch(() => {});
   }
 
   private async _restartScreencast(page: api.Page) {

--- a/tests/library/multiclient.spec.ts
+++ b/tests/library/multiclient.spec.ts
@@ -16,6 +16,7 @@
 
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { expect, playwrightTest } from '../config/browserTest';
+import { ensureSomeFrames } from '../config/utils';
 import type { Browser, BrowserContext, BrowserServer, ConnectOptions, Page } from 'playwright-core';
 
 type ExtraFixtures = {
@@ -379,6 +380,30 @@ test('should avoid side effects upon disconnect', async ({ twoPages, server }) =
 
   expect(error.message).toContain(kTargetClosedErrorMessage);
   expect(counter).toBe(savedCounter);
+});
+
+test('screencast should deliver cached last frame to a new client', async ({ twoPages, server, trace, video }) => {
+  test.skip(trace === 'on', 'trace=on has screencast active on the page already');
+  test.skip(video === 'on', 'video=on has screencast active on the page already');
+
+  const { pageA, pageB } = twoPages;
+  await pageA.goto(server.EMPTY_PAGE);
+  await pageA.evaluate(() => document.body.style.backgroundColor = 'red');
+
+  const framesA: Buffer[] = [];
+  await pageA.screencast.start({ onFrame: ({ data }) => framesA.push(data), size: { width: 320, height: 240 } });
+  await ensureSomeFrames(pageA);
+  expect(framesA.length).toBeGreaterThan(0);
+  const lastFrameA = framesA[framesA.length - 1];
+
+  const framesB: Buffer[] = [];
+  await pageB.screencast.start({ onFrame: ({ data }) => framesB.push(data) });
+  // Second client should receive the cached last frame without waiting for a browser repaint.
+  await expect.poll(() => framesB.length, { timeout: 5000 }).toBeGreaterThan(0);
+  expect(framesB[0].equals(lastFrameA)).toBe(true);
+
+  await pageA.screencast.stop();
+  await pageB.screencast.stop();
 });
 
 test('should stop tracing upon disconnect', async ({ twoPages, trace }) => {


### PR DESCRIPTION
## Summary
- Cache the last screencast frame on the server and, when another client joins an already-active screencast, deliver it on the next tick.
- Drop the dashboard's `page.screenshot()` workaround that forced a first frame.

Fixes https://github.com/microsoft/playwright/issues/40349