### PR TITLE
fix(mcp): default stdio sessions to isolated

### DIFF
--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -173,8 +173,8 @@ Supported values: `chrome`, `firefox`, `webkit`, `msedge`.
 
 Playwright MCP supports three profile modes:
 
--   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Override with `--user-data-dir`.
--   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
+-   **Isolated (stdio default)**: Each stdio client session starts fresh, with no login state or cookies preserved between sessions. You can load initial state with `--storage-state`.
+-   **Persistent (HTTP/SSE default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Stdio clients can opt in with `--user-data-dir`.
 -   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). Pass `--extension` to enable.
 
 ### Configuration file

--- a/packages/playwright-core/src/tools/backend/tracing.ts
+++ b/packages/playwright-core/src/tools/backend/tracing.ts
@@ -30,7 +30,8 @@ const tracingStart = defineTool({
   },
 
   handle: async (context, params, response) => {
-    const browserContext = await context.ensureBrowserContext();
+    const tab = await context.ensureTab();
+    const browserContext = tab.page.context();
     const tracesDir = await context.outputFile({ prefix: '', suggestedFilename: `traces`, ext: '' }, { origin: 'code' });
     const name = 'trace-' + Date.now();
     await browserContext.tracing.start({
@@ -43,8 +44,7 @@ const tracingStart = defineTool({
     response.addFileLink('Action log', `${tracesDir}/${name}.trace`);
     response.addFileLink('Network log', `${tracesDir}/${name}.network`);
     response.addFileLink('Resources', `${tracesDir}/resources`);
-    // eslint-disable-next-line no-restricted-syntax
-    (browserContext.tracing as any)[traceLegendSymbol] = { tracesDir, name };
+    traceLegend.set(browserContext, { tracesDir, name });
   },
 });
 
@@ -61,18 +61,16 @@ const tracingStop = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    await browserContext.tracing.stop();
-    // eslint-disable-next-line no-restricted-syntax
-    const traceLegend = (browserContext.tracing as any)[traceLegendSymbol];
-    if (!traceLegend)
+    const legend = traceLegend.get(browserContext);
+    if (!legend)
       throw new Error('Tracing is not started');
-    // eslint-disable-next-line no-restricted-syntax
-    delete (browserContext.tracing as any)[traceLegendSymbol];
+    await browserContext.tracing.stop();
+    traceLegend.delete(browserContext);
 
     response.addTextResult(`Trace recording stopped.`);
-    response.addFileLink('Trace', `${traceLegend.tracesDir}/${traceLegend.name}.trace`);
-    response.addFileLink('Network log', `${traceLegend.tracesDir}/${traceLegend.name}.network`);
-    response.addFileLink('Resources', `${traceLegend.tracesDir}/resources`);
+    response.addFileLink('Trace', `${legend.tracesDir}/${legend.name}.trace`);
+    response.addFileLink('Network log', `${legend.tracesDir}/${legend.name}.network`);
+    response.addFileLink('Resources', `${legend.tracesDir}/resources`);
   },
 });
 
@@ -81,4 +79,4 @@ export default [
   tracingStop,
 ];
 
