### PR TITLE
fix(mcp): reject channel names in config browserName with corrected sample

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -187,12 +187,17 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
     if (browser.launchOptions.channel === undefined)
       browser.launchOptions.channel = 'chrome';
   } else if (browserName !== 'chromium' && browserName !== 'firefox' && browserName !== 'webkit') {
-    const channel = browserName as string;
-    if (!isChromiumChannelName(channel))
-      throw new Error(`Unsupported browser "${channel}". Use one of: chromium, firefox, webkit, ${chromiumChannelNames().join(', ')}.`);
-    browserName = 'chromium';
-    browser.browserName = 'chromium';
-    browser.launchOptions.channel = browser.launchOptions.channel ?? channel;
+    const value = browserName as string;
+    const lines = [
+      `Unsupported "browser.browserName": "${value}". It must be one of: "chromium", "firefox", "webkit".`,
+    ];
+    if (isChromiumChannelName(value)) {
+      lines.push(`To use "${value}", set it as the launch channel instead:`);
+      lines.push(JSON.stringify({ browser: { browserName: 'chromium', launchOptions: { channel: value } } }, null, 2));
+    } else {
+      lines.push(`Supported Chromium channels (set via "browser.launchOptions.channel"): ${chromiumChannelNames().join(', ')}.`);
+    }
+    throw new Error(lines.join('\n'));
   }
 
   if (browser.browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import os from 'os';
 
 import dotenv from 'dotenv';
+import { chromiumChannelNames, isChromiumChannelName } from '@utils/chromiumChannels';
 import { playwright } from '../../inprocess';
 import { configFromIniFile } from './configIni';
 
@@ -185,6 +186,13 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
     // Assign channel only if the browserName is not provided, otherwise assume full control to the user.
     if (browser.launchOptions.channel === undefined)
       browser.launchOptions.channel = 'chrome';
+  } else if (browserName !== 'chromium' && browserName !== 'firefox' && browserName !== 'webkit') {
+    const channel = browserName as string;
+    if (!isChromiumChannelName(channel))
+      throw new Error(`Unsupported browser "${channel}". Use one of: chromium, firefox, webkit, ${chromiumChannelNames().join(', ')}.`);
+    browserName = 'chromium';
+    browser.browserName = 'chromium';
+    browser.launchOptions.channel = browser.launchOptions.channel ?? channel;
   }
 
   if (browser.browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
@@ -228,29 +236,23 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
 function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: string } {
   let browserName: 'chromium' | 'firefox' | 'webkit' | undefined;
   let channel: string | undefined;
-  switch (cliOptions.browser) {
-    case 'chrome':
-    case 'chrome-beta':
-    case 'chrome-canary':
-    case 'chrome-dev':
-    case 'msedge':
-    case 'msedge-beta':
-    case 'msedge-canary':
-    case 'msedge-dev':
-      browserName = 'chromium';
-      channel = cliOptions.browser;
-      break;
-    case 'chromium':
-      // Never use old headless.
-      browserName = 'chromium';
-      channel = 'chrome-for-testing';
-      break;
-    case 'firefox':
-      browserName = 'firefox';
-      break;
-    case 'webkit':
-      browserName = 'webkit';
-      break;
+  if (cliOptions.browser && isChromiumChannelName(cliOptions.browser)) {
+    browserName = 'chromium';
+    channel = cliOptions.browser;
+  } else {
+    switch (cliOptions.browser) {
+      case 'chromium':
+        // Never use old headless.
+        browserName = 'chromium';
+        channel = 'chrome-for-testing';
+        break;
+      case 'firefox':
+        browserName = 'firefox';
+        break;
+      case 'webkit':
+        browserName = 'webkit';
+        break;
+    }
   }
 
   // Launch options

--- a/packages/utils/chromiumChannels.ts
+++ b/packages/utils/chromiumChannels.ts
@@ -25,6 +25,10 @@ export function isChromiumChannelName(channel: string): boolean {
   return channelToDefaultUserDataDir.has(channel);
 }
 
+export function chromiumChannelNames(): string[] {
+  return [...channelToDefaultUserDataDir.keys()];
+}
+
 const channelToDefaultUserDataDir = new Map<string, Record<string, string>>([
   ['chrome', {
     'linux': path.join(os.homedir(), '.config', 'google-chrome'),

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 
-import { test, expect, parseResponse } from './fixtures';
+import { test, expect, mcpServerPath, parseResponse } from './fixtures';
 import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
 
 test('config user data dir', async ({ startClient, server }, testInfo) => {
@@ -103,21 +104,19 @@ test.describe(() => {
     });
   });
 
-  test('browserName msedge in config file', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1570' } }, async ({ startClient }, testInfo) => {
+  test('browserName msedge in config file', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1570' } }, async ({}, testInfo) => {
     const configPath = testInfo.outputPath('config.json');
     await fs.promises.writeFile(configPath, JSON.stringify({
       browser: {
         browserName: 'msedge',
       },
-      capabilities: ['config'],
     }, null, 2));
 
-    const { client } = await startClient({ args: ['--config', configPath] });
-    const result = await client.callTool({ name: 'browser_get_config' });
-    expect(result.isError).toBeFalsy();
-    const config = JSON.parse(parseResponse(result).result);
-    expect(config.browser.browserName).toBe('chromium');
-    expect(config.browser.launchOptions.channel).toBe('msedge');
+    const stderr = await runMCP(['--config', configPath]);
+    expect(stderr).toContain(`Unsupported "browser.browserName": "msedge"`);
+    expect(stderr).toContain(`It must be one of: "chromium", "firefox", "webkit"`);
+    expect(stderr).toContain(`To use "msedge", set it as the launch channel instead:`);
+    expect(stderr).toContain(`"channel": "msedge"`);
   });
 });
 
@@ -190,3 +189,13 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   // From CLI arg (--isolated).
   expect(config.browser.isolated).toBe(true);
 });
+
+async function runMCP(args: string[]): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn('node', [...mcpServerPath, ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', chunk => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', () => resolve(stderr));
+  });
+}

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -102,6 +102,23 @@ test.describe(() => {
       page: expect.stringContaining(`Firefox`),
     });
   });
