### PR TITLE
chore(extension): simplify tab attach/detach plumbing

### DIFF
--- a/packages/extension/src/connectedTabGroup.ts
+++ b/packages/extension/src/connectedTabGroup.ts
@@ -50,9 +50,6 @@ export class ConnectedTabGroup {
   private _connection: RelayConnection;
   private _groupId: number | null = null;
   private _groupTabIds: Set<number> = new Set();
-  // Subset of `_groupTabIds` the debugger is actually attached to; drives the
-  // badge. A chrome:// tab can sit in the group without being attached.
-  private _attachedTabIds: Set<number> = new Set();
   private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
   private _onTabRemovedListener: (tabId: number) => void;
 
@@ -82,43 +79,41 @@ export class ConnectedTabGroup {
 
   private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab): void {
     if (changeInfo.groupId !== undefined)
-      this._onTabGroupChanged(tabId, changeInfo.groupId, tab.url);
+      this._onTabGroupChanged(tabId, tab);
     if (changeInfo.url === undefined)
       return;
     // Chrome resets per-tab badge state on navigation, so re-apply it.
-    if (this._attachedTabIds.has(tabId))
+    if (this._connection.attachedTabs.has(tabId))
       void this._updateBadge(tabId, CONNECTED_BADGE);
     else if (this._groupTabIds.has(tabId) && !isNonDebuggableUrl(changeInfo.url))
-      void this._connection.attachTab(tabId);
+      this._connection.attachTab(tab);
   }
 
   // Single entry point for group membership changes, whether the user dragged
   // or we grouped the tab ourselves. Attaches on entry (if debuggable) and
   // detaches on exit; a chrome:// tab stays in the group until it navigates
   // (handled in _onTabUpdated).
-  private _onTabGroupChanged(tabId: number, newGroupId: number, url: string | undefined): void {
-    const inOurGroup = this._groupId !== null && newGroupId === this._groupId;
+  private _onTabGroupChanged(tabId: number, tab: chrome.tabs.Tab): void {
+    const inOurGroup = this._groupId !== null && tab.groupId === this._groupId;
     const wasInGroup = this._groupTabIds.has(tabId);
     if (inOurGroup === wasInGroup)
       return;
     if (inOurGroup) {
       this._groupTabIds.add(tabId);
-      if (!isNonDebuggableUrl(url))
-        void this._connection.attachTab(tabId);
+      if (!isNonDebuggableUrl(tab.url))
+        this._connection.attachTab(tab);
     } else {
       this._groupTabIds.delete(tabId);
-      if (this._attachedTabIds.has(tabId))
-        void this._connection.detachTab(tabId);
+      if (this._connection.attachedTabs.has(tabId))
+        this._connection.detachTab(tabId);
     }
   }
 
   private _onTabRemoved(tabId: number): void {
     this._groupTabIds.delete(tabId);
-    this._attachedTabIds.delete(tabId);
   }
 
   private _onTabAttached(tabId: number): void {
-    this._attachedTabIds.add(tabId);
     void this._updateBadge(tabId, CONNECTED_BADGE);
     void this._addTabToGroup(tabId);
   }
@@ -127,18 +122,14 @@ export class ConnectedTabGroup {
   // badge but leave the tab in the group — the user's intent is still there,
   // and a subsequent navigation will re-attach via _onTabUpdated.
   private _onTabDetached(tabId: number): void {
-    this._attachedTabIds.delete(tabId);
     void this._updateBadge(tabId, { text: '' });
   }
 
   private _onConnectionClose(): void {
     chrome.tabs.onUpdated.removeListener(this._onTabUpdatedListener);
     chrome.tabs.onRemoved.removeListener(this._onTabRemovedListener);
-    const attachedIds = [...this._attachedTabIds];
     const groupTabs = [...this._groupTabIds];
-    this._attachedTabIds.clear();
     this._groupTabIds.clear();
-    attachedIds.forEach(id => void this._updateBadge(id, { text: '' }));
     if (groupTabs.length) {
       this._retryOnDrag(() => chrome.tabs.ungroup(groupTabs)).catch(error => {
         debugLog('Error ungrouping tabs on close:', error);

--- a/packages/extension/src/protocolHandlers.ts
+++ b/packages/extension/src/protocolHandlers.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { debugLog } from './relayConnection';
-
 export type ProtocolCommand = {
   id: number;
   method: string;
@@ -42,7 +40,7 @@ export interface ProtocolHandler {
   forwardChromeEvent(fullMethod: string, args: any[]): void;
   // The UI added a tab to the Playwright group. Handler tells the relay the
   // tab is now available; the relay attaches via the usual command path.
-  onUserAttachRequest(tabId: number): Promise<void>;
+  onUserAttachRequest(tab: chrome.tabs.Tab): void;
   // The UI removed a tab. RelayConnection has already detached the debugger
   // and called notifyTabDetached; the handler only sends the wire-level
   // detach notification (if the protocol has one).
@@ -96,7 +94,7 @@ export class ProtocolV1Handler implements ProtocolHandler {
     });
   }
 
-  async onUserAttachRequest(_tabId: number): Promise<void> {
+  onUserAttachRequest(_tab: chrome.tabs.Tab): void {
     // v1 is single-tab by design; dragging extra tabs into the group is a no-op.
   }
 
@@ -148,15 +146,10 @@ export class ProtocolV2Handler implements ProtocolHandler {
     this._context.sendMessage({ method: fullMethod, params: args });
   }
 
-  async onUserAttachRequest(tabId: number): Promise<void> {
+  onUserAttachRequest(tab: chrome.tabs.Tab): void {
     // Simulate a "new tab opened" event; the relay responds by calling
     // chrome.debugger.attach, which flows through handleCommand.
-    try {
-      const tab = await chrome.tabs.get(tabId);
-      this._context.sendMessage({ method: 'chrome.tabs.onCreated', params: [tab] });
-    } catch (error: any) {
-      debugLog('Error requesting attach for tab:', error);
-    }
+    this._context.sendMessage({ method: 'chrome.tabs.onCreated', params: [tab] });
   }
 
   onUserDetachRequest(tabId: number): void {

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -59,6 +59,10 @@ export class RelayConnection {
   ontabattached?: (tabId: number) => void;
   ontabdetached?: (tabId: number) => void;
 
+  get attachedTabs(): ReadonlySet<number> {
+    return this._attachedTabs;
+  }
+
   constructor(ws: WebSocket, protocolVersion: number) {
     this._ws = ws;
     this._selectedTabPromise = new Promise(resolve => this._selectedTabResolve = resolve);
@@ -91,23 +95,21 @@ export class RelayConnection {
 
   // Called when the UI adds a tab to the Playwright group. The handler asks
   // the relay to attach; the normal command path fires ontabattached.
-  async attachTab(tabId: number): Promise<void> {
-    if (this._closed || this._attachedTabs.has(tabId))
+  attachTab(tab: chrome.tabs.Tab): void {
+    if (this._closed || this._attachedTabs.has(tab.id!))
       return;
-    await this._handler.onUserAttachRequest(tabId);
+    this._handler.onUserAttachRequest(tab);
   }
 
   // Called when the UI removes a tab from the Playwright group. We detach the
   // debugger and update bookkeeping; the handler emits the wire-level detach
   // notification for protocols that have one.
-  async detachTab(tabId: number): Promise<void> {
+  detachTab(tabId: number): void {
     if (this._closed || !this._attachedTabs.has(tabId))
       return;
-    try {
-      await chrome.debugger.detach({ tabId });
-    } catch (error: any) {
+    chrome.debugger.detach({ tabId }).catch(error => {
       debugLog('Error detaching tab:', error);
-    }
+    });
     this._notifyTabDetached(tabId);
     this._handler.onUserDetachRequest(tabId);
     this._checkLastTabDetached();
@@ -142,9 +144,10 @@ export class RelayConnection {
     for (const l of this._eventListeners)
       l.remove();
     this._eventListeners = [];
-    for (const tabId of this._attachedTabs)
+    for (const tabId of [...this._attachedTabs]) {
       chrome.debugger.detach({ tabId }).catch(() => {});
-    this._attachedTabs.clear();
+      this._notifyTabDetached(tabId);
+    }
     this.onclose?.();
   }
 


### PR DESCRIPTION
## Summary

- `onUserAttachRequest` takes a `Tab` and is sync; V2 handler drops the `chrome.tabs.get` round-trip.
- `RelayConnection.attachTab`/`detachTab` are sync.
- `_onTabGroupChanged` takes a `Tab` and reads `tab.groupId` instead of a separate param.
- Drop the `_attachedTabIds` mirror in `ConnectedTabGroup` — expose `RelayConnection.attachedTabs` and notify detached tabs on connection close so badge cleanup flows through `ontabdetached`.