### PR TITLE
fix(ct): use receiver-free mount typings

### DIFF
--- a/packages/playwright-ct-core/src/mount.ts
+++ b/packages/playwright-ct-core/src/mount.ts
@@ -27,8 +27,8 @@ import type { Page as PageImpl } from 'playwright-core/lib/client/page';
 let boundCallbacksForMount: Function[] = [];
 
 interface MountResult extends Locator {
-  unmount(locator: Locator): Promise<void>;
-  update(options: Omit<MountOptions, 'hooksConfig'> | string | JsxComponent): Promise<void>;
+  unmount: () => Promise<void>;
+  update: (options: ObjectComponentOptions | JsxComponent) => Promise<void>;
 }
 
 type TestFixtures = PlaywrightTestArgs & PlaywrightTestOptions & {

--- a/packages/playwright-ct-react/index.d.ts
+++ b/packages/playwright-ct-react/index.d.ts
@@ -23,15 +23,15 @@ export interface MountOptions<HooksConfig> {
 }
 
 export interface MountResult extends Locator {
-  unmount(): Promise<void>;
-  update(component: React.JSX.Element): Promise<void>;
+  unmount: () => Promise<void>;
+  update: (component: React.JSX.Element) => Promise<void>;
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig>(
+  mount: <HooksConfig>(
     component: React.JSX.Element,
     options?: MountOptions<HooksConfig>
-  ): Promise<MountResult>;
+  ) => Promise<MountResult>;
 }
 
 export const test: TestType<ComponentFixtures>;

--- a/packages/playwright-ct-react17/index.d.ts
+++ b/packages/playwright-ct-react17/index.d.ts
@@ -21,15 +21,15 @@ export interface MountOptions<HooksConfig> {
 }
 
 export interface MountResult extends Locator {
-  unmount(): Promise<void>;
-  update(component: JSX.Element): Promise<void>;
+  unmount: () => Promise<void>;
+  update: (component: JSX.Element) => Promise<void>;
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig>(
+  mount: <HooksConfig>(
     component: JSX.Element,
     options?: MountOptions<HooksConfig>
-  ): Promise<MountResult>;
+  ) => Promise<MountResult>;
 }
 
 export const test: TestType<ComponentFixtures>;

--- a/packages/playwright-ct-vue/index.d.ts
+++ b/packages/playwright-ct-vue/index.d.ts
@@ -39,28 +39,30 @@ export interface MountOptionsJsx<HooksConfig> {
 }
 
 export interface MountResult<Component> extends Locator {
-  unmount(): Promise<void>;
-  update(options: {
+  unmount: () => Promise<void>;
+  update: (options: {
     props?: Partial<ComponentProps<Component>>;
     slots?: Partial<ComponentSlots>;
     on?: Partial<ComponentEvents>;
-  }): Promise<void>;
+  }) => Promise<void>;
 }
 
 export interface MountResultJsx extends Locator {
-  unmount(): Promise<void>;
-  update(component: JSX.Element): Promise<void>;
+  unmount: () => Promise<void>;
+  update: (component: JSX.Element) => Promise<void>;
 }
 
 export interface ComponentFixtures {
-  mount<HooksConfig>(
-    component: JSX.Element,
-    options?: MountOptionsJsx<HooksConfig>
-  ): Promise<MountResultJsx>;
-  mount<HooksConfig, Component = unknown>(
-    component: Component,
-    options?: MountOptions<HooksConfig, Component>
-  ): Promise<MountResult<Component>>;
+  mount: {
+    <HooksConfig>(
+      component: JSX.Element,
+      options?: MountOptionsJsx<HooksConfig>
+    ): Promise<MountResultJsx>;
+    <HooksConfig, Component = unknown>(
+      component: Component,
+      options?: MountOptions<HooksConfig, Component>
+    ): Promise<MountResult<Component>>;
+  };
 }
 
 export const test: TestType<ComponentFixtures>;


### PR DESCRIPTION
## Summary
Previously, component testing `mount` was typed as a method, so using them with destructuring would look like an unbound method invocation.

No functional changes - just typings.

Fixes #40423
