### PR TITLE
feat: support ConnectOptions in remoteEndpoint for exposeNetwork

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -136,7 +136,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   const endpoint = config.browser.remoteEndpoint!;
   const playwrightObject = playwright as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
-  const browser = await connectToBrowser(playwrightObject, { endpoint });
+  const browser = await connectToBrowser(playwrightObject, { endpoint, exposeNetwork: config.browser.exposeNetwork });
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
   return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
 }

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -135,10 +135,11 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
     };
   }
 
-  const endpoint = config.browser.remoteEndpoint!;
+  const remoteEndpoint = config.browser.remoteEndpoint!;
+  const connectOptions = typeof remoteEndpoint === 'string' ? { endpoint: remoteEndpoint } : remoteEndpoint;
   const playwrightObject = playwright as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
-  const browser = await connectToBrowser(playwrightObject, { endpoint, exposeNetwork: config.browser.exposeNetwork });
+  const browser = await connectToBrowser(playwrightObject, connectOptions);
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
   return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
 }

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -119,7 +119,9 @@ async function createCDPBrowser(config: FullConfig): Promise<playwrightTypes.Bro
 
 async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo> {
   testDebug('create browser (remote)');
-  const descriptor = await serverRegistry.find(config.browser.remoteEndpoint!);
+  const remoteEndpoint = config.browser.remoteEndpoint!;
+  const endpoint = typeof remoteEndpoint === 'string' ? remoteEndpoint : remoteEndpoint.endpoint;
+  const descriptor = await serverRegistry.find(endpoint);
   if (descriptor) {
     const browser = await connectToBrowserAcrossVersions(descriptor);
     return {
@@ -135,7 +137,6 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
     };
   }
 
-  const remoteEndpoint = config.browser.remoteEndpoint!;
   const connectOptions = typeof remoteEndpoint === 'string' ? { endpoint: remoteEndpoint } : remoteEndpoint;
   const playwrightObject = playwright as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -138,7 +138,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   const endpoint = config.browser.remoteEndpoint!;
   const playwrightObject = playwright as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
-  const browser = await connectToBrowser(playwrightObject, { endpoint });
+  const browser = await connectToBrowser(playwrightObject, { endpoint, exposeNetwork: config.browser.exposeNetwork });
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
   return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
 }

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -87,6 +87,14 @@ export type Config = {
     remoteEndpoint?: string;
 
     /**
+     * Expose network for remote browser connections. When set to `'<loopback>'`,
+     * the remote browser can access localhost on the client machine via SOCKS proxy tunneling.
+     * Only applies when `remoteEndpoint` is configured.
+     * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect-option-expose-network
+     */
+    exposeNetwork?: string;
+
+    /**
      * Paths to TypeScript files to add as initialization scripts for Playwright page.
      */
     initPage?: string[];

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -83,16 +83,18 @@ export type Config = {
 
     /**
      * Remote endpoint to connect to an existing Playwright server.
+     * Can be a URL string or a ConnectOptions object for advanced configuration
+     * (e.g. `exposeNetwork`, `headers`, `slowMo`, `timeout`).
+     * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect
      */
-    remoteEndpoint?: string;
-
-    /**
-     * Expose network for remote browser connections. When set to `'<loopback>'`,
-     * the remote browser can access localhost on the client machine via SOCKS proxy tunneling.
-     * Only applies when `remoteEndpoint` is configured.
-     * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect-option-expose-network
-     */
-    exposeNetwork?: string;
+    remoteEndpoint?: string | {
+      endpoint: string;
+      browserName?: string;
+      headers?: Record<string, string>;
+      exposeNetwork?: string;
+      slowMo?: number;
+      timeout?: number;
+    };
 
     /**
      * Paths to TypeScript files to add as initialization scripts for Playwright page.

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -30,17 +30,6 @@ export type ToolCapability =
   'vision' |
   'devtools';
 
-/**
- * Options for connecting to a remote Playwright server.
- * Extends `playwright.ConnectOptions` with a required `endpoint` field.
- */
-export type ConnectOptions = playwright.ConnectOptions & {
-  /**
-   * A Playwright server URL to connect to.
-   */
-  endpoint: string;
-};
-
 export type Config = {
   /**
    * The browser to use.
@@ -98,7 +87,7 @@ export type Config = {
      * (e.g. `exposeNetwork`, `headers`, `slowMo`, `timeout`).
      * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect
      */
-    remoteEndpoint?: string | ConnectOptions;
+    remoteEndpoint?: string | playwright.ConnectOptions & { endpoint: string };
 
     /**
      * Paths to TypeScript files to add as initialization scripts for Playwright page.

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -30,6 +30,17 @@ export type ToolCapability =
   'vision' |
   'devtools';
 
+/**
+ * Options for connecting to a remote Playwright server.
+ * Extends `playwright.ConnectOptions` with a required `endpoint` field.
+ */
+export type ConnectOptions = playwright.ConnectOptions & {
+  /**
+   * A Playwright server URL to connect to.
+   */
+  endpoint: string;
+};
+
 export type Config = {
   /**
    * The browser to use.
@@ -87,14 +98,7 @@ export type Config = {
      * (e.g. `exposeNetwork`, `headers`, `slowMo`, `timeout`).
      * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect
      */
-    remoteEndpoint?: string | {
-      endpoint: string;
-      browserName?: string;
-      headers?: Record<string, string>;
-      exposeNetwork?: string;
-      slowMo?: number;
-      timeout?: number;
-    };
+    remoteEndpoint?: string | ConnectOptions;
 
     /**
      * Paths to TypeScript files to add as initialization scripts for Playwright page.

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -174,7 +174,7 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   expect(config.browser.isolated).toBe(true);
 });
 
-test('remoteEndpoint as ConnectOptions object', async ({ startClient, server, wsEndpoint }) => {
+test('remoteEndpoint as ConnectOptions object', async ({ startClient, wsEndpoint }) => {
   const { client } = await startClient({
     config: {
       browser: {
@@ -186,10 +186,11 @@ test('remoteEndpoint as ConnectOptions object', async ({ startClient, server, ws
     },
   });
 
-  expect(await client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX },
-  })).toHaveResponse({
-    snapshot: expect.stringContaining('Hello, world!'),
+  // Verify the object form of remoteEndpoint connects successfully
+  // by taking a snapshot of the default blank page.
+  const result = await client.callTool({
+    name: 'browser_snapshot',
   });
+
+  expect(result.isError).toBeFalsy();
 });

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -173,3 +173,36 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   // From CLI arg (--isolated).
   expect(config.browser.isolated).toBe(true);
 });
+
+test('remoteEndpoint as ConnectOptions object with exposeNetwork', async ({ startClient, server, wsEndpoint }) => {
+  server.setRoute('/remote-test.html', (req, res) => {
+    res.end('<html><body>remote-expose-network</body></html>');
+  });
+
+  const { client } = await startClient({
+    config: {
+      browser: {
+        remoteEndpoint: {
+          endpoint: wsEndpoint,
+          exposeNetwork: '*',
+        },
+        isolated: true,
+      },
+    },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + '/remote-test.html' },
+  });
+
+  expect(result.isError).toBeFalsy();
+
+  const snapshot = await client.callTool({
+    name: 'browser_snapshot',
+  });
+
+  expect(snapshot).toHaveResponse({
+    include: ['remote-expose-network'],
+  });
+});

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -174,7 +174,12 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   expect(config.browser.isolated).toBe(true);
 });
 
-test('remoteEndpoint as ConnectOptions object', async ({ startClient, wsEndpoint }) => {
+test('remoteEndpoint as ConnectOptions object', async ({ startClient, server, wsEndpoint }) => {
+  server.setContent('/', `
+    <title>Title</title>
+    <body>Hello, world!</body>
+  `, 'text/html');
+
   const { client } = await startClient({
     config: {
       browser: {
@@ -186,11 +191,10 @@ test('remoteEndpoint as ConnectOptions object', async ({ startClient, wsEndpoint
     },
   });
 
-  // Verify the object form of remoteEndpoint connects successfully
-  // by taking a snapshot of the default blank page.
-  const result = await client.callTool({
-    name: 'browser_snapshot',
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining('Hello, world!'),
   });
-
-  expect(result.isError).toBeFalsy();
 });

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -174,35 +174,22 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   expect(config.browser.isolated).toBe(true);
 });
 
-test('remoteEndpoint as ConnectOptions object with exposeNetwork', async ({ startClient, server, wsEndpoint }) => {
-  server.setRoute('/remote-test.html', (req, res) => {
-    res.end('<html><body>remote-expose-network</body></html>');
-  });
-
+test('remoteEndpoint as ConnectOptions object', async ({ startClient, server, wsEndpoint }) => {
   const { client } = await startClient({
     config: {
       browser: {
         remoteEndpoint: {
           endpoint: wsEndpoint,
-          exposeNetwork: '*',
         },
         isolated: true,
       },
     },
   });
 
-  const result = await client.callTool({
+  expect(await client.callTool({
     name: 'browser_navigate',
-    arguments: { url: server.PREFIX + '/remote-test.html' },
-  });
-
-  expect(result.isError).toBeFalsy();
-
-  const snapshot = await client.callTool({
-    name: 'browser_snapshot',
-  });
-
-  expect(snapshot).toHaveResponse({
-    include: ['remote-expose-network'],
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining('Hello, world!'),
   });
 });

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -198,3 +198,29 @@ test('remoteEndpoint as ConnectOptions object', async ({ startClient, server, ws
     snapshot: expect.stringContaining('Hello, world!'),
   });
 });
+
+test('remoteEndpoint as ConnectOptions object with exposeNetwork', async ({ startClient, server, wsEndpoint }) => {
+  server.setContent('/', `
+    <title>Title</title>
+    <body>exposed-network-content</body>
+  `, 'text/html');
+
+  const { client } = await startClient({
+    config: {
+      browser: {
+        remoteEndpoint: {
+          endpoint: wsEndpoint,
+          exposeNetwork: '*',
+        },
+        isolated: true,
+      },
+    },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining('exposed-network-content'),
+  });
+});


### PR DESCRIPTION
Fixes #40478

## Problem

When using `playwright-cli` with a remote browser endpoint via config, `exposeNetwork` (and other `ConnectOptions`) cannot be passed through to the `connectToBrowser` call. This prevents users from accessing `localhost` on the client machine from the remote browser (via SOCKS proxy tunneling).

## Solution

Per @dgozman's suggestion, change `remoteEndpoint` from `string` to `string | playwright.ConnectOptions & { endpoint: string }`:

```ts
remoteEndpoint?: string | playwright.ConnectOptions & { endpoint: string };
// Expands to: string | { endpoint: string; exposeNetwork?: string; headers?: Record<string, string>; slowMo?: number; timeout?: number }
```

This removes the previously proposed separate `exposeNetwork` field and instead mirrors the existing `ConnectOptions` shape from Playwright's API (same pattern as `browserType.connect(options: api.ConnectOptions & { wsEndpoint: string })` elsewhere in the codebase).

### Usage

**Simple (existing behavior):**
```json
{ "browser": { "remoteEndpoint": "wss://..." } }
```

**With options:**
```json
{
  "browser": {
    "remoteEndpoint": {
      "endpoint": "wss://...",
      "exposeNetwork": "*",
      "headers": { "x-custom": "value" }
    }
  }
}
```

### Changes
- `config.d.ts`: `remoteEndpoint?: string | playwright.ConnectOptions & { endpoint: string }` (inline intersection), removed separate `exposeNetwork` field
- `browserFactory.ts`: Extracts `endpoint` string for `serverRegistry.find()`, then builds `connectOptions` from the union — if string, wraps as `{ endpoint }`, otherwise passes as-is to `connectToBrowser`
- `tests/mcp/config.spec.ts`: Added test for `remoteEndpoint` as ConnectOptions object with `exposeNetwork: '*'` — connects to a remote browser, navigates to a local server route, and verifies content is accessible