### PR TITLE
fix(mcp): handle page crash event in Tab constructor

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -115,6 +115,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       eventsHelper.addEventListener(p, 'response', response => this._handleResponse(response)),
       eventsHelper.addEventListener(p, 'requestfailed', request => this._handleRequestFailed(request)),
       eventsHelper.addEventListener(p, 'close', () => this._onClose()),
+      eventsHelper.addEventListener(p, 'crash', () => this._onClose()),
       eventsHelper.addEventListener(p, 'filechooser', chooser => {
         this.setModalState({
           type: 'fileChooser',

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -149,3 +149,35 @@ test('reuse first tab when navigating', async ({ startClient, cdpServer, server 
   expect(pages.length).toBe(1);
   expect(await pages[0].title()).toBe('Title');
 });
+
+test('crashed tab is removed from tabs list and server recovers', async ({ client, mcpBrowser }) => {
+  test.skip(mcpBrowser !== 'chromium', 'Crash via chrome://crash is chromium-only');
+
+  // Open a second tab alongside the initial one
+  await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'new' },
+  });
+
+  // Crash the second tab; navigation to chrome://crash throws, that's expected
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'chrome://crash' },
+  }).catch(() => {});
+
+  // Crashed tab must be gone — only the initial tab (index 0) should remain
+  expect(await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  })).toHaveResponse({
+    result: `- 0: (current) [](about:blank)`,
+  });
+
+  // Server must recover: subsequent navigation must work without hanging
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: 'data:text/html,<body>recovered</body>' },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining('recovered'),
+  });
+});


### PR DESCRIPTION
## Summary

The `Tab` constructor registers listeners for various page events, including `close`, but not `crash`. These are two distinct Playwright events:

- `close` — fired when a page is closed normally
- `crash` — fired when the renderer process crashes (e.g. OOM, GPU crash, or certain unhandled conditions in complex SPAs)

When a renderer crash occurs, `_onClose()` is never called, leaving the tab as a **zombie** in the `_tabs` array — technically present but non-functional. Any subsequent tool call that tries to interact with the page will either hang indefinitely or fail with confusing errors like `Target closed`, without the MCP server properly recovering.

## Change

Add a single `crash` event listener that calls the same `_onClose()` handler already used for `close`:

```ts
eventsHelper.addEventListener(p, 'crash', () => this._onClose()),
```

This ensures consistent cleanup regardless of how the page terminates.

## Testing

Manually verified by navigating to a page that triggers a renderer crash — after the fix, the MCP backend correctly removes the tab and recovers on the next tool call.