### PR TITLE
fix(extension): keep service worker alive while the connect page is open

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -36,6 +36,8 @@ type PageMessage = {
   type: 'disconnect';
 } | {
   type: 'rejectConnection';
+} | {
+  type: 'keepalive';
 };
 
 class PlaywrightExtension {
@@ -95,6 +97,10 @@ class PlaywrightExtension {
           this._pendingConnections.reject(sender.tab.id);
         sendResponse({ success: true });
         return true;
+      case 'keepalive':
+        // Connect page pings us every ~20s so receiving this message resets
+        // the MV3 service worker idle timer and keeps the relay WebSocket alive.
+        return false;
     }
   }
 

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -105,6 +105,12 @@ const ConnectApp: React.FC = () => {
         await loadTabs();
     };
     void runAsync();
+    // Ping the background every 20s so the MV3 service worker (which owns the
+    // relay WebSocket) stays above its 30s idle timeout while the user decides.
+    const keepalive = setInterval(() => {
+      chrome.runtime.sendMessage({ type: 'keepalive' }).catch(() => {});
+    }, 20_000);
+    return () => clearInterval(keepalive);
   }, []);
 
   const handleReject = useCallback((message: string) => {


### PR DESCRIPTION
## Summary
- Chrome MV3 terminates an idle extension service worker after ~30s. While the user was deciding on the connect page, the relay WebSocket (owned by the SW) was closed from under Playwright — surface: \`Extension disconnected: undefined\` and the CLI daemon exiting.
- Drive a 20s keepalive from the connect page via \`chrome.runtime.sendMessage({ type: 'keepalive' })\`. Each wake-up resets the SW idle timer and keeps the relay WebSocket alive. The interval is cleared on the React cleanup, so closing the tab naturally lets the SW idle out and the pending-connection-closed path takes over.

Fixes the following timeout error:
```sh
$ node packages/playwright-core/lib/tools/cli-client/cli.js attach --extension=chrome-canary

Daemon pid=25809: Target page, context or browser has been closed
Browser logs:

Extension disconnected: undefined

Call log:
  - <ws connecting> ws://[::1]:60659/cdp/269a8d43-a9e7-4ffd-a945-f0cf83e1a504
  - <ws connected> ws://[::1]:60659/cdp/269a8d43-a9e7-4ffd-a945-f0cf83e1a504
  - <ws disconnected> ws://[::1]:60659/cdp/269a8d43-a9e7-4ffd-a945-f0cf83e1a504 code=1000 reason=Extension disconnected: undefined
```
