### PR TITLE
fix(mcp): skip base64 image response when filename param is provided in browser_take_screenshot

### DIFF
--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -67,7 +67,8 @@ const screenshot = defineTabTool({
       response.addCode(`await page.screenshot(${formatObject({ ...options, path: resolvedFile.relativeName })});`);
 
     await response.addFileResult(resolvedFile, data);
-    await response.registerImageResult(data, fileType);
+    if (!params.filename)
+      await response.registerImageResult(data, fileType);
   }
 });
 


### PR DESCRIPTION
Closes microsoft/playwright-mcp#1581

## Problem

When `browser_take_screenshot` is called with an explicit `filename` parameter, the screenshot is correctly saved to disk, but the raw image buffer is still registered in the MCP response as base64. A typical 1280x720 PNG becomes 400 KB–1 MB of base64 text, which can consume 70–80% of a 200k-token context window in a single call.

## Root cause

In `screenshot.ts`, `registerImageResult()` is called unconditionally regardless of whether `filename` was provided:

```typescript
await response.addFileResult(resolvedFile, data);
await response.registerImageResult(data, fileType); // always runs
```

The only workaround today is the global `--image-responses omit` flag, which also suppresses images when the LLM genuinely needs them for visual analysis.

## Fix

Skip `registerImageResult()` when `filename` is explicitly provided. The caller already knows where the file is saved and does not need the raw buffer in the LLM context.

```typescript
await response.addFileResult(resolvedFile, data);
if (!params.filename)
  await response.registerImageResult(data, fileType);
```

When `filename` is omitted the behaviour is unchanged: the image is still sent to the LLM for immediate visual analysis.

## Related closed issues

- microsoft/playwright-mcp#1185 — proposed the same fix; closed without a code change
- microsoft/playwright-mcp#277
- microsoft/playwright-mcp#1274
- microsoft/playwright-mcp#889