### PR TITLE
Revert "devops: use positive paths filters for test workflows (#40384)"

### DIFF
--- a/.github/workflows/tests_components.yml
+++ b/.github/workflows/tests_components.yml
@@ -6,26 +6,15 @@ on:
       - main
       - release-*
   pull_request:
-    paths:
-      - 'packages/playwright/**'
-      - 'packages/playwright-core/**'
-      - '!packages/playwright-core/src/server/bidi/**'
-      - '!packages/playwright-core/src/tools/**'
-      - 'packages/playwright-test/**'
-      - 'packages/playwright-ct-core/**'
-      - 'packages/playwright-ct-react/**'
-      - 'packages/playwright-ct-react17/**'
-      - 'packages/playwright-ct-solid/**'
-      - 'packages/playwright-ct-vue/**'
-      - 'packages/injected/**'
-      - 'packages/isomorphic/**'
-      - 'packages/protocol/**'
-      - 'packages/utils/**'
-      - 'tests/components/**'
-      - 'utils/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/tests_components.yml'
+    paths-ignore:
+      - 'browser_patches/**'
+      - 'docs/**'
+      - 'packages/extension/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'packages/playwright-core/src/tools/**'
+      - 'tests/bidi/**'
+      - 'tests/extension/**'
+      - 'tests/mcp/**'
     branches:
       - main
       - release-*

--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -6,24 +6,13 @@ on:
       - main
       - release-*
   pull_request:
-    paths:
-      - 'packages/playwright/**'
-      - 'packages/playwright-core/**'
-      - '!packages/playwright-core/src/server/bidi/**'
-      - '!packages/playwright-core/src/tools/dashboard/**'
-      - '!packages/playwright-core/src/tools/trace/**'
-      - 'packages/playwright-test/**'
-      - 'packages/injected/**'
-      - 'packages/isomorphic/**'
-      - 'packages/protocol/**'
-      - 'packages/utils/**'
-      - 'tests/config/**'
-      - 'tests/mcp/**'
-      - 'utils/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/actions/**'
-      - '.github/workflows/tests_mcp.yml'
+    paths-ignore:
+      - 'browser_patches/**'
+      - 'docs/**'
+      - 'packages/extension/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'tests/bidi/**'
+      - 'tests/extension/**'
     branches:
       - main
       - release-*

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -6,20 +6,15 @@ on:
       - main
       - release-*
   pull_request:
-    paths:
-      - 'packages/**'
-      - '!packages/extension/**'
-      - '!packages/playwright-core/src/server/bidi/**'
-      - '!packages/playwright-core/src/tools/**'
-      - 'tests/**'
-      - '!tests/bidi/**'
-      - '!tests/extension/**'
-      - '!tests/mcp/**'
-      - 'utils/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/actions/**'
-      - '.github/workflows/tests_primary.yml'
+    paths-ignore:
+      - 'browser_patches/**'
+      - 'docs/**'
+      - 'packages/extension/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'packages/playwright-core/src/tools/**'
+      - 'tests/bidi/**'
+      - 'tests/extension/**'
+      - 'tests/mcp/**'
     branches:
       - main
       - release-*

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -6,13 +6,6 @@ on:
       - main
       - release-*
   pull_request:
-    paths-ignore:
-      - 'browser_patches/**'
-      - 'docs/**'
-      - 'packages/extension/**'
-      - 'packages/playwright-core/src/server/bidi/**'
-      - 'tests/bidi/**'
-      - 'tests/extension/**'
     types: [ labeled ]
     branches:
       - main

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -6,6 +6,13 @@ on:
       - main
       - release-*
   pull_request:
+    paths-ignore:
+      - 'browser_patches/**'
+      - 'docs/**'
+      - 'packages/extension/**'
+      - 'packages/playwright-core/src/server/bidi/**'
+      - 'tests/bidi/**'
+      - 'tests/extension/**'
     types: [ labeled ]
     branches:
       - main


### PR DESCRIPTION
This reverts commit 442a58a1ae5414af154986a3e07ef90c5cc2ca5a except for `.github/workflows/tests_secondary.yml` which is only triggered by label.