### PR TITLE
test(ui-mode): ignore HMR websockets in leak test

### DIFF
--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -787,12 +787,12 @@ test('should not leak websocket connections', {
   });
 
   const [ws1] = await Promise.all([
-    page.waitForEvent('websocket'),
+    page.waitForEvent('websocket', w => !w.url().includes('hmr')),
     page.getByTitle('Reload').click(),
   ]);
 
   await Promise.all([
-    page.waitForEvent('websocket'),
+    page.waitForEvent('websocket', w => !w.url().includes('hmr')),
     page.getByTitle('Reload').click(),
   ]);
 


### PR DESCRIPTION
## Summary
- `should not leak websocket connections` was flaky after HMR was enabled for html-reporter and trace viewer. Filter out HMR websocket events so `waitForEvent` latches onto the UI mode connection.