### PR TITLE
test(electron): share single electron app across tests/page

### DIFF
--- a/tests/electron/electron-app.js
+++ b/tests/electron/electron-app.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const { app, protocol, BrowserWindow } = require('electron');
+const { app, protocol } = require('electron');
 const path = require('path');
 
 assert(process.env.PWTEST_ELECTRON_USER_DATA_DIR, 'PWTEST_ELECTRON_USER_DATA_DIR env var is not set');
@@ -12,12 +12,4 @@ app.whenReady().then(() => {
     const url = request.url.substring('vscode-file'.length + 3);
     callback({ path: path.join(__dirname, 'assets', url) });
   });
-  // Sandboxed windows share process with their window.open() children
-  // and can script them. We use that heavily in our tests.
-  const window = new BrowserWindow({
-    width: 800,
-    height: 600,
-    webPreferences: { sandbox: true },
-  });
-  window.loadURL('about:blank');
 });

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -123,8 +123,9 @@ test('should dispatch ready event', async ({ launchElectronApp }) => {
   ]);
 });
 
-test('should script application', async ({ app: electronApp }) => {
-  const appPath = await electronApp.evaluate(async ({ app }) => app.getAppPath());
+test('should script application', async ({ launchElectronApp }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const appPath = await app.evaluate(async ({ app }) => app.getAppPath());
   expect(appPath).toBe(path.resolve(__dirname));
 });
 
@@ -135,16 +136,20 @@ test('should preserve args', async ({ launchElectronApp, isMac }) => {
   expect(argv).toEqual([expect.stringContaining(electronPath), expect.stringContaining(path.join('electron', 'electron-app-args.js')), 'foo', 'bar', '& <>^|\\"']);
 });
 
-test('should return windows', async ({ app, page }) => {
+test('should return windows', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   expect(app.windows()).toEqual([page]);
 });
 
-test('should evaluate handle', async ({ app }) => {
+test('should evaluate handle', async ({ launchElectronApp }) => {
+  const app = await launchElectronApp('electron-app.js');
   const appHandle = await app.evaluateHandle(({ app }) => app);
   expect(await app.evaluate(({ app }, appHandle) => app === appHandle, appHandle)).toBeTruthy();
 });
 
-test('should infer evaluate types', async ({ app }) => {
+test('should infer evaluate types', async ({ launchElectronApp }) => {
+  const app = await launchElectronApp('electron-app.js');
   // No-arg evaluate, returning a primitive.
   const appPath: string = await app.evaluate(({ app }) => app.getAppPath());
   expect(typeof appPath).toBe('string');
@@ -173,7 +178,9 @@ test('should infer evaluate types', async ({ app }) => {
 
 });
 
-test('should register custom selector engine', async ({ page, server }) => {
+test('should register custom selector engine', async ({ launchElectronApp, newWindow, server }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   const tag = `electron-tag-${test.info().workerIndex}`;
   await selectors.register(tag, `({
     query(root, selector) { return root.querySelector(selector); },
@@ -185,7 +192,9 @@ test('should register custom selector engine', async ({ page, server }) => {
   expect(await page.$$eval(`${tag}=DIV`, es => es.length)).toBe(2);
 });
 
-test('should route network', async ({ app, page }) => {
+test('should route network', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await app.context().route('**/empty.html', async (route, request) => {
     await route.fulfill({
       status: 200,
@@ -197,14 +206,18 @@ test('should route network', async ({ app, page }) => {
   expect(await page.title()).toBe('Hello World');
 });
 
-test('should support init script', async ({ app, page }) => {
+test('should support init script', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
   await app.context().addInitScript('window.magic = 42;');
+  const page = await newWindow(app);
   await page.goto('data:text/html,<script>window.copy = magic</script>');
   expect(await page.evaluate(() => window['copy'])).toBe(42);
 });
 
-test('should expose function', async ({ app, page }) => {
+test('should expose function', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
   await app.context().exposeFunction('add', (a, b) => a + b);
+  const page = await newWindow(app);
   await page.goto('data:text/html,<script>window["result"] = add(20, 22);</script>');
   expect(await page.evaluate(() => window['result'])).toBe(42);
 });
@@ -219,7 +232,8 @@ test('should wait for first window', async ({ launchElectronApp }) => {
   expect(await window.title()).toBe('Hello World!');
 });
 
-test('should have a clipboard instance', async ({ app }) => {
+test('should have a clipboard instance', async ({ launchElectronApp }) => {
+  const app = await launchElectronApp('electron-app.js');
   const clipboardContentToWrite = 'Hello from Playwright';
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), clipboardContentToWrite);
   const clipboardContentRead = await app.evaluate(async ({ clipboard }) => clipboard.readText());

--- a/tests/electron/electron-screenshot.spec.ts
+++ b/tests/electron/electron-screenshot.spec.ts
@@ -25,6 +25,8 @@ test.afterEach(async ({}, testInfo) => {
   expect(fs.existsSync(screenshots[0].path!)).toBe(true);
 });
 
-test('should capture screenshot', async ({ page }) => {
+test('should capture screenshot', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await page.setContent('<h1>Electron</h1>');
 });

--- a/tests/electron/electron-tracing.spec.ts
+++ b/tests/electron/electron-tracing.spec.ts
@@ -18,12 +18,16 @@ import { electronTest as test, expect } from './electronTest';
 
 test.skip(({ trace }) => trace === 'on');
 
-test('should record trace', async ({ page, server, runAndTrace }) => {
-  const traceViewer = await runAndTrace(async () => {
-    await page.goto(server.PREFIX + '/input/button.html');
-    await page.click('button');
-    expect(await page.evaluate('result')).toBe('Clicked');
-  });
+test('should record trace', async ({ launchElectronApp, newWindow, server, showTraceViewer }, testInfo) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
+  const traceFile = testInfo.outputPath('trace.zip');
+  await app.context().tracing.start({ snapshots: true, screenshots: true, sources: true });
+  await page.goto(server.PREFIX + '/input/button.html');
+  await page.click('button');
+  expect(await page.evaluate('result')).toBe('Clicked');
+  await app.context().tracing.stop({ path: traceFile });
+  const traceViewer = await showTraceViewer(traceFile);
   await expect(traceViewer.actionTitles).toHaveText([
     /Navigate/,
     /Click/,
@@ -31,13 +35,17 @@ test('should record trace', async ({ page, server, runAndTrace }) => {
   ]);
 });
 
-test('should support custom protocol', async ({ app, page, runAndTrace }) => {
+test('should support custom protocol', async ({ launchElectronApp, newWindow, showTraceViewer }, testInfo) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await app.evaluate(({ BrowserWindow }) => {
     void BrowserWindow.getAllWindows()[0].loadURL('vscode-file://index.html');
   });
-  const traceViewer = await runAndTrace(async () => {
-    await page.click('button');
-  });
+  const traceFile = testInfo.outputPath('trace.zip');
+  await app.context().tracing.start({ snapshots: true, screenshots: true, sources: true });
+  await page.click('button');
+  await app.context().tracing.stop({ path: traceFile });
+  const traceViewer = await showTraceViewer(traceFile);
   const frame = await traceViewer.snapshotFrame('Click');
   await expect(frame.locator('button')).toHaveCSS('color', 'rgb(255, 0, 0)');
   await expect(frame.locator('button')).toHaveCSS('font-weight', '700');

--- a/tests/electron/electron-window.spec.ts
+++ b/tests/electron/electron-window.spec.ts
@@ -16,25 +16,33 @@
 
 import { electronTest as test, expect } from './electronTest';
 
-test('should click the button', async ({ page, server }) => {
+test('should click the button', async ({ launchElectronApp, newWindow, server }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await page.goto(server.PREFIX + '/input/button.html');
   await page.click('button');
   expect(await page.evaluate('result')).toBe('Clicked');
 });
 
-test('should check the box', async ({ page }) => {
+test('should check the box', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await page.setContent(`<input id='checkbox' type='checkbox'></input>`);
   await page.check('input');
   expect(await page.evaluate('checkbox.checked')).toBe(true);
 });
 
-test('should not check the checked box', async ({ page }) => {
+test('should not check the checked box', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await page.setContent(`<input id='checkbox' type='checkbox' checked></input>`);
   await page.check('input');
   expect(await page.evaluate('checkbox.checked')).toBe(true);
 });
 
-test('should type into a textarea', async ({ page }) => {
+test('should type into a textarea', async ({ launchElectronApp, newWindow }) => {
+  const app = await launchElectronApp('electron-app.js');
+  const page = await newWindow(app);
   await page.evaluate(() => {
     const textarea = document.createElement('textarea');
     document.body.appendChild(textarea);

--- a/tests/electron/electronTest.ts
+++ b/tests/electron/electronTest.ts
@@ -15,12 +15,11 @@
  */
 
 import { baseTest } from '../config/baseTest';
-import { execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import type { ElectronApplication, Electron } from '@playwright/electron';
-import { mergeTests, electron, test as electronBaseTest } from '@playwright/electron';
+import type { ElectronApplication, Electron, Page } from '@playwright/electron';
+import { electron } from '@playwright/electron';
 import type { PageTestFixtures, PageWorkerFixtures } from '../page/pageTestApi';
 import type { TraceViewerFixtures } from '../config/traceViewerFixtures';
 import { traceViewerFixtures } from '../config/traceViewerFixtures';
@@ -33,30 +32,17 @@ const { removeFolders } = utils;
 
 type LocalFixtures = PageTestFixtures & {
   launchElectronApp: (appFile: string, args?: string[], options?: Parameters<Electron['launch']>[0]) => Promise<ElectronApplication>;
+  newWindow: (app: ElectronApplication) => Promise<Page>;
   createUserDataDir: () => Promise<string>;
-  _electronDiag: void;
 };
 
-let diagSeq = 0;
+type LocalWorkerFixtures = PageWorkerFixtures & {
+  sharedApp: ElectronApplication;
+};
 
-function countElectronProcesses(): number {
-  try {
-    if (process.platform === 'win32') {
-      const out = execFileSync('tasklist', ['/FI', 'IMAGENAME eq electron*', '/NH'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-      return out.split('\n').filter(l => /electron/i.test(l)).length;
-    }
-    // BSD pgrep (macOS) has no -c, so use ps+grep. `|| echo 0` keeps grep's
-    // no-match exit code from tripping execFileSync.
-    const out = execFileSync('sh', ['-c', 'ps -A -o comm= | grep -ic electron || echo 0'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-    return parseInt(out.trim(), 10) || 0;
-  } catch {
-    return -1;
-  }
-}
-
-export const electronTest = mergeTests(baseTest, electronBaseTest)
+export const electronTest = baseTest
     .extend<TraceViewerFixtures>(traceViewerFixtures)
-    .extend<LocalFixtures, PageWorkerFixtures>({
+    .extend<LocalFixtures, LocalWorkerFixtures>({
       browserVersion: [({}, use) => use(process.env.ELECTRON_CHROMIUM_VERSION), { scope: 'worker' }],
       browserMajorVersion: [({}, use) =>  use(Number(process.env.ELECTRON_CHROMIUM_VERSION.split('.')[0])), { scope: 'worker' }],
       electronMajorVersion: [({}, use) => use(parseInt(require('electron/package.json').version.split('.')[0], 10)), { scope: 'worker' }],
@@ -66,7 +52,7 @@ export const electronTest = mergeTests(baseTest, electronBaseTest)
       isHeadlessShell: [false, { scope: 'worker' }],
       isFrozenWebkit: [false, { scope: 'worker' }],
 
-      createUserDataDir: async ({ mode }, run) => {
+      createUserDataDir: async ({}, run) => {
         const dirs: string[] = [];
         // We do not put user data dir in testOutputPath,
         // because we do not want to upload them as test result artifacts.
@@ -78,26 +64,58 @@ export const electronTest = mergeTests(baseTest, electronBaseTest)
         await removeFolders(dirs);
       },
 
-      appOptions: async ({ createUserDataDir }, use) => {
-        // This env prevents 'Electron Security Policy' console message.
-        process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
-        const userDataDir = await createUserDataDir();
-        await use({
+      sharedApp: [async ({}, use) => {
+        const userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'playwright-test-'));
+        const app = await electron.launch({
           args: [path.join(__dirname, 'electron-app.js')],
-          env: inheritAndCleanEnv({ PWTEST_ELECTRON_USER_DATA_DIR: userDataDir }),
+          env: inheritAndCleanEnv({
+            // Prevents 'Electron Security Policy' console message.
+            ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+            PWTEST_ELECTRON_USER_DATA_DIR: userDataDir,
+          }),
+        });
+        await use(app);
+        await app.close();
+        await removeFolders([userDataDir]);
+      }, { scope: 'worker' }],
+
+      newWindow: async ({}, use) => {
+        await use(async (app: ElectronApplication) => {
+          const [page] = await Promise.all([
+            app.waitForEvent('window'),
+            app.evaluate(({ BrowserWindow }) => {
+              const window = new BrowserWindow({
+                width: 800,
+                height: 600,
+                webPreferences: { sandbox: true },
+              });
+              void window.loadURL('about:blank');
+            }),
+          ]);
+          return page;
         });
       },
 
+      page: async ({ sharedApp, newWindow }, use) => {
+        const page = await newWindow(sharedApp);
+        await use(page);
+        for (const window of sharedApp.windows())
+          await window.close().catch(() => {});
+      },
+
       launchElectronApp: async ({ createUserDataDir }, use) => {
-        // This env prevents 'Electron Security Policy' console message.
-        process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
         const apps: ElectronApplication[] = [];
         const userDataDir = await createUserDataDir();
         await use(async (appFile: string, args: string[] = [], options?: Parameters<Electron['launch']>[0]) => {
           const app = await electron.launch({
             ...options,
             args: [path.join(__dirname, appFile), ...args],
-            env: inheritAndCleanEnv({ ...options?.env, PWTEST_ELECTRON_USER_DATA_DIR: userDataDir }),
+            env: inheritAndCleanEnv({
+              // Prevents 'Electron Security Policy' console message.
+              ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+              ...options?.env,
+              PWTEST_ELECTRON_USER_DATA_DIR: userDataDir,
+            }),
           });
           apps.push(app);
           return app;
@@ -105,20 +123,4 @@ export const electronTest = mergeTests(baseTest, electronBaseTest)
         for (const app of apps)
           await app.close();
       },
-
-      _electronDiag: [async ({}, use, testInfo) => {
-        const seq = ++diagSeq;
-        const startedAt = Date.now();
-        const procsBefore = process.env.CI ? countElectronProcesses() : -1;
-        await use();
-        if (!process.env.CI)
-          return;
-        const durMs = Date.now() - startedAt;
-        const rssMb = Math.round(process.memoryUsage().rss / 1024 / 1024);
-        const freeMb = Math.round(os.freemem() / 1024 / 1024);
-        const totalMb = Math.round(os.totalmem() / 1024 / 1024);
-        const procsAfter = countElectronProcesses();
-        const title = testInfo.titlePath.slice(-2).join(' > ');
-        process.stderr.write(`[ediag] seq=${seq} dur=${durMs}ms rss=${rssMb}M free=${freeMb}/${totalMb}M eproc=${procsBefore}->${procsAfter} :: ${title}\n`);
-      }, { auto: true }],
     });


### PR DESCRIPTION
## Summary
- Tests under `tests/page` now reuse a single worker-scoped Electron app (`sharedApp`) and open a fresh `BrowserWindow` per test via a new `newWindow` fixture. This eliminates the ~1270 launch/close cycles per worker that were triggering a 15s phase transition on macOS.
- Tests under `tests/electron` continue to launch their own apps via `launchElectronApp(...)`, but no longer use the `page` fixture; they use `newWindow(app)` instead, or rely on app files that open their own window.
- Dropped the `app`, `appOptions`, and `context` fixture overrides since `electronBaseTest` is no longer merged in. `electron-app.js` no longer opens a default window.