### PR TITLE
devops: warn in merge-report comment when triggering run was cancelled

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -37,6 +37,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NODE_OPTIONS: --max-old-space-size=8192
         HTML_REPORT_URL: 'https://mspwblobreport.z1.web.core.windows.net/run-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}-${{ github.sha }}/index.html'
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
 
     - name: Azure Login
       uses: azure/login@v2

--- a/tests/config/ghaMarkdownReporter.ts
+++ b/tests/config/ghaMarkdownReporter.ts
@@ -52,6 +52,11 @@ class MarkdownReporter implements Reporter {
   async onEnd(result: FullResult) {
     const summary = this._generateSummary();
     const lines: string[] = [];
+    const incompleteWarning = this._incompleteRunWarning();
+    if (incompleteWarning) {
+      lines.push(incompleteWarning);
+      lines.push(``);
+    }
     if (this._fatalErrors.length)
       lines.push(`**${this._fatalErrors.length} fatal errors, not part of any test**`);
     if (summary.unexpected.length) {
@@ -85,6 +90,13 @@ class MarkdownReporter implements Reporter {
     const reportFile = path.resolve(this._options.configDir, maybeRelativeFile);
     await fs.promises.mkdir(path.dirname(reportFile), { recursive: true });
     await fs.promises.writeFile(reportFile, report);
+  }
+
+  protected _incompleteRunWarning(): string | undefined {
+    const conclusion = process.env.WORKFLOW_RUN_CONCLUSION;
+    if (!conclusion || conclusion === 'success' || conclusion === 'failure')
+      return undefined;
+    return `> [!WARNING]\n> The triggering workflow run ended with status \`${conclusion}\`. Results below may be incomplete — blob reports from cancelled or timed-out shards are missing, so passing/failing counts do not reflect the full test suite.`;
   }
 
   protected _generateSummary() {


### PR DESCRIPTION
When the upstream tests workflow is cancelled or times out, blob reports from in-flight shards never get uploaded, so the merged report silently shows only the shards that did finish — often a misleading "everything passed" comment on the PR.

This forwards `workflow_run.conclusion` to the merge-reports step and prepends a GitHub-rendered `> [!WARNING]` callout to the markdown comment when the conclusion is anything other than `success`/`failure` (i.e. `cancelled`, `timed_out`, `startup_failure`, etc.).