### PR TITLE
Fall back when the ts ESM loader cannot be registered from archives

### DIFF
--- a/packages/playwright/src/common/esmLoaderHost.ts
+++ b/packages/playwright/src/common/esmLoaderHost.ts
@@ -22,6 +22,10 @@ import { singleTSConfig, transformConfig } from '../transform/transform';
 
 let loaderChannel: PortTransport | undefined;
 
+function isArchivePath(filePath: string) {
+  return filePath.includes('.zip/') || filePath.includes('.zip\\');
+}
+
 export function registerESMLoader() {
   // Opt-out switch.
   if (process.env.PW_DISABLE_TS_ESM)
@@ -40,11 +44,21 @@ export function registerESMLoader() {
     return false;
 
   const { port1, port2 } = new MessageChannel();
+  const esmLoaderPath = require.resolve('../transform/esmLoader.js');
   // register will wait until the loader is initialized.
-  register(url.pathToFileURL(require.resolve('../transform/esmLoader.js')), {
-    data: { port: port2 },
-    transferList: [port2],
-  });
+  try {
+    register(url.pathToFileURL(esmLoaderPath), {
+      data: { port: port2 },
+      transferList: [port2],
+    });
+  } catch (error: any) {
+    // Yarn Plug'n'Play may resolve Playwright from a zip archive. Node's loader
+    // registration can then fail while importing the loader's sibling files.
+    // Fall back to running without the ts ESM loader instead of crashing.
+    if (error?.code === 'ERR_MODULE_NOT_FOUND' && isArchivePath(esmLoaderPath))
+      return false;
+    throw error;
+  }
   loaderChannel = createPortTransport(port1);
   return true;
 }


### PR DESCRIPTION
This makes Playwright fall back instead of crashing when its ts ESM loader is resolved from an archive-backed path.

We hit this under Node.js 24.15.0 with Yarn 4.14.1 Plug'n'Play, where `require.resolve('../transform/esmLoader.js')` pointed into Yarn's zip cache. `node:module.register()` then tried to initialize the loader from that archive-backed `file://` URL, and the loader failed while importing its sibling modules (for example `./compilationCache.js`) with `ERR_MODULE_NOT_FOUND`.

This change keeps the existing behavior for normal installs, but if loader registration fails with `ERR_MODULE_NOT_FOUND` from a zip-backed path, it returns `false` and lets the existing non-loader path continue instead of aborting Playwright startup.

I haven't added a regression test here because reproducing the exact Node + PnP zip-backed loader failure path inside Playwright's test matrix looked non-trivial, and I didn't want to guess at a brittle fixture. The change is intentionally narrow to the observed failure mode.

I drafted this patch and PR with assistance from OpenAI Codex, then reviewed the change before opening the PR.
