### PR TITLE
chore(bidi): fix error message when adoptElementHandle() fails

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -615,7 +615,11 @@ export class BidiPage implements PageDelegate {
     const fromContext = toBidiExecutionContext(handle._context);
     const nodeId = await fromContext.nodeIdForElementHandle(handle);
     const executionContext = toBidiExecutionContext(to);
-    return await executionContext.remoteObjectForNodeId(to, nodeId) as dom.ElementHandle<T>;
+    try {
+      return await executionContext.remoteObjectForNodeId(to, nodeId) as dom.ElementHandle<T>;
+    } catch {
+      throw new Error(dom.kUnableToAdoptErrorMessage);
+    }
   }
 
   async inputActionEpilogue(): Promise<void> {

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -11,7 +11,6 @@ page/elementhandle-scroll-into-view.spec.ts › should wait for display:none to 
 page/elementhandle-scroll-into-view.spec.ts › should wait for nested display:none to become visible [fail]
 page/elementhandle-scroll-into-view.spec.ts › should work @smoke [fail]
 page/frame-evaluate.spec.ts › should allow cross-frame element handles [fail]
-page/frame-evaluate.spec.ts › should not allow cross-frame element handles when frames do not script each other [fail]
 page/frame-evaluate.spec.ts › should dispose context on cross-origin navigation [fail]
 page/frame-evaluate.spec.ts › should dispose context on navigation [fail]
 page/frame-hierarchy.spec.ts › should support framesets [fail]


### PR DESCRIPTION
Fixes "should not allow cross-frame element handles when frames do not script each other" in `page/frame-evaluate.spec.ts`.
