### PR TITLE
chore(bidi): rewrite serialization error message

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiExecutionContext.ts
+++ b/packages/playwright-core/src/server/bidi/bidiExecutionContext.ts
@@ -93,7 +93,7 @@ export class BidiExecutionContext implements js.ExecutionContextDelegate {
       serializationOptions: returnByValue ? {} : { maxObjectDepth: 0, maxDomDepth: 0 },
       awaitPromise: true,
       userActivation: true,
-    });
+    }).catch(rewriteError);
     if (response.type === 'exception')
       throw new js.JavaScriptErrorInEvaluate(response.exceptionDetails.text);
     if (response.type === 'success') {
@@ -192,6 +192,12 @@ export class BidiExecutionContext implements js.ExecutionContextDelegate {
       return response.result;
     throw new js.JavaScriptErrorInEvaluate('Unexpected response type: ' + JSON.stringify(response));
   }
+}
+
+function rewriteError(error: Error): never {
+  if (error.message.includes('too much recursion') || error.message.includes('stack limit exceeded'))
+    throw new Error('Cannot serialize result: object reference chain is too long.');
+  throw error;
 }
 
 function renderPreview(remoteObject: bidi.Script.RemoteValue, nested = false): string {

--- a/tests/bidi/expectations/bidi-chromium-page.txt
+++ b/tests/bidi/expectations/bidi-chromium-page.txt
@@ -102,7 +102,6 @@ page/page-emulate-media.spec.ts › should keep reduced motion and color emulati
 page/page-emulate-media.spec.ts › should work during navigation [fail]
 page/page-evaluate-no-stall.spec.ts › should throw when no main execution context [fail]
 page/page-evaluate.spec.ts › should throw a nice error after a navigation [fail]
-page/page-evaluate.spec.ts › should throw for too deep reference chain [fail]
 page/page-evaluate.spec.ts › should throw when evaluation triggers reload [fail]
 page/page-event-console.spec.ts › should not throw when there are console messages in detached iframes [fail]
 page/page-event-console.spec.ts › should trigger correct Log [timeout]

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -1,4 +1,5 @@
 library/agent-perform.spec.ts › retrieve a secret [timeout]
+library/browsercontext-add-cookies.spec.ts › should allow unnamed cookies [fail]
 library/browsercontext-basic.spec.ts › fetch with keepalive should throw when offline [fail]
 library/browsercontext-basic.spec.ts › should disable javascript [fail]
 library/browsercontext-basic.spec.ts › should emulate media in cross-process iframe [fail]
@@ -134,6 +135,7 @@ library/inspector/cli-codegen-3.spec.ts › cli codegen › should generate fram
 library/launcher.spec.ts › should throw a friendly error if its headed and there is no xserver on linux running [fail]
 library/locator-dispatchevent-touch.spec.ts › should support touch points in touch event arguments [fail]
 library/multiclient.spec.ts › last emulateMedia wins [fail]
+library/multiclient.spec.ts › screencast should deliver cached last frame to a new client [fail]
 library/multiclient.spec.ts › should unroute websockets [timeout]
 library/page-clock.spec.ts › popup › should tick after popup [flaky]
 library/page-event-crash.spec.ts › should be able to close context when page crashes [timeout]

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -423,8 +423,8 @@ it('should return undefined for non-serializable objects', async ({ page }) => {
 
 it('should throw for too deep reference chain', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33997' }
-}, async ({ page, browserName }) => {
-  it.fixme(browserName === 'firefox', 'Firefox Juggler -> Playwright serialiser does not throw for deep references.\nThis causes large objects to get serialised back to the Playwright client.\nThere our validators throw \'Maximum call stack size exceeded\'.');
+}, async ({ page, browserName, isBidi }) => {
+  it.fixme(browserName === 'firefox' && !isBidi, 'Firefox Juggler -> Playwright serialiser does not throw for deep references.\nThis causes large objects to get serialised back to the Playwright client.\nThere our validators throw \'Maximum call stack size exceeded\'.');
   await expect(page.evaluate(depth => {
     const obj = {};
     let temp = obj;


### PR DESCRIPTION
Fixes "should throw for too deep reference chain" in `page/page-evaluate.spec.ts`.