### PR TITLE
chore(test): allowlist TestInfoError fields at worker/runner IPC boundary

### DIFF
--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -27,8 +27,8 @@ Error stack. Set when [Error] (or its subclass) has been thrown.
 - type: ?<[Object]>
   - `name` <[string]> Matcher name (e.g. `toBeVisible`).
   - `pass` <[boolean]> Whether the matcher passed.
-  - `expected` ?<[string]> Expected value formatted as a string.
-  - `actual` ?<[string]> Received value formatted as a string.
+  - `expected` ?<[any]> Expected value.
+  - `actual` ?<[any]> Received value.
   - `log` ?<[Array]<[string]>> Matcher log lines, if any.
   - `timeout` ?<[int]> Matcher timeout in milliseconds, set when the matcher timed out.
   - `ariaSnapshot` ?<[string]> Aria snapshot of the receiver at the time of failure, if available.

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -83,11 +83,16 @@ export type AttachmentPayload = {
   stepId?: string;
 };
 
-export type TestInfoErrorImpl = TestInfoError;
+export type TestInfoErrorPayload = {
+  message?: string;
+  stack?: string;
+  value?: string;
+  cause?: TestInfoErrorPayload;
+};
 
 export type TestPausedPayload = {
   testId: string;
-  errors: TestInfoErrorImpl[];
+  errors: TestInfoErrorPayload[];
   status: TestStatus;
 };
 
