### PR TITLE
test: reduce flakiness in library and ui-mode tests

### DIFF
--- a/tests/library/chromium/tracing.spec.ts
+++ b/tests/library/chromium/tracing.spec.ts
@@ -27,7 +27,7 @@ it('should output a trace', async ({ browser, server }, testInfo) => {
   const page = await browser.newPage();
   const outputTraceFile = testInfo.outputPath(path.join(`trace.json`));
   await browser.startTracing(page, { screenshots: true, path: outputTraceFile });
-  for (let i = 0; i < 20; i++)
+  for (let i = 0; i < 11; i++)
     await page.goto(server.PREFIX + '/grid.html');
   await browser.stopTracing();
   expect(fs.existsSync(outputTraceFile)).toBe(true);

--- a/tests/library/firefox/launcher.spec.ts
+++ b/tests/library/firefox/launcher.spec.ts
@@ -60,7 +60,7 @@ it('should support custom firefox policies', async ({ browserType, mode, asset, 
   const policiesPath = testInfo.outputPath('policies.json');
   await fs.promises.writeFile(policiesPath, JSON.stringify(policies));
 
-  const port = 48112;
+  const port = 13122;
   const server = new TestServer(asset(''), port, loopback, {
     key: await fs.promises.readFile(asset('client-certificates/client/localhost/localhost.key')),
     cert: await fs.promises.readFile(asset('client-certificates/client/localhost/localhost.pem')),

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -99,7 +99,7 @@ test('should show empty trace viewer', async ({ showTraceViewer }, testInfo) => 
 });
 
 test('should open two trace viewers', async ({ showTraceViewer }, testInfo) => {
-  const port = testInfo.workerIndex + 48321;
+  const port = testInfo.workerIndex + 13321;
   const traceViewer1 = await showTraceViewer(testInfo.outputPath(), { host: 'localhost', port });
   await expect(traceViewer1.page).toHaveTitle('Playwright Trace Viewer');
   const traceViewer2 = await showTraceViewer(testInfo.outputPath(), { host: 'localhost', port });

--- a/tests/playwright-test/ui-mode-fixtures.ts
+++ b/tests/playwright-test/ui-mode-fixtures.ts
@@ -21,7 +21,7 @@ import type { TestChildProcess } from '../config/commonFixtures';
 import { cliEntrypoint, test as base, writeFiles, removeFolders } from './playwright-test-fixtures';
 import type { Files, RunOptions } from './playwright-test-fixtures';
 import type { Browser, Page, TestInfo } from './stable-test-runner';
-import { chromium } from './stable-test-runner';
+import { chromium, expect as baseExpect } from './stable-test-runner';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import { inheritAndCleanEnv } from '../config/utils';
 
@@ -124,6 +124,7 @@ export const test = base
             const [context] = browser.contexts();
             [page] = context.pages();
           }
+          await expect(page).toHaveTitle('Playwright Test');
           return { page, testProcess };
         });
         await browser?.close();
@@ -141,8 +142,6 @@ export const test = base
         });
       },
     });
-
-import { expect as baseExpect } from './stable-test-runner';
 
 // Slow tests are 90s.
 export const expect = baseExpect.configure({ timeout: process.env.CI ? 75000 : 25000 });


### PR DESCRIPTION
## Summary
- Move hardcoded test server ports out of the Linux ephemeral range (32768-60999) so concurrent `listen(0)` callers cannot randomly grab them: firefox launcher (`48112` → `13122`) and trace-viewer (`48321 + workerIndex` → `13321 + workerIndex`).
- Wait for the UI mode app to finish loading in the `runUITest` fixture before returning, so subsequent `page.evaluate` calls don't race against the initial navigation (was flaky on Windows).
- Reduce iteration count in chromium tracing test.