### PR TITLE
feat(test-runner): add {testFileBaseName} token to snapshotPathTemplate

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1933,6 +1933,8 @@ The list of supported tokens:
   * Value: `/home/playwright/tests` (absolute path since `testDir` is resolved relative to directory with config)
 * `{testFileDir}` - Directories in relative path from `testDir` to **test file**.
   * Value: `page`
+* `{testFileBaseName}` - Test file name without the last extension.
+  * Value: `page-click.spec`
 * `{testFileName}` - Test file name with extension.
   * Value: `page-click.spec.ts`
 * `{testFilePath}` - Relative path from `testDir` to **test file**.

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -625,6 +625,7 @@ export class TestInfoImpl implements TestInfo {
         .replace(/\{(.)?platform\}/g, '$1' + process.platform)
         .replace(/\{(.)?projectName\}/g, projectNamePathSegment ? '$1' + projectNamePathSegment : '')
         .replace(/\{(.)?testName\}/g, '$1' + this._fsSanitizedTestName())
+        .replace(/\{(.)?testFileBaseName\}/g, '$1' + parsedRelativeTestFilePath.name)
         .replace(/\{(.)?testFileName\}/g, '$1' + parsedRelativeTestFilePath.base)
         .replace(/\{(.)?testFilePath\}/g, '$1' + relativeTestFilePath)
         .replace(/\{(.)?arg\}/g, '$1' + nameArgument)

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -529,6 +529,8 @@ interface TestProject<TestArgs = {}, WorkerArgs = {}> {
    *     config)
    * - `{testFileDir}` - Directories in relative path from `testDir` to **test file**.
    *   - Value: `page`
+   * - `{testFileBaseName}` - Test file name without the last extension.
+   *   - Value: `page-click.spec`
    * - `{testFileName}` - Test file name with extension.
    *   - Value: `page-click.spec.ts`
    * - `{testFilePath}` - Relative path from `testDir` to **test file**.
@@ -1770,6 +1772,8 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *     config)
    * - `{testFileDir}` - Directories in relative path from `testDir` to **test file**.
    *   - Value: `page`
+   * - `{testFileBaseName}` - Test file name without the last extension.
+   *   - Value: `page-click.spec`
    * - `{testFileName}` - Test file name with extension.
    *   - Value: `page-click.spec.ts`
    * - `{testFilePath}` - Relative path from `testDir` to **test file**.

--- a/tests/playwright-test/snapshot-path-template.spec.ts
+++ b/tests/playwright-test/snapshot-path-template.spec.ts
@@ -80,6 +80,9 @@ test('tokens should expand property', async ({ runInlineTest }, testInfo) => {
       name: 'testFileName',
       snapshotPathTemplate: '{testFileName}',
     }, {
+      name: 'testFileBaseName',
+      snapshotPathTemplate: '{testFileBaseName}',
+    }, {
       name: 'snapshotDir',
       snapshotDir: './a-snapshot-dir',
       snapshotPathTemplate: '{snapshotDir}.png',
@@ -101,6 +104,7 @@ test('tokens should expand property', async ({ runInlineTest }, testInfo) => {
   expect.soft(snapshotPath['testFileDir']).toBe(path.join('a', 'b', 'c'));
   expect.soft(snapshotPath['testFilePath']).toBe(path.join('a', 'b', 'c', 'd.spec.ts'));
   expect.soft(snapshotPath['testFileName']).toBe('d.spec.ts');
+  expect.soft(snapshotPath['testFileBaseName']).toBe('d.spec');
   expect.soft(snapshotPath['snapshotDir']).toBe('a-snapshot-dir.png');
   expect.soft(snapshotPath['snapshotSuffix']).toBe('-' + process.platform);
   expect.soft(snapshotPath['testName']).toBe('suite-test-should-work');


### PR DESCRIPTION
## Summary
- Adds a new `{testFileBaseName}` token to `snapshotPathTemplate`, expanding to the test file name without its last extension (matches `path.parse().name`).
- Sample: for a test file `page/page-click.spec.ts`, `{testFileBaseName}` resolves to `page-click.spec`. The existing `{testFileName}` keeps producing `page-click.spec.ts`.
- Useful on Windows where a test file `01-render.test.ts` and a sibling snapshot folder of the same name collide; users can now write `{testFileDir}/{testFileBaseName}-snapshots/{arg}{ext}` to drop the trailing extension.
- Extended the existing `tokens should expand property` test in `snapshot-path-template.spec.ts` rather than adding a new test.

Fixes https://github.com/microsoft/playwright/issues/24171