### PR TITLE
fix(cli): resolve initPage/initScript paths and surface load errors

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -170,7 +170,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
         const { default: func } = require(initPage);
         await func({ page: this.page });
       } catch (e) {
-        debug('pw:tools:error')(e);
+        const reason = e instanceof Error ? e.message : String(e);
+        throw new Error(`Failed to load init page "${initPage}": ${reason}`, { cause: e });
       }
     }
   }

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -309,8 +309,8 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
       cdpEndpoint: cliOptions.cdpEndpoint,
       cdpHeaders: cliOptions.cdpHeader,
       cdpTimeout: cliOptions.cdpTimeout,
-      initPage: cliOptions.initPage,
-      initScript: cliOptions.initScript,
+      initPage: cliOptions.initPage?.map(p => path.resolve(p)),
+      initScript: cliOptions.initScript?.map(p => path.resolve(p)),
       remoteEndpoint: cliOptions.endpoint,
     },
     extension: cliOptions.extension,
@@ -397,15 +397,29 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
   if (!configFile)
     return {};
 
-  if (configFile.endsWith('.ini'))
-    return configFromIniFile(configFile);
-
-  try {
-    const data = await fs.promises.readFile(configFile, 'utf8');
-    return JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
-  } catch {
-    return configFromIniFile(configFile);
+  let config: Config;
+  if (configFile.endsWith('.ini')) {
+    config = configFromIniFile(configFile);
+  } else {
+    try {
+      const data = await fs.promises.readFile(configFile, 'utf8');
+      config = JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
+    } catch {
+      config = configFromIniFile(configFile);
+    }
   }
+  return resolveConfigPaths(config, path.dirname(path.resolve(configFile)));
+}
+
+// initPage/initScript paths inside a config file are resolved against the
+// config file's directory so they keep working when the CLI is invoked from
+// a different cwd.
+function resolveConfigPaths(config: Config, baseDir: string): Config {
+  if (config.browser?.initPage)
+    config.browser.initPage = config.browser.initPage.map(p => path.resolve(baseDir, p));
+  if (config.browser?.initScript)
+    config.browser.initScript = config.browser.initScript.map(p => path.resolve(baseDir, p));
+  return config;
 }
 
 function pickDefined<T extends object>(obj: T | undefined): Partial<T> {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -115,11 +115,12 @@ export async function resolveCLIConfigForMCP(cliOptions: CLIOptions, env?: NodeJ
   const cliOverrides = configFromCLIOptions(cliOptions);
   const configFile = cliOverrides.configFile ?? envOverrides.configFile;
   const configInFile = await loadConfig(configFile);
+  const configDir = configFile ? path.dirname(path.resolve(configFile)) : process.cwd();
 
   let result = defaultConfig;
-  result = mergeConfig(result, configInFile);
-  result = mergeConfig(result, envOverrides);
-  result = mergeConfig(result, cliOverrides);
+  result = mergeConfig(result, resolveConfigPaths(configInFile, configDir));
+  result = mergeConfig(result, resolveConfigPaths(envOverrides, process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(cliOverrides, process.cwd()));
 
   const browser = await validateBrowserConfig(result.browser);
   if (browser.launchOptions.headless === undefined)
@@ -151,14 +152,17 @@ export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionN
   const envOverrides = configFromEnv(env);
   const configFile = daemonOverrides.configFile ?? envOverrides.configFile;
   const configInFile = await loadConfig(configFile);
+  const configDir = configFile ? path.dirname(path.resolve(configFile)) : process.cwd();
   const globalConfigPath = path.join((env ?? process.env)['PWTEST_CLI_GLOBAL_CONFIG'] ?? os.homedir(), '.playwright', 'cli.config.json');
-  const globalConfigInFile = await loadConfig(fs.existsSync(globalConfigPath) ? globalConfigPath : undefined);
+  const globalConfigExists = fs.existsSync(globalConfigPath);
+  const globalConfigInFile = await loadConfig(globalConfigExists ? globalConfigPath : undefined);
+  const globalConfigDir = globalConfigExists ? path.dirname(globalConfigPath) : process.cwd();
 
   let result = defaultConfig;
-  result = mergeConfig(result, globalConfigInFile);
-  result = mergeConfig(result, configInFile);
-  result = mergeConfig(result, envOverrides);
-  result = mergeConfig(result, daemonOverrides);
+  result = mergeConfig(result, resolveConfigPaths(globalConfigInFile, globalConfigDir));
+  result = mergeConfig(result, resolveConfigPaths(configInFile, configDir));
+  result = mergeConfig(result, resolveConfigPaths(envOverrides, process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(daemonOverrides, process.cwd()));
 
   if (result.browser.isolated === undefined)
     result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint && !result.extension;
@@ -309,8 +313,8 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
       cdpEndpoint: cliOptions.cdpEndpoint,
       cdpHeaders: cliOptions.cdpHeader,
       cdpTimeout: cliOptions.cdpTimeout,
-      initPage: cliOptions.initPage?.map(p => path.resolve(p)),
-      initScript: cliOptions.initScript?.map(p => path.resolve(p)),
+      initPage: cliOptions.initPage,
+      initScript: cliOptions.initScript,
       remoteEndpoint: cliOptions.endpoint,
     },
     extension: cliOptions.extension,
@@ -397,23 +401,21 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
   if (!configFile)
     return {};
 
-  let config: Config;
-  if (configFile.endsWith('.ini')) {
-    config = configFromIniFile(configFile);
-  } else {
-    try {
-      const data = await fs.promises.readFile(configFile, 'utf8');
-      config = JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
-    } catch {
-      config = configFromIniFile(configFile);
-    }
+  if (configFile.endsWith('.ini'))
+    return configFromIniFile(configFile);
+
+  try {
+    const data = await fs.promises.readFile(configFile, 'utf8');
+    return JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
+  } catch {
+    return configFromIniFile(configFile);
   }
-  return resolveConfigPaths(config, path.dirname(path.resolve(configFile)));
 }
 
-// initPage/initScript paths inside a config file are resolved against the
-// config file's directory so they keep working when the CLI is invoked from
-// a different cwd.
+// initPage/initScript paths are resolved against a per-source base dir
+// (config-file dir for entries loaded from a --config file, cwd for entries
+// supplied via CLI flags or PLAYWRIGHT_MCP_INIT_* env vars) so they keep
+// working when the CLI is invoked from a different cwd.
 function resolveConfigPaths(config: Config, baseDir: string): Config {
   if (config.browser?.initPage)
     config.browser.initPage = config.browser.initPage.map(p => path.resolve(baseDir, p));

--- a/tests/mcp/init-page.spec.ts
+++ b/tests/mcp/init-page.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 
 import { test, expect } from './fixtures';
 
@@ -34,6 +35,63 @@ test('--init-page', async ({ startClient }) => {
   })).toHaveResponse({
     inlineSnapshot: expect.stringContaining('Hello world'),
   });
+});
+
+test('init-page relative path from --config resolves against the config dir', async ({ startClient }) => {
+  // Regression for https://github.com/microsoft/playwright-cli/issues/290:
+  // relative initPage entries in a --config file used to resolve against
+  // cwd (or the require() caller), not the config file's directory. We put
+  // the config + init page in a sibling subdir of cwd so a cwd-based
+  // resolution would miss the file. Same resolution path also covers
+  // browser.initScript.
+  const configDir = test.info().outputPath('cfg');
+  const cwd = test.info().outputPath('cwd');
+  await fs.promises.mkdir(configDir, { recursive: true });
+  await fs.promises.mkdir(cwd, { recursive: true });
+
+  const initPagePath = path.join(configDir, 'initPage.ts');
+  await fs.promises.writeFile(initPagePath, `
+    export default async ({ page }) => {
+      await page.setContent('<div>From relative initPage</div>');
+    };
+  `);
+  const configPath = path.join(configDir, 'config.json');
+  await fs.promises.writeFile(configPath, JSON.stringify({
+    browser: { initPage: ['./initPage.ts'] },
+  }));
+
+  const { client } = await startClient({
+    cwd,
+    args: [`--config=${configPath}`],
+  });
+  expect(await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  })).toHaveResponse({
+    inlineSnapshot: expect.stringContaining('From relative initPage'),
+  });
+});
+
+test('init-page surfaces load errors instead of silently dropping them', async ({ startClient }) => {
+  // Regression for https://github.com/microsoft/playwright-cli/issues/290:
+  // a failing init-page module used to be swallowed into debug logs, leaving
+  // the user with no signal that their hook never ran.
+  const initPagePath = test.info().outputPath('brokenInitPage.ts');
+  await fs.promises.writeFile(initPagePath, `
+    export default async () => {
+      throw new Error('boom from initPage');
+    };
+  `);
+
+  const { client } = await startClient({
+    args: [`--init-page=${initPagePath}`],
+  });
+  const response: any = await client.callTool({
+    name: 'browser_snapshot',
+    arguments: {},
+  });
+  expect(response.isError).toBe(true);
+  expect(JSON.stringify(response.content)).toContain('boom from initPage');
 });
 
 test('--init-page w/ --init-script', async ({ startClient, server }) => {


### PR DESCRIPTION
Fixes microsoft/playwright-cli#290.

`browser.initPage` and `browser.initScript` entries had two related bugs:

### 1. Path resolution

Relative paths were inconsistent across sources.

- From a `--config` file they resolved against `process.cwd()` (and against the calling module of `require()` at load time), so `"./src/initPage.ts"` silently did not run for users invoking the CLI from anywhere other than the config dir.
- From `--init-page=...` and the `PLAYWRIGHT_MCP_INIT_PAGE` / `PLAYWRIGHT_MCP_INIT_SCRIPT` env vars they reached `require()` raw, which resolves relative to the calling module rather than cwd.

Both sources are now normalised before reaching `require()`:

- `loadConfig()` resolves config-file entries against `path.dirname(path.resolve(configFile))`, matching how Vite/Vitest/ESLint configs treat sibling modules.
- `configFromCLIOptions()` resolves CLI-flag and env-var entries against `process.cwd()`.

### 2. Silent failure

When `require()`ing an init page threw, the error was logged via `debug('pw:tools:error')` and swallowed, leaving the user with no signal. `Tab._initialize` now rethrows ``new Error(`Failed to load init page "<path>": <reason>`, { cause: e })`` so the failure surfaces through the normal tool-response path that awaits `_initializedPromise`.

> [!NOTE]
> This is a behaviour change: a single failing init page used to be silently dropped while subsequent ones still ran. After this PR, the first failing init page aborts initialization and the user sees a real error. That seems closer to the expected contract, but happy to soften (e.g. log loudly + continue) if maintainers prefer.

### Tests

- `init-page relative path from --config resolves against the config dir` -- config and init page are placed in a sibling subdir of the daemon's cwd so a cwd-based resolution would miss the file. The same resolution code covers `initScript`.
- `init-page surfaces load errors instead of silently dropping them` -- asserts `response.isError === true` and the original error message present in `response.content`.

Verified failing on `main` (with these tests in place) and passing on this branch.

### Verified locally

- `npm run build` clean.
- `npx playwright test --config=tests/mcp/playwright.config.ts --project=chrome init-page` -- 4/4 passing.
- ESLint clean on the changed files.
- Full test suite not run locally; relying on CI.

### Out of scope

Other path-bearing config fields (`browser.userDataDir`, `browser.storageState`, `browser.launchOptions.executablePath`, `outputDir`) have the same bug class but are not touched here. Happy to file a follow-up if maintainers want a broader sweep.