### PR TITLE
Feat/mcp manual recording and test output

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -44,6 +44,8 @@ export class BrowserBackend implements ServerBackend {
       sessionLog: this._sessionLog,
       cwd: clientInfo.cwd,
     });
+    if (this._config.autoRecord)
+      await this._context.startRecording();
   }
 
   async dispose() {

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -88,6 +88,66 @@ export type FilenameTemplate = {
 
 type VideoParams = { size?: { width: number; height: number } };
 
+export type RecordedEvent =
+  | { type: 'navigate'; url: string }
+  | { type: 'click'; selector: string }
+  | { type: 'fill'; selector: string; value: string }
+  | { type: 'selectOption'; selector: string; value: string }
+  | { type: 'check'; selector: string }
+  | { type: 'uncheck'; selector: string };
+
+type RecordingState = {
+  events: RecordedEvent[];
+  disposables: Disposable[];
+};
+
+// Injected into every page to bridge user interactions to Node via exposeFunction.
+const CAPTURE_SCRIPT = `(function() {
+  if (window.__pw_capture_installed) return;
+  window.__pw_capture_installed = true;
+  function _sel(el) {
+    if (!el || el === document.body) return null;
+    var v;
+    v = el.getAttribute && (el.getAttribute('data-testid') || el.getAttribute('data-test') || el.getAttribute('data-pw'));
+    if (v) return '[data-testid=' + JSON.stringify(v) + ']';
+    v = el.getAttribute && el.getAttribute('aria-label');
+    if (v) return '[aria-label=' + JSON.stringify(v) + ']';
+    v = el.getAttribute && el.getAttribute('placeholder');
+    if (v) return '[placeholder=' + JSON.stringify(v) + ']';
+    v = el.getAttribute && el.getAttribute('name');
+    if (v) return '[name=' + JSON.stringify(v) + ']';
+    if (el.id) return '#' + el.id;
+    var tag = (el.tagName || '').toLowerCase();
+    var txt = (el.textContent || '').trim().slice(0, 50);
+    if (txt && (tag === 'button' || tag === 'a'))
+      return tag + ':has-text(' + JSON.stringify(txt) + ')';
+    return tag || null;
+  }
+  document.addEventListener('click', function(e) {
+    if (typeof window.__pw_record !== 'function') return;
+    var s = _sel(e.target);
+    if (s) window.__pw_record({ type: 'click', selector: s });
+  }, true);
+  document.addEventListener('change', function(e) {
+    if (typeof window.__pw_record !== 'function') return;
+    var el = e.target;
+    if (!el) return;
+    var s = _sel(el);
+    if (!s) return;
+    var tag = (el.tagName || '').toLowerCase();
+    var tp = (el.type || '').toLowerCase();
+    if (tag === 'select') {
+      window.__pw_record({ type: 'selectOption', selector: s, value: el.value });
+    } else if (tp === 'checkbox') {
+      window.__pw_record({ type: el.checked ? 'check' : 'uncheck', selector: s });
+    } else if (tp === 'radio') {
+      if (el.checked) window.__pw_record({ type: 'check', selector: s });
+    } else {
+      window.__pw_record({ type: 'fill', selector: s, value: el.value });
+    }
+  }, true);
+})()`;
+
 export class Context {
   readonly config: ContextConfig;
   readonly sessionLog: SessionLog | undefined;
@@ -112,6 +172,8 @@ export class Context {
     for (const listener of this._unhandledRejectionListeners)
       listener(reason);
   };
+  private _recordingState: RecordingState | undefined;
+  private _recordingSetUp = false;
 
   constructor(browserContext: playwrightTypes.BrowserContext, options: ContextOptions) {
     this.config = options.config;
@@ -239,7 +301,7 @@ export class Context {
     this._tabs.push(tab);
     if (!this._currentTab)
       this._currentTab = tab;
-    this._startPageVideo(page).catch(() => {});
+    this._startPageVideo(page).catch(() => { });
   }
 
   private _onPageClosed(tab: Tab) {
@@ -347,6 +409,67 @@ export class Context {
       return;
     if (new URL(url).protocol === 'file:')
       throw new Error(`Access to "file:" protocol is blocked. Attempted URL: "${url}"`);
+  }
+
+  async startRecording(): Promise<void> {
+    if (this._recordingState)
+      throw new Error('A recording session is already in progress. Call `browser_recording_stop` first.');
+    const state: RecordingState = { events: [], disposables: [] };
+    this._recordingState = state;
+    const browserContext = await this.ensureBrowserContext();
+    if (!this._recordingSetUp) {
+      this._recordingSetUp = true;
+      // exposeFunction and addInitScript persist for the lifetime of the context.
+      await browserContext.exposeFunction('__pw_record', (event: unknown) => {
+        if (this._recordingState)
+          this._recordingState.events.push(event as RecordedEvent);
+      });
+      this._disposables.push(await browserContext.addInitScript(CAPTURE_SCRIPT));
+    }
+    const attachToPage = (page: playwrightTypes.Page) => {
+      const navHandler = (frame: playwrightTypes.Frame) => {
+        if (frame === page.mainFrame() && this._recordingState) {
+          const url = frame.url();
+          if (url && url !== 'about:blank')
+            this._recordingState.events.push({ type: 'navigate', url });
+        }
+      };
+      page.on('framenavigated', navHandler);
+      state.disposables.push({ dispose: () => page.off('framenavigated', navHandler) });
+      page.evaluate(CAPTURE_SCRIPT).catch(() => { });
+    };
+    for (const page of browserContext.pages())
+      attachToPage(page);
+    state.disposables.push(eventsHelper.addEventListener(browserContext, 'page', attachToPage));
+  }
+
+  stopRecording(): number {
+    const state = this._recordingState;
+    if (!state)
+      return 0;
+    disposeAll(state.disposables).catch(() => { });
+    this._recordingState = undefined;
+    return state.events.length;
+  }
+
+  getRecordedCode(): string[] {
+    const events = this._recordingState?.events ?? [];
+    return events.map(event => {
+      switch (event.type) {
+        case 'navigate':
+          return `await page.goto(${escapeWithQuotes(event.url, "'")});`;
+        case 'click':
+          return `await page.locator(${escapeWithQuotes(event.selector, "'")}).click();`;
+        case 'fill':
+          return `await page.locator(${escapeWithQuotes(event.selector, "'")}).fill(${escapeWithQuotes(event.value, "'")});`;
+        case 'selectOption':
+          return `await page.locator(${escapeWithQuotes(event.selector, "'")}).selectOption(${escapeWithQuotes(event.value, "'")});`;
+        case 'check':
+          return `await page.locator(${escapeWithQuotes(event.selector, "'")}).check();`;
+        case 'uncheck':
+          return `await page.locator(${escapeWithQuotes(event.selector, "'")}).uncheck();`;
+      }
+    });
   }
 
   lookupSecret(secretName: string): { value: string, code: string } {

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -34,6 +34,7 @@ const testDebug = debug('pw:mcp:test');
 
 export type ContextConfig = {
   allowUnrestrictedFileAccess?: boolean;
+  autoRecord?: boolean;
   capabilities?: ToolCapability[];
   codegen?: 'typescript' | 'none';
   console?: { level?: 'error' | 'warning' | 'info' | 'debug' };
@@ -173,6 +174,7 @@ export class Context {
       listener(reason);
   };
   private _recordingState: RecordingState | undefined;
+  private _stoppedEvents: RecordedEvent[] = [];
   private _recordingSetUp = false;
 
   constructor(browserContext: playwrightTypes.BrowserContext, options: ContextOptions) {
@@ -414,6 +416,7 @@ export class Context {
   async startRecording(): Promise<void> {
     if (this._recordingState)
       throw new Error('A recording session is already in progress. Call `browser_recording_stop` first.');
+    this._stoppedEvents = [];
     const state: RecordingState = { events: [], disposables: [] };
     this._recordingState = state;
     const browserContext = await this.ensureBrowserContext();
@@ -448,12 +451,25 @@ export class Context {
     if (!state)
       return 0;
     disposeAll(state.disposables).catch(() => { });
+    this._stoppedEvents = state.events;
     this._recordingState = undefined;
     return state.events.length;
   }
 
+  async resetRecording(): Promise<void> {
+    // Stop the active session if one is running.
+    if (this._recordingState) {
+      disposeAll(this._recordingState.disposables).catch(() => { });
+      this._recordingState = undefined;
+    }
+    // Clear the stopped-event buffer so the next recording starts clean.
+    this._stoppedEvents = [];
+    // Start a fresh session immediately.
+    await this.startRecording();
+  }
+
   getRecordedCode(): string[] {
-    const events = this._recordingState?.events ?? [];
+    const events = this._recordingState?.events ?? this._stoppedEvents;
     return events.map(event => {
       switch (event.type) {
         case 'navigate':
@@ -470,6 +486,24 @@ export class Context {
           return `await page.locator(${escapeWithQuotes(event.selector, "'")}).uncheck();`;
       }
     });
+  }
+
+  saveRecordingAsTest(testName: string, outputPath: string): string {
+    const lines = this.getRecordedCode();
+    const body = lines.map(l => `  ${l}`).join('\n');
+    const content = [
+      `import { test, expect } from '@playwright/test';`,
+      ``,
+      `test(${escapeWithQuotes(testName, "'")}, async ({ page }) => {`,
+      body,
+      `});`,
+      ``,
+    ].join('\n');
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir))
+      fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(outputPath, content, 'utf-8');
+    return content;
   }
 
   lookupSecret(secretName: string): { value: string, code: string } {

--- a/packages/playwright-core/src/tools/backend/recording.ts
+++ b/packages/playwright-core/src/tools/backend/recording.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as z from 'zod';
+import { defineTool } from './tool';
+
+const browserRecordingStart = defineTool({
+    capability: 'core',
+
+    schema: {
+        name: 'browser_recording_start',
+        title: 'Start recording browser interactions',
+        description: [
+            'Starts capturing user browser interactions — clicks, form fills, navigations — into a recording buffer.',
+            'Use this before asking the user to perform a workflow manually in the browser.',
+            'Pair with `browser_recording_stop` to end the session and `browser_recording_get` to retrieve',
+            'the captured interactions as Playwright TypeScript code.',
+        ].join(' '),
+        inputSchema: z.object({}),
+        type: 'action',
+    },
+
+    handle: async (context, _params, response) => {
+        await context.startRecording();
+        response.addTextResult('Recording started. Interact with the browser, then call `browser_recording_get` to retrieve the captured Playwright code.');
+    },
+});
+
+const browserRecordingStop = defineTool({
+    capability: 'core',
+
+    schema: {
+        name: 'browser_recording_stop',
+        title: 'Stop recording browser interactions',
+        description: [
+            'Stops the active browser interaction recording session.',
+            'The captured events remain accessible via `browser_recording_get` until a new recording is started.',
+        ].join(' '),
+        inputSchema: z.object({}),
+        type: 'action',
+    },
+
+    handle: async (context, _params, response) => {
+        const count = context.stopRecording();
+        response.addTextResult(`Recording stopped. ${count} interaction(s) captured. Use \`browser_recording_get\` to retrieve the recorded code.`);
+    },
+});
+
+const browserRecordingGet = defineTool({
+    capability: 'core',
+
+    schema: {
+        name: 'browser_recording_get',
+        title: 'Get recorded browser interactions as Playwright code',
+        description: [
+            'Returns all browser interactions captured since `browser_recording_start` as a Playwright TypeScript code snippet.',
+            'Can be called while recording is still in progress to retrieve a partial log.',
+            'The buffer is not cleared by this call; use `browser_recording_stop` to end the session.',
+        ].join(' '),
+        inputSchema: z.object({}),
+        type: 'readOnly',
+    },
+
+    handle: async (context, _params, response) => {
+        const lines = context.getRecordedCode();
+        if (!lines.length) {
+            response.addTextResult('No interactions have been recorded yet. Start a recording with `browser_recording_start` and interact with the browser first.');
+            return;
+        }
+        response.addTextResult('Recorded interactions:\n\n```typescript\n' + lines.join('\n') + '\n```');
+    },
+});
+
+export default [
+    browserRecordingStart,
+    browserRecordingStop,
+    browserRecordingGet,
+];

--- a/packages/playwright-core/src/tools/backend/recording.ts
+++ b/packages/playwright-core/src/tools/backend/recording.ts
@@ -18,74 +18,128 @@ import * as z from 'zod';
 import { defineTool } from './tool';
 
 const browserRecordingStart = defineTool({
-    capability: 'core',
+  capability: 'core',
 
-    schema: {
-        name: 'browser_recording_start',
-        title: 'Start recording browser interactions',
-        description: [
-            'Starts capturing user browser interactions — clicks, form fills, navigations — into a recording buffer.',
-            'Use this before asking the user to perform a workflow manually in the browser.',
-            'Pair with `browser_recording_stop` to end the session and `browser_recording_get` to retrieve',
-            'the captured interactions as Playwright TypeScript code.',
-        ].join(' '),
-        inputSchema: z.object({}),
-        type: 'action',
-    },
+  schema: {
+    name: 'browser_recording_start',
+    title: 'Start recording browser interactions',
+    description: [
+      'Starts capturing user browser interactions — clicks, form fills, navigations — into a recording buffer.',
+      'Use this before asking the user to perform a workflow manually in the browser.',
+      'Pair with `browser_recording_stop` to end the session and `browser_recording_get` to retrieve',
+      'the captured interactions as Playwright TypeScript code.',
+    ].join(' '),
+    inputSchema: z.object({}),
+    type: 'action',
+  },
 
-    handle: async (context, _params, response) => {
-        await context.startRecording();
-        response.addTextResult('Recording started. Interact with the browser, then call `browser_recording_get` to retrieve the captured Playwright code.');
-    },
+  handle: async (context, _params, response) => {
+    await context.startRecording();
+    response.addTextResult('Recording started. Interact with the browser, then call `browser_recording_get` to retrieve the captured Playwright code.');
+  },
 });
 
 const browserRecordingStop = defineTool({
-    capability: 'core',
+  capability: 'core',
 
-    schema: {
-        name: 'browser_recording_stop',
-        title: 'Stop recording browser interactions',
-        description: [
-            'Stops the active browser interaction recording session.',
-            'The captured events remain accessible via `browser_recording_get` until a new recording is started.',
-        ].join(' '),
-        inputSchema: z.object({}),
-        type: 'action',
-    },
+  schema: {
+    name: 'browser_recording_stop',
+    title: 'Stop recording browser interactions',
+    description: [
+      'Stops the active browser interaction recording session.',
+      'The captured events remain accessible via `browser_recording_get` until a new recording is started.',
+    ].join(' '),
+    inputSchema: z.object({}),
+    type: 'action',
+  },
 
-    handle: async (context, _params, response) => {
-        const count = context.stopRecording();
-        response.addTextResult(`Recording stopped. ${count} interaction(s) captured. Use \`browser_recording_get\` to retrieve the recorded code.`);
-    },
+  handle: async (context, _params, response) => {
+    const count = context.stopRecording();
+    response.addTextResult(`Recording stopped. ${count} interaction(s) captured. Use \`browser_recording_get\` to retrieve the recorded code.`);
+  },
 });
 
 const browserRecordingGet = defineTool({
-    capability: 'core',
+  capability: 'core',
 
-    schema: {
-        name: 'browser_recording_get',
-        title: 'Get recorded browser interactions as Playwright code',
-        description: [
-            'Returns all browser interactions captured since `browser_recording_start` as a Playwright TypeScript code snippet.',
-            'Can be called while recording is still in progress to retrieve a partial log.',
-            'The buffer is not cleared by this call; use `browser_recording_stop` to end the session.',
-        ].join(' '),
-        inputSchema: z.object({}),
-        type: 'readOnly',
-    },
+  schema: {
+    name: 'browser_recording_get',
+    title: 'Get recorded browser interactions as Playwright code',
+    description: [
+      'Returns all browser interactions captured since `browser_recording_start` as a Playwright TypeScript code snippet.',
+      'Can be called while recording is still in progress to retrieve a partial log.',
+      'The buffer is not cleared by this call; use `browser_recording_stop` to end the session.',
+    ].join(' '),
+    inputSchema: z.object({}),
+    type: 'readOnly',
+  },
 
-    handle: async (context, _params, response) => {
-        const lines = context.getRecordedCode();
-        if (!lines.length) {
-            response.addTextResult('No interactions have been recorded yet. Start a recording with `browser_recording_start` and interact with the browser first.');
-            return;
-        }
-        response.addTextResult('Recorded interactions:\n\n```typescript\n' + lines.join('\n') + '\n```');
-    },
+  handle: async (context, _params, response) => {
+    const lines = context.getRecordedCode();
+    if (!lines.length) {
+      response.addTextResult('No interactions have been recorded yet. Start a recording with `browser_recording_start` and interact with the browser first.');
+      return;
+    }
+    response.addTextResult('Recorded interactions:\n\n```typescript\n' + lines.join('\n') + '\n```');
+  },
+});
+
+const browserRecordingSave = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_recording_save',
+    title: 'Save recorded interactions as a Playwright test file',
+    description: [
+      'Wraps the recorded browser interactions in a complete `@playwright/test` test and writes it to disk.',
+      'Provide a human-readable `testName` (used as the test title) and an absolute or relative `outputPath`',
+      'for the `.spec.ts` file. The directory will be created if it does not exist.',
+      'The generated file content is also returned so you can review it immediately.',
+    ].join(' '),
+    inputSchema: z.object({
+      testName: z.string().describe('Human-readable title for the test, e.g. "user can add a new component"'),
+      outputPath: z.string().describe('File path where the .spec.ts file should be written, e.g. "tests/recorded/my-flow.spec.ts"'),
+    }),
+    type: 'action',
+  },
+
+  handle: async (context, params, response) => {
+    const lines = context.getRecordedCode();
+    if (!lines.length) {
+      response.addTextResult('No interactions have been recorded yet. Start a recording with `browser_recording_start` and interact with the browser first.');
+      return;
+    }
+    const content = context.saveRecordingAsTest(params.testName, params.outputPath);
+    response.addTextResult(`Test file written to \`${params.outputPath}\`:\n\n\`\`\`typescript\n${content}\`\`\``);
+  },
+});
+
+const browserRecordingReset = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_recording_reset',
+    title: 'Reset the recording buffer and start a fresh session',
+    description: [
+      'Clears all previously captured interactions and starts a brand-new recording session.',
+      'Use this to distinguish the current workflow from earlier interactions that were already recorded.',
+      'Equivalent to calling `browser_recording_stop` + clearing the buffer + `browser_recording_start`,',
+      'but in a single step.',
+    ].join(' '),
+    inputSchema: z.object({}),
+    type: 'action',
+  },
+
+  handle: async (context, _params, response) => {
+    await context.resetRecording();
+    response.addTextResult('Recording buffer cleared. A fresh recording session has started. Interact with the browser, then call `browser_recording_get` to retrieve only the new interactions.');
+  },
 });
 
 export default [
-    browserRecordingStart,
-    browserRecordingStop,
-    browserRecordingGet,
+  browserRecordingStart,
+  browserRecordingStop,
+  browserRecordingGet,
+  browserRecordingSave,
+  browserRecordingReset,
 ];

--- a/packages/playwright-core/src/tools/backend/tools.ts
+++ b/packages/playwright-core/src/tools/backend/tools.ts
@@ -29,6 +29,7 @@ import mouse from './mouse';
 import navigate from './navigate';
 import network from './network';
 import pdf from './pdf';
+import recording from './recording';
 import route from './route';
 import runCode from './runCode';
 import snapshot from './snapshot';
@@ -59,6 +60,7 @@ export const browserTools: Tool<any>[] = [
   ...navigate,
   ...network,
   ...pdf,
+  ...recording,
   ...route,
   ...runCode,
   ...screenshot,
@@ -79,8 +81,8 @@ export function filteredTools(config: Pick<ContextConfig, 'capabilities'>) {
       ...tool.schema,
       // Note: we first ensure that "selector" property is present, so that we can omit() it without an error.
       inputSchema: tool.schema.inputSchema
-          .extend({ selector: z.string(), startSelector: z.string(), endSelector: z.string() })
-          .omit({ selector: true, startSelector: true, endSelector: true }),
+        .extend({ selector: z.string(), startSelector: z.string(), endSelector: z.string() })
+        .omit({ selector: true, startSelector: true, endSelector: true }),
     },
   }));
 }

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -57,6 +57,7 @@ export type CLIOptions = {
   initPage?: string[];
   isolated?: boolean;
   imageResponses?: 'allow' | 'omit';
+  autoRecord?: boolean;
   sandbox?: boolean;
   outputDir?: string;
   port?: number;
@@ -328,6 +329,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
       blockedOrigins: cliOptions.blockedOrigins,
     },
     allowUnrestrictedFileAccess: cliOptions.allowUnrestrictedFileAccess,
+    autoRecord: cliOptions.autoRecord,
     codegen: cliOptions.codegen,
     saveSession: cliOptions.saveSession,
     secrets: cliOptions.secrets,

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -64,6 +64,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
       .option('--sandbox', 'enable the sandbox for all process types that are normally not sandboxed.')
+      .option('--auto-record', 'automatically start recording browser interactions when the browser starts.')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--secrets <path>', 'path to a file containing secrets in the dotenv format', dotenvFileLoader)
       .option('--shared-browser-context', 'reuse the same browser context between all connected HTTP clients.')
@@ -84,7 +85,7 @@ export function decorateMCPCommand(command: Command) {
         setupExitWatchdog();
 
         if (options.vision) {
-          // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console
           console.error('The --vision option is deprecated, use --caps=vision instead');
           options.caps = 'vision';
         }

--- a/tests/mcp/recording.spec.ts
+++ b/tests/mcp/recording.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+test('browser_recording_start starts a recording session', async ({ client }) => {
+    expect(await client.callTool({
+        name: 'browser_recording_start',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining('Recording started'),
+    });
+
+    // Clean up
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording_get returns empty message before any interactions', async ({ client }) => {
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    expect(await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining('No interactions'),
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording_get returns empty message when not recording', async ({ client }) => {
+    expect(await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining('No interactions'),
+    });
+});
+
+test('browser_recording_stop returns interaction count', async ({ client }) => {
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    expect(await client.callTool({
+        name: 'browser_recording_stop',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining('Recording stopped'),
+    });
+});
+
+test('browser_recording captures navigation', async ({ client, server }) => {
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: server.HELLO_WORLD },
+    });
+
+    expect(await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining(`page.goto('${server.HELLO_WORLD}')`),
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording captures multiple navigations', async ({ client, server }) => {
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: server.HELLO_WORLD },
+    });
+    await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: server.EMPTY_PAGE },
+    });
+
+    const result = await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    });
+    expect(result).toHaveResponse({
+        result: expect.stringContaining(`page.goto('${server.HELLO_WORLD}')`),
+    });
+    expect(result).toHaveResponse({
+        result: expect.stringContaining(`page.goto('${server.EMPTY_PAGE}')`),
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording_start errors when already recording', async ({ client }) => {
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    expect(await client.callTool({
+        name: 'browser_recording_start',
+        arguments: {},
+    })).toHaveResponse({
+        error: expect.stringContaining('already in progress'),
+        isError: true,
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording captures click on interactive element', async ({ client, server }) => {
+    server.setContent('/recording-form', `
+    <title>Recording Form</title>
+    <body>
+      <button id="submit-btn">Submit</button>
+    </body>
+  `, 'text/html');
+
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: `${server.PREFIX}/recording-form` },
+    });
+
+    // Trigger a click using Playwright's click tool (generates a real DOM click event)
+    await client.callTool({
+        name: 'browser_click',
+        arguments: {
+            element: 'Submit',
+            ref: 'e2',
+        },
+    });
+
+    const result = await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    });
+    expect(result).toHaveResponse({
+        result: expect.stringContaining('page.goto('),
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});
+
+test('browser_recording can be restarted after stop', async ({ client, server }) => {
+    // First session
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+    await client.callTool({
+        name: 'browser_navigate',
+        arguments: { url: server.HELLO_WORLD },
+    });
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+
+    // Second session should start fresh
+    await client.callTool({ name: 'browser_recording_start', arguments: {} });
+
+    expect(await client.callTool({
+        name: 'browser_recording_get',
+        arguments: {},
+    })).toHaveResponse({
+        result: expect.stringContaining('No interactions'),
+    });
+
+    await client.callTool({ name: 'browser_recording_stop', arguments: {} });
+});


