### PR TITLE
feat(mcp): make browser_annotate cancelable

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -50,7 +50,7 @@ export class BrowserBackend implements ServerBackend {
     await this._context?.dispose().catch(e => debug('pw:tools:error')(e));
   }
 
-  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}): Promise<mcpServer.CallToolResult> {
+  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}, signal?: AbortSignal): Promise<mcpServer.CallToolResult> {
     const json = !!rawArguments._meta?.json;
     const formatError = (message: string): mcpServer.CallToolResult => ({
       content: [{ type: 'text' as const, text: json ? JSON.stringify({ isError: true, error: message }, null, 2) : `### Error\n${message}` }],
@@ -68,7 +68,7 @@ export class BrowserBackend implements ServerBackend {
     context.setRunningTool(name);
     let responseObject: mcpServer.CallToolResult;
     try {
-      await tool.handle(context, parsedArguments, response);
+      await tool.handle(context, parsedArguments, response, signal);
       for (const reason of context.drainPendingUnhandledRejections())
         response.addError(formatRejectionReason(reason));
       responseObject = await response.serialize();

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -134,11 +134,6 @@ const annotate = defineTabTool({
     const daemon = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore' });
     daemon.unref();
 
-    if (signal?.aborted) {
-      response.addTextResult('Annotation cancelled.');
-      return;
-    }
-
     // Spawn the annotate client in JSON mode to capture the raw payload over stdout.
     const client = spawn(process.execPath, [...daemonArgs, '--annotate', '--json'], {
       stdio: ['pipe', 'pipe', 'inherit'],
@@ -147,12 +142,8 @@ const annotate = defineTabTool({
     signal?.addEventListener('abort', onAbort);
     const stdoutChunks: Buffer[] = [];
     client.stdout!.on('data', chunk => stdoutChunks.push(chunk));
-    let exitCode: number | null;
-    try {
-      exitCode = await new Promise<number | null>(resolve => client.on('exit', code => resolve(code)));
-    } finally {
-      signal?.removeEventListener('abort', onAbort);
-    }
+    const exitCode = await new Promise<number | null>(resolve => client.on('exit', code => resolve(code)));
+    signal?.removeEventListener('abort', onAbort);
     if (signal?.aborted) {
       response.addTextResult('Annotation cancelled.');
       return;

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -124,7 +124,7 @@ const annotate = defineTabTool({
     type: 'readOnly',
   },
 
-  handle: async (tab, params, response) => {
+  handle: async (tab, params, response, signal) => {
     // eslint-disable-next-line no-restricted-syntax -- _guid is the cross-process page identifier shared with the dashboard daemon.
     const pageId = (tab.page as any)._guid as string;
     const daemonScript = libPath('entry', 'dashboardApp.js');
@@ -134,13 +134,29 @@ const annotate = defineTabTool({
     const daemon = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore' });
     daemon.unref();
 
+    if (signal?.aborted) {
+      response.addTextResult('Annotation cancelled.');
+      return;
+    }
+
     // Spawn the annotate client in JSON mode to capture the raw payload over stdout.
     const client = spawn(process.execPath, [...daemonArgs, '--annotate', '--json'], {
       stdio: ['pipe', 'pipe', 'inherit'],
     });
+    const onAbort = () => client.kill();
+    signal?.addEventListener('abort', onAbort);
     const stdoutChunks: Buffer[] = [];
     client.stdout!.on('data', chunk => stdoutChunks.push(chunk));
-    const exitCode = await new Promise<number | null>(resolve => client.on('exit', code => resolve(code)));
+    let exitCode: number | null;
+    try {
+      exitCode = await new Promise<number | null>(resolve => client.on('exit', code => resolve(code)));
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
+    }
+    if (signal?.aborted) {
+      response.addTextResult('Annotation cancelled.');
+      return;
+    }
     if (exitCode !== 0) {
       response.addError(`Annotation client exited with code ${exitCode}`);
       return;

--- a/packages/playwright-core/src/tools/backend/tool.ts
+++ b/packages/playwright-core/src/tools/backend/tool.ts
@@ -52,7 +52,7 @@ export type Tool<Input extends z.Schema = z.Schema> = {
   capability: ToolCapability;
   skillOnly?: boolean;
   schema: ToolSchema<Input>;
-  handle: (context: Context, params: z.output<Input>, response: Response) => Promise<void>;
+  handle: (context: Context, params: z.output<Input>, response: Response, signal?: AbortSignal) => Promise<void>;
 };
 
 export function defineTool<Input extends z.Schema>(tool: Tool<Input>): Tool<Input> {
@@ -64,13 +64,13 @@ export type TabTool<Input extends z.Schema = z.Schema> = {
   skillOnly?: boolean;
   schema: ToolSchema<Input>;
   clearsModalState?: ModalState['type'];
-  handle: (tab: Tab, params: z.output<Input>, response: Response) => Promise<void>;
+  handle: (tab: Tab, params: z.output<Input>, response: Response, signal?: AbortSignal) => Promise<void>;
 };
 
 export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Tool<Input> {
   return {
     ...tool,
-    handle: async (context, params, response) => {
+    handle: async (context, params, response, signal) => {
       const tab = await context.ensureTab();
       const modalStates = tab.modalStates().map(state => state.type);
       if (tool.clearsModalState && !modalStates.includes(tool.clearsModalState))
@@ -78,7 +78,7 @@ export function defineTabTool<Input extends z.Schema>(tool: TabTool<Input>): Too
       else if (!tool.clearsModalState && modalStates.length)
         response.addError(`Error: Tool "${tool.schema.name}" does not handle the modal state.`);
       else
-        return tool.handle(tab, params, response);
+        return tool.handle(tab, params, response, signal);
     },
   };
 }

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -176,7 +176,11 @@ function addServerListener(server: ServerType, event: 'close' | 'initialized', l
 
 export async function start(serverBackendFactory: ServerBackendFactory, options: { host?: string; port?: number, allowedHosts?: string[], socketPath?: string } = {}) {
   if (options.port === undefined) {
-    await connect(serverBackendFactory, new StdioServerTransport(), false);
+    const transport = new StdioServerTransport();
+    // The SDK's StdioServerTransport doesn't detect peer disconnect — it never listens for stdin
+    // end-of-stream. Wire it up so callTool requests can be cancelled when the client goes away.
+    process.stdin.on('end', () => void transport.close());
+    await connect(serverBackendFactory, transport, false);
     return;
   }
 

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -38,9 +38,6 @@ export type ClientInfo = {
   clientName: string;
 };
 
-export type ProgressParams = { message?: string, progress?: number, total?: number };
-export type ProgressCallback = (params: ProgressParams) => void;
-
 class BackendManager {
   private _backends = new Map<ServerBackend, ServerBackendFactory>();
 
@@ -65,7 +62,7 @@ const backendManager = new BackendManager();
 
 export interface ServerBackend {
   initialize?(clientInfo: ClientInfo): Promise<void>;
-  callTool(name: string, args: CallToolRequest['params']['arguments'], progress: ProgressCallback): Promise<CallToolResult & { isClose?: boolean }>;
+  callTool(name: string, args: CallToolRequest['params']['arguments'], signal: AbortSignal): Promise<CallToolResult & { isClose?: boolean }>;
   dispose?(): Promise<void>;
 }
 
@@ -103,21 +100,6 @@ export function createServer(name: string, version: string, factory: ServerBacke
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     serverDebug('callTool', request);
 
-    const progressToken = request.params._meta?.progressToken;
-    let progressCounter = 0;
-
-    const progress = progressToken ? (params: ProgressParams) => {
-      extra.sendNotification({
-        method: 'notifications/progress',
-        params: {
-          progressToken,
-          progress: params.progress ?? ++progressCounter,
-          total: params.total,
-          message: params.message,
-        },
-      }).catch(e => serverDebug('notification', e));
-    } : () => {};
-
     try {
       if (!backendPromise) {
         backendPromise = initializeServer(server, factory, runHeartbeat).catch(e => {
@@ -127,7 +109,7 @@ export function createServer(name: string, version: string, factory: ServerBacke
       }
 
       const backend = await backendPromise;
-      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, progress);
+      const toolResult = await backend.callTool(request.params.name, request.params.arguments || {}, extra.signal);
       if (toolResult.isClose) {
         await backendManager.disposeBackend(backend).catch(serverDebug);
         backendPromise = undefined;

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -262,6 +262,38 @@ test('should annotate via direct browser_annotate MCP call', async ({ connectToD
   expect(text).toMatch(/- \[Annotation image\]\(.*\.png\)/);
 });
 
+test('should cancel browser_annotate when the MCP request is aborted', async ({ connectToDashboard, boundBrowser, startClient, cliEnv, server }) => {
+  const page = await boundBrowser.newPage();
+  await page.goto(server.EMPTY_PAGE);
+
+  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
+  const { client } = await startClient({
+    args: ['--endpoint=default', '--caps=devtools'],
+    env: {
+      ...cliEnv,
+      PWTEST_DASHBOARD_APP_BIND_TITLE: bindTitle,
+    },
+  });
+
+  const controller = new AbortController();
+  const annotatePromise = client.callTool({ name: 'browser_annotate' }, undefined, { signal: controller.signal }).catch(() => {});
+
+  const browser = await connectToDashboard(bindTitle);
+  try {
+    const dashboard = browser.contexts()[0].pages()[0];
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+
+    controller.abort();
+
+    await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
+  } finally {
+    await browser.close().catch(() => {});
+  }
+
+  await annotatePromise;
+});
+
+
 test('should switch screencast to -s session on show --annotate', async ({ connectToDashboard, cli, server }) => {
   server.setContent('/red', '<html><head><style>html,body{margin:0;height:100vh;background:#ff0000}</style></head><body></body></html>', 'text/html');
   server.setContent('/green', '<html><head><style>html,body{margin:0;height:100vh;background:#00ff00}</style></head><body></body></html>', 'text/html');

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -293,6 +293,34 @@ test('should cancel browser_annotate when the MCP request is aborted', async ({ 
   await annotatePromise;
 });
 
+test('should cancel browser_annotate when the MCP client disconnects', async ({ connectToDashboard, boundBrowser, startClient, cliEnv, server }) => {
+  const page = await boundBrowser.newPage();
+  await page.goto(server.EMPTY_PAGE);
+
+  const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
+  const { client } = await startClient({
+    args: ['--endpoint=default', '--caps=devtools'],
+    env: {
+      ...cliEnv,
+      PWTEST_DASHBOARD_APP_BIND_TITLE: bindTitle,
+    },
+  });
+
+  void client.callTool({ name: 'browser_annotate' }).catch(() => {});
+
+  const browser = await connectToDashboard(bindTitle);
+  try {
+    const dashboard = browser.contexts()[0].pages()[0];
+    await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
+
+    await client.close();
+
+    await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
+  } finally {
+    await browser.close().catch(() => {});
+  }
+});
+
 
 test('should switch screencast to -s session on show --annotate', async ({ connectToDashboard, cli, server }) => {
   server.setContent('/red', '<html><head><style>html,body{margin:0;height:100vh;background:#ff0000}</style></head><body></body></html>', 'text/html');


### PR DESCRIPTION
## Summary
- Replace dead `ProgressCallback` plumbing in the MCP server with the `AbortSignal` from the SDK request handler `extra`.
- Thread the signal through `ServerBackend.callTool`, `BrowserBackend.callTool`, and `Tool`/`TabTool.handle`.
- `browser_annotate` kills its foreground annotate child when the MCP client cancels the request (`notifications/cancelled`).

Stacks on top of #40491 (now merged).