### PR TITLE
fix(test-runner): cap webServer availability probe timeout to 1s

### DIFF
--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -209,17 +209,22 @@ export class WebServerPlugin implements TestRunnerPlugin {
   }
 }
 
+// Avoid OS-default TCP connect timeout (~2 min) when SYNs are silently dropped, e.g. WSL mirrored networking. See #40430.
+const PORT_AVAILABILITY_CHECK_TIMEOUT = 1000;
+
 async function isPortUsed(port: number): Promise<boolean> {
   const innerIsPortUsed = (host: string) => new Promise<boolean>(resolve => {
-    const conn = net
-        .connect(port, host)
-        .on('error', () => {
-          resolve(false);
-        })
-        .on('connect', () => {
-          conn.end();
-          resolve(true);
-        });
+    const conn = net.connect(port, host);
+    conn.setTimeout(PORT_AVAILABILITY_CHECK_TIMEOUT);
+    conn.on('error', () => resolve(false));
+    conn.on('timeout', () => {
+      conn.destroy();
+      resolve(false);
+    });
+    conn.on('connect', () => {
+      conn.end();
+      resolve(true);
+    });
   });
   return await innerIsPortUsed('127.0.0.1') || await innerIsPortUsed('::1');
 }

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -202,10 +202,22 @@ export async function isURLAvailable(url: URL, ignoreHTTPSErrors: boolean, onLog
   return statusCode >= 200 && statusCode < 404;
 }
 
+// Avoid OS-default TCP connect timeout (~2 min) when SYNs are silently dropped, e.g. WSL mirrored networking. See #40430.
+// A request-level setTimeout is not enough — Happy Eyeballs only assigns a socket once one address connects.
+const URL_AVAILABILITY_CHECK_TIMEOUT = 1000;
+
 async function httpStatusCode(url: URL, ignoreHTTPSErrors: boolean, onLog?: (data: string) => void, onStdErr?: (data: string) => void): Promise<number> {
   return new Promise(resolve => {
     onLog?.(`HTTP GET: ${url}`);
-    httpRequest({
+    let resolved = false;
+    const safeResolve = (status: number) => {
+      if (resolved)
+        return;
+      resolved = true;
+      clearTimeout(timer);
+      resolve(status);
+    };
+    const { cancel } = httpRequest({
       url: url.toString(),
       headers: { Accept: '*/*' },
       rejectUnauthorized: !ignoreHTTPSErrors
@@ -213,13 +225,16 @@ async function httpStatusCode(url: URL, ignoreHTTPSErrors: boolean, onLog?: (dat
       res.resume();
       const statusCode = res.statusCode ?? 0;
       onLog?.(`HTTP Status: ${statusCode}`);
-      resolve(statusCode);
+      safeResolve(statusCode);
     }, error => {
       if ((error as NodeJS.ErrnoException).code === 'DEPTH_ZERO_SELF_SIGNED_CERT')
         onStdErr?.(`[WebServer] Self-signed certificate detected. Try adding ignoreHTTPSErrors: true to config.webServer.`);
       onLog?.(`Error while checking if ${url} is available: ${error.message}`);
-      resolve(0);
+      safeResolve(0);
     });
+    const timer = setTimeout(() => {
+      cancel(new Error(`Request to ${url} timed out after ${URL_AVAILABILITY_CHECK_TIMEOUT}ms`));
+    }, URL_AVAILABILITY_CHECK_TIMEOUT);
   });
 }
 

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import type http from 'http';
+import net from 'net';
 import path from 'path';
 import { test, expect, parseTestRunnerOutput } from './playwright-test-fixtures';
 import type { RunResult } from './playwright-test-fixtures';
@@ -406,6 +407,44 @@ test('should be able to use an existing server when reuseExistingServer:true', a
   expect(result.output).not.toContain('[WebServer] ');
   expect(result.report.suites[0].specs[0].tests[0].results[0].status).toContain('passed');
   await new Promise(resolve => server.close(resolve));
+});
+
+test('should not hang on a non-responding URL probe (regression for #40430)', async ({ runInlineTest }, { workerIndex }) => {
+  const port = workerIndex * 2 + 10500;
+  // Stand-in for WSL silent-drop networking: TCP accepts but no HTTP response. Without a probe timeout this would hang.
+  const sockets = new Set<net.Socket>();
+  const hungServer = net.createServer(socket => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>(resolve => hungServer.listen(port, resolve));
+  try {
+    const start = Date.now();
+    const result = await runInlineTest({
+      'test.spec.ts': `
+        import { test } from '@playwright/test';
+        test('noop', () => {});
+      `,
+      'playwright.config.ts': `
+        module.exports = {
+          webServer: {
+            command: 'node -e "setInterval(() => {}, 1000)"',
+            url: 'http://localhost:${port}',
+            reuseExistingServer: false,
+            timeout: 3000,
+          }
+        };
+      `,
+    });
+    const elapsed = Date.now() - start;
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Timed out waiting 3000ms from config.webServer.');
+    expect(elapsed).toBeLessThan(30_000);
+  } finally {
+    for (const socket of sockets)
+      socket.destroy();
+    await new Promise<void>(resolve => hungServer.close(() => resolve()));
+  }
 });
 
 test('should throw when a server is already running on the given port and strict is true', async ({ runInlineTest }, { workerIndex }) => {


### PR DESCRIPTION
## Summary

Cap each pre-launch `webServer` availability probe at 1s so we no longer hang on the OS-default TCP connect timeout (~2 min) when SYNs are silently dropped — notably on WSL mirrored networking where Windows Defender Firewall drops packets to closed loopback ports.

- `isPortUsed()`: explicit `socket.setTimeout()`, treat `timeout` like a connection error.
- `httpStatusCode()`: wrap the request with a timer that calls `cancel()`. A request-level `setTimeout` is not enough — Happy Eyeballs only assigns a socket to the request once one address connects, so until then there is no socket for the request-level timeout to attach to.
- Added regression test that stands up a TCP peer which accepts SYNs but never replies; without the fix the probe hangs indefinitely.

Fixes https://github.com/microsoft/playwright/issues/40430