### PR TITLE
fix(test): deduplicate tags when same tag appears in multiple scopes

### DIFF
--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -303,10 +303,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     this.parent._collectTagTitlePath(path);
     path.push(this.title);
     const titleTags = path.join(' ').match(/@[\S]+/g) || [];
-    return [
-      ...titleTags,
-      ...this._tags,
-    ];
+    return [...new Set([...titleTags, ...this._tags])];
   }
 
   _serialize(): any {

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -183,6 +183,34 @@ test('should be included in testInfo if coming from describe or global tag', asy
   expect(result.exitCode).toBe(0);
 });
 
+test('should deduplicate tags when same tag appears in both describe and test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+    import { test, expect } from '@playwright/test';
+    test.describe('suite', { tag: '@foo' }, () => {
+      test('test', { tag: '@foo' }, async ({}, testInfo) => {
+        expect(testInfo.tags).toStrictEqual(['@foo']);
+      });
+    });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test('should deduplicate inline tags when same tag appears in both describe title and test title', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+    import { test, expect } from '@playwright/test';
+    test.describe('@foo suite', () => {
+      test('@foo test', async ({}, testInfo) => {
+        expect(testInfo.tags).toStrictEqual(['@foo']);
+      });
+    });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
 test('should not parse file names as tags', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'reporter.ts': `


### PR DESCRIPTION
## Summary
- `testInfo.tags` was returning duplicate entries when the same tag appeared in multiple scopes (e.g. both `describe` and `test` options, or both title strings)
- Fix deduplicates by wrapping the combined tag array in `new Set()`

<img width="1159" height="848" alt="image" src="https://github.com/user-attachments/assets/376572c0-591e-4640-95b3-488098be726c" />


Fixes https://github.com/microsoft/playwright/issues/40368