### PR TITLE
fix(cli): validate open args client-side, clean up on failures

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -52,6 +52,7 @@ export interface Output {
 
   errorUnknownCommand(name: string | undefined, globalHelp: string): never;
   errorUnknownOption(opts: string[], commandHelp: string): never;
+  errorTooManyArguments(expected: number, received: number, commandHelp: string): never;
   errorAttachConflict(): never;
   errorDetachNotAttached(session: string): never;
   errorBrowserNotOpenForTool(session: string): never;
@@ -91,6 +92,13 @@ export class TextOutput implements Output {
 
   errorUnknownOption(opts: string[], commandHelp: string): never {
     console.error(`Unknown option${opts.length > 1 ? 's' : ''}: ${opts.map(f => `--${f}`).join(', ')}`);
+    console.log('');
+    console.log(commandHelp);
+    return process.exit(1);
+  }
+
+  errorTooManyArguments(expected: number, received: number, commandHelp: string): never {
+    console.error(`error: too many arguments: expected ${expected}, received ${received}`);
     console.log('');
     console.log(commandHelp);
     return process.exit(1);
@@ -271,6 +279,11 @@ export class JsonOutput implements Output {
 
   errorUnknownOption(opts: string[], _commandHelp: string): never {
     this._emit({ isError: true, error: `Unknown option${opts.length > 1 ? 's' : ''}: ${opts.map(f => `--${f}`).join(', ')}` });
+    return process.exit(1);
+  }
+
+  errorTooManyArguments(expected: number, received: number, _commandHelp: string): never {
+    this._emit({ isError: true, error: `error: too many arguments: expected ${expected}, received ${received}` });
     return process.exit(1);
   }
 

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -110,6 +110,7 @@ export async function program(options?: { embedderVersion?: string}) {
     output.errorUnknownCommand(commandName, help.global);
 
   validateFlags(args, command, output);
+  validateArgs(args, command, output);
 
   const registry = await Registry.load();
   const sessionName = resolveSessionName(args.session as string);
@@ -149,7 +150,7 @@ export async function program(options?: { embedderVersion?: string}) {
       const { pid } = await startSession(sessionName, registry, clientInfo, args, 'open');
       const newEntry = await registry.loadEntry(clientInfo, sessionName);
       const params = args._.slice(1);
-      const toolText = await runInSession(newEntry, clientInfo, { _: ['goto', ...(params.length ? params : ['about:blank'])] }, output);
+      const toolText = await runInSessionOrStop(newEntry, clientInfo, { _: ['goto', ...(params.length ? params : ['about:blank'])] }, output);
       output.open(sessionName, pid, toolText);
       return;
     }
@@ -173,7 +174,7 @@ export async function program(options?: { embedderVersion?: string}) {
       args.session = attachSessionName;
       const { pid } = await startSession(attachSessionName, registry, clientInfo, args, 'attach');
       const newEntry = await registry.loadEntry(clientInfo, attachSessionName);
-      const toolText = await runInSession(newEntry, clientInfo, { _: ['snapshot'], filename: '<auto>' }, output);
+      const toolText = await runInSessionOrStop(newEntry, clientInfo, { _: ['snapshot'], filename: '<auto>' }, output);
       output.attach(attachSessionName, pid, targetName, toolText);
       return;
     }
@@ -255,6 +256,19 @@ async function runInSession(entry: SessionFile, clientInfo: ClientInfo, args: Mi
   const session = new Session(entry);
   const result = await session.run(clientInfo, args, { raw, json: output.json });
   return result.text;
+}
+
+// Used by `open` / `attach` after `startSession`: if the implicit goto/snapshot
+// fails post-spawn (e.g. tool runtime error), stop the freshly-spawned daemon
+// so we don't strand a detached browser. Pre-spawn arg validation lives in
+// `validateArgs`; this is a defense-in-depth backstop for runtime errors.
+async function runInSessionOrStop(entry: SessionFile, clientInfo: ClientInfo, args: MinimistArgs, output: Output): Promise<string> {
+  try {
+    return await runInSession(entry, clientInfo, args, output);
+  } catch (e) {
+    await new Session(entry).stop().catch(() => {});
+    throw e;
+  }
 }
 
 async function runInitWorkspace(args: MinimistArgs, output: Output) {
@@ -389,6 +403,12 @@ function validateFlags(args: MinimistArgs, command: { flags: Record<string, 'boo
   }
   if (unknownFlags.length)
     output.errorUnknownOption(unknownFlags, command.help);
+}
+
+function validateArgs(args: MinimistArgs, command: { args: string[], help: string }, output: Output) {
+  const positional = args._.slice(1);
+  if (positional.length > command.args.length)
+    output.errorTooManyArguments(command.args.length, positional.length, command.help);
 }
 
 export function calculateSha1(buffer: Buffer | string): string {

--- a/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/helpGenerator.ts
@@ -162,7 +162,7 @@ function isBooleanSchema(schema: zodType.ZodTypeAny): boolean {
 export function generateHelpJSON() {
   const booleanOptions = new Set<string>();
 
-  const commandEntries: Record<string, { help: string, flags: Record<string, 'boolean' | 'string'>, raw?: boolean }> = {};
+  const commandEntries: Record<string, { help: string, flags: Record<string, 'boolean' | 'string'>, args: string[], raw?: boolean }> = {};
   for (const [name, command] of Object.entries(commands)) {
     const flags: Record<string, 'boolean' | 'string'> = {};
     if (command.options) {
@@ -174,7 +174,8 @@ export function generateHelpJSON() {
           booleanOptions.add(flagName);
       }
     }
-    commandEntries[name] = { help: generateCommandHelp(command), flags };
+    const args: string[] = command.args ? Object.keys((command.args as zodType.ZodObject<any>).shape) : [];
+    commandEntries[name] = { help: generateCommandHelp(command), flags, args };
     if (command.raw)
       commandEntries[name].raw = true;
   }

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -21,6 +21,7 @@ import os from 'os';
 import path from 'path';
 
 import { getAsBooleanFromENV, guessClientName } from '@utils/env';
+import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { libPath } from '../../package';
 import { startCliDaemonServer } from './daemon';
 import { setupExitWatchdog } from '../mcp/watchdog';
@@ -72,12 +73,7 @@ export function decorateProgram(program: Command) {
           const message = process.env.PWDEBUGIMPL ? (error as Error).stack || (error as Error).message : (error as Error).message;
           console.log(`### Error\n${message}`);
           console.log('<EOF>');
-          // Hygiene cleanup in createExtensionBrowser releases the http server
-          // and websocket connections, but the chrome subprocess + WS lifecycle
-          // leave behind libuv state we can't reach from JS, so the event loop
-          // would otherwise stay alive for ~5 seconds.
-          // eslint-disable-next-line no-restricted-properties
-          process.exit(1);
+          gracefullyProcessExitDoNotHang(1);
         }
       });
 }


### PR DESCRIPTION
## Summary
- `cli open foo bar` used to spawn a daemon and launch a browser before `parseCommand` rejected the extra positional arg, leaving the detached daemon (and browser) running after the cli exited.
- Emit each command's positional arg names in `help.json` and add a client-side `validateArgs` so bad arg counts reject before `startSession`.
- Wrap the implicit `goto` / `snapshot` in `open` / `attach` with `runInSessionOrStop` as a runtime backstop — if the implicit tool fails post-spawn, the freshly-spawned daemon is stopped instead of stranded.
- Swap `process.exit(1)` for `gracefullyProcessExitDoNotHang(1)` in the daemon startup catch so any post-browser-launch startup failure closes the browser too.