### PR TITLE
feat(reporter): expose worker info on fixture teardown errors

### DIFF
--- a/docs/src/test-reporter-api/class-reporter.md
+++ b/docs/src/test-reporter-api/class-reporter.md
@@ -150,6 +150,12 @@ Called on some global error, for example unhandled exception in the worker proce
 
 The error.
 
+### param: Reporter.onError.workerInfo
+* since: v1.60
+- `workerInfo` ?<[WorkerInfo]>
+
+When the error originates from a worker fixture teardown, contains information about the worker that produced it. `undefined` for errors that are not associated with a specific worker.
+
 ## optional async method: Reporter.onExit
 * since: v1.33
 

--- a/docs/src/test-reporter-api/class-reporter.md
+++ b/docs/src/test-reporter-api/class-reporter.md
@@ -154,7 +154,7 @@ The error.
 * since: v1.60
 - `workerInfo` ?<[WorkerInfo]>
 
-When the error originates from a worker fixture teardown, contains information about the worker that produced it. `undefined` for errors that are not associated with a specific worker.
+Contains information about the worker that produced this error. `undefined` for errors that are not associated with a specific worker.
 
 ## optional async method: Reporter.onExit
 * since: v1.33

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -39,3 +39,21 @@ Error location in the source code.
 - type: ?<[string]>
 
 Source code snippet with highlighted error.
+
+## property: TestError.timestamp
+* since: v1.60
+- type: ?<[float]>
+
+Time when the error was emitted, in milliseconds since the Unix epoch. Set for errors that originate from a worker fixture teardown.
+
+## property: TestError.workerIndex
+* since: v1.60
+- type: ?<[int]>
+
+Index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See [`property: TestInfo.workerIndex`].
+
+## property: TestError.parallelIndex
+* since: v1.60
+- type: ?<[int]>
+
+Parallel slot index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See [`property: TestInfo.parallelIndex`].

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -39,21 +39,3 @@ Error location in the source code.
 - type: ?<[string]>
 
 Source code snippet with highlighted error.
-
-## property: TestError.timestamp
-* since: v1.60
-- type: ?<[float]>
-
-Time when the error was emitted, in milliseconds since the Unix epoch. Set for errors that originate from a worker fixture teardown.
-
-## property: TestError.workerIndex
-* since: v1.60
-- type: ?<[int]>
-
-Index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See [`property: TestInfo.workerIndex`].
-
-## property: TestError.parallelIndex
-* since: v1.60
-- type: ?<[int]>
-
-Parallel slot index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See [`property: TestInfo.parallelIndex`].

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -212,6 +212,7 @@ export type JsonOnErrorEvent = {
   method: 'onError';
   params: {
     error: reporterTypes.TestError;
+    workerInfo?: { workerIndex: number, parallelIndex: number };
   };
 };
 
@@ -313,7 +314,7 @@ export class TeleReporterReceiver {
       return;
     }
     if (method === 'onError') {
-      this._onError(params.error);
+      this._onError(params.error, params.workerInfo);
       return;
     }
     if (method === 'onStdIO') {
@@ -438,8 +439,14 @@ export class TeleReporterReceiver {
     })));
   }
 
-  private _onError(error: reporterTypes.TestError) {
-    this._reporter.onError?.(error);
+  private _onError(error: reporterTypes.TestError, workerInfo?: { workerIndex: number, parallelIndex: number }) {
+    const fullWorkerInfo: reporterTypes.WorkerInfo | undefined = workerInfo ? {
+      workerIndex: workerInfo.workerIndex,
+      parallelIndex: workerInfo.parallelIndex,
+      config: this._config,
+      project: (this._rootSuite._entries[0] as TeleSuite)?.project() ?? baseFullConfig.projects[0],
+    } : undefined;
+    this._reporter.onError?.(error, fullWorkerInfo);
   }
 
   private _onStdIO(type: JsonStdIOType, testId: string | undefined, resultId: string | undefined, data: string, isBase64: boolean) {

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -41,6 +41,7 @@ export type JsonProject = {
   grepInvert: JsonPattern[];
   metadata: Metadata;
   name: string;
+  id?: string;
   dependencies: string[];
   // This is relative to root dir.
   snapshotDir: string;
@@ -212,7 +213,7 @@ export type JsonOnErrorEvent = {
   method: 'onError';
   params: {
     error: reporterTypes.TestError;
-    workerInfo?: { workerIndex: number, parallelIndex: number };
+    workerInfo?: { workerIndex: number, parallelIndex: number, projectId?: string };
   };
 };
 
@@ -439,13 +440,17 @@ export class TeleReporterReceiver {
     })));
   }
 
