### PR TITLE
chore(extension): warn when Playwright Extension is missing from profile

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -21,6 +21,7 @@ import path from 'path';
 
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { wrapInASCIIBox } from '@utils/ascii';
+import { isChromiumChannelName, defaultUserDataDirForChannel } from '@utils/chromiumChannels';
 import { RecentLogsCollector } from '@utils/debugLogger';
 import { removeFolders } from '@utils/fileUtils';
 import { gracefullyCloseSet } from '@utils/processLauncher';
@@ -94,7 +95,7 @@ export class Chromium extends BrowserType {
     else if (headersMap && !Object.keys(headersMap).some(key => key.toLowerCase() === 'user-agent'))
       headersMap['User-Agent'] = getUserAgent();
 
-    const channel = channelToUserDataDir.has(endpointURL) ? endpointURL : undefined;
+    const channel = isChromiumChannelName(endpointURL) ? endpointURL : undefined;
     if (channel)
       endpointURL = await resolveChannelEndpoint(progress, endpointURL);
 
@@ -467,8 +468,7 @@ async function urlToWSEndpoint(progress: Progress, endpointURL: string, headers:
 }
 
 async function resolveChannelEndpoint(progress: Progress, channel: string): Promise<string> {
-  const dirs = channelToUserDataDir.get(channel)!;
-  const userDataDir = dirs[process.platform];
+  const userDataDir = defaultUserDataDirForChannel(channel);
   if (!userDataDir)
     throw new Error(`Connecting to ${channel} by channel name is not supported on ${process.platform}.`);
 
@@ -535,46 +535,3 @@ function remoteDebuggingHint(channel: string): string {
 and check "Allow remote debugging for this browser instance".
 `;
 }
-
-const channelToUserDataDir = new Map<string, Record<string, string>>([
-  ['chrome', {
-    'linux': path.join(os.homedir(), '.config', 'google-chrome'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Google', 'Chrome', 'User Data'),
-  }],
-  ['chrome-beta', {
-    'linux': path.join(os.homedir(), '.config', 'google-chrome-beta'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome Beta'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Google', 'Chrome Beta', 'User Data'),
-  }],
-  ['chrome-dev', {
-    'linux': path.join(os.homedir(), '.config', 'google-chrome-unstable'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome Dev'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Google', 'Chrome Dev', 'User Data'),
-  }],
-  ['chrome-canary', {
-    'linux': path.join(os.homedir(), '.config', 'google-chrome-canary'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome Canary'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Google', 'Chrome SxS', 'User Data'),
-  }],
-  ['msedge', {
-    'linux': path.join(os.homedir(), '.config', 'microsoft-edge'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Microsoft Edge'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Microsoft', 'Edge', 'User Data'),
-  }],
-  ['msedge-beta', {
-    'linux': path.join(os.homedir(), '.config', 'microsoft-edge-beta'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Microsoft Edge Beta'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Microsoft', 'Edge Beta', 'User Data'),
-  }],
-  ['msedge-dev', {
-    'linux': path.join(os.homedir(), '.config', 'microsoft-edge-dev'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Microsoft Edge Dev'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Microsoft', 'Edge Dev', 'User Data'),
-  }],
-  ['msedge-canary', {
-    'linux': path.join(os.homedir(), '.config', 'microsoft-edge-canary'),
-    'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Microsoft Edge Canary'),
-    'win32': path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'Microsoft', 'Edge SxS', 'User Data'),
-  }],
-]);

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -29,10 +29,8 @@ const debugLogger = debug('pw:mcp:relay');
 export async function createExtensionBrowser(config: FullConfig, clientName: string): Promise<playwrightTypes.Browser> {
   const channel = config.browser.launchOptions.channel || 'chrome';
   const userDataDir = config.browser.userDataDir ?? defaultUserDataDirForChannel(channel);
-  if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir)) {
-    // eslint-disable-next-line no-console
-    console.error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
-  }
+  if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir))
+    throw new Error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
 
   const httpServer = createHttpServer();
   await startHttpServer(httpServer, {});

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -16,7 +16,9 @@
 
 import debug from 'debug';
 import { createHttpServer, startHttpServer } from '@utils/network';
+import { defaultUserDataDirForChannel } from '@utils/chromiumChannels';
 import { playwright } from '../../inprocess';
+import { isPlaywrightExtensionInstalled, playwrightExtensionInstallUrl } from '../utils/extension';
 import { CDPRelayServer } from './cdpRelay';
 
 import type * as playwrightTypes from '../../..';
@@ -25,11 +27,18 @@ import type { FullConfig } from './config';
 const debugLogger = debug('pw:mcp:relay');
 
 export async function createExtensionBrowser(config: FullConfig, clientName: string): Promise<playwrightTypes.Browser> {
+  const channel = config.browser.launchOptions.channel || 'chrome';
+  const userDataDir = config.browser.userDataDir ?? defaultUserDataDirForChannel(channel);
+  if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir)) {
+    // eslint-disable-next-line no-console
+    console.error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
+  }
+
   const httpServer = createHttpServer();
   await startHttpServer(httpServer, {});
   const relay = new CDPRelayServer(
       httpServer,
-      config.browser.launchOptions.channel || 'chrome',
+      channel,
       config.browser.userDataDir,
       config.browser.launchOptions.executablePath);
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -14,7 +14,32 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 // Also pinned via the "key" field in packages/extension/manifest.json.
 export const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
 export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-mcp-bridge/${playwrightExtensionId}`;
+
+export async function isPlaywrightExtensionInstalled(userDataDir: string): Promise<boolean> {
+  // Covers two install shapes: web store drops the extension into Default/Extensions/<id>;
+  // `--load-extension` does not, and only shows up as the id inside Default/Preferences.
+  if (await pathExists(path.join(userDataDir, 'Default', 'Extensions', playwrightExtensionId)))
+    return true;
+  try {
+    const prefs = await fs.promises.readFile(path.join(userDataDir, 'Default', 'Preferences'), 'utf-8');
+    return prefs.includes(`"${playwrightExtensionId}"`);
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.promises.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/utils/chromiumChannels.ts
+++ b/packages/utils/chromiumChannels.ts
@@ -14,78 +14,18 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
-import net from 'net';
 import os from 'os';
 import path from 'path';
 
-import { isPlaywrightExtensionInstalled } from '../utils/extension';
-
-export type ChannelSession = {
-  channel: string;
-  userDataDir: string;
-  endpoint?: string;
-  extensionInstalled: boolean;
-};
-
-export async function listChannelSessions(): Promise<ChannelSession[]> {
-  if (process.env.PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST)
-    return [];
-  const result: ChannelSession[] = [];
-  for (const [channel, dirs] of channelToUserDataDir) {
-    const userDataDir = dirs[process.platform];
-    if (!userDataDir)
-      continue;
-    if (!await pathExists(userDataDir))
-      continue;
-    const [endpoint, extensionInstalled] = await Promise.all([
-      readEndpoint(userDataDir),
-      isPlaywrightExtensionInstalled(userDataDir),
-    ]);
-    result.push({ channel, userDataDir, endpoint, extensionInstalled });
-  }
-  return result;
+export function defaultUserDataDirForChannel(channel: string): string | undefined {
+  return channelToDefaultUserDataDir.get(channel)?.[process.platform];
 }
 
-async function pathExists(p: string): Promise<boolean> {
-  try {
-    await fs.promises.access(p);
-    return true;
-  } catch {
-    return false;
-  }
+export function isChromiumChannelName(channel: string): boolean {
+  return channelToDefaultUserDataDir.has(channel);
 }
 
-async function readEndpoint(userDataDir: string): Promise<string | undefined> {
-  let contents: string;
-  try {
-    contents = await fs.promises.readFile(path.join(userDataDir, 'DevToolsActivePort'), 'utf-8');
-  } catch {
-    return undefined;
-  }
-  const port = parseInt(contents.trim().split('\n')[0], 10);
-  if (!Number.isFinite(port))
-    return undefined;
-  if (!await isPortOpen(port))
-    return undefined;
-  return `http://localhost:${port}`;
-}
-
-async function isPortOpen(port: number): Promise<boolean> {
-  return new Promise(resolve => {
-    const socket = net.createConnection(port, '127.0.0.1');
-    const done = (value: boolean) => {
-      socket.destroy();
-      resolve(value);
-    };
-    socket.once('connect', () => done(true));
-    socket.once('error', () => done(false));
-    socket.setTimeout(250, () => done(false));
-  });
-}
-
-// Keep in sync with packages/utils/chromiumChannels.ts.
-const channelToUserDataDir = new Map<string, Record<string, string>>([
+const channelToDefaultUserDataDir = new Map<string, Record<string, string>>([
   ['chrome', {
     'linux': path.join(os.homedir(), '.config', 'google-chrome'),
     'darwin': path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome'),

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from './ascii';
+export * from './chromiumChannels';
 export * from './comparators';
 export * from './crypto';
 export * from './debug';

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -79,6 +79,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
 
     let browserContext: BrowserContext | undefined;
     const userDataDir = testInfo.outputPath('extension-user-data-dir');
+    // --load-extension does not populate Default/Extensions/<id>; create the folder
+    // so the relay's extension-installed check recognizes the test profile.
+    await fs.mkdir(path.join(userDataDir, 'Default', 'Extensions', extensionId), { recursive: true });
     await use({
       userDataDir,
       launch: async (mode?: 'disable-extension') => {

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -255,6 +255,30 @@ test(`custom executablePath`, async ({ startClient, server }) => {
   }).toPass();
 });
 
+test(`warns when extension is missing in custom userDataDir`, async ({ startClient, server }) => {
+  const executablePath = test.info().outputPath('echo.sh');
+  await fs.writeFile(executablePath, '#!/bin/bash\n', { mode: 0o755 });
+  const userDataDir = test.info().outputPath('empty-profile');
+
+  const { client, stderr } = await startClient({
+    args: [`--extension`],
+    config: {
+      browser: {
+        userDataDir,
+        launchOptions: { executablePath },
+      }
+    },
+  });
+
+  // The call hangs as MCP server never connects to the extension.
+  client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  }).catch(() => {});
+
+  await expect.poll(stderr).toContain(`Playwright Extension not found in "${userDataDir}"`);
+});
+
 test(`bypass connection dialog with token`, async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
 

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -255,28 +255,23 @@ test(`custom executablePath`, async ({ startClient, server }) => {
   }).toPass();
 });
 
-test(`warns when extension is missing in custom userDataDir`, async ({ startClient, server }) => {
-  const executablePath = test.info().outputPath('echo.sh');
-  await fs.writeFile(executablePath, '#!/bin/bash\n', { mode: 0o755 });
+test(`fails when extension is missing in custom userDataDir`, async ({ startClient, server }) => {
   const userDataDir = test.info().outputPath('empty-profile');
 
-  const { client, stderr } = await startClient({
+  const { client } = await startClient({
     args: [`--extension`],
     config: {
-      browser: {
-        userDataDir,
-        launchOptions: { executablePath },
-      }
+      browser: { userDataDir },
     },
   });
 
-  // The call hangs as MCP server never connects to the extension.
-  client.callTool({
+  expect(await client.callTool({
     name: 'browser_navigate',
     arguments: { url: server.HELLO_WORLD },
-  }).catch(() => {});
-
-  await expect.poll(stderr).toContain(`Playwright Extension not found in "${userDataDir}"`);
+  })).toHaveResponse({
+    error: expect.stringContaining(`Playwright Extension not found in "${userDataDir}"`),
+    isError: true,
+  });
 });
 
 test(`bypass connection dialog with token`, async ({ browserWithExtension, startClient, server }) => {


### PR DESCRIPTION
## Summary
- Before spawning Chrome, the MCP relay checks whether the Playwright Extension is present in the target user-data-dir. If missing, we log a hint with the install URL to stderr and continue (instead of the previous 5s connect timeout).
- Extension presence is detected via `Default/Extensions/<id>` (web store install) with a fallback of grepping `Default/Preferences` for the id (`--load-extension`).
- Extracts the Chromium channel → default user-data-dir map into shared `packages/utils/chromiumChannels.ts`, used by `chromium.ts` and the MCP relay. `cli-client/channelSessions.ts` keeps its own copy since its strict per-file build can't resolve `@utils/*` at runtime.