### PR TITLE
fix(test-runner): reject workers=0 or negative value

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -225,8 +225,12 @@ function resolveWorkers(workers: string | number): number {
     const parsedWorkers = parseInt(workers, 10);
     if (isNaN(parsedWorkers))
       throw new Error(`Workers ${workers} must be a number or percentage.`);
+    if (parsedWorkers < 1)
+      throw new Error(`Workers must be a positive number, received ${parsedWorkers}.`);
     return parsedWorkers;
   }
+  if (workers < 1)
+    throw new Error(`Workers must be a positive number, received ${workers}.`);
   return workers;
 }
 

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -552,6 +552,18 @@ test('should throw when workers option is invalid', async ({ runInlineTest }) =>
   expect(result.output).toContain('config.workers must be a number or percentage');
 });
 
+test('should throw when workers is negative via CLI (regression for #39938)', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `module.exports = {};`,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('pass', () => {});
+    `,
+  }, { workers: -1 });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers must be a positive number');
+});
+
 test('should work with undefined values and base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
## Summary
- `--workers=0` and `--workers=-1` (or numeric `0`/negative in top-level config) silently exit 0 with no tests run — a CI false-pass risk.
- `resolveWorkers` only guarded against `NaN` and percentages; the integer `< 1` cases fell through.
- Added `< 1` check for both the parsed-string and numeric branches; the existing percentage path (`Math.max(1, …)`) is unaffected.
- One regression test covering the CLI `-1` case as suggested in the prior thread.

Fixes https://github.com/microsoft/playwright/issues/39938