@@ -100,14 +105,14 @@ export type CustomMessageRequestPayload = {
 
 export type CustomMessageResponsePayload = {
   response: any;
-  error?: TestInfoErrorImpl;
+  error?: TestInfoErrorPayload;
 };
 
 export type TestEndPayload = {
   testId: string;
   duration: number;
   status: TestStatus;
-  errors: TestInfoErrorImpl[];
+  errors: TestInfoErrorPayload[];
   hasNonRetriableError: boolean;
   expectedStatus: TestStatus;
   annotations: { type: string, description?: string }[];
@@ -128,7 +133,7 @@ export type StepEndPayload = {
   testId: string;
   stepId: string;
   wallTime: number;  // milliseconds since unix epoch
-  error?: TestInfoErrorImpl;
+  error?: TestInfoErrorPayload;
   suggestedRebaseline?: string;
   annotations: { type: string, description?: string }[];
 };
@@ -144,7 +149,7 @@ export type RunPayload = {
 };
 
 export type DonePayload = {
-  fatalErrors: TestInfoErrorImpl[];
+  fatalErrors: TestInfoErrorPayload[];
   skipTestsDueToSetupFailure: string[];  // test ids
   fatalUnknownTestIds?: string[];
   stoppedDueToUnhandledErrorInTestFail?: boolean;
@@ -156,7 +161,7 @@ export type TestOutputPayload = {
 };
 
 export type TeardownErrorsPayload = {
-  fatalErrors: TestInfoErrorImpl[];
+  fatalErrors: TestInfoErrorPayload[];
 };
 
 export type EnvProducedPayload = [string, string | null][];
@@ -181,4 +186,17 @@ export function stdioChunkToParams(chunk: Uint8Array | string): TestOutputPayloa
   if (typeof chunk !== 'string')
     return { text: util.inspect(chunk) };
   return { text: chunk };
+}
+
+export function toTestInfoErrorPayload(error: TestInfoError): TestInfoErrorPayload {
+  const result: TestInfoErrorPayload = {};
+  if (error.message !== undefined)
+    result.message = error.message;
+  if (error.stack !== undefined)
+    result.stack = error.stack;
+  if (error.value !== undefined)
+    result.value = error.value;
+  if (error.cause !== undefined)
+    result.cause = toTestInfoErrorPayload(error.cause);
+  return result;
 }

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -22,7 +22,7 @@ import { startProfiling, stopProfiling } from '@utils/profiler';
 
 import { serializeError } from '../util';
 
-import type { EnvProducedPayload, ProcessInitParams, TestInfoErrorImpl } from './ipc';
+import type { EnvProducedPayload, ProcessInitParams, TestInfoErrorPayload } from './ipc';
 
 export type ProtocolRequest = {
   id: number;
@@ -32,7 +32,7 @@ export type ProtocolRequest = {
 
 export type ProtocolResponse = {
   id?: number;
-  error?: TestInfoErrorImpl;
+  error?: TestInfoErrorPayload;
   method?: string;
   params?: any;
   result?: any;

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -30,7 +30,7 @@ import { ansiRegex, isString, stripAnsiEscapes } from '@isomorphic/stringUtils';
 
 import type { RawStack } from '@isomorphic/stackTrace';
 import type { Location } from './../types/testReporter';
-import type { TestInfoErrorImpl } from './common/ipc';
+import type { TestInfoError } from './../types/test';
 import type { StackFrame } from '@protocol/channels';
 import type { TestCase } from './common/test';
 
@@ -74,7 +74,7 @@ export function filteredStackTrace(rawStack: RawStack): StackFrame[] {
   return frames;
 }
 
-export function serializeError(error: Error | any): TestInfoErrorImpl {
+export function serializeError(error: Error | any): TestInfoError {
   if (error instanceof Error)
     return filterStackTrace(error);
   return {

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -29,12 +29,12 @@ import { TimeoutManager, TimeoutManagerError } from './timeoutManager';
 import { addSuffixToFilePath, filteredStackTrace, getContainedPath, normalizeAndSaveAttachment, sanitizeFilePathBeforeExtension, trimLongString, windowsFilesystemFriendlyLength } from '../util';
 import { TestTracing } from './testTracing';
 import { testInfoError } from './util';
-import { transform } from '../common';
+import { ipc, transform } from '../common';
 
 import type { RunnableDescription } from './timeoutManager';
-import type { FullProject, TestInfo, TestStatus, TestStepInfo, TestAnnotation } from '../../types/test';
+import type { FullProject, TestInfo, TestInfoError, TestStatus, TestStepInfo, TestAnnotation } from '../../types/test';
 import type { FullConfig, Location } from '../../types/testReporter';
-import type { config as commonConfig, FullConfigInternal, ipc, test as testNs } from '../common';
+import type { config as commonConfig, FullConfigInternal, test as testNs } from '../common';
 import type { StackFrame } from '@protocol/channels';
 
 export type TestStepCategory = 'expect' | 'fixture' | 'hook' | 'pw:api' | 'test.step' | 'test.attach';
@@ -60,7 +60,7 @@ export interface TestStepInternal extends TestStepData {
   boxedStack?: StackFrame[];
   steps: TestStepInternal[];
   endWallTime?: number;
-  error?: ipc.TestInfoErrorImpl;
+  error?: TestInfoError;
   infectParentStepsWithError?: boolean;
 }
 
@@ -137,16 +137,16 @@ export class TestInfoImpl implements TestInfo {
   snapshotSuffix: string = '';
   readonly outputDir: string;
   readonly snapshotDir: string;
-  errors: ipc.TestInfoErrorImpl[] = [];
+  errors: TestInfoError[] = [];
   readonly _attachmentsPush: (...items: TestInfo['attachments']) => number;
   private _workerParams: ipc.WorkerInitParams;
   private _ignoreTimeoutsCounter = 0;
 
-  get error(): ipc.TestInfoErrorImpl | undefined {
+  get error(): TestInfoError | undefined {
     return this.errors[0];
   }
 
-  set error(e: ipc.TestInfoErrorImpl | undefined) {
+  set error(e: TestInfoError | undefined) {
     if (e === undefined)
       throw new Error('Cannot assign testInfo.error undefined value!');
     this.errors[0] = e;
@@ -355,7 +355,7 @@ export class TestInfoImpl implements TestInfo {
             testId: this.testId,
             stepId,
             wallTime: step.endWallTime,
-            error: step.error,
+            error: step.error ? ipc.toTestInfoErrorPayload(step.error) : undefined,
             suggestedRebaseline: result.suggestedRebaseline,
             annotations: step.info.annotations,
           };
@@ -484,7 +484,7 @@ export class TestInfoImpl implements TestInfo {
     const shouldPause = (this._workerParams.pauseAtEnd && !this._isFailure()) || (this._workerParams.pauseOnError && this._isFailure());
     if (shouldPause) {
       await Promise.race([
-        this._callbacks.onTestPaused({ testId: this.testId, errors: this._isFailure() ? this.errors : [], status: this.status }),
+        this._callbacks.onTestPaused({ testId: this.testId, errors: this._isFailure() ? this.errors.map(ipc.toTestInfoErrorPayload) : [], status: this.status }),
         this._interruptedPromise,
       ]);
     }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -28,8 +28,7 @@ import { getPlaywrightVersion } from 'playwright-core/lib/coreBundle';
 import { filteredStackTrace } from '../util';
 
 import type { TestStepCategory, TestInfoImpl } from './testInfo';
-import type { PlaywrightWorkerOptions, TestInfo, TraceMode } from '../../types/test';
-import type { ipc } from '../common';
+import type { PlaywrightWorkerOptions, TestInfo, TestInfoError, TraceMode } from '../../types/test';
 import type { SerializedError, StackFrame } from '@protocol/channels';
 import type * as trace from '@trace/trace';
 import type EventEmitter from 'events';
@@ -250,7 +249,7 @@ export class TestTracing {
     this._testInfo.attachments.push({ name: 'trace', path: tracePath, contentType: 'application/zip' });
   }
 
-  appendForError(error: ipc.TestInfoErrorImpl) {
+  appendForError(error: TestInfoError) {
     const rawStack = error.stack?.split('\n') || [];
     const stack = rawStack ? filteredStackTrace(rawStack) : [];
     this._appendTraceEvent({
@@ -260,7 +259,7 @@ export class TestTracing {
     });
   }
 
-  _formatError(error: ipc.TestInfoErrorImpl) {
+  _formatError(error: TestInfoError) {
     const parts: string[] = [error.message || String(error.value)];
     if (error.cause)
       parts.push('[cause]: ' + this._formatError(error.cause));

--- a/packages/playwright/src/worker/util.ts
+++ b/packages/playwright/src/worker/util.ts
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-import util from 'util';
-
 import { serializeError } from '../util';
 
-import type { ipc } from '../common';
+import type { TestInfoError } from '../../types/test';
 import type { MatcherResultProperty } from '../matchers/matcherHint';
 
-export function testInfoError(error: Error | any): ipc.TestInfoErrorImpl {
+export function testInfoError(error: Error | any): TestInfoError {
   const result = serializeError(error);
   const matcherResult = (error instanceof Error ? (error as any).matcherResult : undefined) as MatcherResultProperty | undefined;
   if (matcherResult) {
-    const serialized: NonNullable<ipc.TestInfoErrorImpl['matcherResult']> = {
+    const serialized: NonNullable<TestInfoError['matcherResult']> = {
       name: matcherResult.name,
       pass: matcherResult.pass,
     };
     if (matcherResult.expected !== undefined)
-      serialized.expected = inspectForIpc(matcherResult.expected);
+      serialized.expected = matcherResult.expected;
     if (matcherResult.actual !== undefined)
-      serialized.actual = inspectForIpc(matcherResult.actual);
+      serialized.actual = matcherResult.actual;
     if (matcherResult.log !== undefined)
       serialized.log = matcherResult.log;
     if (matcherResult.timeout !== undefined)
@@ -42,10 +40,4 @@ export function testInfoError(error: Error | any): ipc.TestInfoErrorImpl {
     result.matcherResult = serialized;
   }
   return result;
-}
-
-function inspectForIpc(value: unknown): string {
-  if (typeof value === 'string')
-    return value;
-  return util.inspect(value, { depth: 10 });
 }

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -30,7 +30,7 @@ import { testInfoError } from './util';
 import type { TimeSlot } from './timeoutManager';
 import type { Location } from '../../types/testReporter';
 import type { config as commonConfig, FullConfigInternal, test as testNs } from '../common';
-import type { TestAnnotation } from '../../types/test';
+import type { TestAnnotation, TestInfoError } from '../../types/test';
 
 export class WorkerMain extends ProcessRunner {
   private _params: ipc.WorkerInitParams;
@@ -40,7 +40,7 @@ export class WorkerMain extends ProcessRunner {
   private _fixtureRunner: FixtureRunner;
 
   // Accumulated fatal errors that cannot be attributed to a test.
-  private _fatalErrors: ipc.TestInfoErrorImpl[] = [];
+  private _fatalErrors: TestInfoError[] = [];
   // Whether we should skip running remaining tests in this suite because
   // of a setup error, usually beforeAll hook.
   private _skipRemainingTestsInSuite: testNs.Suite | undefined;
@@ -130,12 +130,12 @@ export class WorkerMain extends ProcessRunner {
 
     if (this._fatalErrors.length) {
       this._appendProcessTeardownDiagnostics(this._fatalErrors[this._fatalErrors.length - 1]);
-      const payload: ipc.TeardownErrorsPayload = { fatalErrors: this._fatalErrors };
+      const payload: ipc.TeardownErrorsPayload = { fatalErrors: this._fatalErrors.map(ipc.toTestInfoErrorPayload) };
       this.dispatchEvent('teardownErrors', payload);
     }
   }
 
-  private _appendProcessTeardownDiagnostics(error: ipc.TestInfoErrorImpl) {
+  private _appendProcessTeardownDiagnostics(error: TestInfoError) {
     if (!this._lastRunningTests.length)
       return;
     const count = this._totalRunningTests === 1 ? '1 test' : `${this._totalRunningTests} tests`;
@@ -255,7 +255,7 @@ export class WorkerMain extends ProcessRunner {
       void this._stop();
     } finally {
       const donePayload: ipc.DonePayload = {
-        fatalErrors: this._fatalErrors,
+        fatalErrors: this._fatalErrors.map(ipc.toTestInfoErrorPayload),
         skipTestsDueToSetupFailure: [],
         fatalUnknownTestIds,
         stoppedDueToUnhandledErrorInTestFail: this._stoppedDueToUnhandledErrorInTestFail,
@@ -278,7 +278,7 @@ export class WorkerMain extends ProcessRunner {
       const response = await this._currentTest._onCustomMessageCallback?.(payload.request);
       return { response };
     } catch (error) {
-      return { response: {}, error: testInfoError(error) };
+      return { response: {}, error: ipc.toTestInfoErrorPayload(testInfoError(error)) };
     }
   }
 
@@ -649,7 +649,7 @@ function buildTestEndPayload(testInfo: TestInfoImpl): ipc.TestEndPayload {
     testId: testInfo.testId,
     duration: testInfo.duration,
     status: testInfo.status!,
-    errors: testInfo.errors,
+    errors: testInfo.errors.map(ipc.toTestInfoErrorPayload),
     hasNonRetriableError: testInfo._hasNonRetriableError,
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -10023,14 +10023,14 @@ export interface TestInfoError {
     pass: boolean;
 
     /**
-     * Expected value formatted as a string.
+     * Expected value.
      */
-    expected?: string;
+    expected?: any;
 
     /**
-     * Received value formatted as a string.
+     * Received value.
      */
-    actual?: string;
+    actual?: any;
 
     /**
      * Matcher log lines, if any.


### PR DESCRIPTION
## Summary

- Narrow the IPC error payload (renamed `TestInfoErrorImpl` → `TestInfoErrorPayload`) to an explicit allowlist: `message`, `stack`, `value`, `cause`.
- Funnel every worker→runner dispatch site (`StepEndPayload`, `TestEndPayload`, `TestPausedPayload`, `CustomMessageResponsePayload`, `DonePayload`, `TeardownErrorsPayload`) through `toTestInfoErrorPayload` so `matcherResult` — and anything else added to the public `TestInfoError` in the future — doesn't silently cross IPC.
- Worker-internal holders (`TestInfoImpl.errors`, `TestStepInternal.error`, `WorkerMain._fatalErrors`) keep the full `TestInfoError` so `errorContext.ts` and `ArtifactsRecorder` can still read `matcherResult.ariaSnapshot`.