### PR TITLE
feat(extension): require tab selection on connect page

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -26,16 +26,14 @@ type PageMessage = {
   type: 'getTabs';
 } | {
   type: 'connectToTab';
-  // Picked in the connect page; absent when the user clicked plain "Allow"
-  // without selecting a tab.
+  // Picked in the connect page; absent on the token-bypass path where no tab
+  // selection happens.
   tab?: chrome.tabs.Tab;
   clientName?: string;
 } | {
   type: 'getConnectionStatus';
 } | {
   type: 'disconnect';
-} | {
-  type: 'rejectConnection';
 } | {
   type: 'keepalive';
 };
@@ -68,7 +66,7 @@ class PlaywrightExtension {
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true;
       case 'connectToTab': {
-        // Plain "Allow" (no specific pick) falls back to the connect page itself
+        // Token-bypass (no specific pick) falls back to the connect page itself
         // so `ConnectedTabGroup` always has a concrete tab to start from. Both
         // sender.tab and UI-supplied tabs come from chrome.tabs.query / runtime
         // message sender, where `id` is always defined.
@@ -91,11 +89,6 @@ class PlaywrightExtension {
         } catch (error: any) {
           sendResponse({ success: false, error: error.message });
         }
-        return true;
-      case 'rejectConnection':
-        if (sender.tab?.id !== undefined)
-          this._pendingConnections.reject(sender.tab.id);
-        sendResponse({ success: true });
         return true;
       case 'keepalive':
         // Connect page pings us every ~20s so receiving this message resets
@@ -138,7 +131,7 @@ class PlaywrightExtension {
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
     const tabs = await chrome.tabs.query({});
-    return tabs.filter(tab => !isNonDebuggableUrl(tab.url) && !tab.url?.startsWith('chrome-extension:'));
+    return tabs.filter(tab => !isNonDebuggableUrl(tab.url));
   }
 
   private async _onActionClicked(): Promise<void> {

--- a/packages/extension/src/pendingConnection.ts
+++ b/packages/extension/src/pendingConnection.ts
@@ -80,14 +80,6 @@ export class PendingConnections {
     this._map.set(selectorTabId, entry);
   }
 
-  reject(selectorTabId: number): void {
-    const entry = this._map.get(selectorTabId);
-    if (!entry)
-      return;
-    this._map.delete(selectorTabId);
-    entry.close('Rejected by user');
-  }
-
   async take(selectorTabId: number): Promise<RelayConnection | undefined> {
     const entry = this._map.get(selectorTabId);
     if (!entry)

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -30,9 +30,13 @@ const SUPPORTED_PROTOCOL_VERSION = 2;
 const ConnectApp: React.FC = () => {
   const [tabs, setTabs] = useState<chrome.tabs.Tab[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
-  const [showButtons, setShowButtons] = useState(true);
   const [showTabList, setShowTabList] = useState(true);
   const [clientInfo, setClientInfo] = useState('unknown');
+
+  const setError = useCallback((message: string) => {
+    setShowTabList(false);
+    setStatus({ type: 'error', message });
+  }, []);
 
   useEffect(() => {
     const runAsync = async () => {
@@ -40,18 +44,18 @@ const ConnectApp: React.FC = () => {
       const relayUrl = params.get('mcpRelayUrl');
 
       if (!relayUrl) {
-        handleReject('Missing mcpRelayUrl parameter in URL.');
+        setError('Missing mcpRelayUrl parameter in URL.');
         return;
       }
 
       try {
         const host = new URL(relayUrl).hostname;
         if (host !== '127.0.0.1' && host !== '[::1]') {
-          handleReject(`Playwright extension only allows loopback connections (127.0.0.1 or [::1]). Received host: ${host}`);
+          setError(`Playwright extension only allows loopback connections (127.0.0.1 or [::1]). Received host: ${host}`);
           return;
         }
       } catch (e) {
-        handleReject(`Invalid mcpRelayUrl parameter in URL: ${relayUrl}. ${e}`);
+        setError(`Invalid mcpRelayUrl parameter in URL: ${relayUrl}. ${e}`);
         return;
       }
 
@@ -72,7 +76,6 @@ const ConnectApp: React.FC = () => {
       const requestedVersion = isNaN(parsedVersion) ? 1 : parsedVersion;
       if (requestedVersion > SUPPORTED_PROTOCOL_VERSION) {
         const extensionVersion = chrome.runtime.getManifest().version;
-        setShowButtons(false);
         setShowTabList(false);
         setStatus({
           type: 'error',
@@ -85,7 +88,11 @@ const ConnectApp: React.FC = () => {
       // The background decides per protocolVersion: v1 opens the relay WS
       // immediately (the daemon expects a prompt connection); v2 just records
       // the descriptor and defers the WS until the user clicks Allow.
-      await connectionRequested(relayUrl, requestedVersion);
+      const response = await chrome.runtime.sendMessage({ type: 'connectionRequested', mcpRelayUrl: relayUrl, protocolVersion: requestedVersion });
+      if (!response.success) {
+        setError(response.error);
+        return;
+      }
 
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
@@ -94,7 +101,7 @@ const ConnectApp: React.FC = () => {
         return;
       }
       if (token) {
-        handleReject('Invalid token provided.');
+        setError('Invalid token provided.');
         return;
       }
 
@@ -113,21 +120,6 @@ const ConnectApp: React.FC = () => {
     return () => clearInterval(keepalive);
   }, []);
 
-  const handleReject = useCallback((message: string) => {
-    setShowButtons(false);
-    setShowTabList(false);
-    setStatus({ type: 'error', message });
-    // Ask the background to close the pending MCP relay connection so the
-    // client daemon sees a disconnect and exits.
-    chrome.runtime.sendMessage({ type: 'rejectConnection' }).catch(() => {});
-  }, []);
-
-  const connectionRequested = useCallback(async (mcpRelayUrl: string, protocolVersion: number) => {
-    const response = await chrome.runtime.sendMessage({ type: 'connectionRequested', mcpRelayUrl, protocolVersion });
-    if (!response.success)
-      handleReject(response.error);
-  }, [handleReject]);
-
   const loadTabs = useCallback(async () => {
     const response = await chrome.runtime.sendMessage({ type: 'getTabs' });
     if (response.success)
@@ -137,7 +129,6 @@ const ConnectApp: React.FC = () => {
   }, []);
 
   const handleConnectToTab = useCallback(async (tab?: chrome.tabs.Tab) => {
-    setShowButtons(false);
     setShowTabList(false);
 
     try {
@@ -166,7 +157,7 @@ const ConnectApp: React.FC = () => {
   useEffect(() => {
     const listener = (message: any) => {
       if (message.type === 'pendingConnectionClosed') {
-        handleReject('Pending client connection closed.');
+        setError('Pending client connection closed.');
         document.title = 'Playwright Extension';
       }
     };
@@ -174,7 +165,7 @@ const ConnectApp: React.FC = () => {
     return () => {
       chrome.runtime.onMessage.removeListener(listener);
     };
-  }, [handleReject]);
+  }, [setError]);
 
   return (
     <div className='app-container'>
@@ -182,16 +173,6 @@ const ConnectApp: React.FC = () => {
         {status && (
           <div className='status-container'>
             <StatusBanner status={status} />
-            {showButtons && (
-              <div className='button-container'>
-                <Button variant='primary' onClick={() => handleConnectToTab()}>
-                  Allow
-                </Button>
-                <Button variant='reject' onClick={() => handleReject('Connection rejected. This tab can be closed.')}>
-                  Reject
-                </Button>
-              </div>
-            )}
           </div>
         )}
 

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs/promises';
-import { test as base, expect, extensionId } from './extension-fixtures';
+import { test as base, expect, extensionId, clickAllowAndSelect } from './extension-fixtures';
 
 import type { CliResult } from './extension-fixtures';
 import type { Page } from 'playwright';
@@ -58,28 +58,20 @@ async function expectDaemonExited(cliPromise: Promise<CliResult>): Promise<void>
   await expect.poll(() => isAlive(pid)).toBe(false);
 }
 
-test('daemon exits when user rejects the extension connection', async ({ startAttach, protocolVersion }) => {
-  // v2 defers opening the relay WS until the user clicks Allow, so a Reject
-  // without a prior connection leaves the daemon waiting — intentionally.
-  test.skip(protocolVersion === 2, 'v2 defers the relay connection until Allow');
-  const { confirmationPage, cliPromise } = await startAttach();
-  await confirmationPage.getByRole('button', { name: 'Reject' }).click();
-  await expectDaemonExited(cliPromise);
-});
-
 test('daemon exits when user closes the connect tab', async ({ startAttach, protocolVersion }) => {
-  // Same as above — closing the tab before Allow never opens a relay WS in v2.
+  // v2 defers opening the relay WS until the user clicks Allow, so closing the
+  // tab before Allow never opens a relay WS in v2.
   test.skip(protocolVersion === 2, 'v2 defers the relay connection until Allow');
   const { confirmationPage, cliPromise } = await startAttach();
   // Wait for the page to fully load and the connection to the relay to be established before closing it.
-  await expect(confirmationPage.getByRole('button', { name: 'Reject' })).toBeVisible();
+  await expect(confirmationPage.locator('.tab-item').first()).toBeVisible();
   await confirmationPage.close();
   await expectDaemonExited(cliPromise);
 });
 
 test('attach <url> --extension', async ({ startAttach, cli, server }) => {
   const { confirmationPage, cliPromise } = await startAttach();
-  await confirmationPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(confirmationPage, 'Welcome');
 
   {
     const { output } = await cliPromise;

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -237,6 +237,6 @@ export async function connectAndNavigate(
   );
   const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
   return await navigatePromise;
 }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -30,7 +30,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
@@ -104,7 +104,7 @@ test(`browser_run_code can evaluate in a web worker`, async ({ startExtensionCli
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   await navigateResponse;
 
@@ -204,7 +204,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   });
 
   const selectorPage = await confirmationPagePromise;
-  await selectorPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -16,25 +16,6 @@
 
 import { test, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 
-test('connect page hides chrome-extension:// tabs from the selector', async ({ browserWithExtension, startClient, server }) => {
-  const browserContext = await browserWithExtension.launch();
-
-  const extraExtensionPage = await browserContext.newPage();
-  await extraExtensionPage.goto(`chrome-extension://${extensionId}/status.html`);
-
-  const client = await startWithExtensionFlag(browserWithExtension, startClient);
-
-  const connectPagePromise = browserContext.waitForEvent('page', p =>
-    p.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
-  );
-  client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } }).catch(() => {});
-
-  const connectPage = await connectPagePromise;
-  await expect(connectPage.locator('.tab-item').first()).toBeVisible();
-
-  await expect(connectPage.locator('.tab-item', { hasText: 'chrome-extension://' })).toHaveCount(0);
-});
-
 test('connect page is not in group before selection', async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
 
@@ -55,7 +36,7 @@ test('connect page is not in group before selection', async ({ startExtensionCli
   });
   expect(groupId).toBe(-1);
 
-  await connectPage.getByRole('button', { name: 'Allow', exact: true }).click();
+  await clickAllowAndSelect(connectPage, 'Welcome');
   await navigatePromise;
 });
 


### PR DESCRIPTION
## Summary
- Drop the plain Allow/Reject buttons from the connect dialog — the only way to approve is now "Allow & select" on a specific tab.
- Stop filtering `chrome-extension://` URLs from the tab list so the connect page itself (or other extension pages) can be selected.
- Remove the `rejectConnection` message and `PendingConnections.reject`; tab close already cleans up pending entries.