+
+  test('browserName msedge in config file', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1570' } }, async ({ startClient }, testInfo) => {
+    const configPath = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configPath, JSON.stringify({
+      browser: {
+        browserName: 'msedge',
+      },
+      capabilities: ['config'],
+    }, null, 2));
+
+    const { client } = await startClient({ args: ['--config', configPath] });
+    const result = await client.callTool({ name: 'browser_get_config' });
+    expect(result.isError).toBeFalsy();
+    const config = JSON.parse(parseResponse(result).result);
+    expect(config.browser.browserName).toBe('chromium');
+    expect(config.browser.launchOptions.channel).toBe('msedge');
+  });
 });
 
 test('config ignoreDefaultArgs merged with persistent mode defaults', async ({ startClient, mcpBrowser }, testInfo) => {

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 
 import { test, expect, mcpServerPath, parseResponse } from './fixtures';
+import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
+
+const { spawnAsync } = utils;
 
 test('config user data dir', async ({ startClient, server }, testInfo) => {
   server.setContent('/', `
@@ -112,11 +114,19 @@ test.describe(() => {
       },
     }, null, 2));
 
-    const stderr = await runMCP(['--config', configPath]);
-    expect(stderr).toContain(`Unsupported "browser.browserName": "msedge"`);
-    expect(stderr).toContain(`It must be one of: "chromium", "firefox", "webkit"`);
-    expect(stderr).toContain(`To use "msedge", set it as the launch channel instead:`);
-    expect(stderr).toContain(`"channel": "msedge"`);
+    const { stderr } = await spawnAsync('node', [...mcpServerPath, '--config', configPath]);
+    expect(stderr.trim()).toBe([
+      `Unsupported "browser.browserName": "msedge". It must be one of: "chromium", "firefox", "webkit".`,
+      `To use "msedge", set it as the launch channel instead:`,
+      `{`,
+      `  "browser": {`,
+      `    "browserName": "chromium",`,
+      `    "launchOptions": {`,
+      `      "channel": "msedge"`,
+      `    }`,
+      `  }`,
+      `}`,
+    ].join('\n'));
   });
 });
 
@@ -189,13 +199,3 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   // From CLI arg (--isolated).
   expect(config.browser.isolated).toBe(true);
 });
-
-async function runMCP(args: string[]): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const child = spawn('node', [...mcpServerPath, ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
-    let stderr = '';
-    child.stderr.on('data', chunk => { stderr += chunk.toString(); });
-    child.on('error', reject);
-    child.on('close', () => resolve(stderr));
-  });
-}


### PR DESCRIPTION
## Summary
Putting a Chromium channel name (e.g. `"msedge"`) in `browser.browserName` of an MCP config file used to crash with `TypeError: Cannot read properties of undefined (reading 'launchPersistentContext')` because the value went straight to `playwright[browserName]`.

`browserName` is now validated against its declared type (`"chromium" | "firefox" | "webkit"`) at config-load time, and when the value is a known Chromium channel the error includes a corrected config snippet:

```
Unsupported "browser.browserName": "msedge". It must be one of: "chromium", "firefox", "webkit".
To use "msedge", set it as the launch channel instead:
{
  "browser": {
    "browserName": "chromium",
    "launchOptions": {
      "channel": "msedge"
    }
  }
}
```

For unknown values the error lists the supported channels (set via `browser.launchOptions.channel`).

The CLI path (`--browser=msedge`) was unchanged in behavior, only refactored to share `isChromiumChannelName`/`chromiumChannelNames` from `@utils/chromiumChannels`.

Fixes https://github.com/microsoft/playwright-mcp/issues/1570