### PR TITLE
fix(server): default run-server and launchServer to localhost

### DIFF
--- a/docs/src/api/class-android.md
+++ b/docs/src/api/class-android.md
@@ -206,7 +206,7 @@ throw if multiple devices are connected.
 * since: v1.45
 - `host` <[string]>
 
-Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider hardening it with picking a specific interface.
+Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware this exposes the device RPC to anything that can reach the listening port.
 
 ### option: Android.launchServer.port
 * since: v1.28

--- a/docs/src/api/class-browserserver.md
+++ b/docs/src/api/class-browserserver.md
@@ -31,5 +31,3 @@ Browser websocket url.
 
 Browser websocket endpoint which can be used as an argument to [`method: BrowserType.connect`] to establish connection
 to the browser.
-
-Note that if the listen `host` option in `launchServer` options is not specified, localhost will be output anyway, even if the actual listening address is an unspecified address.

--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -437,7 +437,7 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
 * since: v1.45
 - `host` <[string]>
 
-Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider hardening it with picking a specific interface.
+Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware this exposes the browser RPC to anything that can reach the listening port.
 
 ### option: BrowserType.launchServer.port
 * since: v1.8

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -16118,9 +16118,9 @@ export interface BrowserType<Unused = {}> {
     headless?: boolean;
 
     /**
-     * Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the
-     * unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider
-     * hardening it with picking a specific interface.
+     * Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the
+     * loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware
+     * this exposes the browser RPC to anything that can reach the listening port.
      */
     host?: string;
 
@@ -17366,9 +17366,9 @@ export interface Android {
     deviceSerialNumber?: string;
 
     /**
-     * Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the
-     * unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider
-     * hardening it with picking a specific interface.
+     * Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the
+     * loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware
+     * this exposes the device RPC to anything that can reach the listening port.
      */
     host?: string;
 
@@ -19544,9 +19544,6 @@ export interface BrowserServer {
    * Browser websocket endpoint which can be used as an argument to
    * [browserType.connect(endpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect)
    * to establish connection to the browser.
-   *
-   * Note that if the listen `host` option in `launchServer` options is not specified, localhost will be output anyway,
-   * even if the actual listening address is an unspecified address.
    */
   wsEndpoint(): string;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -16118,9 +16118,9 @@ export interface BrowserType<Unused = {}> {
     headless?: boolean;
 
     /**
-     * Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the
-     * unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider
-     * hardening it with picking a specific interface.
+     * Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the
+     * loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware
+     * this exposes the browser RPC to anything that can reach the listening port.
      */
     host?: string;
 
@@ -17366,9 +17366,9 @@ export interface Android {
     deviceSerialNumber?: string;
 
     /**
-     * Host to use for the web socket. It is optional and if it is omitted, the server will accept connections on the
-     * unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise. Consider
-     * hardening it with picking a specific interface.
+     * Host to use for the web socket. It is optional and defaults to `localhost`, accepting connections only from the
+     * loopback interface. Pass an explicit address (e.g. `0.0.0.0`) to accept connections from the network — be aware
+     * this exposes the device RPC to anything that can reach the listening port.
      */
     host?: string;
 
@@ -19544,9 +19544,6 @@ export interface BrowserServer {
    * Browser websocket endpoint which can be used as an argument to
    * [browserType.connect(endpoint[, options])](https://playwright.dev/docs/api/class-browsertype#browser-type-connect)
    * to establish connection to the browser.
-   *
-   * Note that if the listen `host` option in `launchServer` options is not specified, localhost will be output anyway,
-   * even if the actual listening address is an unspecified address.
    */
   wsEndpoint(): string;
 

--- a/packages/utils/wsServer.ts
+++ b/packages/utils/wsServer.ts
@@ -60,6 +60,10 @@ export class WSServer {
   async listen(port: number = 0, hostname: string | undefined, path: string): Promise<string> {
     debugLogger.log('server', `Server started at ${new Date()}`);
 
+    // Default to loopback so the WebSocket RPC is not exposed to the network unless
+    // the caller explicitly opts in by passing a host (e.g. '0.0.0.0').
+    hostname ??= 'localhost';
+
     const server = createHttpServer(this._delegate.onRequest);
     server.on('error', error => debugLogger.log('server', String(error)));
     this.server = server;
@@ -71,7 +75,7 @@ export class WSServer {
           reject(new Error('Could not bind server socket'));
           return;
         }
-        const wsEndpoint = typeof address === 'string' ? `${address}${path}` : `ws://${hostname || 'localhost'}:${address.port}${path}`;
+        const wsEndpoint = typeof address === 'string' ? `${address}${path}` : `ws://${hostname}:${address.port}${path}`;
         resolve(wsEndpoint);
       }).on('error', reject);
     });


### PR DESCRIPTION
Previously run-server and BrowserType.launchServer() bound to 0.0.0.0 when no host was provided, exposing the Playwright RPC WebSocket to the LAN while logging "ws://localhost:..." (giving the false impression of loopback-only binding). Default the WSServer hostname to 'localhost' so network exposure is now opt-in via an explicit host argument.