### PR TITLE
docs(assertions): specify how to set a global timeout for expect.toPa…

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -270,7 +270,19 @@ await expect(async () => {
 });
 ```
 
-Note that by default `toPass` has timeout 0 and does not respect custom [expect timeout](./test-timeouts.md#expect-timeout).
+Note that by default `toPass` has timeout 0 and does not respect custom [expect timeout](./test-timeouts.md#expect-timeout). Instead, you can configure a global timeout for expect.toPass() using the (config)[./test-api/class-testconfig.md#property-testconfigexpect]:
+
+```js
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  expect: {
+    toPass: {
+			timeout: 10_000
+		}
+  },
+});
+```
 
 ## Add custom matchers using expect.extend
 


### PR DESCRIPTION
Hey, I noticed that the docs are missing how to configure a global timeout for expect.toPass() and were bit unclear before. So I specified that section after #23937 was merged.