### PR TITLE
fix(glob): throw on page.route() for unbalanced braces in glob patterns

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -56,10 +56,14 @@ export function globToRegexPattern(glob: string): string {
 
     switch (c) {
       case '{':
+        if (inGroup)
+          throw new Error(`Invalid glob pattern "${glob}": nested '{' is not supported`);
         inGroup = true;
         tokens.push('(');
         break;
       case '}':
+        if (!inGroup)
+          throw new Error(`Invalid glob pattern "${glob}": unmatched '}'`);
         inGroup = false;
         tokens.push(')');
         break;
@@ -74,6 +78,8 @@ export function globToRegexPattern(glob: string): string {
         tokens.push(escapedChars.has(c) ? '\\' + c : c);
     }
   }
+  if (inGroup)
+    throw new Error(`Invalid glob pattern "${glob}": unmatched '{'`);
   tokens.push('$');
   return tokens.join('');
 }

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -16,7 +16,7 @@
 
 import { assert } from '@isomorphic/assert';
 import { headersObjectToArray } from '@isomorphic/headers';
-import { serializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
+import { resolveGlobToRegexPattern, serializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
 import { LongStandingScope, ManualPromise } from '@isomorphic/manualPromise';
 import { MultiMap } from '@isomorphic/multimap';
 import { isString } from '@isomorphic/rtti';
@@ -590,6 +590,8 @@ export class WebSocketRouteHandler {
   constructor(baseURL: string | undefined, url: URLMatch, handler: WebSocketRouteHandlerCallback) {
     this._baseURL = baseURL;
     this.url = url;
+    if (isString(url))
+      resolveGlobToRegexPattern(baseURL, url, true);
     this.handler = handler;
   }
 
@@ -834,6 +836,8 @@ export class RouteHandler {
     this._baseURL = baseURL;
     this._times = times;
     this.url = url;
+    if (isString(url))
+      resolveGlobToRegexPattern(baseURL, url);
     this.handler = handler;
     this._savedZone = platform.zones.current().pop();
   }

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -590,8 +590,6 @@ export class WebSocketRouteHandler {
   constructor(baseURL: string | undefined, url: URLMatch, handler: WebSocketRouteHandlerCallback) {
     this._baseURL = baseURL;
     this.url = url;
-    if (isString(url))
-      resolveGlobToRegexPattern(baseURL, url, true);
     this.handler = handler;
   }
 

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { deserializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
+import { deserializeURLMatch, resolveGlobToRegexPattern, urlMatches } from '@isomorphic/urlMatch';
 import { createGuid } from '@utils/crypto';
 import { BrowserContext } from '../browserContext';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
@@ -329,6 +329,11 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async setWebSocketInterceptionPatterns(params: channels.PageSetWebSocketInterceptionPatternsParams, progress: Progress): Promise<void> {
+    const baseURL = this._context._options.baseURL;
+    for (const pattern of params.patterns) {
+      if (pattern.glob)
+        resolveGlobToRegexPattern(baseURL, pattern.glob, true);
+    }
     this._webSocketInterceptionPatterns = params.patterns;
     if (params.patterns.length && !this._routeWebSocketInitScript)
       this._routeWebSocketInitScript = await WebSocketRouteDispatcher.install(progress, this.connection, this._context);

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { deserializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
+import { deserializeURLMatch, resolveGlobToRegexPattern, urlMatches } from '@isomorphic/urlMatch';
 import { Page, Worker } from '../page';
 import { Dispatcher } from './dispatcher';
 import { parseError, serializeError } from '../errors';
@@ -219,6 +219,11 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async setWebSocketInterceptionPatterns(params: channels.PageSetWebSocketInterceptionPatternsParams, progress: Progress): Promise<void> {
+    const baseURL = this._page.browserContext._options.baseURL;
+    for (const pattern of params.patterns) {
+      if (pattern.glob)
+        resolveGlobToRegexPattern(baseURL, pattern.glob, true);
+    }
     this._webSocketInterceptionPatterns = params.patterns;
     if (params.patterns.length && !this._routeWebSocketInitScript)
       this._routeWebSocketInitScript = await WebSocketRouteDispatcher.install(progress, this.connection, this._page);

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -98,6 +98,12 @@ it('should not support ? in glob pattern', async ({ page, server }) => {
   expect(await page.content()).toContain('index123hello');
 });
 
+it('should throw for unbalanced braces in glob pattern', async ({ page }) => {
+  await expect(page.route('http://*/foo{', () => {})).rejects.toThrow(`Invalid glob pattern "http://*/foo{": unmatched '{'`);
+  await expect(page.route('}foo', () => {})).rejects.toThrow(`Invalid glob pattern "}foo": unmatched '}'`);
+  await expect(page.route('**/img.{png,{gif}}', () => {})).rejects.toThrow(`Invalid glob pattern "**/img.{png,{gif}}": nested '{' is not supported`);
+});
+
 it('should work when POST is redirected with 302', async ({ page, server }) => {
   server.setRedirect('/rredirect', '/empty.html');
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
## Summary

- `globToRegexPattern()` now throws a descriptive error for nested `{`, unmatched `}`, and unclosed `{`
- `RouteHandler` and `WebSocketRouteHandler` constructors call `resolveGlobToRegexPattern()` eagerly so the error surfaces immediately when `page.route()` / `context.route()` is called, not silently at request-match time
- Added test covering all three invalid cases

Fixes https://github.com/microsoft/playwright/issues/40422