-  private _onError(error: reporterTypes.TestError, workerInfo?: { workerIndex: number, parallelIndex: number }) {
-    const fullWorkerInfo: reporterTypes.WorkerInfo | undefined = workerInfo ? {
-      workerIndex: workerInfo.workerIndex,
-      parallelIndex: workerInfo.parallelIndex,
-      config: this._config,
-      project: (this._rootSuite._entries[0] as TeleSuite)?.project() ?? baseFullConfig.projects[0],
-    } : undefined;
+  private _onError(error: reporterTypes.TestError, workerInfo?: { workerIndex: number, parallelIndex: number, projectId?: string }) {
+    let fullWorkerInfo: reporterTypes.WorkerInfo | undefined;
+    if (workerInfo) {
+      const project = (workerInfo.projectId !== undefined ? this._config.projects.find(p => (p as any).__projectId === workerInfo.projectId) : undefined) ?? this._config.projects[0] ?? baseFullConfig.projects[0];
+      fullWorkerInfo = {
+        workerIndex: workerInfo.workerIndex,
+        parallelIndex: workerInfo.parallelIndex,
+        config: this._config,
+        project,
+      };
+    }
     this._reporter.onError?.(error, fullWorkerInfo);
   }
 
@@ -482,7 +487,7 @@ export class TeleReporterReceiver {
   }
 
   private _parseProject(project: JsonProject): TeleFullProject {
-    return {
+    const parsed: TeleFullProject = {
       metadata: project.metadata,
       name: project.name,
       outputDir: this._absolutePath(project.outputDir),
@@ -500,6 +505,9 @@ export class TeleReporterReceiver {
       ignoreSnapshots: project.ignoreSnapshots ?? false,
       use: project.use,
     };
+    if (project.id !== undefined)
+      (parsed as any).__projectId = project.id;
+    return parsed;
   }
 
   private _parseAttachments(attachments: JsonAttachment[]): reporterTypes.TestResult['attachments'] {

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -41,7 +41,6 @@ export type JsonProject = {
   grepInvert: JsonPattern[];
   metadata: Metadata;
   name: string;
-  id?: string;
   dependencies: string[];
   // This is relative to root dir.
   snapshotDir: string;
@@ -213,7 +212,7 @@ export type JsonOnErrorEvent = {
   method: 'onError';
   params: {
     error: reporterTypes.TestError;
-    workerInfo?: { workerIndex: number, parallelIndex: number, projectId?: string };
+    workerInfo?: { workerIndex: number, parallelIndex: number, projectName: string };
   };
 };
 
@@ -440,16 +439,18 @@ export class TeleReporterReceiver {
     })));
   }
 
-  private _onError(error: reporterTypes.TestError, workerInfo?: { workerIndex: number, parallelIndex: number, projectId?: string }) {
+  private _onError(error: reporterTypes.TestError, workerInfo?: { workerIndex: number, parallelIndex: number, projectName: string }) {
     let fullWorkerInfo: reporterTypes.WorkerInfo | undefined;
     if (workerInfo) {
-      const project = (workerInfo.projectId !== undefined ? this._config.projects.find(p => (p as any).__projectId === workerInfo.projectId) : undefined) ?? this._config.projects[0] ?? baseFullConfig.projects[0];
-      fullWorkerInfo = {
-        workerIndex: workerInfo.workerIndex,
-        parallelIndex: workerInfo.parallelIndex,
-        config: this._config,
-        project,
-      };
+      const project = this._config.projects.find(p => p.name === workerInfo.projectName);
+      if (project) {
+        fullWorkerInfo = {
+          workerIndex: workerInfo.workerIndex,
+          parallelIndex: workerInfo.parallelIndex,
+          config: this._config,
+          project,
+        };
+      }
     }
     this._reporter.onError?.(error, fullWorkerInfo);
   }
@@ -487,7 +488,7 @@ export class TeleReporterReceiver {
   }
 
   private _parseProject(project: JsonProject): TeleFullProject {
-    const parsed: TeleFullProject = {
+    return {
       metadata: project.metadata,
       name: project.name,
       outputDir: this._absolutePath(project.outputDir),
@@ -505,9 +506,6 @@ export class TeleReporterReceiver {
       ignoreSnapshots: project.ignoreSnapshots ?? false,
       use: project.use,
     };
-    if (project.id !== undefined)
-      (parsed as any).__projectId = project.id;
-    return parsed;
   }
 
   private _parseAttachments(attachments: JsonAttachment[]): reporterTypes.TestResult['attachments'] {

--- a/packages/playwright/src/reporters/internalReporter.ts
+++ b/packages/playwright/src/reporters/internalReporter.ts
@@ -25,7 +25,7 @@ import * as babel from '../transform/babelBundle';
 import { wrapReporterAsV2 } from './reporterV2';
 
 import type { AnyReporter, ReporterV2 } from './reporterV2';
-import type { FullConfig, FullResult, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
+import type { FullConfig, FullResult, TestCase, TestError, TestResult, TestStep, WorkerInfo } from '../../types/testReporter';
 
 
 export class InternalReporter implements ReporterV2 {
@@ -93,9 +93,9 @@ export class InternalReporter implements ReporterV2 {
     await this._reporter.onExit?.();
   }
 
-  onError(error: TestError) {
+  onError(error: TestError, workerInfo?: WorkerInfo) {
     addLocationAndSnippetToError(this._config, error);
-    this._reporter.onError?.(error);
+    this._reporter.onError?.(error, workerInfo);
   }
 
   onStepBegin(test: TestCase, result: TestResult, step: TestStep) {

--- a/packages/playwright/src/reporters/multiplexer.ts
+++ b/packages/playwright/src/reporters/multiplexer.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ReportConfigureParams, ReportEndParams, ReporterV2 } from './reporterV2';
-import type { FullConfig, FullResult, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
+import type { FullConfig, FullResult, TestCase, TestError, TestResult, TestStep, WorkerInfo } from '../../types/testReporter';
 import type { test } from '../common';
 
 export class Multiplexer implements ReporterV2 {
@@ -88,9 +88,9 @@ export class Multiplexer implements ReporterV2 {
       await wrapAsync(() => reporter.onExit?.());
   }
 
-  onError(error: TestError) {
+  onError(error: TestError, workerInfo?: WorkerInfo) {
     for (const reporter of this._reporters)
-      wrap(() => reporter.onError?.(error));
+      wrap(() => reporter.onError?.(error, workerInfo));
   }
 
   onStepBegin(test: TestCase, result: TestResult, step: TestStep) {

--- a/packages/playwright/src/reporters/reporterV2.ts
+++ b/packages/playwright/src/reporters/reporterV2.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { FullConfig, FullResult, Reporter, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
+import type { FullConfig, FullResult, Reporter, Suite, TestCase, TestError, TestResult, TestStep, WorkerInfo } from '../../types/testReporter';
 
 export interface ReportConfigureParams {
   config: FullConfig;
@@ -38,7 +38,7 @@ export interface ReporterV2 {
   onReportEnd?(params: ReportEndParams): void;
   onEnd?(result: FullResult): Promise<{ status?: FullResult['status'] } | undefined | void> | void;
   onExit?(): void | Promise<void>;
-  onError?(error: TestError): void;
+  onError?(error: TestError, workerInfo?: WorkerInfo): void;
   onStepBegin?(test: TestCase, result: TestResult, step: TestStep): void;
   onStepEnd?(test: TestCase, result: TestResult, step: TestStep): void;
   printsToStdio?(): boolean;
@@ -64,7 +64,7 @@ export function wrapReporterAsV2(reporter: Reporter | ReporterV2): ReporterV2 {
 
 class ReporterV2Wrapper implements ReporterV2 {
   private _reporter: Reporter;
-  private _deferred: { error?: TestError, stdout?: StdIOChunk, stderr?: StdIOChunk }[] | null = [];
+  private _deferred: { error?: { error: TestError, workerInfo?: WorkerInfo }, stdout?: StdIOChunk, stderr?: StdIOChunk }[] | null = [];
   private _config!: FullConfig;
 
   constructor(reporter: Reporter) {
@@ -86,7 +86,7 @@ class ReporterV2Wrapper implements ReporterV2 {
     this._deferred = null;
     for (const item of deferred) {
       if (item.error)
-        this.onError(item.error);
+        this.onError(item.error.error, item.error.workerInfo);
       if (item.stdout)
         this.onStdOut(item.stdout.chunk, item.stdout.test, item.stdout.result);
       if (item.stderr)
@@ -126,12 +126,12 @@ class ReporterV2Wrapper implements ReporterV2 {
     await this._reporter.onExit?.();
   }
 
-  onError(error: TestError) {
+  onError(error: TestError, workerInfo?: WorkerInfo) {
     if (this._deferred) {
-      this._deferred.push({ error });
+      this._deferred.push({ error: { error, workerInfo } });
       return;
     }
-    this._reporter.onError?.(error);
+    this._reporter.onError?.(error, workerInfo);
   }
 
   onStepBegin(test: TestCase, result: TestResult, step: TestStep) {

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -135,10 +135,13 @@ export class TeleReporterEmitter implements ReporterV2 {
     });
   }
 
-  onError(error: reporterTypes.TestError): void {
+  onError(error: reporterTypes.TestError, workerInfo?: reporterTypes.WorkerInfo): void {
     this._messageSink({
       method: 'onError',
-      params: { error }
+      params: {
+        error,
+        workerInfo: workerInfo ? { workerIndex: workerInfo.workerIndex, parallelIndex: workerInfo.parallelIndex } : undefined,
+      },
     });
   }
 

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -18,7 +18,6 @@ import path from 'path';
 
 import { createGuid } from '@utils/crypto';
 
-import { getProjectId } from '../common/config';
 import { serializeRegexPatterns } from '../isomorphic/teleReceiver';
 
 import type { ReporterV2 } from './reporterV2';
@@ -144,7 +143,7 @@ export class TeleReporterEmitter implements ReporterV2 {
         workerInfo: workerInfo ? {
           workerIndex: workerInfo.workerIndex,
           parallelIndex: workerInfo.parallelIndex,
-          projectId: getProjectId(workerInfo.project),
+          projectName: workerInfo.project.name,
         } : undefined,
       },
     });
@@ -209,7 +208,6 @@ export class TeleReporterEmitter implements ReporterV2 {
     const report: teleReceiver.JsonProject = {
       metadata: project.metadata,
       name: project.name,
-      id: getProjectId(project),
       outputDir: this._relativePath(project.outputDir),
       repeatEach: project.repeatEach,
       retries: project.retries,

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -18,6 +18,7 @@ import path from 'path';
 
 import { createGuid } from '@utils/crypto';
 
+import { getProjectId } from '../common/config';
 import { serializeRegexPatterns } from '../isomorphic/teleReceiver';
 
 import type { ReporterV2 } from './reporterV2';
@@ -140,7 +141,11 @@ export class TeleReporterEmitter implements ReporterV2 {
       method: 'onError',
       params: {
         error,
-        workerInfo: workerInfo ? { workerIndex: workerInfo.workerIndex, parallelIndex: workerInfo.parallelIndex } : undefined,
+        workerInfo: workerInfo ? {
+          workerIndex: workerInfo.workerIndex,
+          parallelIndex: workerInfo.parallelIndex,
+          projectId: getProjectId(workerInfo.project),
+        } : undefined,
       },
     });
   }
@@ -204,6 +209,7 @@ export class TeleReporterEmitter implements ReporterV2 {
     const report: teleReceiver.JsonProject = {
       metadata: project.metadata,
       name: project.name,
+      id: getProjectId(project),
       outputDir: this._relativePath(project.outputDir),
       repeatEach: project.repeatEach,
       retries: project.retries,

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -243,8 +243,9 @@ export class Dispatcher {
     });
     worker.on('teardownErrors', (params: ipc.TeardownErrorsPayload) => {
       this._testRun.hasWorkerErrors = true;
+      const timestamp = Date.now();
       for (const error of params.fatalErrors)
-        this._testRun.reporter.onError?.(error);
+        this._testRun.reporter.onError?.({ ...error, timestamp, workerIndex: worker.workerIndex, parallelIndex: worker.parallelIndex });
     });
     worker.on('exit', () => {
       const producedEnv = this._producedEnvByProjectId.get(testGroup.projectId) || {};

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -243,9 +243,14 @@ export class Dispatcher {
     });
     worker.on('teardownErrors', (params: ipc.TeardownErrorsPayload) => {
       this._testRun.hasWorkerErrors = true;
-      const timestamp = Date.now();
+      const workerInfo = {
+        config: this._testRun.config.config,
+        project: project.project,
+        workerIndex: worker.workerIndex,
+        parallelIndex: worker.parallelIndex,
+      };
       for (const error of params.fatalErrors)
-        this._testRun.reporter.onError?.({ ...error, timestamp, workerIndex: worker.workerIndex, parallelIndex: worker.parallelIndex });
+        this._testRun.reporter.onError?.(error, workerInfo);
     });
     worker.on('exit', () => {
       const producedEnv = this._producedEnvByProjectId.get(testGroup.projectId) || {};

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import type { TestStatus, Metadata, PlaywrightTestOptions, PlaywrightWorkerOptions, ReporterDescription, FullConfig, FullProject, Location } from './test';
-export type { FullConfig, FullProject, TestStatus, Location } from './test';
+import type { TestStatus, Metadata, PlaywrightTestOptions, PlaywrightWorkerOptions, ReporterDescription, FullConfig, FullProject, Location, WorkerInfo } from './test';
+export type { FullConfig, FullProject, TestStatus, Location, WorkerInfo } from './test';
 
 /**
  * Result of the full test run.
@@ -119,8 +119,8 @@ export interface FullResult {
  * [reporter.onStdOut(chunk, test, result)](https://playwright.dev/docs/api/class-reporter#reporter-on-std-out) and
  * [reporter.onStdErr(chunk, test, result)](https://playwright.dev/docs/api/class-reporter#reporter-on-std-err) are
  * called when standard output is produced in the worker process, possibly during a test execution, and
- * [reporter.onError(error)](https://playwright.dev/docs/api/class-reporter#reporter-on-error) is called when
- * something went wrong outside of the test execution.
+ * [reporter.onError(error[, workerInfo])](https://playwright.dev/docs/api/class-reporter#reporter-on-error) is called
+ * when something went wrong outside of the test execution.
  *
  * If your custom reporter does not print anything to the terminal, implement
  * [reporter.printsToStdio()](https://playwright.dev/docs/api/class-reporter#reporter-prints-to-stdio) and return
@@ -169,8 +169,10 @@ export interface Reporter {
   /**
    * Called on some global error, for example unhandled exception in the worker process.
    * @param error The error.
+   * @param workerInfo When the error originates from a worker fixture teardown, contains information about the worker that produced it.
+   * `undefined` for errors that are not associated with a specific worker.
    */
-  onError?(error: TestError): void;
+  onError?(error: TestError, workerInfo?: WorkerInfo): void;
 
   /**
    * Called immediately before test runner exists. At this point all the reporters have received the
@@ -570,12 +572,6 @@ export interface TestError {
   message?: string;
 
   /**
-   * Parallel slot index of the worker that emitted this error. Set for errors that originate from a worker fixture
-   * teardown. See [testInfo.parallelIndex](https://playwright.dev/docs/api/class-testinfo#test-info-parallel-index).
-   */
-  parallelIndex?: number;
-
-  /**
    * Source code snippet with highlighted error.
    */
   snippet?: string;
@@ -586,21 +582,9 @@ export interface TestError {
   stack?: string;
 
   /**
-   * Time when the error was emitted, in milliseconds since the Unix epoch. Set for errors that originate from a worker
-   * fixture teardown.
-   */
-  timestamp?: number;
-
-  /**
    * The value that was thrown. Set when anything except the [Error] (or its subclass) has been thrown.
    */
   value?: string;
-
-  /**
-   * Index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See
-   * [testInfo.workerIndex](https://playwright.dev/docs/api/class-testinfo#test-info-worker-index).
-   */
-  workerIndex?: number;
 }
 
 /**

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -570,6 +570,12 @@ export interface TestError {
   message?: string;
 
   /**
+   * Parallel slot index of the worker that emitted this error. Set for errors that originate from a worker fixture
+   * teardown. See [testInfo.parallelIndex](https://playwright.dev/docs/api/class-testinfo#test-info-parallel-index).
+   */
+  parallelIndex?: number;
+
+  /**
    * Source code snippet with highlighted error.
    */
   snippet?: string;
@@ -580,9 +586,21 @@ export interface TestError {
   stack?: string;
 
   /**
+   * Time when the error was emitted, in milliseconds since the Unix epoch. Set for errors that originate from a worker
+   * fixture teardown.
+   */
+  timestamp?: number;
+
+  /**
    * The value that was thrown. Set when anything except the [Error] (or its subclass) has been thrown.
    */
   value?: string;
+
+  /**
+   * Index of the worker that emitted this error. Set for errors that originate from a worker fixture teardown. See
+   * [testInfo.workerIndex](https://playwright.dev/docs/api/class-testinfo#test-info-worker-index).
+   */
+  workerIndex?: number;
 }
 
 /**

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -169,8 +169,8 @@ export interface Reporter {
   /**
    * Called on some global error, for example unhandled exception in the worker process.
    * @param error The error.
-   * @param workerInfo When the error originates from a worker fixture teardown, contains information about the worker that produced it.
-   * `undefined` for errors that are not associated with a specific worker.
+   * @param workerInfo Contains information about the worker that produced this error. `undefined` for errors that are not associated with
+   * a specific worker.
    */
   onError?(error: TestError, workerInfo?: WorkerInfo): void;
 

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -547,6 +547,37 @@ onEnd
 onExit
 `);
     });
+
+    test('onError exposes worker info for fixture teardown errors (#39063)', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'reporter.ts': `
+          class Reporter {
+            printsToStdio() { return true; }
+            onError(error) {
+              console.log('teardownError:'
+                + ' message=' + (error.message || '').split('\\n')[0]
+                + ' timestampType=' + typeof error.timestamp
+                + ' workerIndexType=' + typeof error.workerIndex
+                + ' parallelIndexType=' + typeof error.parallelIndex);
+            }
+          }
+          module.exports = Reporter;
+        `,
+        'playwright.config.ts': `module.exports = { reporter: './reporter.ts' };`,
+        'a.spec.ts': `
+          import { test as base } from '@playwright/test';
+          const test = base.extend<{}, { brokenWorker: void }>({
+            brokenWorker: [async ({}, use) => {
+              await use();
+              throw new Error('teardown failed');
+            }, { scope: 'worker' }],
+          });
+          test('uses worker fixture', async ({ brokenWorker }) => {});
+        `,
+      }, { reporter: '', workers: 1 });
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('teardownError: message=Error: teardown failed timestampType=number workerIndexType=number parallelIndexType=number');
+    });
   });
 }
 

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -548,17 +548,15 @@ onExit
 `);
     });
 
-    test('onError exposes worker info for fixture teardown errors (#39063)', async ({ runInlineTest }) => {
+    test('onError receives workerInfo for fixture teardown errors (#39063)', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'reporter.ts': `
           class Reporter {
             printsToStdio() { return true; }
-            onError(error) {
+            onError(error, workerInfo) {
               console.log('teardownError:'
                 + ' message=' + (error.message || '').split('\\n')[0]
-                + ' timestampType=' + typeof error.timestamp
-                + ' workerIndexType=' + typeof error.workerIndex
-                + ' parallelIndexType=' + typeof error.parallelIndex);
+                + ' workerInfo=' + (workerInfo ? typeof workerInfo.workerIndex + '/' + typeof workerInfo.parallelIndex : 'undefined'));
             }
           }
           module.exports = Reporter;
@@ -576,7 +574,7 @@ onExit
         `,
       }, { reporter: '', workers: 1 });
       expect(result.exitCode).toBe(1);
-      expect(result.output).toContain('teardownError: message=Error: teardown failed timestampType=number workerIndexType=number parallelIndexType=number');
+      expect(result.output).toContain('teardownError: message=Error: teardown failed workerInfo=number/number');
     });
   });
 }

--- a/tests/playwright-test/reporter.spec.ts
+++ b/tests/playwright-test/reporter.spec.ts
@@ -556,12 +556,12 @@ onExit
             onError(error, workerInfo) {
               console.log('teardownError:'
                 + ' message=' + (error.message || '').split('\\n')[0]
-                + ' workerInfo=' + (workerInfo ? typeof workerInfo.workerIndex + '/' + typeof workerInfo.parallelIndex : 'undefined'));
+                + ' workerInfo=' + (workerInfo ? typeof workerInfo.workerIndex + '/' + typeof workerInfo.parallelIndex + '/' + workerInfo.project.name : 'undefined'));
             }
           }
           module.exports = Reporter;
         `,
-        'playwright.config.ts': `module.exports = { reporter: './reporter.ts' };`,
+        'playwright.config.ts': `module.exports = { projects: [{ name: 'foo' }], reporter: './reporter.ts' };`,
         'a.spec.ts': `
           import { test as base } from '@playwright/test';
           const test = base.extend<{}, { brokenWorker: void }>({
@@ -574,7 +574,7 @@ onExit
         `,
       }, { reporter: '', workers: 1 });
       expect(result.exitCode).toBe(1);
-      expect(result.output).toContain('teardownError: message=Error: teardown failed workerInfo=number/number');
+      expect(result.output).toContain('teardownError: message=Error: teardown failed workerInfo=number/number/foo');
     });
   });
 }

--- a/utils/generate_types/overrides-testReporter.d.ts
+++ b/utils/generate_types/overrides-testReporter.d.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { TestStatus, Metadata, PlaywrightTestOptions, PlaywrightWorkerOptions, ReporterDescription, FullConfig, FullProject, Location } from './test';
-export type { FullConfig, FullProject, TestStatus, Location } from './test';
+import type { TestStatus, Metadata, PlaywrightTestOptions, PlaywrightWorkerOptions, ReporterDescription, FullConfig, FullProject, Location, WorkerInfo } from './test';
+export type { FullConfig, FullProject, TestStatus, Location, WorkerInfo } from './test';
 
 /**
  * Result of the full test run.


### PR DESCRIPTION
## Summary
- Adds three optional fields to `TestError` — `timestamp`, `workerIndex`, `parallelIndex` — populated when the error originates from a worker fixture teardown and is forwarded via `Reporter.onError`.
- Lets reporters correlate teardown errors with the worker that produced them and place them on a timeline (esp. useful when merging shards).
- Public API surface: docs + auto-regenerated types only; existing reporters keep working unchanged.

Fixes https://github.com/microsoft/playwright/issues/39063