### PR TITLE
fix(page): restore test timeout after page.pause() in headless mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ test-results
 /packages/playwright-core/api.json
 /packages/playwright-cli
 .env
+CLAUDE.md
 /tests/installation/output/
 /tests/installation/.registry.json
 .cache/

--- a/packages/playwright-core/src/client/clientInstrumentation.ts
+++ b/packages/playwright-core/src/client/clientInstrumentation.ts
@@ -37,6 +37,7 @@ export interface ClientInstrumentation {
   onApiCallBegin(apiCall: ApiCallData, channel: { type: string, method: string, params?: Record<string, any> }): void;
   onApiCallEnd(apiCall: ApiCallData): void;
   onWillPause(options: { keepTestTimeout: boolean }): void;
+  onDidResume(options: { keepTestTimeout: boolean }): void;
   onPage(page: Page): void;
 
   runBeforeCreateBrowserContext(options: BrowserContextOptions): Promise<void>;
@@ -51,6 +52,7 @@ export interface ClientInstrumentationListener {
   onApiCallBegin?(apiCall: ApiCallData, channel: { type: string, method: string, params?: Record<string, any>  }): void;
   onApiCallEnd?(apiCall: ApiCallData): void;
   onWillPause?(options: { keepTestTimeout: boolean }): void;
+  onDidResume?(options: { keepTestTimeout: boolean }): void;
   onPage?(page: Page): void;
   runBeforeCreateBrowserContext?(options: BrowserContextOptions): Promise<void>;
   runBeforeCreateRequestContext?(options: NewContextOptions): Promise<void>;

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -840,6 +840,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     this._browserContext.setDefaultTimeout(0);
     this._instrumentation?.onWillPause({ keepTestTimeout: !!_options?.__testHookKeepTestTimeout });
     await this._closedOrCrashedScope.safeRace(this.context()._channel.pause());
+    this._instrumentation?.onDidResume({ keepTestTimeout: !!_options?.__testHookKeepTestTimeout });
     this._browserContext.setDefaultNavigationTimeout(defaultNavigationTimeout);
     this._browserContext.setDefaultTimeout(defaultTimeout);
   }

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -303,10 +303,10 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     this.parent._collectTagTitlePath(path);
     path.push(this.title);
     const titleTags = path.join(' ').match(/@[\S]+/g) || [];
-    return [
+    return [...new Set([
       ...titleTags,
       ...this._tags,
-    ];
+    ])];
   }
 
   _serialize(): any {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -155,6 +155,10 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
         if (!keepTestTimeout)
           globals.currentTestInfo()?._setIgnoreTimeouts(true);
       },
+      onDidResume: ({ keepTestTimeout }) => {
+        if (!keepTestTimeout)
+          globals.currentTestInfo()?._setIgnoreTimeouts(false);
+      },
       runBeforeCreateBrowserContext: async (options: BrowserContextOptions) => {
         for (const [key, value] of Object.entries(_combinedContextOptions)) {
           if (!(key in options))

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -896,6 +896,32 @@ test('page.pause() should disable test timeout', async ({ runInlineTest }) => {
   expect(result.output).toContain('success!');
 });
 
+test('page.pause() should not permanently disable test timeout in headless mode', async ({ runInlineTest }) => {
+  // Unset PWTEST_UNDER_TEST to simulate a real production headless run where
+  // the debugger is not enabled and page.pause() returns immediately.
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+
+      test('test', async ({ page }) => {
+        test.setTimeout(500);
+        // In production headless mode page.pause() is a no-op and returns immediately.
+        // The test timeout must remain active afterwards.
+        await page.pause();
+        // A plain JS timer that exceeds the test timeout. If the test timeout was
+        // incorrectly disabled by page.pause(), this would complete and the test
+        // would pass. With the timeout active, the test fails at 500ms.
+        await new Promise(f => setTimeout(f, 2000));
+        console.log('\\n%%should not reach here');
+      });
+    `,
+  }, {}, { PWTEST_UNDER_TEST: '' });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Test timeout of 500ms exceeded');
+  expect(result.output).not.toContain('should not reach here');
+});
+
 test('window.playwright should be undefined by default', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -183,6 +183,48 @@ test('should be included in testInfo if coming from describe or global tag', asy
   expect(result.exitCode).toBe(0);
 });
 
+test('should deduplicate tags when same tag appears in describe and test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+        onError(error) {
+          console.log(error);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = { reporter: './reporter' };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe('@smoke tests', () => {
+        test('@smoke create test', () => {});
+        test.describe('@smoke nested', () => {
+          test('@smoke deeply nested test', () => {});
+        });
+      });
+      test.describe('suite', { tag: '@foo' }, () => {
+        test('test', { tag: '@foo' }, () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    `title=@smoke create test, tags=@smoke`,
+    `title=@smoke deeply nested test, tags=@smoke`,
+    `title=test, tags=@foo`,
+  ]);
+});
+
 test('should not parse file names as tags', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'reporter.ts': `


### PR DESCRIPTION
## Summary

- `page.pause()` calls `onWillPause()` which increments the ignore-timeouts counter, but never decremented it
- In headed/inspector mode this is intentional — timeouts stay off during the debug session
- In headless mode, `channel.pause()` resolves immediately (no inspector to handle it), leaving the counter permanently elevated and disabling the test timeout for the rest of the test
- Add `onDidResume()` to `ClientInstrumentation`, called after `channel.pause()` resolves, so the counter is always balanced

Fixes #38754