### PR TITLE
chore(build): clean all packages, not just published ones

### DIFF
--- a/utils/build/clean.js
+++ b/utils/build/clean.js
@@ -1,16 +1,19 @@
 // @ts-check
-const { workspace } = require('../workspace');
 const fs = require('fs');
 const path = require('path');
 
 const rmSync = (dir) => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
 
-for (const pkg of workspace.packages()) {
-  rmSync(path.join(pkg.path, 'node_modules'));
-  rmSync(path.join(pkg.path, 'lib'));
-  rmSync(path.join(pkg.path, 'dist'));
-  rmSync(path.join(pkg.path, 'src', 'generated'));
-  const bundles = path.join(pkg.path, 'bundles');
+const packagesDir = path.join(__dirname, '..', '..', 'packages');
+for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory())
+    continue;
+  const pkgPath = path.join(packagesDir, entry.name);
+  rmSync(path.join(pkgPath, 'node_modules'));
+  rmSync(path.join(pkgPath, 'lib'));
+  rmSync(path.join(pkgPath, 'dist'));
+  rmSync(path.join(pkgPath, 'src', 'generated'));
+  const bundles = path.join(pkgPath, 'bundles');
   if (fs.existsSync(bundles) && fs.statSync(bundles).isDirectory()) {
     for (const bundle of fs.readdirSync(bundles, { withFileTypes: true })) {
       if (bundle.isDirectory())


### PR DESCRIPTION
## Summary
- `clean.js` iterated `workspace.packages()` (the 14 published npm packages), so internal packages under `packages/` were never cleaned.
- Stale outputs left behind: `extension/dist`, `html-reporter/dist`, `injected/lib`, `playwright-electron/lib`.
- Walk `packages/*` directly so every package directory is covered.