### PR TITLE
fix(proxy): preserve HTTP env proxy request target

### DIFF
--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -58,7 +58,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   if (proxyURL) {
     const parsedProxyURL = normalizeProxyURL(proxyURL);
     if (params.url.startsWith('http:')) {
-      parsedProxyURL.pathname = url.toString();
+      options.path = url.toString();
       url = parsedProxyURL;
     } else {
       options.agent = new HttpsProxyAgent(parsedProxyURL);

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -431,6 +431,21 @@ test('should use proxy with connectOverCDP', async ({ browserType, server }, tes
   }
 });
 
+test('should use env proxy with connectOverCDP discovery request', async ({ browserType, server, proxyServer, mode }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40394' });
+  test.skip(mode !== 'default'); // Out of process transport does not allow us to set env vars dynamically.
+  proxyServer.forwardTo(server.PORT);
+
+  const oldValue = process.env.HTTP_PROXY;
+  try {
+    process.env.HTTP_PROXY = proxyServer.URL;
+    await browserType.connectOverCDP(server.PREFIX).catch(() => {});
+    expect(proxyServer.requestUrls).toEqual([`${server.PREFIX}/json/version/`]);
+  } finally {
+    process.env.HTTP_PROXY = oldValue;
+  }
+});
+
 test('should be able to connect via localhost', async ({ browserType }, testInfo) => {
   const port = 9339 + testInfo.workerIndex;
   const browserServer = await browserType.launch({


### PR DESCRIPTION
## Summary

Fixes HTTP proxy handling in `httpRequest()` when proxy settings come from environment variables.

When `http_proxy`/`HTTP_PROXY` is set and `NO_PROXY` is empty, `connectOverCDP("http://localhost:<port>")` performs CDP discovery through the proxy by requesting `/json/version/`.

In the broken path, Playwright mutates the proxy URL pathname

```ts
parsedProxyURL.pathname = url.toString();
```

Because `URL.pathname` normalizes the value as a path, this serializes the request target as

```
GET /http://localhost:<port>/json/version/ HTTP/1.1
```

For HTTP proxying, the request target must remain absolute-form

```
GET http://localhost:<port>/json/version/ HTTP/1.1
```

This patch stores the original target URL in `options.path` instead, preserving the correct proxy request target while still sending the request to the proxy server.

Related context

- https://github.com/microsoft/playwright/issues/35206
- https://github.com/microsoft/playwright/pull/35389

## Testing

```bash
npx playwright test \
--config=tests/library/playwright.config.ts \
--project=chromium-library \
tests/library/chromium/connect-over-cdp.spec.ts \
-g "should use env proxy with connectOverCDP discovery request" \
--reporter=line
```

Before the fix, the regression test fails with

```diff
- "http://localhost:<port>/json/version/"
+ "/http://localhost:<port>/json/version/"
```

After the fix, the test passes


---
fixes #40394