### PR TITLE
feat(dashboard): use ListView for session tabs sidebar

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -239,9 +239,10 @@ export const Dashboard: React.FC<DashboardProps> = ({ model }) => {
   }
 
   const overlayText = selectedTab ? undefined : 'Select a session';
+  const modeLabel = annotating ? 'Dashboard: annotate' : recording ? 'Dashboard: record' : 'Dashboard';
 
   return (
-    <div className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '') + (recording ? ' recording' : '')}>
+    <main className={'dashboard-view' + (interactive ? ' interactive' : '') + (annotating ? ' annotate' : '') + (recording ? ' recording' : '')} aria-label={modeLabel}>
       {/* Toolbar */}
       <div ref={toolbarRef} className='toolbar'>
         {annotating ? (
@@ -468,6 +469,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ model }) => {
           )}
         </div>
       </div>
-    </div>
+    </main>
   );
 };

--- a/packages/dashboard/src/sessionSidebar.css
+++ b/packages/dashboard/src/sessionSidebar.css
@@ -214,21 +214,18 @@
   background: var(--color-neutral-muted);
 }
 
-.sidebar-tab-list {
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.sidebar-tabs-loading,
-.sidebar-tabs-empty {
+.sidebar-tabs-loading {
   color: var(--color-fg-subtle);
   font-size: 12px;
   padding: 4px 12px 6px 38px;
+  margin: 0;
+  flex: none;
+  display: block;
+  justify-content: flex-start;
+  text-align: left;
 }
 
-.sidebar-tab {
+.sidebar-session .list-view-entry {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -236,15 +233,11 @@
   color: var(--color-fg-muted);
   border-radius: 0;
   padding: 4px 4px 4px 24px;
+  line-height: 1.4;
 }
 
-.sidebar-tab:hover {
+.sidebar-session .list-view-entry:hover {
   background: var(--color-neutral-muted);
-}
-
-.sidebar-tab.active {
-  background: var(--color-neutral-subtle);
-  color: var(--color-fg-default);
 }
 
 .sidebar-tab-favicon {
@@ -253,20 +246,6 @@
   flex-shrink: 0;
   margin-top: 0;
   align-self: center;
-}
-
-.sidebar-tab-select {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 1;
-  min-width: 0;
-  cursor: pointer;
-}
-
-.sidebar-tab-select:focus-visible {
-  outline: 1px solid var(--color-accent-emphasis);
-  outline-offset: 2px;
 }
 
 .sidebar-tab-favicon.placeholder {
@@ -313,7 +292,7 @@
   transition: opacity 120ms ease;
 }
 
-.sidebar-tab:hover .sidebar-tab-close,
+.sidebar-session .list-view-entry:hover .sidebar-tab-close,
 .sidebar-tab-close:focus-visible {
   opacity: 1;
   pointer-events: auto;

--- a/packages/dashboard/src/sessionSidebar.tsx
+++ b/packages/dashboard/src/sessionSidebar.tsx
@@ -19,6 +19,7 @@ import './sessionSidebar.css';
 import { SettingsButton } from './settingsView';
 import { BrowserIcon } from './icons';
 import { ToolbarButton } from '@web/components/toolbarButton';
+import { ListView } from '@web/components/listView';
 
 import type { SessionStatus, Tab } from './dashboardChannel';
 import type { DashboardModel } from './dashboardModel';
@@ -26,6 +27,8 @@ import type { DashboardModel } from './dashboardModel';
 type SessionSidebarProps = {
   model: DashboardModel;
 };
+
+const TabListView = ListView<Tab>;
 
 function tabFavicon(url: string): string {
   try {
@@ -51,6 +54,27 @@ function normalizeWorkspacePath(workspace: string, homeDir: string | undefined):
   }
   return normalized;
 }
+
+const TabRow: React.FC<{ tab: Tab; model: DashboardModel }> = ({ tab, model }) => {
+  return <>
+    {tab.faviconUrl
+      ? <img className='sidebar-tab-favicon' src={tab.faviconUrl} alt='' aria-hidden='true' />
+      : <span className='sidebar-tab-favicon placeholder' aria-hidden='true'>{tabFavicon(tab.url)}</span>}
+    <span className='sidebar-tab-text'>
+      <span className='sidebar-tab-title'>{tab.title || 'New Tab'}</span>
+      <span className='sidebar-tab-url'>{tab.url || 'about:blank'}</span>
+    </span>
+    <ToolbarButton
+      className='sidebar-tab-close'
+      icon='close'
+      title='Close tab'
+      onClick={e => {
+        e.stopPropagation();
+        model.closeTab(tab);
+      }}
+    />
+  </>;
+};
 
 export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model }) => {
   const { sessions, clientInfo, loadingSessions, tabs: allTabs } = model.state;
@@ -103,96 +127,71 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model }) => {
       <SettingsButton />
     </div>
     <div className='dashboard-shell-sidebar-content'>
-      {loadingSessions && <div className='sidebar-empty' role='status' aria-live='polite'>Loading sessions...</div>}
-      {!loadingSessions && openSessions.length === 0 && <div className='sidebar-empty' role='status' aria-live='polite'>No open sessions.</div>}
+      {loadingSessions && <p className='sidebar-empty' role='status' aria-live='polite'>Loading sessions...</p>}
+      {!loadingSessions && openSessions.length === 0 && <p className='sidebar-empty' role='status' aria-live='polite'>No open sessions.</p>}
       {workspaceGroups.map(([workspace, entries]) => {
         const workspacePath = normalizeWorkspacePath(workspace, clientInfo?.homeDir);
-        return <section key={workspace} className='workspace-group'>
+        return <section key={workspace} className='workspace-group' aria-label={`Workspace ${workspacePath}`}>
           <h3 className='workspace-header'>
             <span className='workspace-path-full' title={workspacePath}>{workspacePath}</span>
           </h3>
-          <div className='sidebar-session-list' role='list'>
-            {entries.map(session => {
-              const guid = session.browser.guid;
-              const browserType = session.browser.browserName;
-              const channel = session.browser.launchOptions?.channel;
-              const byContext = tabsByBrowserAndContext.get(guid);
-              const contextEntries = byContext ? [...byContext.entries()] : [];
-              const rows: { contextGuid: string | null; tabs: Tab[] | undefined }[] =
-                allTabs === null
-                  ? [{ contextGuid: null, tabs: undefined }]
-                  : contextEntries.length === 0
-                    ? [{ contextGuid: null, tabs: [] }]
-                    : contextEntries.map(([contextGuid, tabs]) => ({ contextGuid, tabs }));
-              return <React.Fragment key={guid}>
-                {rows.map((row, rowIdx) => <div key={row.contextGuid ?? `placeholder-${rowIdx}`} className='session-chip sidebar-session' role='listitem' title={session.title}>
-                  <div className='sidebar-session-row'>
-                    <div className='session-browser-icon-wrap' title={channel || browserType}>
-                      <span className='session-browser-icon' aria-hidden='true'>
-                        <BrowserIcon browserName={browserType} channel={channel} />
-                      </span>
-                      <ToolbarButton
-                        className='session-browser-close'
-                        icon='close'
-                        title='Close session'
-                        onClick={() => model.closeSession(session)}
-                      />
-                    </div>
-                    <span className='session-chip-name'>{session.title}</span>
-                    <div className='sidebar-session-row-actions'>
-                      {row.contextGuid && <ToolbarButton
-                        className='sidebar-session-new-tab'
-                        icon='add'
-                        title='New tab'
-                        onClick={() => model.newTab(guid, row.contextGuid!)}
-                      />}
-                    </div>
+          {entries.map(session => {
+            const guid = session.browser.guid;
+            const browserType = session.browser.browserName;
+            const channel = session.browser.launchOptions?.channel;
+            const byContext = tabsByBrowserAndContext.get(guid);
+            const contextEntries = byContext ? [...byContext.entries()] : [];
+            const rows: { contextGuid: string | null; tabs: Tab[] | undefined }[] =
+              allTabs === null
+                ? [{ contextGuid: null, tabs: undefined }]
+                : contextEntries.length === 0
+                  ? [{ contextGuid: null, tabs: [] }]
+                  : contextEntries.map(([contextGuid, tabs]) => ({ contextGuid, tabs }));
+            return rows.map((row, rowIdx) => {
+              const activeTab = row.tabs?.find(t => t.context === activeContext && t.selected);
+              const rowKey = `${guid}-${row.contextGuid ?? `placeholder-${rowIdx}`}`;
+              return <section
+                key={rowKey}
+                className={'sidebar-session session-chip' + (activeTab ? ' active' : '')}
+                aria-label={`Session ${session.title}`}
+              >
+                <header className='sidebar-session-row'>
+                  <div className='session-browser-icon-wrap' title={channel || browserType}>
+                    <span className='session-browser-icon' aria-hidden='true'>
+                      <BrowserIcon browserName={browserType} channel={channel} />
+                    </span>
+                    <ToolbarButton
+                      className='session-browser-close'
+                      icon='close'
+                      title='Close session'
+                      onClick={() => model.closeSession(session)}
+                    />
                   </div>
-                  <div className='sidebar-tab-list' role='list' aria-label={`${session.title} tabs`}>
-                    {row.tabs === undefined && <div className='sidebar-tabs-loading' role='status' aria-live='polite'>Loading tabs...</div>}
-                    {row.tabs?.length === 0 && <div className='sidebar-tabs-empty' role='status' aria-live='polite'>No tabs open.</div>}
-                    {row.tabs?.map(tab => <div
-                      key={tab.page}
-                      className={'sidebar-tab' + (tab.context === activeContext && tab.selected ? ' active' : '')}
-                      role='listitem'
-                    >
-                      <div
-                        className='sidebar-tab-select'
-                        role='button'
-                        tabIndex={0}
-                        aria-current={tab.context === activeContext && tab.selected ? 'page' : undefined}
-                        title={tab.url || tab.title}
-                        onClick={() => model.selectTab(tab)}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            model.selectTab(tab);
-                          }
-                        }}
-                      >
-                        {tab.faviconUrl
-                          ? <img className='sidebar-tab-favicon' src={tab.faviconUrl} alt='' aria-hidden='true' />
-                          : <span className='sidebar-tab-favicon placeholder' aria-hidden='true'>{tabFavicon(tab.url)}</span>}
-                        <span className='sidebar-tab-text'>
-                          <span className='sidebar-tab-title'>{tab.title || 'New Tab'}</span>
-                          <span className='sidebar-tab-url'>{tab.url || 'about:blank'}</span>
-                        </span>
-                      </div>
-                      <ToolbarButton
-                        className='sidebar-tab-close'
-                        icon='close'
-                        title='Close tab'
-                        onClick={e => {
-                          e.stopPropagation();
-                          model.closeTab(tab);
-                        }}
-                      />
-                    </div>)}
+                  <span className='session-chip-name'>{session.title}</span>
+                  <div className='sidebar-session-row-actions'>
+                    {row.contextGuid && <ToolbarButton
+                      className='sidebar-session-new-tab'
+                      icon='add'
+                      title='New tab'
+                      onClick={() => model.newTab(guid, row.contextGuid!)}
+                    />}
                   </div>
-                </div>)}
-              </React.Fragment>;
-            })}
-          </div>
+                </header>
+                {row.tabs === undefined
+                  ? <p className='sidebar-tabs-loading' role='status' aria-live='polite'>Loading tabs...</p>
+                  : <TabListView
+                    name={`sidebar-tabs-${rowKey}`}
+                    ariaLabel={`${session.title} tabs`}
+                    items={row.tabs}
+                    id={tab => tab.page}
+                    selectedItem={activeTab}
+                    onSelected={tab => model.selectTab(tab)}
+                    noItemsMessage='No tabs open.'
+                    render={tab => <TabRow tab={tab} model={model} />}
+                  />}
+              </section>;
+            });
+          })}
         </section>;
       })}
     </div>

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -116,6 +116,7 @@ export class DashboardConnection implements Transport {
   private _pushTabsScheduled = false;
   private _visible = true;
   private _pendingReveal: { sessionName: string; workspaceDir?: string } | undefined;
+  private _annotateWaitingForAttach = false;
 
   _recordingDir: string;
   _streams = new Map<string, { handle: fs.promises.FileHandle; path: string }>();
@@ -286,10 +287,16 @@ export class DashboardConnection implements Transport {
   }
 
   emitAnnotate() {
+    // Defer until a page is attached so the client can fetch a screenshot.
+    if (!this._attachedPage) {
+      this._annotateWaitingForAttach = true;
+      return;
+    }
     this.sendEvent?.('annotate', {});
   }
 
   emitCancelAnnotate() {
+    this._annotateWaitingForAttach = false;
     this.sendEvent?.('cancelAnnotate', {});
   }
 
@@ -348,6 +355,10 @@ export class DashboardConnection implements Transport {
         this._attachedPage = undefined;
       attached.dispose();
       throw e;
+    }
+    if (this._annotateWaitingForAttach && this._attachedPage === attached) {
+      this._annotateWaitingForAttach = false;
+      this.sendEvent?.('annotate', {});
     }
   }
 

