### PR TITLE
fix(mcp): surface unhandled rejections instead of crashing the server

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -69,13 +69,22 @@ export class BrowserBackend implements ServerBackend {
     let responseObject: mcpServer.CallToolResult;
     try {
       await tool.handle(context, parsedArguments, response);
+      for (const reason of context.drainPendingUnhandledRejections())
+        response.addError(formatRejectionReason(reason));
       responseObject = await response.serialize();
       this._sessionLog?.logResponse(name, parsedArguments, responseObject);
     } catch (error: any) {
-      return formatError(String(error));
+      const messages = [String(error), ...context.drainPendingUnhandledRejections().map(formatRejectionReason)];
+      return formatError(messages.join('\n\n'));
     } finally {
       context.setRunningTool(undefined);
     }
     return responseObject;
   }
+}
+
+function formatRejectionReason(reason: unknown): string {
+  if (reason instanceof Error)
+    return reason.stack ?? reason.message;
+  return String(reason);
 }

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -105,6 +105,10 @@ export class Context {
   private _disposables: Disposable[] = [];
 
   private _runningToolName: string | undefined;
+  private _pendingUnhandledRejections: unknown[] = [];
+  private _onUnhandledRejection = (reason: unknown) => {
+    this._pendingUnhandledRejections.push(reason);
+  };
 
   constructor(browserContext: playwrightTypes.BrowserContext, options: ContextOptions) {
     this.config = options.config;
@@ -112,15 +116,23 @@ export class Context {
     this.options = options;
     this._rawBrowserContext = browserContext;
     testDebug('create context');
+    process.on('unhandledRejection', this._onUnhandledRejection);
   }
 
   async dispose() {
+    process.off('unhandledRejection', this._onUnhandledRejection);
     await disposeAll(this._disposables);
     for (const tab of this._tabs)
       await tab.dispose();
     this._tabs.length = 0;
     this._currentTab = undefined;
     await this.stopVideoRecording();
+  }
+
+  drainPendingUnhandledRejections(): unknown[] {
+    const reasons = this._pendingUnhandledRejections.slice();
+    this._pendingUnhandledRejections.length = 0;
+    return reasons;
   }
 
   debugger() {

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -106,8 +106,11 @@ export class Context {
 
   private _runningToolName: string | undefined;
   private _pendingUnhandledRejections: unknown[] = [];
+  private _unhandledRejectionListeners = new Set<(reason: unknown) => void>();
   private _onUnhandledRejection = (reason: unknown) => {
     this._pendingUnhandledRejections.push(reason);
+    for (const listener of this._unhandledRejectionListeners)
+      listener(reason);
   };
 
   constructor(browserContext: playwrightTypes.BrowserContext, options: ContextOptions) {
@@ -133,6 +136,11 @@ export class Context {
     const reasons = this._pendingUnhandledRejections.slice();
     this._pendingUnhandledRejections.length = 0;
     return reasons;
+  }
+
+  onUnhandledRejection(listener: (reason: unknown) => void): () => void {
+    this._unhandledRejectionListeners.add(listener);
+    return () => this._unhandledRejectionListeners.delete(listener);
   }
 
   debugger() {

--- a/packages/playwright-core/src/tools/backend/runCode.ts
+++ b/packages/playwright-core/src/tools/backend/runCode.ts
@@ -50,23 +50,38 @@ const runCode = defineTabTool({
       __end__,
     };
     vm.createContext(context);
-    await tab.waitForCompletion(async () => {
-      // Compile the user function separately to avoid template literal escaping issues
-      // when the code contains backticks.
-      context.__fn__ = vm.runInContext('(' + code + ')', context);
-      const snippet = '(async () => {\n' +
-          '  try {\n' +
-          '    const result = await __fn__(page);\n' +
-          '    __end__.resolve(JSON.stringify(result));\n' +
-          '  } catch (e) {\n' +
-          '    __end__.reject(e);\n' +
-          '  }\n' +
-          '})()';
-      await vm.runInContext(snippet, context);
-      const result = await __end__;
-      if (typeof result === 'string')
-        response.addTextResult(result);
+    // User-installed callbacks (e.g. page.route handlers) can throw
+    // asynchronously while __fn__ awaits an operation that depends on them
+    // (e.g. a page.evaluate awaiting a fetch the route never fulfills).
+    // Settle __end__ on the first such rejection so we unblock instead of
+    // waiting for a timeout. The Context-level handler still records it for
+    // surfacing on the response.
+    const unsubscribe = tab.context.onUnhandledRejection(reason => {
+      if (!__end__.isDone())
+        __end__.reject(reason instanceof Error ? reason : new Error(String(reason)));
     });
+    try {
+      await tab.waitForCompletion(async () => {
+        // Compile the user function separately to avoid template literal escaping issues
+        // when the code contains backticks.
+        context.__fn__ = vm.runInContext('(' + code + ')', context);
+        const snippet = '(async () => {\n' +
+            '  try {\n' +
+            '    const result = await __fn__(page);\n' +
+            '    __end__.resolve(JSON.stringify(result));\n' +
+            '  } catch (e) {\n' +
+            '    __end__.reject(e);\n' +
+            '  }\n' +
+            '})()';
+        const iifePromise = vm.runInContext(snippet, context) as Promise<void>;
+        await Promise.race([iifePromise, __end__]);
+        const result = await __end__;
+        if (typeof result === 'string')
+          response.addTextResult(result);
+      });
+    } finally {
+      unsubscribe();
+    }
   },
 });
 

--- a/tests/mcp/run-code.spec.ts
+++ b/tests/mcp/run-code.spec.ts
@@ -108,6 +108,40 @@ test('browser_run_code return value', async ({ client, server }) => {
   expect(content).toContain('[LOG] Submit');
 });
 
+test('browser_run_code route handler exception keeps server alive', async ({ client, server }) => {
+  server.setContent('/', '<button>Submit</button>', 'text/html');
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const code = `async (page) => {
+    await page.unroute('**/*').catch(() => {});
+    await page.route('**/route-throws.json', async (route) => {
+      const path = new URL(route.request().url()).pathname;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ path }) });
+    });
+    return await page.evaluate(async () => {
+      const response = await fetch('/route-throws.json');
+      return response.text();
+    });
+  }`;
+  expect(await client.callTool({
+    name: 'browser_run_code',
+    arguments: { code },
+  })).toHaveResponse({
+    error: expect.stringContaining('ReferenceError: URL is not defined'),
+    isError: true,
+  });
+
+  // Subsequent tool calls should still work because the transport remains alive.
+  const followUp = await client.callTool({
+    name: 'browser_tabs',
+    arguments: { action: 'list' },
+  });
+  expect(followUp.isError).toBeFalsy();
+});
+
 test('browser_run_code with filename', async ({ client, server }) => {
   server.setContent('/', `
     <button onclick="console.log('Clicked')">Click</button>


### PR DESCRIPTION
## Summary
- Capture process-level `unhandledRejection` events in the MCP `Context` and surface them on the next tool response, so a user-installed callback (e.g. a `page.route` handler) that throws asynchronously no longer tears down the MCP transport.

Fixes https://github.com/microsoft/playwright-mcp/issues/1572