### PR TITLE
docs(cli): clarify --profile expects a user data directory

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -47,7 +47,7 @@ const open = declareCommand({
     config: z.string().optional().describe('Path to the configuration file, defaults to .playwright/cli.config.json'),
     headed: z.boolean().optional().describe('Run browser in headed mode'),
     persistent: z.boolean().optional().describe('Use persistent browser profile'),
-    profile: z.string().optional().describe('Use persistent browser profile, store profile in specified directory.'),
+    profile: z.string().optional().describe('Path to a persistent user data directory.'),
   }),
   toolName: '',
   toolParams: () => ({}),


### PR DESCRIPTION
Refs microsoft/playwright-cli#256.

The current `--profile` help text "store profile in specified directory" reads as if the flag accepts a path to a specific Chromium profile (e.g. `.../google-chrome/Default`), but Playwright then nests its own profile inside it as `Default/Default`. The flag actually expects the *user data directory* (the parent that contains profile subfolders), and Chromium uses the `Default` subprofile within it.

Updates the description from:

> Use persistent browser profile, store profile in specified directory.

to:

> Path to a persistent user data directory. For Chromium, pass the parent user-data dir, not a profile subdirectory like Default.

Documentation only; no behavior change. The reporter's "Option B" (supporting non-`Default` profiles via something like `--profile-directory`) would require Playwright API plumbing on the launch side and is out of scope for this PR -- happy to file separately if there's appetite.