### PR TITLE
devops(mcp): one CI job per browser project

### DIFF
--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -31,15 +31,25 @@ env:
 
 jobs:
   test_mcp:
-    name: ${{ matrix.os }} - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+    name: ${{ matrix.os }} - ${{ matrix.project }}
     # Used for authentication of flakiness upload
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        os: [ubuntu-latest, macos-latest]
+        project: [chrome, chromium, firefox, webkit]
+        include:
+          - os: windows-latest
+            project: chrome
+          - os: windows-latest
+            project: chromium
+          - os: windows-latest
+            project: firefox
+          - os: windows-latest
+            project: webkit
+          - os: windows-latest
+            project: msedge
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
@@ -49,9 +59,8 @@ jobs:
     - uses: ./.github/actions/run-test
       with:
         node-version: "22"
-        command: npm run test-mcp -- --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        bot-name: "mcp-${{ matrix.os }}"
-        shard-index: ${{ matrix.shardIndex }}
+        command: npm run test-mcp -- --project=${{ matrix.project }}
+        bot-name: "mcp-${{ matrix.os }}-${{ matrix.project }}"
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
         flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Summary
- Replace shard-based MCP CI matrix (3 OS × 2 shards = 6 jobs) with one job per `(os, project)` combo (13 jobs).
- Each job runs a single browser via `--project=`, increasing parallelism.
- `bot-name` now includes the project so the flakiness dashboard distinguishes browsers.