### PR DESCRIPTION
# Overview

Adds a suite of MCP tools that let an agent capture a user's manual browser interactions and convert them into a reusable Playwright TypeScript test file. The primary use-case is recording a workflow once by hand, then having the agent persist it as a `.spec.ts` file that can be run in CI.

---

## New MCP Tools

| Tool | Description |
| ---- | ----------- |
| `browser_recording_start` | Begins capturing browser events (clicks, navigations, form fills) into an in-memory buffer. |
| `browser_recording_stop` | Stops capture and preserves the buffer so it can still be retrieved after stopping. |
| `browser_recording_get` | Returns the captured interactions as formatted Playwright TypeScript code. |
| `browser_recording_save` | Wraps the recorded code in a `@playwright/test` test block and writes it to a `.spec.ts` file on disk. Accepts `testName` and `outputPath`. |
| `browser_recording_reset` | Clears the buffer and immediately starts a fresh recording session — use this to distinguish one workflow from a previous one without restarting the server. |

---

## Implementation Details

## Event capture (context.ts)

- New `RecordedEvent` type covers `navigate`, `click`, and `fill` interactions.
- `_recordingState` holds the active session; listeners are attached to every open page and any page opened during the session.
- `_stoppedEvents` preserves the last completed session's buffer after `stopRecording()` is called, so `browser_recording_get` and `browser_recording_save` still work after stopping.
- `startRecording()` clears `_stoppedEvents` before opening a new session.
- `resetRecording()` tears down any active session, clears the buffer, and immediately calls `startRecording()` — single-call session boundary.
- `saveRecordingAsTest(testName, outputPath)` wraps recorded lines in a `test(...)` block using `@playwright/test` and writes the file to disk.

