### PR TITLE
devops(mcp): skip MCP tests on extension-only changes

### DIFF
--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -9,8 +9,10 @@ on:
     paths-ignore:
       - 'browser_patches/**'
       - 'docs/**'
+      - 'packages/extension/**'
       - 'packages/playwright-core/src/server/bidi/**'
       - 'tests/bidi/**'
+      - 'tests/extension/**'
     branches:
       - main
       - release-*


### PR DESCRIPTION
## Summary
- Add `packages/extension/**` and `tests/extension/**` to `paths-ignore` in the MCP workflow so MCP tests are skipped for extension-only PRs.