### PR TITLE
chore(extension): integrate extension into root build

### DIFF
--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build extension
-        run: npm run build-extension
+        run: npm run build
       - name: Package extension
         working-directory: ./packages/extension
         run: |

--- a/.github/workflows/tests_extension.yml
+++ b/.github/workflows/tests_extension.yml
@@ -48,6 +48,5 @@ jobs:
         node-version: 22
     - run: npm ci
     - run: npm run build
-    - run: npm run build-extension
     - run: npx playwright install --with-deps chromium
     - run: npm run test-extension

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test-mcp": "playwright test --config=tests/mcp/playwright.config.ts",
     "ctest-mcp": "playwright test --config=tests/mcp/playwright.config.ts --project=chrome",
     "test-extension": "playwright test --config=tests/extension/playwright.config.ts",
-    "build-extension": "npm run build -w @playwright/extension",
     "eslint": "eslint --cache",
     "tsc": "tsc -p .",
     "doc": "node utils/doclint/cli.js",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -14,12 +14,5 @@
   "author": {
     "name": "Microsoft Corporation"
   },
-  "license": "Apache-2.0",
-  "scripts": {
-    "build": "tsc --project . && tsc --project tsconfig.ui.json && vite build && vite build --config vite.sw.config.mts",
-    "watch": "tsc --watch --project . & tsc --watch --project tsconfig.ui.json & vite build --watch & vite build --watch --config vite.sw.config.mts",
-    "test": "playwright test",
-    "lint": "tsc --project .",
-    "clean": "rm -rf dist test-results"
-  }
+  "license": "Apache-2.0"
 }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -915,6 +915,25 @@ for (const webPackage of webPackages) {
   }));
 }
 
+// Build/watch extension UI pages and service worker.
+for (const config of ['vite.config.mts', 'vite.sw.config.mts']) {
+  steps.push(new ProgramStep({
+    command: 'npx',
+    args: [
+      'vite',
+      'build',
+      '--config',
+      config,
+      ...(watchMode ? ['--watch', '--minify=false'] : []),
+      ...(withSourceMaps ? ['--sourcemap=inline'] : []),
+      '--clearScreen=false',
+    ],
+    shell: true,
+    cwd: path.join(__dirname, '..', '..', 'packages', 'extension'),
+    concurrent: true,
+  }));
+}
+
 // Generate CLI help.
 onChanges.push({
   inputs: [

--- a/utils/build/clean.js
+++ b/utils/build/clean.js
@@ -8,6 +8,7 @@ const rmSync = (dir) => fs.rmSync(dir, { recursive: true, force: true, maxRetrie
 for (const pkg of workspace.packages()) {
   rmSync(path.join(pkg.path, 'node_modules'));
   rmSync(path.join(pkg.path, 'lib'));
+  rmSync(path.join(pkg.path, 'dist'));
   rmSync(path.join(pkg.path, 'src', 'generated'));
   const bundles = path.join(pkg.path, 'bundles');
   if (fs.existsSync(bundles) && fs.statSync(bundles).isDirectory()) {


### PR DESCRIPTION
## Summary
- Run extension's vite + service-worker builds from `utils/build/build.js` alongside the other web packages, so `npm run build` and `npm run watch` cover the extension.
- Extend `utils/build/clean.js` to also remove `packages/*/dist`.
- Drop the now-redundant scripts from `packages/extension/package.json` and the `build-extension` entry from the root `package.json`. Update `tests_extension.yml` and `publish_extension.yml` accordingly.