### PR TITLE
devops: drop service mode from transport job

### DIFF
--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -144,13 +144,11 @@ jobs:
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
         flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
-  transport_linux:
-    name: "Transport"
+  driver_linux:
+    name: "Driver"
     environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
-      matrix:
-        mode: [driver, service]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v6
@@ -158,12 +156,12 @@ jobs:
       with:
         browsers-to-install: chromium
         command: npm run ctest
-        bot-name: "${{ matrix.mode }}"
+        bot-name: "driver"
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
         flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
-        PWTEST_MODE: ${{ matrix.mode }}
+        PWTEST_MODE: driver
 
   tracing_linux:
     name: Tracing ${{ matrix.browser }} ${{ matrix.channel }}

--- a/tests/config/testMode.ts
+++ b/tests/config/testMode.ts
@@ -16,7 +16,7 @@
 
 import { oop, client } from '../../packages/playwright-core/lib/coreBundle';
 
-export type TestModeName = 'default' | 'driver' | 'service' | 'service2' | 'wsl';
+export type TestModeName = 'default' | 'driver';
 
 const { start } = oop;
 

--- a/tests/config/testModeFixtures.ts
+++ b/tests/config/testModeFixtures.ts
@@ -36,10 +36,6 @@ export const testModeTest = test.extend<TestModeTestFixtures, TestModeWorkerOpti
   playwright: [async ({ mode }, run) => {
     const testMode = {
       'default': new DefaultTestMode(),
-      'service': new DefaultTestMode(),
-      'service2': new DefaultTestMode(),
-      'service-grid': new DefaultTestMode(),
-      'wsl': new DefaultTestMode(),
       'driver': new DriverTestMode(),
     }[mode];
     const playwright = await testMode.setup();

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -59,25 +59,6 @@ const runId = process.env.PLAYWRIGHT_SERVICE_RUN_ID || new Date().toISOString();
 let connectOptions: any;
 let webServer: Config['webServer'];
 
-if (mode === 'service') {
-  connectOptions = { wsEndpoint: 'ws://localhost:3333/' };
-  webServer = {
-    command: 'npx playwright run-server --port=3333',
-    url: 'http://localhost:3333',
-    reuseExistingServer: !process.env.CI,
-  };
-}
-if (mode === 'service2') {
-  process.env.PW_VERSION_OVERRIDE = process.env.PW_VERSION_OVERRIDE || '1.39';
-  connectOptions = {
-    wsEndpoint: `${process.env.PLAYWRIGHT_SERVICE_URL}?cap=${JSON.stringify({ os, runId })}`,
-    timeout: 3 * 60 * 1000,
-    exposeNetwork: '<loopback>',
-    headers: {
-      'x-mpt-access-key': process.env.PLAYWRIGHT_SERVICE_ACCESS_KEY!
-    }
-  };
-}
 if (channel === 'webkit-wsl') {
   connectOptions = { wsEndpoint: 'ws://localhost:3777/' };
   webServer = {


### PR DESCRIPTION
## Summary
- Remove the `service` mode from the `transport_linux` matrix and rename the job to `Driver`.