--- a/packages/web/src/components/listView.tsx
+++ b/packages/web/src/components/listView.tsx
@@ -82,7 +82,7 @@ export function ListView<T>({
       itemListRef.current.scrollTop = scrollPositions.get(name) || 0;
   }, [name]);
 
-  return <div className={clsx(`list-view vbox`, name + '-list-view')} role={items.length > 0 ? 'list' : undefined} aria-label={ariaLabel}>
+  return <div className={clsx(`list-view vbox`, name + '-list-view')} role={items.length > 0 ? 'listbox' : undefined} aria-label={ariaLabel}>
     <div
       className={clsx('list-view-content', notSelectable && 'not-selectable')}
       tabIndex={0}
@@ -126,7 +126,7 @@ export function ListView<T>({
         return <div
           key={id?.(item, index) || index}
           onDoubleClick={() => onAccepted?.(item, index)}
-          role='listitem'
+          role='option'
           className={clsx(
               'list-view-entry',
               selectedItem === item && 'selected',

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -58,12 +58,12 @@ class TraceViewerPage {
     this.actionTitles = page.locator('.action-title');
     this.actionsTree = page.getByTestId('actions-tree');
     this.callLines = page.locator('.call-tab .call-line');
-    this.logLines = page.getByRole('list', { name: 'Log entries' }).getByRole('listitem');
-    this.consoleLines = page.getByRole('tabpanel', { name: 'Console' }).getByRole('listitem');
+    this.logLines = page.getByRole('listbox', { name: 'Log entries' }).getByRole('option');
+    this.consoleLines = page.getByRole('tabpanel', { name: 'Console' }).getByRole('option');
     this.consoleLineMessages = page.locator('.console-line-message');
     this.errorMessages = page.locator('.error-message');
     this.consoleStacks = page.locator('.console-stack');
-    this.networkRequests = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+    this.networkRequests = page.getByRole('listbox', { name: 'Network requests' }).getByRole('option');
     this.snapshotContainer = page.locator('.snapshot-container iframe.snapshot-visible[name=snapshot]');
     this.metadataTab = page.getByRole('tabpanel', { name: 'Metadata' });
     this.sourceCodeTab = page.getByRole('tabpanel', { name: 'Source' });
@@ -84,10 +84,7 @@ class TraceViewerPage {
   }
 
   stackFrames(options: { selected?: boolean } = {}) {
-    const entry = this.page.getByRole('list', { name: 'Stack trace' }).getByRole('listitem');
-    if (options.selected)
-      return entry.locator(':scope.selected');
-    return entry;
+    return this.page.getByRole('listbox', { name: 'Stack trace' }).getByRole('option', options);
   }
 
   actionIconsText(action: string) {

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -38,18 +38,18 @@ test('should show browser session chip', async ({ cli, server, startDashboardSer
   await cli('open', server.EMPTY_PAGE);
 
   const dashboard = await startDashboardServer();
-  const chips = dashboard.locator('.session-chip');
-  await expect(chips).toHaveCount(1);
+  const sessions = dashboard.getByRole('region', { name: /^Session / });
+  await expect(sessions).toHaveCount(1);
 });
 
 test('should show placeholder chip for browser with no contexts', async ({ boundBrowser, startDashboardServer }) => {
   expect(boundBrowser.contexts()).toHaveLength(0);
 
   const dashboard = await startDashboardServer();
-  const chips = dashboard.locator('.session-chip');
-  await expect(chips).toHaveCount(1);
-  await expect(chips.locator('.sidebar-tabs-empty')).toHaveText('No tabs open.');
-  await expect(chips.locator('.sidebar-session-new-tab')).toHaveCount(0);
+  const sessions = dashboard.getByRole('region', { name: /^Session / });
+  await expect(sessions).toHaveCount(1);
+  await expect(sessions.getByText('No tabs open.')).toBeVisible();
+  await expect(sessions.getByRole('button', { name: 'New tab' })).toHaveCount(0);
 });
 
 test('should show one row per context for a single browser', async ({ boundBrowser, server, startDashboardServer }) => {
@@ -58,13 +58,13 @@ test('should show one row per context for a single browser', async ({ boundBrows
   await pageA.goto(server.EMPTY_PAGE);
 
   const dashboard = await startDashboardServer();
-  const chips = dashboard.locator('.session-chip');
-  await expect(chips).toHaveCount(1);
+  const sessions = dashboard.getByRole('region', { name: /^Session / });
+  await expect(sessions).toHaveCount(1);
 
   const contextB = await boundBrowser.newContext();
   const pageB = await contextB.newPage();
   await pageB.goto(server.EMPTY_PAGE);
-  await expect(chips).toHaveCount(2);
+  await expect(sessions).toHaveCount(2);
 });
 
 test('should show current workspace sessions first', async ({ cli, server, startDashboardServer }) => {
@@ -79,16 +79,16 @@ test('should show current workspace sessions first', async ({ cli, server, start
 
   const checkOrder = async (first: string, second: string) => {
     const dashboard = await startDashboardServer({ cwd: first });
-    const workspaceGroups = dashboard.locator('.workspace-group');
+    const workspaceGroups = dashboard.getByRole('region', { name: /^Workspace / });
     await expect(workspaceGroups).toHaveCount(2);
 
     // Current workspace (first) should be first.
-    await expect(workspaceGroups.nth(0).locator('.workspace-path-full')).toHaveText(displayPath(first));
-    await expect(workspaceGroups.nth(0).locator('.session-chip')).toHaveCount(1);
+    await expect(workspaceGroups.nth(0).getByRole('heading', { level: 3 })).toHaveText(displayPath(first));
+    await expect(workspaceGroups.nth(0).getByRole('region', { name: /^Session / })).toHaveCount(1);
 
     // Other workspace (second) should be second.
-    await expect(workspaceGroups.nth(1).locator('.workspace-path-full')).toHaveText(displayPath(second));
-    await expect(workspaceGroups.nth(1).locator('.session-chip')).toHaveCount(1);
+    await expect(workspaceGroups.nth(1).getByRole('heading', { level: 3 })).toHaveText(displayPath(second));
+    await expect(workspaceGroups.nth(1).getByRole('region', { name: /^Session / })).toHaveCount(1);
   };
 
   await test.step('open dashboard in workspace A', async () => {
@@ -100,13 +100,16 @@ test('should show current workspace sessions first', async ({ cli, server, start
   });
 });
 
+function activeSession(dashboard: import('playwright-core').Page) {
+  return dashboard.getByRole('region', { name: /^Session / }).filter({ has: dashboard.getByRole('option', { selected: true }) });
+}
+
 test('should activate session when show is called with -s', async ({ cli, server, startDashboardServer }) => {
   await cli('-s=sessA', 'open', server.EMPTY_PAGE);
   await cli('-s=sessB', 'open', server.EMPTY_PAGE);
 
   const dashboard = await startDashboardServer({ session: 'sessB' });
-  const activeSession = dashboard.locator('.sidebar-session:has(.sidebar-tab.active)');
-  await expect(activeSession.locator('.session-chip-name')).toHaveText('sessB');
+  await expect(activeSession(dashboard)).toHaveAccessibleName('Session sessB');
 });
 
 function isAlive(pid: number): boolean {
@@ -133,7 +136,7 @@ test('daemon show: closing page exits the process', async ({ cli, connectToDashb
 });
 
 async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page, text: string) {
-  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
+  await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
   const box = await dashboard.locator('img#display').boundingBox();
   const x0 = box!.x + box!.width * 0.3;
   const y0 = box!.y + box!.height * 0.3;
@@ -165,7 +168,7 @@ test('should capture annotations via show --annotate', async ({ connectToDashboa
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
-  await dashboard.locator('.sidebar-tab').first().click();
+  await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotatePromise = cli('show', '--annotate');
   let done = false;
@@ -213,9 +216,8 @@ test('should enter annotate mode on fresh dashboard.tsx mount with -s --annotate
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
-    await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
-    const activeSession = dashboard.locator('.sidebar-session:has(.sidebar-tab.active)');
-    await expect(activeSession.locator('.session-chip-name')).toHaveText('second');
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+    await expect(activeSession(dashboard)).toHaveAccessibleName('Session second');
     await drawAndSubmitAnnotation(dashboard, 'fresh');
   } finally {
     await browser.close().catch(() => {});
@@ -261,9 +263,8 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   let done = false;
   void annotatePromise.finally(() => { done = true; });
 
-  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
-  const activeSession = dashboard.locator('.sidebar-session:has(.sidebar-tab.active)');
-  await expect(activeSession.locator('.session-chip-name')).toHaveText('second');
+  await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+  await expect(activeSession(dashboard)).toHaveAccessibleName('Session second');
 
   await expect.poll(async () => {
     const c = await sampleCenter();
@@ -283,7 +284,7 @@ test('should disengage annotate mode when --annotate client disconnects', async 
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
-  await dashboard.locator('.sidebar-tab').first().click();
+  await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotateClient = childProcess({
     command: [process.execPath, require.resolve('../../packages/playwright-core/lib/tools/cli-client/cli.js'), 'show', '--annotate'],
@@ -295,11 +296,11 @@ test('should disengage annotate mode when --annotate client disconnects', async 
     }),
   });
 
-  await expect(dashboard.locator('div.dashboard-view.annotate')).toBeVisible();
+  await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
 
   await annotateClient.kill();
 
-  await expect(dashboard.locator('div.dashboard-view')).not.toHaveClass(/annotate/);
+  await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
 });
 
 async function installSaveFilePickerMock(page: import('playwright-core').Page): Promise<() => Promise<Buffer>> {
@@ -348,7 +349,7 @@ test('save recording streams WebM bytes to the chosen file', async ({ cli, serve
   const awaitBytes = await installSaveFilePickerMock(page);
 
   const dashboard = await startDashboardServer();
-  await dashboard.locator('.sidebar-tab').first().click();
+  await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
   await expect(dashboard.locator('img#display')).toBeVisible();
 
   // Enter recording mode from the normal toolbar.

--- a/tests/mcp/test-debug.spec.ts
+++ b/tests/mcp/test-debug.spec.ts
@@ -67,6 +67,9 @@ Call log:
   - Expect "toBeVisible" with timeout 1000ms
   - waiting for getByRole('button', { name: 'Missing' })
 
+Aria snapshot:
+- button "Submit"
+
 
 ### Page state
 - Page URL: about:blank
@@ -185,6 +188,9 @@ Error: element(s) not found
 Call log:
   - Expect "toBeVisible" with timeout 1000ms
   - waiting for getByRole('button', { name: 'Missing' })
+
+Aria snapshot:
+- button "Submit"
 
 
 ### Page state

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -599,10 +599,10 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       ]);
       await expect(page.locator('.source-line-running')).toContainText('page.evaluate');
 
-      await expect(page.getByRole('list', { name: 'Stack trace' }).getByRole('listitem')).toContainText([
+      await expect(page.getByRole('listbox', { name: 'Stack trace' }).getByRole('option')).toContainText([
         /a.test.js:[\d]+/,
       ]);
-      await expect(page.getByRole('list', { name: 'Stack trace' }).getByRole('listitem').and(page.locator('.selected'))).toContainText('a.test.js');
+      await expect(page.getByRole('listbox', { name: 'Stack trace' }).getByRole('option', { selected: true })).toContainText('a.test.js');
     });
 
     test('should not show stack trace', async ({ runInlineTest, page, showReport }) => {

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -34,7 +34,7 @@ test('should filter network requests by resource type', async ({ runUITest, serv
 
   await page.getByText('Network', { exact: true }).click();
 
-  const networkItems = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+  const networkItems = page.getByRole('listbox', { name: 'Network requests' }).getByRole('option');
 
   await page.getByText('JS', { exact: true }).click();
   await expect(networkItems).toHaveCount(1);
@@ -79,7 +79,7 @@ test('should filter network requests by multiple resource types', async ({ runUI
 
   await page.getByText('Network', { exact: true }).click();
 
-  const networkItems = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+  const networkItems = page.getByRole('listbox', { name: 'Network requests' }).getByRole('option');
   await expect(networkItems).toHaveCount(10);
 
   await page.getByText('JS', { exact: true }).click();
@@ -120,7 +120,7 @@ test('should filter network requests by url', async ({ runUITest, server }) => {
 
   await page.getByText('Network', { exact: true }).click();
 
-  const networkItems = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+  const networkItems = page.getByRole('listbox', { name: 'Network requests' }).getByRole('option');
 
   await page.getByPlaceholder('Filter network').fill('script.');
   await expect(networkItems).toHaveCount(1);
@@ -247,7 +247,7 @@ test('should pretty-print response bodies and show formatting errors', async ({ 
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
   await page.getByRole('tab', { name: 'Network' }).click();
 
-  const networkList = page.getByRole('list', { name: 'Network requests' }).getByRole('listitem');
+  const networkList = page.getByRole('listbox', { name: 'Network requests' }).getByRole('option');
   const responsePanel = page.getByRole('tabpanel', { name: 'Response' });
 
   // Pretty printed by default
@@ -352,7 +352,7 @@ test('should not duplicate network entries from beforeAll', {
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
 
   await page.getByText('Network', { exact: true }).click();
-  await expect(page.getByRole('list', { name: 'Network requests' }).getByText('empty.html')).toHaveCount(1);
+  await expect(page.getByRole('listbox', { name: 'Network requests' }).getByText('empty.html')).toHaveCount(1);
 });
 
 test('should toggle sections inside network details', async ({ runUITest, server }) => {
@@ -370,7 +370,7 @@ test('should toggle sections inside network details', async ({ runUITest, server
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
 
   await page.getByRole('tab', { name: 'Network' }).click();
-  await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
+  await page.getByRole('option').filter({ hasText: 'post-data-1' }).click();
   const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
 
   await headersPanel.getByRole('button', { name: 'Request Headers × 16' }).click();
@@ -387,7 +387,7 @@ test('should toggle sections inside network details', async ({ runUITest, server
 
   // Re-opening should preserve open state
   await page.getByRole('tabpanel', { name: 'Network' }).getByRole('button', { name: 'Close' }).click();
-  await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
+  await page.getByRole('option').filter({ hasText: 'post-data-1' }).click();
   await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
   await expect(headersPanel.getByRole('region', { name: 'General' })).toContainText(/Start.+Duration\d+ms/);
 });
@@ -414,7 +414,7 @@ test('should copy network request', async ({ runUITest, server }) => {
   await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
 
   await page.getByRole('tab', { name: 'Network' }).click();
-  await page.getByRole('listitem').filter({ hasText: 'post-data-1' }).click();
+  await page.getByRole('option').filter({ hasText: 'post-data-1' }).click();
 
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
 
@@ -470,7 +470,7 @@ test('should preserve selection during test run', async ({ runUITest, server }, 
 
   await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
   await page.getByRole('tab', { name: 'Network' }).click();
-  await page.getByRole('listitem').filter({ hasText: 'network.html' }).click();
+  await page.getByRole('option').filter({ hasText: 'network.html' }).click();
   const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
   await expect(headersPanel).toBeVisible();
 

--- a/tests/playwright-test/ui-mode-test-output.spec.ts
+++ b/tests/playwright-test/ui-mode-test-output.spec.ts
@@ -148,12 +148,12 @@ test('should collapse repeated console messages for test', async ({ runUITest })
   await page.getByRole('tab', { name: 'Console' }).click();
   await expect(page.getByRole('tabpanel', { name: 'Console' })).toMatchAriaSnapshot(`
     - tabpanel "Console":
-      - list:
-        - listitem: /page message/
-        - listitem: /10 page message/
-        - listitem: /10 node message/
-        - listitem: /10 page message/
-        - listitem: /10 page message/
+      - listbox:
+        - option /page message/
+        - option /10 page message/
+        - option /10 node message/
+        - option /10 page message/
+        - option /10 page message/
   `);
 });
 
@@ -189,14 +189,14 @@ test('should format console messages in page', async ({ runUITest }, testInfo) =
   ]);
 
   await expect(page.locator('.console-tab')).toMatchAriaSnapshot(`
-    - list:
-      - listitem: "/<anonymous>:1 Object {a: 1}/"
-      - listitem: "/<anonymous>:4 Date/"
-      - listitem: "/<anonymous>:5 Regex \/a\//"
-      - listitem: "/<anonymous>:6 Number 0 one 2/"
-      - listitem: "/<anonymous>:7 Download the React DevTools for a better development experience: https:\/\/fb\.me\/react-devtools/"
-      - listitem: "/<anonymous>:8 Array of values/"
-      - listitem: "/Failed to load resource: net::ERR_CONNECTION_REFUSED/"
+    - listbox:
+      - option /<anonymous>:1 Object/
+      - option /<anonymous>:4 Date/
+      - option /<anonymous>:5 Regex/
+      - option /<anonymous>:6 Number 0 one 2/
+      - option /<anonymous>:7 Download the React DevTools/
+      - option /<anonymous>:8 Array of values/
+      - option /Failed to load resource/
   `);
 
   const label = page.getByText('React DevTools');


### PR DESCRIPTION
## Summary
- Move dashboard session-tabs sidebar to the shared ListView component.
- Switch ListView from `list`/`listitem` to `listbox`/`option` roles so `aria-selected` is semantically valid and queryable via `getByRole(..., { selected: true })`.
- Update test consumers (trace viewer fixtures, ui-mode network/output, html reporter, dashboard).