### PR TITLE
test(cdp): properly restore HTTP_PROXY env var to fix flake

### DIFF
--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -439,10 +439,14 @@ test('should use env proxy with connectOverCDP discovery request', async ({ brow
   const oldValue = process.env.HTTP_PROXY;
   try {
     process.env.HTTP_PROXY = proxyServer.URL;
-    await browserType.connectOverCDP(server.PREFIX).catch(() => {});
+    const error = await browserType.connectOverCDP(server.PREFIX).catch(e => e);
+    expect(error.message).toContain(`Unexpected status 404 when connecting to ${server.PREFIX}/json/version/`);
     expect(proxyServer.requestUrls).toEqual([`${server.PREFIX}/json/version/`]);
   } finally {
-    process.env.HTTP_PROXY = oldValue;
+    if (oldValue === undefined)
+      delete process.env.HTTP_PROXY;
+    else
+      process.env.HTTP_PROXY = oldValue;
   }
 });
 


### PR DESCRIPTION
## Summary
- `process.env.X = undefined` coerces to the string `"undefined"`, leaking a bogus proxy into subsequent tests run by the same worker — making `should be able to connect via localhost` fail with `getaddrinfo ENOTFOUND undefined`. Delete the var when the original was unset.
- Also assert that the discovery request actually fails with 404 so the test's intent is enforced.