### PR TITLE
feat(extension): redesign connect page

### DIFF
--- a/packages/extension/src/ui/connect.css
+++ b/packages/extension/src/ui/connect.css
@@ -25,75 +25,52 @@ body {
   background-color: #ffffff;
   color: #1f2328;
   margin: 0;
-  padding: 16px;
+  padding: 24px 16px 96px;
   min-height: 100vh;
   font-size: 14px;
+  box-sizing: border-box;
 }
 
 .content-wrapper {
-  max-width: 600px;
+  max-width: 640px;
   margin: 0 auto;
 }
 
-/* Status Banner */
-.status-container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.status-banner {
-  padding: 12px;
-  font-size: 14px;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-}
-
-.status-banner.connected {
-  color: #1f2328;
-}
-
-.status-banner.connected::before {
-  content: "\2705";
-  margin-right: 8px;
-}
-
-.status-banner.error {
-  color: #1f2328;
-}
-
-.status-banner.error::before {
-  content: "\274C";
-  margin-right: 8px;
-}
-
-/* Warning banner */
-.warning-banner {
+/* Heading */
+.status-heading {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.35;
   margin: 0 0 16px 0;
-  padding: 12px;
-  background-color: #fff8e1;
-  border: 1px solid #f0c674;
-  border-radius: 6px;
+  color: #1f2328;
+}
+
+.status-heading.connected::before {
+  content: "\2705 ";
+}
+
+.status-heading.error::before {
+  content: "\274C ";
+}
+
+/* Warning text (replaces the yellow banner) */
+.warning-text {
+  display: flex;
+  gap: 8px;
   font-size: 13px;
   line-height: 1.5;
-  color: #5c4408;
+  color: #656d76;
+  margin: 0 0 24px 0;
 }
 
-.warning-banner strong {
-  color: #1f2328;
+.warning-icon {
+  flex: none;
+  color: #9a6700;
+  font-size: 14px;
+  line-height: 1.4;
 }
 
 /* Buttons */
-.button-container {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .button {
   padding: 8px 16px;
   border-radius: 6px;
@@ -109,26 +86,27 @@ body {
 }
 
 .button.primary {
-  background-color: #f8f9fa;
-  color: #3c4043;
-  border: 1px solid #dadce0;
+  background-color: #1f6feb;
+  color: #ffffff;
+  border: 1px solid #1f6feb;
 }
 
 .button.primary:hover {
-  background-color: #f1f3f4;
-  border-color: #dadce0;
-  box-shadow: 0 1px 2px 0 rgba(60,64,67,.1);
+  background-color: #1a5fcc;
+  border-color: #1a5fcc;
 }
 
 .button.default {
-  background-color: #f6f8fa;
+  background-color: #ffffff;
   color: #24292f;
+  border: 1px solid #d0d7de;
 }
 
 .button.default:hover {
-  background-color: #f3f4f6;
+  background-color: #f6f8fa;
 }
 
+/* Reject variant kept for back-compat (status page); connect page uses default. */
 .button.reject {
   background-color: #da3633;
   color: #ffffff;
@@ -140,47 +118,57 @@ body {
   border-color: #c73836;
 }
 
-/* Connection header */
-.connection-header {
+/* Footer with action buttons */
+.footer {
+  position: sticky;
+  bottom: 0;
+  background-color: #ffffff;
+  margin-top: 24px;
+  padding: 16px 0;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 12px;
-  margin-bottom: 16px;
-}
-
-.client-info {
-  font-size: 14px;
-  color: #1f2328;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid #d0d7de;
 }
 
 /* Tab selection */
+.tab-section {
+  margin-top: 8px;
+}
+
 .tab-section-title {
-  padding-left: 12px;
   font-size: 12px;
   font-weight: 400;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
   color: #656d76;
+}
+
+.tab-list {
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 .tab-item {
   display: flex;
   align-items: center;
-  padding: 12px 0 12px 12px;
-  margin-bottom: 8px;
+  padding: 10px 12px;
   background-color: #ffffff;
   cursor: pointer;
-  border-radius: 6px;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.15s ease;
+  border-bottom: 1px solid #d0d7de;
+}
+
+.tab-list .tab-item:last-child {
+  border-bottom: none;
 }
 
 .tab-item:hover {
-  background-color: #f8f9fa;
+  background-color: #f6f8fa;
 }
 
 .tab-item.selected {
-  background-color: #f6f8fa;
+  background-color: #ddf4ff;
 }
 
 .tab-item.disabled {
@@ -191,13 +179,24 @@ body {
 .tab-radio {
   margin-right: 12px;
   flex-shrink: 0;
+  accent-color: #1f6feb;
 }
 
 .tab-favicon {
   width: 16px;
   height: 16px;
-  margin-right: 8px;
+  margin-right: 10px;
   flex-shrink: 0;
+}
+
+.tab-favicon-plus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  color: #656d76;
+  font-weight: 600;
 }
 
 .tab-content {
@@ -235,7 +234,7 @@ body {
 
 /* Auth token section */
 .auth-token-section {
-  margin: 16px 0;
+  margin: 24px 0 0 0;
   padding: 12px;
   background-color: #f6f8fa;
   border-radius: 6px;
@@ -261,8 +260,10 @@ body {
   color: #1f2328;
   border: none;
   flex: 1;
+  min-width: 0;
   padding: 0;
-  word-break: break-all;
+  white-space: nowrap;
+  overflow-x: auto;
 }
 
 .auth-token-refresh {

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -16,7 +16,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { Button, TabItem } from './tabItem';
+import { Button, NewTabRadioItem, TabRadioItem } from './tabItem';
 import { AuthTokenSection, getOrCreateAuthToken } from './authToken';
 
 import type { TabInfo } from './tabItem';
@@ -29,6 +29,8 @@ type Status =
 
 const SUPPORTED_PROTOCOL_VERSION = 2;
 
+const NEW_TAB_VALUE = '__new_tab__';
+
 const ConnectApp: React.FC = () => {
   const [tabs, setTabs] = useState<TabInfo[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
@@ -36,6 +38,7 @@ const ConnectApp: React.FC = () => {
   const [showTabList, setShowTabList] = useState(true);
   const [clientInfo, setClientInfo] = useState('unknown');
   const [mcpRelayUrl, setMcpRelayUrl] = useState('');
+  const [selectedTabKey, setSelectedTabKey] = useState<string>(NEW_TAB_VALUE);
 
   useEffect(() => {
     const runAsync = async () => {
@@ -66,7 +69,7 @@ const ConnectApp: React.FC = () => {
         setClientInfo(info);
         setStatus({
           type: 'connecting',
-          message: `"${info}" is trying to connect to the Playwright Extension.`
+          message: `"${info}" wants to connect to this browser using the Playwright Extension.`
         });
       } catch (e) {
         setStatus({ type: 'error', message: 'Failed to parse client version.' });
@@ -162,6 +165,15 @@ const ConnectApp: React.FC = () => {
     }
   }, [clientInfo, mcpRelayUrl]);
 
+  const handleAllow = useCallback(() => {
+    if (selectedTabKey === NEW_TAB_VALUE || !showTabList) {
+      void handleConnectToTab();
+      return;
+    }
+    const tab = tabs.find(t => String(t.id) === selectedTabKey);
+    void handleConnectToTab(tab);
+  }, [handleConnectToTab, selectedTabKey, showTabList, tabs]);
+
   useEffect(() => {
     const listener = (message: any) => {
       if (message.type === 'pendingConnectionClosed') {
@@ -175,57 +187,59 @@ const ConnectApp: React.FC = () => {
     };
   }, [handleReject]);
 
+  const isConnecting = status?.type === 'connecting';
+
   return (
     <div className='app-container'>
       <div className='content-wrapper'>
-        {status && (
-          <div className='status-container'>
-            <StatusBanner status={status} />
-            {showButtons && (
-              <div className='button-container'>
-                <Button variant='primary' onClick={() => handleConnectToTab()}>
-                  Allow
-                </Button>
-                <Button variant='reject' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
-                  Reject
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
+        {status && <StatusHeader status={status} />}
 
-        {status?.type === 'connecting' && (
-          <div className='warning-banner'>
-            <strong>⚠️ Warning:</strong> Allowing this connection exposes the entire browser to the client,
+        {isConnecting && (
+          <div className='warning-text'>
+            <span className='warning-icon' aria-hidden='true'>⚠</span>
+            Allowing this connection exposes the entire browser to the client,
             including any signed-in sessions, cookies, and content in other tabs and windows.
             Once approved, the client may also be able to reconnect later without showing this dialog again,
             unless you regenerate the token below and then restart the browser.
           </div>
         )}
 
-        {status?.type === 'connecting' && (
+        {isConnecting && showTabList && (
+          <div className='tab-section'>
+            <div className='tab-section-title'>
+              Select a tab to allow, or open a new one. You can drag more tabs into the Playwright tab group later.
+            </div>
+            <div className='tab-list' role='radiogroup' aria-label='Select a tab'>
+              {tabs.map(tab => (
+                <TabRadioItem
+                  key={tab.id}
+                  tab={tab}
+                  name='connect-tab'
+                  checked={selectedTabKey === String(tab.id)}
+                  onSelect={() => setSelectedTabKey(String(tab.id))}
+                />
+              ))}
+              <NewTabRadioItem
+                name='connect-tab'
+                checked={selectedTabKey === NEW_TAB_VALUE}
+                onSelect={() => setSelectedTabKey(NEW_TAB_VALUE)}
+              />
+            </div>
+          </div>
+        )}
+
+        {isConnecting && (
           <AuthTokenSection />
         )}
 
-        {showTabList && (
-          <div>
-            <div className='tab-section-title'>
-              You can drag tabs into the Playwright group later to make them accessible to the client.
-              Optionally, select a tab to allow and immediately switch to it:
-            </div>
-            <div>
-              {tabs.map(tab => (
-                <TabItem
-                  key={tab.id}
-                  tab={tab}
-                  button={
-                    <Button variant='primary' onClick={() => handleConnectToTab(tab)}>
-                      Allow &amp; select
-                    </Button>
-                  }
-                />
-              ))}
-            </div>
+        {showButtons && (
+          <div className='footer'>
+            <Button variant='default' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
+              Reject
+            </Button>
+            <Button variant='primary' onClick={handleAllow}>
+              Allow
+            </Button>
           </div>
         )}
       </div>
@@ -245,9 +259,9 @@ const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensio
   );
 };
 
-const StatusBanner: React.FC<{ status: Status }> = ({ status }) => {
+const StatusHeader: React.FC<{ status: Status }> = ({ status }) => {
   return (
-    <div className={`status-banner ${status.type}`}>
+    <h1 className={`status-heading ${status.type}`}>
       {'versionMismatch' in status ? (
         <VersionMismatchError
           extensionVersion={status.versionMismatch.extensionVersion}
@@ -255,7 +269,7 @@ const StatusBanner: React.FC<{ status: Status }> = ({ status }) => {
       ) : (
         status.message
       )}
-    </div>
+    </h1>
   );
 };
 

--- a/packages/extension/src/ui/tabItem.tsx
+++ b/packages/extension/src/ui/tabItem.tsx
@@ -65,3 +65,69 @@ export const TabItem: React.FC<TabItemProps> = ({
     </div>
   );
 };
+
+export interface TabRadioItemProps {
+  tab: TabInfo;
+  name: string;
+  checked: boolean;
+  onSelect: () => void;
+}
+
+export const TabRadioItem: React.FC<TabRadioItemProps> = ({
+  tab,
+  name,
+  checked,
+  onSelect,
+}) => {
+  return (
+    <label className={`tab-item tab-item-radio${checked ? ' selected' : ''}`}>
+      <input
+        type='radio'
+        name={name}
+        className='tab-radio'
+        checked={checked}
+        onChange={onSelect}
+      />
+      <img
+        src={tab.favIconUrl || 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><rect width="16" height="16" fill="%23f6f8fa"/></svg>'}
+        alt=''
+        className='tab-favicon'
+      />
+      <div className='tab-content'>
+        <div className='tab-title'>
+          {tab.title || 'Untitled'}
+        </div>
+        <div className='tab-url'>{tab.url}</div>
+      </div>
+    </label>
+  );
+};
+
+export interface NewTabRadioItemProps {
+  name: string;
+  checked: boolean;
+  onSelect: () => void;
+}
+
+export const NewTabRadioItem: React.FC<NewTabRadioItemProps> = ({
+  name,
+  checked,
+  onSelect,
+}) => {
+  return (
+    <label className={`tab-item tab-item-radio tab-item-new${checked ? ' selected' : ''}`}>
+      <input
+        type='radio'
+        name={name}
+        className='tab-radio'
+        checked={checked}
+        onChange={onSelect}
+      />
+      <div className='tab-favicon tab-favicon-plus' aria-hidden='true'>+</div>
+      <div className='tab-content'>
+        <div className='tab-title'>New tab</div>
+        <div className='tab-url'>Open a fresh tab for the client</div>
+      </div>
+    </label>
+  );
+};

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -17,7 +17,6 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { chromium } from 'playwright';
 import { spawn } from 'child_process';
 import { test as base, expect } from '../mcp/fixtures';
 import { kTargetClosedErrorMessage } from '../config/errors';
@@ -72,7 +71,8 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
     await use(extensionDir);
   },
 
-  browserWithExtension: async ({ mcpBrowser, pathToExtension }, use, testInfo) => {
+  // @ts-expect-error _decorateContext is private/internal
+  browserWithExtension: async ({ mcpBrowser, pathToExtension, playwright, _decorateContext }, use, testInfo) => {
     // The flags no longer work in Chrome since
     // https://chromium.googlesource.com/chromium/src/+/290ed8046692651ce76088914750cb659b65fb17%5E%21/chrome/browser/extensions/extension_service.cc?pli=1#
     test.skip('chromium' !== mcpBrowser, '--load-extension is not supported for official builds of Chromium');
@@ -82,7 +82,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
     await use({
       userDataDir,
       launch: async (mode?: 'disable-extension') => {
-        browserContext = await chromium.launchPersistentContext(userDataDir, {
+        browserContext = await playwright.chromium.launchPersistentContext(userDataDir, {
           channel: mcpBrowser,
           // Opening the browser singleton only works in headed.
           headless: false,
@@ -98,6 +98,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
         // background to be ready so tests can reach `chrome.*` via it.
         if (!browserContext.serviceWorkers().length)
           await browserContext.waitForEvent('serviceworker');
+
+        // needed for dogfooding --debug=cli
+        await _decorateContext(browserContext);
 
         return browserContext;
       }
@@ -218,7 +221,8 @@ export async function startWithExtensionFlag(browserWithExtension: BrowserWithEx
 // with the click — the request reaches the background while the page is being
 // torn down. Swallow the resulting "Target closed" error.
 export async function clickAllowAndSelect(connectPage: Page, tabTitle: RegExp | string): Promise<void> {
-  await connectPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Allow & select' }).click().catch(e => {
+  await connectPage.locator('.tab-item', { hasText: tabTitle }).click();
+  await connectPage.getByRole('button', { name: 'Allow', exact: true }).click().catch(e => {
     if (!e?.message?.includes(kTargetClosedErrorMessage))
       throw e;
   });

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -243,7 +243,7 @@ test(`extension needs update`, async ({ startExtensionClient, server }) => {
   });
 
   const confirmationPage = await confirmationPagePromise;
-  await expect(confirmationPage.locator('.status-banner')).toContainText(`Playwright client trying to connect requires newer extension version`);
+  await expect(confirmationPage.locator('.status-heading')).toContainText(`Playwright client trying to connect requires newer extension version`);
 
   expect(await navigateResponse).toHaveResponse({
     error: expect.stringContaining('Extension connection timeout.'),
@@ -327,7 +327,7 @@ test(`pending connection closed when client disconnects`, async ({ startExtensio
   // Close the MCP client, which tears down the relay WebSocket.
   await client.close();
 
-  await expect(selectorPage.locator('.status-banner')).toContainText('Pending client connection closed.');
+  await expect(selectorPage.locator('.status-heading')).toContainText('Pending client connection closed.');
   await expect(selectorPage).toHaveTitle('Playwright Extension');
 
   // The connect tab should be removed from the Playwright group.

--- a/tests/extension/playwright.config.ts
+++ b/tests/extension/playwright.config.ts
@@ -19,6 +19,8 @@ import { defineConfig } from '@playwright/test';
 import type { TestOptions } from '../mcp/fixtures';
 import type { ExtensionTestOptions } from './extension-fixtures';
 
+process.env.PWTEST_UNDER_TEST = '1';
+
 export default defineConfig<TestOptions & ExtensionTestOptions>({
   testDir: './',
   fullyParallel: true,


### PR DESCRIPTION
## Summary
- Restructure the extension connect dialog: prominent heading, muted warning, single tab list with **+ New tab** default.
- Replace per-row "Allow & select" buttons with a footer **Allow** (primary) + **Reject** (ghost).
- Show the auth token directly (no disclosure), with horizontal scroll for long tokens.
- Enable `--debug=cli` for the extension test config (`PWTEST_UNDER_TEST=1`) so this dialog can be iterated on while paused.

<img width="1280" height="720" alt="connect-redesign" src="https://github.com/user-attachments/assets/7541a9c1-58cd-4525-92f0-b7583b311ca8" />

<sub>Image dropped via the Playwright extension + `playwright cli drop`.</sub>