### PR TITLE
fix(glob): throw descriptive error for unbalanced braces in glob patterns

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -56,10 +56,14 @@ export function globToRegexPattern(glob: string): string {
 
     switch (c) {
       case '{':
+        if (inGroup)
+          throw new Error(`Invalid glob pattern "${glob}": nested '{' is not supported`);
         inGroup = true;
         tokens.push('(');
         break;
       case '}':
+        if (!inGroup)
+          throw new Error(`Invalid glob pattern "${glob}": unmatched '}'`);
         inGroup = false;
         tokens.push(')');
         break;
@@ -74,6 +78,8 @@ export function globToRegexPattern(glob: string): string {
         tokens.push(escapedChars.has(c) ? '\\' + c : c);
     }
   }
+  if (inGroup)
+    throw new Error(`Invalid glob pattern "${glob}": unmatched '{'`);
   tokens.push('$');
   return tokens.join('');
 }

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -164,6 +164,14 @@ it('should work with glob', async () => {
     expect(urlMatches(undefined, `${prefix}:blank`, `${prefix}:*`)).toBeTruthy();
     expect(urlMatches(undefined, `not${prefix}:blank`, `${prefix}:*`)).toBeFalsy();
   }
+
+  // Unbalanced braces must throw early with a descriptive error.
+  expect(() => globToRegexPattern('{foo')).toThrow(`Invalid glob pattern "{foo": unmatched '{'`);
+  expect(() => globToRegexPattern('}foo')).toThrow(`Invalid glob pattern "}foo": unmatched '}'`);
+  expect(() => globToRegexPattern('**/*.png?{')).toThrow(`Invalid glob pattern "**/*.png?{": unmatched '{'`);
+  expect(() => globToRegexPattern('https://example.com/{a')).toThrow(`Invalid glob pattern "https://example.com/{a": unmatched '{'`);
+  expect(() => globToRegexPattern('{a,b')).toThrow(`Invalid glob pattern "{a,b": unmatched '{'`);
+  expect(() => globToRegexPattern('{a,{b}}')).toThrow(`Invalid glob pattern "{a,{b}}": nested '{' is not supported`);
 });
 
 it('should intercept by glob', async function({ page, server, isAndroid }) {


### PR DESCRIPTION
## Summary
- `globToRegexPattern()` unconditionally emitted `(` / `)` for `{` / `}` with no balance check, producing invalid regex (e.g. `/^(foo$/`) that threw `SyntaxError` at request-match time and silently aborted navigation
- Added guards to throw a clear `Invalid glob pattern` error at parse time for unmatched `{`, unmatched `}`, and nested `{`
- Added 6 test assertions covering the reported patterns

Fixes https://github.com/microsoft/playwright/issues/40422


<img width="1169" height="876" alt="image" src="https://github.com/user-attachments/assets/f45864a1-f45c-46e9-9e78-c1d94c39dc49" />
