### PR TITLE
fix(selectors): handle regex separators

### DIFF
--- a/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
+++ b/packages/playwright-core/src/utils/isomorphic/selectorParser.ts
@@ -206,10 +206,50 @@ function parseSelectorString(selector: string): ParsedSelectorStrings {
     return !!match && !!match[1];
   };
 
+  const shouldSkipRegexLiteral = () => {
+    const prefix = selector.substring(start, index).trim();
+    if (/^(?:internal:(?:text|label|has-text|has-not-text)|text(?::light)?)\s*=$/.test(prefix))
+      return true;
+    if (/^(?:internal:(?:attr|testid|role)|role)\s*=/.test(prefix))
+      return /(?:^|[\[=])\s*$/.test(prefix);
+    return false;
+  };
+
+  const skipRegexLiteral = () => {
+    let position = index + 1;
+    let inClass = false;
+    while (position < selector.length) {
+      const c = selector[position];
+      if (c === '\\' && position + 1 < selector.length) {
+        position += 2;
+        continue;
+      }
+      if (c === '[') {
+        inClass = true;
+        position++;
+        continue;
+      }
+      if (c === ']' && inClass) {
+        inClass = false;
+        position++;
+        continue;
+      }
+      if (c === '/' && !inClass) {
+        position++;
+        while (position < selector.length && /[a-z]/i.test(selector[position]))
+          position++;
+        return position;
+      }
+      position++;
+    }
+  };
+
   while (index < selector.length) {
     const c = selector[index];
     if (c === '\\' && index + 1 < selector.length) {
       index += 2;
+    } else if (!quote && c === '/' && shouldSkipRegexLiteral()) {
+      index = skipRegexLiteral() ?? index + 1;
     } else if (c === quote) {
       quote = undefined;
       index++;

--- a/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+++ b/packages/playwright-core/src/utils/isomorphic/stringUtils.ts
@@ -97,8 +97,7 @@ export function normalizeEscapedRegexQuotes(source: string) {
 }
 
 function escapeRegexForSelector(re: RegExp): string {
-  // Unicode mode does not allow "identity character escapes", so we do not escape and
-  // hope that it does not contain quotes and/or >> signs.
+  // Unicode mode does not allow "identity character escapes", so we do not escape.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape
   // TODO: rework RE usages in internal selectors away from literal representation to json, e.g. {source,flags}.
   if (re.unicode || (re as any).unicodeSets)

--- a/tests/page/selectors-text.spec.ts
+++ b/tests/page/selectors-text.spec.ts
@@ -78,6 +78,9 @@ it('should work @smoke', async ({ page }) => {
   expect(await page.$eval(`text="Hi>>">>span`, e => e.outerHTML)).toBe(`<span></span>`);
   expect(await page.$eval(`text=/Hi\\>\\>/ >> span`, e => e.outerHTML)).toBe(`<span></span>`);
 
+  await page.setContent(`<div>nothing</div>`);
+  expect(await page.getByText(/<a > >> c/u).count()).toBe(0);
+
   await page.setContent(`<div>a<br>b</div><div>a</div>`);
   expect(await page.$eval(`text=a`, e => e.outerHTML)).toBe('<div>a<br>b</div>');
   expect(await page.$eval(`text=b`, e => e.outerHTML)).toBe('<div>a<br>b</div>');


### PR DESCRIPTION
## Summary
- keep selector splitting from treating `>>` inside regex literals as a selector separator
- add regression coverage for `getByText(/<a > >> c/u)`

Fixes https://github.com/microsoft/playwright/issues/40446