-const traceLegendSymbol = Symbol('tracesDir');
+const traceLegend = new WeakMap<object, { tracesDir: string, name: string }>();

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -121,6 +121,10 @@ export async function resolveCLIConfigForMCP(cliOptions: CLIOptions, env?: NodeJ
   result = mergeConfig(result, envOverrides);
   result = mergeConfig(result, cliOverrides);
 
+  const isStdio = result.server?.port === undefined;
+  if (result.browser.isolated === undefined && isStdio)
+    result.browser.isolated = !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint && !result.extension;
+
   const browser = await validateBrowserConfig(result.browser);
   if (browser.launchOptions.headless === undefined)
     browser.launchOptions.headless = os.platform() === 'linux' && !process.env.DISPLAY;

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -270,6 +270,37 @@ test.describe('resolveCLIConfigForMCP', () => {
     expect(config.browser.launchOptions.headless).toBeDefined();
   });
 
+  test('defaults to isolated under stdio transport', async () => {
+    const config = await resolveCLIConfigForMCP({}, emptyEnv);
+    expect(config.browser.isolated).toBe(true);
+  });
+
+  test('defaults to persistent under HTTP transport', async () => {
+    const config = await resolveCLIConfigForMCP({ port: 0 }, emptyEnv);
+    expect(config.browser.isolated).not.toBe(true);
+  });
+
+  test('explicit user data dir keeps stdio persistent', async () => {
+    const config = await resolveCLIConfigForMCP({ userDataDir: '/tmp/playwright-mcp-user-data' }, emptyEnv);
+    expect(config.browser.isolated).not.toBe(true);
+  });
+
+  test('attached browser modes keep stdio persistent', async () => {
+    const cdpConfig = await resolveCLIConfigForMCP({ cdpEndpoint: 'http://localhost:9222' }, emptyEnv);
+    expect(cdpConfig.browser.isolated).not.toBe(true);
+
+    const remoteConfig = await resolveCLIConfigForMCP({ endpoint: 'ws://localhost:1234' }, emptyEnv);
+    expect(remoteConfig.browser.isolated).not.toBe(true);
+
+    const extensionConfig = await resolveCLIConfigForMCP({ extension: true }, emptyEnv);
+    expect(extensionConfig.browser.isolated).not.toBe(true);
+  });
+
+  test('explicit isolated is honored under HTTP transport', async () => {
+    const config = await resolveCLIConfigForMCP({ port: 0, isolated: true }, emptyEnv);
+    expect(config.browser.isolated).toBe(true);
+  });
+
   test('cli timeout overrides defaults', async () => {
     const config = await resolveCLIConfigForMCP({ timeoutAction: 10000, timeoutNavigation: 30000 }, emptyEnv);
     expect(config.timeouts.action).toBe(10000);

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -43,7 +43,7 @@ test('test reopen browser', async ({ startClient, server }) => {
   });
 
   await expect.poll(() => formatLog(stderr()), { timeout: 0 }).toEqual({
-    'create browser (persistent)': 2,
+    'create browser (isolated)': 2,
     'create context': 2,
     'close browser': 1,
   });

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -129,6 +129,34 @@ test('isolated context', async ({ startClient, server }) => {
   });
 });
 
+test('stdio default sessions do not share storage', async ({ startClient, server }) => {
+  server.setContent('/', `
+    <body>
+    </body>
+    <script>
+      document.body.textContent = localStorage.getItem('test') ? 'Storage: YES' : 'Storage: NO';
+      localStorage.setItem('test', 'test');
+    </script>
+  `, 'text/html');
+
+  const { client: client1 } = await startClient();
+  expect(await client1.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Storage: NO`),
+  });
+  await client1.close();
+
+  const { client: client2 } = await startClient();
+  expect(await client2.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Storage: NO`),
+  });
+});
+
 test('isolated context with storage state', async ({ startClient, server }, testInfo) => {
   const storageStatePath = testInfo.outputPath('storage-state.json');
   await fs.promises.writeFile(storageStatePath, JSON.stringify({

--- a/tests/mcp/profile-lock.spec.ts
+++ b/tests/mcp/profile-lock.spec.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+import crypto from 'crypto';
+import path from 'path';
 import { chromium } from 'playwright';
 
 import { test, expect } from './fixtures';
 import { tools } from '../../packages/playwright-core/lib/coreBundle';
+
+function defaultMcpProfileDir(testOutputDir: string, mcpBrowser: string) {
+  const browserToken = mcpBrowser === 'chromium' ? 'chrome-for-testing' : mcpBrowser;
+  const rootPathToken = crypto.createHash('sha256').update(testOutputDir).digest('hex').slice(0, 7);
+  return path.join(testOutputDir, 'ms-playwright', `mcp-${browserToken}-${rootPathToken}`);
+}
 
 test('isProfileLocked returns false for empty directory', async ({ mcpBrowser }, testInfo) => {
   test.skip(!['chromium', 'chrome', 'msedge'].includes(mcpBrowser!), 'Chromium-only');
@@ -93,4 +101,24 @@ test('stale profile does not prevent browser launch', async ({ mcpBrowser, start
   })).toHaveResponse({
     snapshot: expect.stringContaining('Hello, world!'),
   });
+});
+
+test('stdio default avoids pre-existing profile lock', async ({ mcpBrowser, startClient, server }, testInfo) => {
+  test.skip(!['chromium', 'chrome', 'msedge'].includes(mcpBrowser!), 'Chromium-only');
+  const userDataDir = defaultMcpProfileDir(testInfo.outputPath(), mcpBrowser!);
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    channel: mcpBrowser === 'chromium' ? 'chrome-for-testing' : mcpBrowser,
+    headless: true,
+  });
+  try {
+    const { client } = await startClient();
+    expect(await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.HELLO_WORLD },
+    })).toHaveResponse({
+      snapshot: expect.stringContaining('Hello, world!'),
+    });
+  } finally {
+    await context.close();
+  }
 });

