### PR TITLE
feat(mcp): add browser_annotate tool

### DIFF
--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -230,6 +230,10 @@ async function canConnectTo(descriptor: BrowserDescriptor): Promise<boolean> {
         socket.destroy();
         resolve(true);
       });
+      socket.setTimeout(2000, () => {
+        socket.destroy();
+        resolve(false);
+      });
       socket.on('error', () => resolve(false));
     });
   }
@@ -237,6 +241,10 @@ async function canConnectTo(descriptor: BrowserDescriptor): Promise<boolean> {
     const socket = net.createConnection(descriptor.endpoint ?? (descriptor as any).pipeName, () => {
       socket.destroy();
       resolve(true);
+    });
+    socket.setTimeout(2000, () => {
+      socket.destroy();
+      resolve(false);
     });
     socket.on('error', () => resolve(false));
   });

--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -50,7 +50,7 @@ export class BrowserBackend implements ServerBackend {
     await this._context?.dispose().catch(e => debug('pw:tools:error')(e));
   }
 
-  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}): Promise<mcpServer.CallToolResult> {
+  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}, _progress?: unknown, signal?: AbortSignal): Promise<mcpServer.CallToolResult> {
     const json = !!rawArguments._meta?.json;
     const formatError = (message: string): mcpServer.CallToolResult => ({
       content: [{ type: 'text' as const, text: json ? JSON.stringify({ isError: true, error: message }, null, 2) : `### Error\n${message}` }],
@@ -68,7 +68,7 @@ export class BrowserBackend implements ServerBackend {
     context.setRunningTool(name);
     let responseObject: mcpServer.CallToolResult;
     try {
-      await tool.handle(context, parsedArguments, response);
+      await tool.handle(context, parsedArguments, response, signal);
       for (const reason of context.drainPendingUnhandledRejections())
         response.addError(formatRejectionReason(reason));
       responseObject = await response.serialize();

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -162,7 +162,7 @@ const annotate = defineTabTool({
     if (png)
       await response.addResult('Annotation image', Buffer.from(png, 'base64'), { prefix: 'annotations', ext: 'png', date });
     if (ariaSnapshot)
-      await response.addResult('Annotation snapshot', ariaSnapshot, { prefix: 'annotations', ext: 'yaml', date });
+      await response.addResult('Annotation snapshot', Buffer.from(ariaSnapshot, 'utf8'), { prefix: 'annotations', ext: 'yaml', date });
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+import { spawn } from 'child_process';
+
 import * as z from 'zod';
+
+import { libPath } from '../../package';
 import { defineTabTool, defineTool } from './tool';
 import { elementSchema, optionalElementSchema } from './snapshot';
+
+import type { AnnotationData } from '@dashboard/dashboardChannel';
 
 const resume = defineTool({
   capability: 'devtools',
@@ -108,4 +114,56 @@ const hideHighlight = defineTabTool({
   },
 });
 
-export default [resume, highlight, hideHighlight];
+const annotate = defineTabTool({
+  capability: 'devtools',
+  schema: {
+    name: 'browser_annotate',
+    title: 'Annotate the current page',
+    description: 'Open the Playwright Dashboard in annotation mode for the current page and wait for the user to draw annotations. Returns the annotated screenshot, ARIA snapshot, and the list of annotations.',
+    inputSchema: z.object({}),
+    type: 'readOnly',
+  },
+
+  handle: async (tab, params, response, signal) => {
+    // eslint-disable-next-line no-restricted-syntax -- _guid is the cross-process page identifier shared with the dashboard daemon.
+    const pageId = (tab.page as any)._guid as string;
+    const daemonScript = libPath('entry', 'dashboardApp.js');
+    const daemonArgs = [daemonScript, `--pageId=${pageId}`];
+
+    // Spawn the dashboard daemon (idempotent — the singleton socket guards against duplicates).
+    const daemon = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore' });
+    daemon.unref();
+
+    // Spawn the annotate client in JSON mode to capture the raw payload.
+    const client = spawn(process.execPath, [...daemonArgs, '--annotate'], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    const onAbort = () => client.kill();
+    signal?.addEventListener('abort', onAbort);
+    const stdoutChunks: Buffer[] = [];
+    client.stdout!.on('data', chunk => stdoutChunks.push(chunk));
+    const exitCode = await new Promise<number | null>(resolve => client.on('exit', code => resolve(code)));
+    signal?.removeEventListener('abort', onAbort);
+    if (signal?.aborted)
+      return;
+    if (exitCode !== 0) {
+      response.addError(`Annotation client exited with code ${exitCode}`);
+      return;
+    }
+    const text = Buffer.concat(stdoutChunks).toString('utf8').trim();
+    if (!text) {
+      response.addTextResult('No annotations were submitted.');
+      return;
+    }
+    const { png, ariaSnapshot, annotations } = JSON.parse(text) as { png?: string; ariaSnapshot?: string; annotations: AnnotationData[] };
+    for (const a of annotations)
+      response.addTextResult(`{ x: ${a.x}, y: ${a.y}, width: ${a.width}, height: ${a.height} }: ${a.text}`);
+    const date = new Date();
+    if (png)
+      await response.addResult('Annotation image', Buffer.from(png, 'base64'), { prefix: 'annotations', ext: 'png', date });
+    if (ariaSnapshot)
+      await response.addResult('Annotation snapshot', ariaSnapshot, { prefix: 'annotations', ext: 'yaml', date });
+  },
+});
+
+export default [resume, highlight, hideHighlight, annotate];

--- a/packages/playwright-core/src/tools/backend/tool.ts
+++ b/packages/playwright-core/src/tools/backend/tool.ts
@@ -52,7 +52,7 @@ export type Tool<Input extends z.Schema = z.Schema> = {
   capability: ToolCapability;
   skillOnly?: boolean;
   schema: ToolSchema<Input>;
-  handle: (context: Context, params: z.output<Input>, response: Response) => Promise<void>;
+  handle: (context: Context, params: z.output<Input>, response: Response, signal?: AbortSignal) => Promise<void>;
 };
 
 export function defineTool<Input extends z.Schema>(tool: Tool<Input>): Tool<Input> {
@@ -64,13 +64,13 @@ export type TabTool<Input extends z.Schema = z.Schema> = {
   skillOnly?: boolean;
   schema: ToolSchema<Input>;
   clearsModalState?: ModalState['type'];
-  handle: (tab: Tab, params: z.output<Input>, response: Response) => Promise<void>;
+  handle: (tab: Tab, params: z.output<Input>, response: Response, signal?: AbortSignal) => Promise<void>;
 };
 
 export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Tool<Input> {
   return {
     ...tool,
-    handle: async (context, params, response) => {
+    handle: async (context, params, response, signal) => {
       const tab = await context.ensureTab();
       const modalStates = tab.modalStates().map(state => state.type);
       if (tool.clearsModalState && !modalStates.includes(tool.clearsModalState))
@@ -78,7 +78,7 @@ export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Too
       else if (!tool.clearsModalState && modalStates.length)
         response.addError(`Error: Tool "${tool.schema.name}" does not handle the modal state.`);
       else
-        return tool.handle(tab, params, response);
+        return tool.handle(tab, params, response, signal);
     },
   };
 }

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -217,10 +217,7 @@ export async function program(options?: { embedderVersion?: string}) {
         return;
       }
       if (args.annotate) {
-        const dashboard = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore' });
-        dashboard.unref();
-        const annotate = spawn(process.execPath, [...daemonArgs, '--annotate'], { stdio: 'inherit' });
-        await new Promise<void>(resolve => annotate.on('exit', () => resolve()));
+        await runToolInSession(args, command, registry, clientInfo, sessionName, output);
         return;
       }
       const foreground = args.port !== undefined;
@@ -237,15 +234,19 @@ export async function program(options?: { embedderVersion?: string}) {
       return;
     }
     default: {
-      const entry = registry.entry(clientInfo, sessionName);
-      if (!entry)
-        output.errorBrowserNotOpenForTool(sessionName);
-      if (command.raw)
-        args.raw = true;
-      const text = await runInSession(entry, clientInfo, args, output);
-      output.toolResult(text);
+      await runToolInSession(args, command, registry, clientInfo, sessionName, output);
     }
   }
+}
+
+async function runToolInSession(args: MinimistArgs, command: { raw?: boolean }, registry: Registry, clientInfo: ClientInfo, sessionName: string, output: Output) {
+  const entry = registry.entry(clientInfo, sessionName);
+  if (!entry)
+    output.errorBrowserNotOpenForTool(sessionName);
+  if (command.raw)
+    args.raw = true;
+  const text = await runInSession(entry, clientInfo, args, output);
+  output.toolResult(text);
 }
 
 async function startSession(sessionName: string, registry: Registry, clientInfo: ClientInfo, args: MinimistArgs, mode: 'open' | 'attach') {

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -99,6 +99,7 @@ export class Session {
         else
           resolve({ error });
       });
+      setTimeout(() => { socket.destroy(); resolve({ error: new Error('Connection timeout') }); }, 5000);
     });
   }
 

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -973,6 +973,7 @@ const dashboardShow = declareCommand({
   name: 'show',
   description: 'Show Playwright Dashboard',
   category: 'devtools',
+  raw: true,
   args: z.object({}),
   options: z.object({
     port: numberArg.optional().describe('Start as a blocking HTTP server on this port (use 0 for a random port)'),
@@ -980,7 +981,7 @@ const dashboardShow = declareCommand({
     annotate: z.boolean().optional().describe('Switch the dashboard into annotation mode.'),
     kill: z.boolean().optional().describe('Kill the dashboard daemon.'),
   }),
-  toolName: '',
+  toolName: args => args.annotate ? 'browser_annotate' : '',
   toolParams: () => ({}),
 });
 

--- a/packages/playwright-core/src/tools/cli-daemon/daemon.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/daemon.ts
@@ -78,6 +78,8 @@ export async function startCliDaemonServer(
 
   const server = net.createServer(socket => {
     const connection = new SocketConnection(socket);
+    const abortController = new AbortController();
+    connection.onclose = () => abortController.abort(new Error('CLI client disconnected'));
     connection.onmessage = async message => {
       const { id, method, params } = message;
       try {
@@ -91,7 +93,7 @@ export async function startCliDaemonServer(
         } else if (method === 'run') {
           const { toolName, toolParams } = parseCliCommand(params.args);
           toolParams._meta = { cwd: params.cwd, raw: params.raw || params.json, json: !!params.json };
-          const response = await backend.callTool(toolName, toolParams);
+          const response = await backend.callTool(toolName, toolParams, () => {}, abortController.signal);
           await connection.send({ id, result: formatResult(response) });
         } else {
           throw new Error(`Unknown method: ${method}`);

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -26,7 +26,6 @@ import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
 import { minimist } from '../cli-client/minimist';
-import { saveOutputFile } from '../trace/traceUtils';
 import { DashboardConnection } from './dashboardController';
 
 import type * as api from '../../..';
@@ -68,7 +67,9 @@ async function startDashboardServer(options: DashboardOptions): Promise<Dashboar
     let connection: DashboardConnection;
     // eslint-disable-next-line prefer-const
     connection = new DashboardConnection(() => connections.delete(connection), () => {
-      if (currentReveal.sessionName)
+      if (currentReveal.pageId)
+        connection.revealPage(currentReveal.pageId);
+      else if (currentReveal.sessionName)
         connection.revealSession(currentReveal.sessionName, currentReveal.workspaceDir);
       if (pendingAnnotate) {
         pendingAnnotate = false;
@@ -91,6 +92,11 @@ async function startDashboardServer(options: DashboardOptions): Promise<Dashboar
 
   const reveal = (next: DashboardOptions) => {
     currentReveal = next;
+    if (next.pageId) {
+      for (const connection of connections)
+        connection.revealPage(next.pageId);
+      return;
+    }
     if (!next.sessionName)
       return;
     for (const connection of connections)
@@ -230,6 +236,7 @@ function dashboardSocketPath() {
 type DashboardOptions = {
   sessionName: string;
   workspaceDir: string;
+  pageId?: string;
   kill?: boolean;
   annotate?: boolean;
   port?: number;
@@ -237,11 +244,12 @@ type DashboardOptions = {
 };
 
 function parseOpenArgs(): DashboardOptions {
-  const args = minimist(process.argv.slice(2), { string: ['sessionName', 'workspaceDir', 'host'], boolean: ['annotate', 'kill'] });
+  const args = minimist(process.argv.slice(2), { string: ['sessionName', 'workspaceDir', 'host', 'pageId'], boolean: ['annotate', 'kill'] });
   const portStr = args.port as string | undefined;
   return {
     sessionName: args.sessionName as string,
     workspaceDir: args.workspaceDir as string,
+    pageId: args.pageId as string | undefined,
     port: portStr !== undefined ? Number(portStr) : undefined,
     host: args.host as string | undefined,
     annotate: !!args.annotate,
@@ -378,32 +386,13 @@ async function runAnnotateClient(options: DashboardOptions): Promise<void> {
     return;
   }
   socket.write(JSON.stringify(options) + '\n');
-  const chunks: Buffer[] = [];
+  // eslint-disable-next-line no-restricted-properties
+  socket.pipe(process.stdout, { end: false });
   await new Promise<void>((resolve, reject) => {
-    socket!.on('data', chunk => chunks.push(chunk));
-    socket!.on('end', () => resolve());
-    socket!.on('error', reject);
+    socket!.once('end', resolve);
+    socket!.once('error', reject);
   });
   socket.destroy();
-  const text = Buffer.concat(chunks).toString();
-  if (!text)
-    return;
-  const { png, annotations, ariaSnapshot } = JSON.parse(text) as { png: string; annotations: AnnotationData[], ariaSnapshot: string };
-  for (const a of annotations) {
-    // eslint-disable-next-line no-console
-    console.log(`{ x: ${a.x}, y: ${a.y}, width: ${a.width}, height: ${a.height} }: ${a.text}`);
-  }
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  if (png) {
-    const filePath = await saveOutputFile(`annotations-${timestamp}.png`, Buffer.from(png, 'base64'));
-    // eslint-disable-next-line no-console
-    console.log(`image: ${path.relative(process.cwd(), filePath)}`);
-  }
-  if (ariaSnapshot) {
-    const filePath = await saveOutputFile(`annotations-${timestamp}.yaml`, ariaSnapshot);
-    // eslint-disable-next-line no-console
-    console.log(`snapshot: ${path.relative(process.cwd(), filePath)}`);
-  }
 }
 
 function selfDestructOnParentGone() {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -115,7 +115,7 @@ export class DashboardConnection implements Transport {
   private _pushSessionsScheduled = false;
   private _pushTabsScheduled = false;
   private _visible = true;
-  private _pendingReveal: { sessionName: string; workspaceDir?: string } | undefined;
+  private _pendingReveal: { sessionName?: string; workspaceDir?: string; pageId?: string } | undefined;
   private _annotateWaitingForAttach = false;
 
   _recordingDir: string;
@@ -220,16 +220,24 @@ export class DashboardConnection implements Transport {
     void this._tryRevealPending();
   }
 
+  revealPage(pageId: string) {
+    this._pendingReveal = { pageId };
+    void this._tryRevealPending();
+  }
+
   private async _tryRevealPending() {
     const pending = this._pendingReveal;
     if (!pending)
       return;
-    const slot = [...this._browsers.values()].find(s =>
-      s.descriptor.title === pending.sessionName
-        && (pending.workspaceDir === undefined || s.descriptor.workspaceDir === pending.workspaceDir));
-    if (!slot)
-      return;
-    const page = slot.browser.contexts().flatMap(c => c.pages())[0];
+    const allPages = [...this._browsers.values()].flatMap(s => s.browser.contexts().flatMap(c => c.pages().map(p => ({ slot: s, page: p }))));
+    let page: api.Page | undefined;
+    if (pending.pageId !== undefined) {
+      page = allPages.find(({ page }) => pageId(page) === pending.pageId)?.page;
+    } else if (pending.sessionName !== undefined) {
+      page = allPages.find(({ slot }) =>
+        slot.descriptor.title === pending.sessionName
+          && (pending.workspaceDir === undefined || slot.descriptor.workspaceDir === pending.workspaceDir))?.page;
+    }
     if (!page)
       return;
     this._pendingReveal = undefined;

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -65,7 +65,7 @@ const backendManager = new BackendManager();
 
 export interface ServerBackend {
   initialize?(clientInfo: ClientInfo): Promise<void>;
-  callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback): Promise<CallToolResult & { isClose?: boolean }>;
+  callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback, signal?: AbortSignal): Promise<CallToolResult & { isClose?: boolean }>;
   dispose?(): Promise<void>;
 }
 
@@ -127,7 +127,7 @@ export function createServer(name: string, version: string, factory: ServerBacke
       }
 
       const backend = await backendPromise;
-      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, progress);
+      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, progress, extra.signal);
       if (toolResult.isClose) {
         await backendManager.disposeBackend(backend).catch(serverDebug);
         backendPromise = undefined;
@@ -194,7 +194,10 @@ function addServerListener(server: ServerType, event: 'close' | 'initialized', l
 
 export async function start(serverBackendFactory: ServerBackendFactory, options: { host?: string; port?: number, allowedHosts?: string[], socketPath?: string } = {}) {
   if (options.port === undefined) {
-    await connect(serverBackendFactory, new StdioServerTransport(), false);
+    // eslint-disable-next-line no-restricted-properties
+    const transport = new StdioServerTransport(process.stdin, process.stdout);
+    process.stdin.on('end', () => void transport.close().catch(() => {}));
+    await connect(serverBackendFactory, transport, false);
     return;
   }
 

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -30,7 +30,7 @@ export const test = baseTest.extend<{
   boundBrowser: Browser,
   cliEnv: Record<string, string>,
   startDashboardServer: (options?: { cwd?: string, session?: string }) => Promise<Page>,
-  connectToDashboard: (bindTitle: string) => Promise<Browser>;
+  connectToDashboard: () => Promise<Browser>;
   cli: (...args: any[]) => Promise<{
     output: string,
     error: string,
@@ -41,9 +41,13 @@ export const test = baseTest.extend<{
     daemonPid?: number,
     dashboardPid?: number,
   }>;
+  dashboardBindTitle: string,
 }>({
   cliEnv: async ({}, use) => {
     await use(cliEnv());
+  },
+  dashboardBindTitle: async ({}, use) => {
+    await use(`--playwright-internal-dashboard-${test.info().testId}`);
   },
   startDashboardServer: async ({ childProcess, page }, use) => {
     await use(async (options?: { cwd?: string, session?: string }) => {
@@ -59,13 +63,13 @@ export const test = baseTest.extend<{
       return page;
     });
   },
-  connectToDashboard: async ({ cli, playwright }, use) => {
-    await use(async (bindTitle: string) => {
+  connectToDashboard: async ({ cli, playwright, dashboardBindTitle }, use) => {
+    await use(async () => {
       let endpoint = '';
       await expect(async () => {
         const { output } = await cli('list', '--all', '--json');
         const { servers } = JSON.parse(output);
-        const server = servers.find(s => s.title === bindTitle);
+        const server = servers.find(s => s.title === dashboardBindTitle);
         endpoint = server.endpoint;
       }).toPass();
       return await playwright.chromium.connect(endpoint);
@@ -73,14 +77,14 @@ export const test = baseTest.extend<{
     await cli('show', '--kill');
   },
 
-  cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
+  cli: async ({ mcpBrowser, mcpHeadless, childProcess, dashboardBindTitle }, use) => {
     await fs.promises.mkdir(test.info().outputPath('.playwright'), { recursive: true });
     const allPids: number[] = [];
 
     await use(async (...args: string[]) => {
       const cliArgs = args.filter(arg => typeof arg === 'string');
       const cliOptions = args.findLast(arg => typeof arg === 'object') || {};
-      const result = await runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless });
+      const result = await runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless, dashboardBindTitle });
       if (result.daemonPid)
         allPids.push(result.daemonPid);
       if (result.dashboardPid)
@@ -123,7 +127,7 @@ function cliEnv() {
   };
 }
 
-async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string, env?: Record<string, string>, bindTitle?: string }, options: { mcpBrowser: string, mcpHeadless: boolean }) {
+async function runCli(childProcess: CommonFixtures['childProcess'], args: string[], cliOptions: { cwd?: string, env?: Record<string, string> }, options: { mcpBrowser: string, mcpHeadless: boolean, dashboardBindTitle: string }) {
   const testInfo = test.info();
   const cli = childProcess({
     command: [process.execPath, require.resolve('../../packages/playwright-core/lib/tools/cli-client/cli.js'), ...args],
@@ -133,7 +137,7 @@ async function runCli(childProcess: CommonFixtures['childProcess'], args: string
       PLAYWRIGHT_MCP_BROWSER: options.mcpBrowser,
       PLAYWRIGHT_MCP_HEADLESS: String(options.mcpHeadless),
       PWTEST_PRINT_DASHBOARD_PID_FOR_TEST: '1',
-      PWTEST_DASHBOARD_APP_BIND_TITLE: cliOptions.bindTitle,
+      PWTEST_DASHBOARD_APP_BIND_TITLE: options.dashboardBindTitle,
       ...cliOptions.env,
     }),
   });

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -136,7 +136,8 @@ test('daemon show: closing page exits the process', async ({ cli, connectToDashb
 
 async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page, text: string) {
   await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
-  const box = await dashboard.locator('img#display').boundingBox();
+  await expect(dashboard.locator('.annotate-modal-image')).toBeVisible();
+  const box = await dashboard.locator('.annotate-modal-image').boundingBox();
   const x0 = box!.x + box!.width * 0.3;
   const y0 = box!.y + box!.height * 0.3;
   const x1 = box!.x + box!.width * 0.45;
@@ -270,7 +271,8 @@ test('should capture multiple annotations in one session', async ({ connectToDas
   try {
     const dashboard = browser.contexts()[0].pages()[0];
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
-    const box = await dashboard.locator('img#display').boundingBox();
+    await expect(dashboard.locator('.annotate-modal-image')).toBeVisible();
+    const box = await dashboard.locator('.annotate-modal-image').boundingBox();
     for (const [text, xFrac, yFrac] of [['first', 0.2, 0.2], ['second', 0.6, 0.6]] as const) {
       await dashboard.mouse.move(box!.x + box!.width * xFrac, box!.y + box!.height * yFrac);
       await dashboard.mouse.down();

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -122,13 +122,12 @@ function isAlive(pid: number): boolean {
 }
 
 test('daemon show: closing page exits the process', async ({ cli, connectToDashboard }) => {
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  const { exitCode, dashboardPid } = await cli('show', { bindTitle });
+  const { exitCode, dashboardPid } = await cli('show');
   expect(exitCode).toBe(0);
   expect(dashboardPid).toBeDefined();
   expect(isAlive(dashboardPid)).toBe(true);
 
-  const browser = await connectToDashboard(bindTitle);
+  const browser = await connectToDashboard();
   const page = browser.contexts()[0].pages()[0];
   await page.close();
 
@@ -140,8 +139,8 @@ async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page
   const box = await dashboard.locator('img#display').boundingBox();
   const x0 = box!.x + box!.width * 0.3;
   const y0 = box!.y + box!.height * 0.3;
-  const x1 = box!.x + box!.width * 0.6;
-  const y1 = box!.y + box!.height * 0.6;
+  const x1 = box!.x + box!.width * 0.45;
+  const y1 = box!.y + box!.height * 0.45;
   await dashboard.mouse.move(x0, y0);
   await dashboard.mouse.down();
   await dashboard.mouse.move(x1, y1);
@@ -152,10 +151,11 @@ async function drawAndSubmitAnnotation(dashboard: import('playwright-core').Page
 }
 
 function verifyAnnotateOutput(output: string, expectedText: string, outputDir: string) {
-  const lines = output.trim().split('\n');
+  const lines = output.trim().split('\n').filter(Boolean);
   expect(lines[0]).toMatch(new RegExp(`^\\{ x: \\d+, y: \\d+, width: \\d+, height: \\d+ \\}: ${expectedText}$`));
-  expect(lines[lines.length - 1]).toMatch(/^image: \.playwright-cli[\\/]annotations-.*\.png$/);
-  const pngRel = lines[lines.length - 1].replace(/^image: /, '');
+  const fileLine = lines.find(l => /^- \[Annotation image\]\(.*\.png\)$/.test(l));
+  expect(fileLine).toBeTruthy();
+  const pngRel = fileLine!.replace(/^- \[Annotation image\]\(/, '').replace(/\)$/, '');
   const pngPath = path.resolve(outputDir, pngRel);
   expect(fs.existsSync(pngPath)).toBe(true);
   expect(fs.statSync(pngPath).size).toBeGreaterThan(0);
@@ -163,9 +163,8 @@ function verifyAnnotateOutput(output: string, expectedText: string, outputDir: s
 
 test('should capture annotations via show --annotate', async ({ connectToDashboard, cli, server }) => {
   await cli('open', server.EMPTY_PAGE);
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  await cli('show', { bindTitle });
-  const browser = await connectToDashboard(bindTitle);
+  await cli('show');
+  const browser = await connectToDashboard();
 
   const dashboard = browser.contexts()[0].pages()[0];
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
@@ -185,12 +184,11 @@ test('should capture annotations via show --annotate', async ({ connectToDashboa
 test('should start dashboard and annotate when no dashboard is running', async ({ connectToDashboard, cli, server }) => {
   await cli('open', server.EMPTY_PAGE);
 
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  const annotatePromise = cli('show', '--annotate', { bindTitle });
+  const annotatePromise = cli('show', '--annotate');
   let done = false;
   void annotatePromise.finally(() => { done = true; });
 
-  const browser = await connectToDashboard(bindTitle);
+  const browser = await connectToDashboard();
   try {
     const dashboard = browser.contexts()[0].pages()[0];
     await drawAndSubmitAnnotation(dashboard, 'hi');
@@ -208,12 +206,11 @@ test('should enter annotate mode on fresh dashboard.tsx mount with -s --annotate
   await cli('-s=first', 'open', server.EMPTY_PAGE);
   await cli('-s=second', 'open', server.EMPTY_PAGE);
 
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  const annotatePromise = cli('-s=second', 'show', '--annotate', { bindTitle });
+  const annotatePromise = cli('-s=second', 'show', '--annotate');
   let done = false;
   void annotatePromise.finally(() => { done = true; });
 
-  const browser = await connectToDashboard(bindTitle);
+  const browser = await connectToDashboard();
   try {
     const dashboard = browser.contexts()[0].pages()[0];
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
@@ -228,6 +225,74 @@ test('should enter annotate mode on fresh dashboard.tsx mount with -s --annotate
   expect(exitCode).toBe(0);
 });
 
+test('should annotate via direct browser_annotate MCP call', async ({ connectToDashboard, boundBrowser, startClient, cliEnv, dashboardBindTitle, server }) => {
+  const page = await boundBrowser.newPage();
+  await page.goto(server.EMPTY_PAGE);
+
+  const { client } = await startClient({
+    args: ['--endpoint=default', '--caps=devtools'],
+    env: {
+      ...cliEnv,
+      PWTEST_DASHBOARD_APP_BIND_TITLE: dashboardBindTitle,
+      PWTEST_PRINT_DASHBOARD_PID_FOR_TEST: '1',
+    },
+  });
+  await client.callTool({ name: 'browser_snapshot' });
+
+  const annotatePromise = client.callTool({ name: 'browser_annotate' });
+  let done = false;
+  void annotatePromise.then(() => { done = true; });
+
+  const browser = await connectToDashboard();
+  try {
+    const dashboard = browser.contexts()[0].pages()[0];
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+    await drawAndSubmitAnnotation(dashboard, 'direct-mcp');
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  const result = await annotatePromise;
+  expect(done).toBe(true);
+  const text = (result.content as any).map(c => c.text ?? '').join('\n');
+  expect(text).toMatch(/\{ x: \d+, y: \d+, width: \d+, height: \d+ \}: direct-mcp/);
+  expect(text).toMatch(/- \[Annotation image\]\(.*\.png\)/);
+});
+
+test('should capture multiple annotations in one session', async ({ connectToDashboard, cli, server }) => {
+  await cli('open', server.EMPTY_PAGE);
+
+  const annotatePromise = cli('show', '--annotate');
+  let done = false;
+  void annotatePromise.finally(() => { done = true; });
+
+  const browser = await connectToDashboard();
+  try {
+    const dashboard = browser.contexts()[0].pages()[0];
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+    const box = await dashboard.locator('img#display').boundingBox();
+    for (const [text, xFrac, yFrac] of [['first', 0.2, 0.2], ['second', 0.6, 0.6]] as const) {
+      await dashboard.mouse.move(box!.x + box!.width * xFrac, box!.y + box!.height * yFrac);
+      await dashboard.mouse.down();
+      await dashboard.mouse.move(box!.x + box!.width * (xFrac + 0.15), box!.y + box!.height * (yFrac + 0.15));
+      await dashboard.mouse.up();
+      await dashboard.locator('.annotations-textarea').fill(text);
+      await dashboard.locator('.annotations-textarea').press('Enter');
+    }
+    await dashboard.getByRole('button', { name: 'Submit annotation' }).click();
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  const { output, exitCode } = await annotatePromise;
+  expect(done).toBe(true);
+  expect(exitCode).toBe(0);
+  const lines = output.trim().split('\n').filter(Boolean);
+  expect(lines[0]).toMatch(/^\{ x: \d+, y: \d+, width: \d+, height: \d+ \}: first$/);
+  expect(lines[1]).toMatch(/^\{ x: \d+, y: \d+, width: \d+, height: \d+ \}: second$/);
+});
+
+
 test('should switch screencast to -s session on show --annotate', async ({ connectToDashboard, cli, server }) => {
   server.setContent('/red', '<html><head><style>html,body{margin:0;height:100vh;background:#ff0000}</style></head><body></body></html>', 'text/html');
   server.setContent('/green', '<html><head><style>html,body{margin:0;height:100vh;background:#00ff00}</style></head><body></body></html>', 'text/html');
@@ -235,9 +300,8 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   await cli('-s=first', 'open', server.PREFIX + '/red');
   await cli('-s=second', 'open', server.PREFIX + '/green');
 
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  await cli('-s=first', 'show', { bindTitle });
-  const browser = await connectToDashboard(bindTitle);
+  await cli('-s=first', 'show');
+  const browser = await connectToDashboard();
   const dashboard = browser.contexts()[0].pages()[0];
   await expect(dashboard.locator('#display')).toBeVisible();
 
@@ -277,11 +341,11 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   expect(exitCode).toBe(0);
 });
 
-test('should disengage annotate mode when --annotate client disconnects', async ({ connectToDashboard, cli, childProcess, cliEnv, mcpBrowser, mcpHeadless, server }) => {
+
+test('should disengage annotate mode when --annotate client disconnects', async ({ connectToDashboard, cli, childProcess, cliEnv, dashboardBindTitle, mcpBrowser, mcpHeadless, server }) => {
   await cli('open', server.EMPTY_PAGE);
-  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
-  await cli('show', { bindTitle });
-  const browser = await connectToDashboard(bindTitle);
+  await cli('show');
+  const browser = await connectToDashboard();
 
   const dashboard = browser.contexts()[0].pages()[0];
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
@@ -301,6 +365,36 @@ test('should disengage annotate mode when --annotate client disconnects', async 
   await annotateClient.kill();
 
   await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
+});
+
+test('should disengage annotate mode when MCP client closes mid-annotation', async ({ connectToDashboard, boundBrowser, startClient, cliEnv, dashboardBindTitle, server }) => {
+  const page = await boundBrowser.newPage();
+  await page.goto(server.EMPTY_PAGE);
+
+  const { client } = await startClient({
+    args: ['--endpoint=default', '--caps=devtools'],
+    env: {
+      ...cliEnv,
+      PWTEST_DASHBOARD_APP_BIND_TITLE: dashboardBindTitle,
+      PWTEST_PRINT_DASHBOARD_PID_FOR_TEST: '1',
+    },
+  });
+  await client.callTool({ name: 'browser_snapshot' });
+
+  const annotatePromise = client.callTool({ name: 'browser_annotate' }).catch(e => e);
+
+  const browser = await connectToDashboard();
+  try {
+    const dashboard = browser.contexts()[0].pages()[0];
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+
+    await client.close();
+
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeHidden();
+  } finally {
+    await browser.close().catch(() => {});
+  }
+  await annotatePromise;
 });
 
 async function installSaveFilePickerMock(page: import('playwright-core').Page): Promise<() => Promise<Buffer>> {


### PR DESCRIPTION
## Summary
- Add `browser_annotate` MCP tool that mirrors `playwright cli show --annotate`, taking a page ID so MCP callers don't need a session name.
- Route `playwright cli show --annotate` through the session daemon to the new MCP tool.
- Plumb AbortSignal through MCP so that annotation mode can disengage when the caller disconnects