### PR TITLE
chore(bidi): return null for elements without a bounding box

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -517,7 +517,7 @@ export class BidiPage implements PageDelegate {
 
   async getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null> {
     const box = await handle.evaluate(element => {
-      if (!(element instanceof Element))
+      if (!(element instanceof Element) || element.getClientRects().length === 0)
         return null;
       const rect = element.getBoundingClientRect();
       return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -1,4 +1,3 @@
-page/elementhandle-bounding-box.spec.ts › should return null for invisible elements [fail]
 page/elementhandle-click.spec.ts › should double click the button [fail]
 page/elementhandle-click.spec.ts › should work for TextNodes [fail]
 page/elementhandle-content-frame.spec.ts › should work for cross-frame evaluations [fail]


### PR DESCRIPTION
`element.getBoundingClientRect()` returns a zero-sized box for invisible elements, so we need to check using `element.getClientRects()` whether the element has a layout.
Fixes "should return null for invisible elements" in `page/elementhandle-bounding-box.spec.ts`.