--- a/tests/mcp/roots.spec.ts
+++ b/tests/mcp/roots.spec.ts
@@ -22,9 +22,10 @@ import { test, expect } from './fixtures';
 
 const p = process.platform === 'win32' ? 'c:\\non\\existent\\folder' : '/non/existent/folder';
 
-test('should use separate user data by root path', async ({ startClient, server }, testInfo) => {
+test('persistent mode should use separate user data by root path', async ({ startClient, server }, testInfo) => {
   const { client } = await startClient({
     clientName: 'Visual Studio Code',
+    config: { browser: { isolated: false } },
     roots: [
       {
         name: 'test',
@@ -53,9 +54,10 @@ test('should list all tools when listRoots is slow', async ({ startClient }) => 
   expect(tools.tools.length).toBeGreaterThan(10);
 });
 
-test('should tolerate malformed roots', async ({ startClient, server }, testInfo) => {
+test('persistent mode should tolerate malformed roots', async ({ startClient, server }, testInfo) => {
   const { client } = await startClient({
     clientName: 'Visual Studio Code',
+    config: { browser: { isolated: false } },
     roots: [
       {
         name: 'test',

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -52,22 +52,18 @@ test('list first tab', async ({ client }) => {
       action: 'list',
     },
   })).toHaveResponse({
-    result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+    result: `- 0: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 
 test('create new tab', async ({ client }) => {
   expect(await createTab(client, 'Tab one', 'Body one')).toHaveResponse({
-    tabs: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
     snapshot: `- generic [active] [ref=e1]: Body one`,
   });
 
   expect(await createTab(client, 'Tab two', 'Body two')).toHaveResponse({
-    tabs: `- 0: [](about:blank)
-- 1: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
-- 2: (current) [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
+    tabs: `- 0: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
+- 1: (current) [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
     snapshot: `- generic [active] [ref=e1]: Body two`,
   });
   expect(await client.callTool({
@@ -86,8 +82,7 @@ test('create new tab with url', async ({ client }) => {
       url: `data:text/html,<title>Tab one</title><body>Body one</body>`,
     },
   })).toHaveResponse({
-    result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+    result: `- 0: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 
@@ -99,24 +94,22 @@ test('select tab', async ({ client }) => {
     name: 'browser_tabs',
     arguments: {
       action: 'select',
-      index: 1,
+      index: 0,
     },
   })).toHaveResponse({
-    result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
-- 2: [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
+    result: `- 0: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
+- 1: [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
   });
 
   expect(await client.callTool({
     name: 'browser_tabs',
     arguments: {
       action: 'select',
-      index: 0,
+      index: 1,
     },
   })).toHaveResponse({
-    result: `- 0: (current) [](about:blank)
-- 1: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
-- 2: [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
+    result: `- 0: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
+- 1: (current) [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
   });
 });
 
@@ -128,11 +121,10 @@ test('close tab', async ({ client }) => {
     name: 'browser_tabs',
     arguments: {
       action: 'close',
-      index: 2,
+      index: 1,
     },
   })).toHaveResponse({
-    result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+    result: `- 0: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 


### PR DESCRIPTION
## Summary

Default stdio MCP sessions to isolated browser contexts unless the user explicitly opts into persistence or an attached browser mode.

This avoids default-profile `SingletonLock` collisions for short-lived stdio MCP clients after a previous client disconnects without an explicit `browser_close`. HTTP/SSE transports keep the existing persistent default.

Fixes #40419.

## Changes

- Resolve stdio MCP defaults to `browser.isolated = true` when no persistence or attachment mode is configured.
- Keep HTTP/SSE, `--user-data-dir`, remote endpoint, CDP endpoint, extension, and explicit `--isolated` behavior unchanged.
- Update MCP docs to describe the stdio-vs-HTTP/SSE profile defaults.
- Update MCP tests whose tab/root expectations depend on the default profile mode.
- Keep tracing start/stop on the same isolated browser context when tracing starts before navigation.

## Verification

- RED: `5dafdf939 test(mcp): cover stdio default isolated behavior`
- GREEN: `52afd9c76 fix(mcp): default stdio sessions to isolated`
- `npm run build`
- `npm run ctest-mcp -- tests/mcp/config-resolve.spec.ts tests/mcp/launch.spec.ts tests/mcp/profile-lock.spec.ts tests/mcp/roots.spec.ts tests/mcp/tabs.spec.ts tests/mcp/tracing.spec.ts`
  - `87 passed, 1 skipped`
- `env -u NO_COLOR npm run ctest-mcp -- --workers=3`
  - `589 passed, 3 skipped`
- `npm run flint`

Note: I unset `NO_COLOR` locally only to avoid a Node 25 color-environment warning affecting exact-output MCP tests.