## Auto-record mode (`browserBackend.ts`, `config.ts`, `program.ts`)

- New `--auto-record` CLI flag: when set, recording begins automatically as soon as the browser context is initialized — no need to call `browser_recording_start` explicitly.

## Tool registration (`tools.ts`)

- All five recording tools are registered alongside the existing MCP tool set.

---

## File Changes

```text
packages/playwright-core/src/tools/backend/context.ts        — recording state, event capture, code generation
packages/playwright-core/src/tools/backend/recording.ts      — MCP tool definitions (new file)
packages/playwright-core/src/tools/backend/browserBackend.ts — auto-record on init
packages/playwright-core/src/tools/backend/tools.ts          — register recording tools
packages/playwright-core/src/tools/mcp/config.ts             — autoRecord config field
packages/playwright-core/src/tools/mcp/program.ts            — --auto-record CLI flag
tests/mcp/recording.spec.ts                                  — test coverage (new file)
```

---

## Usage

```bash
# Start with auto-record
node packages/playwright-core/lib/entry/mcp.js --port 8931 --browser chromium --auto-record
```

```text
1. browser_recording_reset             # clear any prior session
2. User interacts with the browser
3. browser_recording_get               # preview the TypeScript code
4. browser_recording_save              # write to .spec.ts
   { testName: "user can create material", outputPath: "tests/e2e/create-material.spec.ts" }
```
