### PR TITLE
docs(python): add FormData class to Python API

### DIFF
--- a/docs/src/api/class-formdata.md
+++ b/docs/src/api/class-formdata.md
@@ -1,6 +1,6 @@
 # class: FormData
 * since: v1.18
-* langs: java, csharp
+* langs: java, csharp, python
 
 The [FormData] is used create form data that is sent via [APIRequestContext].
 
@@ -12,6 +12,22 @@ FormData form = FormData.create()
     .set("lastName", "Doe")
     .set("age", 30);
 page.request().post("http://localhost/submit", RequestOptions.create().setForm(form));
+```
+
+```python async
+form = FormData()
+form.set("firstName", "John")
+form.set("lastName", "Doe")
+form.set("age", 30)
+await page.request.post("http://localhost/submit", form=form)
+```
+
+```python sync
+form = FormData()
+form.set("firstName", "John")
+form.set("lastName", "Doe")
+form.set("age", 30)
+page.request.post("http://localhost/submit", form=form)
 ```
 
 ## method: FormData.append
@@ -58,6 +74,36 @@ multipart.Append("attachment", new FilePayload()
     Buffer = File.ReadAllBytes("my-tble.csv")
 });
 await Page.APIRequest.PostAsync("https://localhost/submit", new() { Multipart = multipart });
+```
+
+```python async
+form = FormData()
+# Only name and value are set.
+form.append("firstName", "John")
+# Name and value are set, filename and Content-Type are inferred from the file path.
+form.append("attachment", Path("pic.jpg"))
+# Name, value, filename and Content-Type are set.
+form.append("attachment", {
+    "name": "table.csv",
+    "mimeType": "text/csv",
+    "buffer": Path("my-table.csv").read_bytes(),
+})
+await page.request.post("http://localhost/submit", multipart=form)
+```
+
+```python sync
+form = FormData()
+# Only name and value are set.
+form.append("firstName", "John")
+# Name and value are set, filename and Content-Type are inferred from the file path.
+form.append("attachment", Path("pic.jpg"))
+# Name, value, filename and Content-Type are set.
+form.append("attachment", {
+    "name": "table.csv",
+    "mimeType": "text/csv",
+    "buffer": Path("my-table.csv").read_bytes(),
+})
+page.request.post("http://localhost/submit", multipart=form)
 ```
 
 ### param: FormData.append.name
@@ -127,6 +173,38 @@ multipart.Set("profilePicture", new FilePayload()
 });
 multipart.Set("age", 30);
 await Page.APIRequest.PostAsync("https://localhost/submit", new() { Multipart = multipart });
+```
+
+```python async
+form = FormData()
+# Only name and value are set.
+form.set("firstName", "John")
+# Name and value are set, filename and Content-Type are inferred from the file path.
+form.set("profilePicture1", Path("john.jpg"))
+# Name, value, filename and Content-Type are set.
+form.set("profilePicture2", {
+    "name": "john.jpg",
+    "mimeType": "image/jpeg",
+    "buffer": Path("john.jpg").read_bytes(),
+})
+form.set("age", 30)
+await page.request.post("http://localhost/submit", multipart=form)
+```
+
+```python sync
+form = FormData()
+# Only name and value are set.
+form.set("firstName", "John")
+# Name and value are set, filename and Content-Type are inferred from the file path.
+form.set("profilePicture1", Path("john.jpg"))
+# Name, value, filename and Content-Type are set.
+form.set("profilePicture2", {
+    "name": "john.jpg",
+    "mimeType": "image/jpeg",
+    "buffer": Path("john.jpg").read_bytes(),
+})
+form.set("age", 30)
+page.request.post("http://localhost/submit", multipart=form)
 ```
 
 ### param: FormData.set.name

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -486,11 +486,11 @@ unless explicitly provided.
 
 ## python-fetch-option-form
 * langs: python
-- `form` <[Object]<[string], [string]|[float]|[boolean]>>
+- `form` <[Object]<[string], [string]|[float]|[boolean]>|[FormData]>
 
 Provides an object that will be serialized as html form using `application/x-www-form-urlencoded` encoding and sent as
 this request body. If this parameter is specified `content-type` header will be set to `application/x-www-form-urlencoded`
-unless explicitly provided.
+unless explicitly provided. Use [FormData] to send multiple values for the same field.
 
 ## csharp-fetch-option-form
 * langs: csharp
@@ -516,7 +516,7 @@ or as file-like object containing file name, mime-type and its content.
 
 ## python-fetch-option-multipart
 * langs: python
-- `multipart` <[Object]<[string], [string]|[float]|[boolean]|[ReadStream]|[Object]>>
+- `multipart` <[Object]<[string], [string]|[float]|[boolean]|[ReadStream]|[Object]>|[FormData]>
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -524,6 +524,7 @@ or as file-like object containing file name, mime-type and its content.
 Provides an object that will be serialized as html form using `multipart/form-data` encoding and sent as
 this request body. If this parameter is specified `content-type` header will be set to `multipart/form-data`
 unless explicitly provided. File values can be passed as file-like object containing file name, mime-type and its content.
+Use [FormData] to send multiple files in the same field.
 
 ## csharp-fetch-option-multipart
 * langs: csharp


### PR DESCRIPTION
## Summary
- Adds Python to the FormData class langs and adds Python `set`/`append` examples.
- Extends `python-fetch-option-form` and `python-fetch-option-multipart` to accept `[FormData]`.

Enables the Python bindings to support repeated form keys (microsoft/playwright-python#2834) and multiple files per multipart field (microsoft/playwright-python#2784).