### PR TITLE
feat(cli): mark read-only commands as raw by default

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -240,6 +240,8 @@ export async function program(options?: { embedderVersion?: string}) {
       const entry = registry.entry(clientInfo, sessionName);
       if (!entry)
         output.errorBrowserNotOpenForTool(sessionName);
+      if (command.raw)
+        args.raw = true;
       const text = await runInSession(entry, clientInfo, args, output);
       output.toolResult(text);
     }

--- a/packages/playwright-core/src/tools/cli-daemon/command.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/command.ts
@@ -24,6 +24,7 @@ export type CommandSchema<Args extends zodType.ZodTypeAny, Options extends zodTy
   category: Category;
   description: string;
   hidden?: boolean;
+  raw?: boolean;
   args?: Args;
   options?: Options;
   toolName: string | ((args: zodType.infer<Args> & zodType.infer<Options>) => string);

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -543,6 +543,7 @@ const cookieList = declareCommand({
   name: 'cookie-list',
   description: 'List all cookies (optionally filtered by domain/path)',
   category: 'storage',
+  raw: true,
   args: z.object({}),
   options: z.object({
     domain: z.string().optional().describe('Filter cookies by domain'),
@@ -556,6 +557,7 @@ const cookieGet = declareCommand({
   name: 'cookie-get',
   description: 'Get a specific cookie by name',
   category: 'storage',
+  raw: true,
   args: z.object({
     name: z.string().describe('Cookie name'),
   }),
@@ -609,6 +611,7 @@ const localStorageList = declareCommand({
   name: 'localstorage-list',
   description: 'List all localStorage key-value pairs',
   category: 'storage',
+  raw: true,
   args: z.object({}),
   toolName: 'browser_localstorage_list',
   toolParams: () => ({}),
@@ -618,6 +621,7 @@ const localStorageGet = declareCommand({
   name: 'localstorage-get',
   description: 'Get a localStorage item by key',
   category: 'storage',
+  raw: true,
   args: z.object({
     key: z.string().describe('Key to get'),
   }),
@@ -663,6 +667,7 @@ const sessionStorageList = declareCommand({
   name: 'sessionstorage-list',
   description: 'List all sessionStorage key-value pairs',
   category: 'storage',
+  raw: true,
   args: z.object({}),
   toolName: 'browser_sessionstorage_list',
   toolParams: () => ({}),
@@ -672,6 +677,7 @@ const sessionStorageGet = declareCommand({
   name: 'sessionstorage-get',
   description: 'Get a sessionStorage item by key',
   category: 'storage',
+  raw: true,
   args: z.object({
     key: z.string().describe('Key to get'),
   }),
@@ -742,6 +748,7 @@ const routeList = declareCommand({
   name: 'route-list',
   description: 'List all active network routes',
   category: 'network',
+  raw: true,
   args: z.object({}),
   toolName: 'browser_route_list',
   toolParams: () => ({}),
@@ -848,6 +855,7 @@ const networkRequestHeaders = declareCommand({
   name: 'request-headers',
   description: 'Print only the request headers for a single network request by its number from the `requests` command.',
   category: 'network',
+  raw: true,
   args: z.object({
     index: numberArg.describe('1-based number of the request as listed by `requests`'),
   }),
@@ -862,6 +870,7 @@ const networkRequestBody = declareCommand({
   name: 'request-body',
   description: 'Print only the request body for a single network request by its number from the `requests` command.',
   category: 'network',
+  raw: true,
   args: z.object({
     index: numberArg.describe('1-based number of the request as listed by `requests`'),
   }),
@@ -876,6 +885,7 @@ const networkResponseHeaders = declareCommand({
   name: 'response-headers',
   description: 'Print only the response headers for a single network request by its number from the `requests` command.',
   category: 'network',
+  raw: true,
   args: z.object({
     index: numberArg.describe('1-based number of the request as listed by `requests`'),
   }),
@@ -890,6 +900,7 @@ const networkResponseBody = declareCommand({
   name: 'response-body',
   description: 'Print the response body for a single network request by its number from the `requests` command. Textual bodies are inlined; binary bodies are saved to a file and the path is printed.',
   category: 'network',
+  raw: true,
   args: z.object({
     index: numberArg.describe('1-based number of the request as listed by `requests`'),
   }),

--- a/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
@@ -162,7 +162,7 @@ function isBooleanSchema(schema: zodType.ZodTypeAny): boolean {
 export function generateHelpJSON() {
   const booleanOptions = new Set<string>();
 
-  const commandEntries: Record<string, { help: string, flags: Record<string, 'boolean' | 'string'> }> = {};
+  const commandEntries: Record<string, { help: string, flags: Record<string, 'boolean' | 'string'>, raw?: boolean }> = {};
   for (const [name, command] of Object.entries(commands)) {
     const flags: Record<string, 'boolean' | 'string'> = {};
     if (command.options) {
@@ -175,6 +175,8 @@ export function generateHelpJSON() {
       }
     }
     commandEntries[name] = { help: generateCommandHelp(command), flags };
+    if (command.raw)
+      commandEntries[name].raw = true;
   }
 
   return {

--- a/tests/mcp/cli-cookies.spec.ts
+++ b/tests/mcp/cli-cookies.spec.ts
@@ -26,7 +26,7 @@ test('cookie-list shows no cookies when empty', async ({ cli, server, mcpBrowser
 
   await cli('open', server.EMPTY_PAGE);
   const { output } = await cli('cookie-list');
-  expect(output).toContain('No cookies found');
+  expect(output).toBe('No cookies found');
 });
 
 test('cookie-set and cookie-get', async ({ cli, server }, testInfo) => {
@@ -40,7 +40,7 @@ test('cookie-set and cookie-get', async ({ cli, server }, testInfo) => {
 
   // Get the cookie
   const { output: getOutput } = await cli('cookie-get', 'testCookie');
-  expect(getOutput).toContain('testCookie=testValue');
+  expect(getOutput).toMatch(/^testCookie=testValue \(domain: [^,]+, path: \/, httpOnly: \w+, secure: \w+, sameSite: \w+\)$/);
 });
 
 test('cookie-list shows cookies', async ({ cli, server }, testInfo) => {
@@ -52,8 +52,10 @@ test('cookie-list shows cookies', async ({ cli, server }, testInfo) => {
   await cli('cookie-set', 'cookie2', 'value2');
 
   const { output } = await cli('cookie-list');
-  expect(output).toContain('cookie1=value1');
-  expect(output).toContain('cookie2=value2');
+  const lines = output.split('\n');
+  expect(lines).toHaveLength(2);
+  expect(lines[0]).toMatch(/^cookie1=value1 \(domain: [^,]+, path: \/\)$/);
+  expect(lines[1]).toMatch(/^cookie2=value2 \(domain: [^,]+, path: \/\)$/);
 });
 
 test('cookie-delete removes cookie', async ({ cli, server }, testInfo) => {
@@ -68,7 +70,7 @@ test('cookie-delete removes cookie', async ({ cli, server }, testInfo) => {
 
   // Verify it's gone
   const { output: getOutput } = await cli('cookie-get', 'testCookie');
-  expect(getOutput).toContain('not found');
+  expect(getOutput).toBe(`Cookie 'testCookie' not found`);
 });
 
 test('cookie-clear removes all cookies', async ({ cli, server }, testInfo) => {
@@ -84,5 +86,5 @@ test('cookie-clear removes all cookies', async ({ cli, server }, testInfo) => {
 
   // Verify they're gone
   const { output: listOutput } = await cli('cookie-list');
-  expect(listOutput).toContain('No cookies found');
+  expect(listOutput).toBe('No cookies found');
 });

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -170,7 +170,7 @@ test('request* and response* commands support --filename', async ({ cli, server 
   expect(read('res-b.json')).toBe('{"name":"John Doe"}');
 });
 
-test('--raw response-body returns just the body', async ({ cli, server }) => {
+test('response-body returns just the body', async ({ cli, server }) => {
   server.setContent('/', `
     <button onclick="fetch('/api')">Click me</button>
   `, 'text/html');
@@ -182,7 +182,7 @@ test('--raw response-body returns just the body', async ({ cli, server }) => {
   const match = list.match(/^(\d+)\. \[GET\] [^ ]+\/api =>/m);
   expect(match).not.toBeNull();
 
-  const { output } = await cli('--raw', 'response-body', match![1]);
+  const { output } = await cli('response-body', match![1]);
   expect(output.trim()).toBe('{"name":"John Doe"}');
 });
 


### PR DESCRIPTION
## Summary
- Adds a `raw?: boolean` flag to the CLI command schema and marks read-only data-fetching commands with it: `cookie-list`, `cookie-get`, `localstorage-list`, `localstorage-get`, `sessionstorage-list`, `sessionstorage-get`, `route-list`, `request-headers`, `request-body`, `response-headers`, `response-body`.
- These commands now emit raw output (no `### Result` wrapper) without needing `--raw`.