### PR TITLE
fix(chromium): recover binary body served as text/plain;charset=utf-8

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -382,14 +382,22 @@ export class CRNetworkManager {
 
       const session = request.session;
       const response = await session.send('Network.getResponseBody', { requestId: request._requestId });
-      if (response.body || !expectedLength)
+      // CDP returns the body as a UTF-8 string for "text" content types. When the
+      // payload contains bytes that are not valid UTF-8 (e.g. binary data served
+      // as text/plain;charset=utf-8), Chromium replaces them with U+FFFD, which
+      // corrupts the body. Detect this and recover via Network.loadNetworkResource
+      // (which streams base64 binary). See #40510.
+      const corrupted = !response.base64Encoded && response.body.includes('\uFFFD');
+      if ((response.body || !expectedLength) && !corrupted)
         return Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8');
 
       // Make sure no network requests sent while reading the body for fulfilled requests.
       if (request._originalRequestRoute?._fulfilled)
         return Buffer.from('');
 
-      // For <link prefetch we are going to receive empty body with non-empty content-length expectation. Reach out for the actual content.
+      // Fall back to Network.loadNetworkResource for:
+      // - <link prefetch> where we receive an empty body with non-empty content-length expectation;
+      // - corrupted text bodies (see above).
       const resource = await session.send('Network.loadNetworkResource', { url: request.request.url(), frameId: this._serviceWorker ? undefined : request.request.frame()!._id, options: { disableCache: false, includeCredentials: true } });
       const chunks: Buffer[] = [];
       while (resource.resource.stream) {

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -459,3 +459,20 @@ it('Response.formData() should parse multipart/form-data in page context', async
   expect(result.filename).toBe('test.txt');
   expect(result.fileContent).toBe('hello');
 });
+
+it('should return raw binary body for text/plain;charset=utf-8 response', async ({ page, server, browserName }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40510' });
+  it.fixme(browserName === 'webkit', 'WebKit corrupts non-UTF-8 bytes in Network.getResponseBody and exposes no alternative API');
+  const binary = Buffer.from([0xb5, 0x6e, 0x4c, 0x0d, 0x28, 0xd4, 0x8b, 0xea, 0x8b, 0x9a, 0x5c, 0x3f, 0x72, 0xf9, 0xa1, 0xcf]);
+  server.setRoute('/binary', (req, res) => {
+    res.setHeader('Content-Type', 'text/plain;charset=utf-8');
+    res.end(binary);
+  });
+  await page.goto(server.EMPTY_PAGE);
+  const [response] = await Promise.all([
+    page.waitForEvent('response'),
+    page.evaluate(() => fetch('/binary')),
+  ]);
+  const body = await response.body();
+  expect(body.toString('hex')).toBe(binary.toString('hex'));
+});


### PR DESCRIPTION
## Summary
- CDP's `Network.getResponseBody` returns a UTF-8 string for "text" content types and silently replaces invalid bytes with U+FFFD, corrupting binary payloads served as `text/plain;charset=utf-8`.
- Detect U+FFFD in the decoded body and recover by re-fetching via `Network.loadNetworkResource` (streams base64 binary), reusing the existing prefetch fallback path.
- WebKit has the same bug but no equivalent fallback API (`Network.getResponseBody` is the only way), so the test is `fixme`'d for WebKit. A proper fix needs a patch to WebKit's `InspectorNetworkAgent` in our browser fork — out of scope here.
- Firefox is unaffected (always returns base64).

Fixes https://github.com/microsoft/playwright/issues/40510
