### PR TITLE
fix(glob): treat unbalanced braces as literals in globToRegexPattern

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -63,13 +63,29 @@ export function globToRegexPattern(glob: string): string {
     }
 
     switch (c) {
-      case '{':
-        inGroup = true;
-        tokens.push('(');
+      case '{': {
+        // Only treat '{' as a group opener when a matching '}' exists ahead;
+        // otherwise emit it as a literal to avoid producing an invalid regex.
+        let hasMatchingClose = false;
+        for (let j = i + 1; j < glob.length; j++) {
+          if (glob[j] === '\\' && j + 1 < glob.length) { j++; continue; }
+          if (glob[j] === '}') { hasMatchingClose = true; break; }
+        }
+        if (hasMatchingClose) {
+          inGroup = true;
+          tokens.push('(');
+        } else {
+          tokens.push('\\{');
+        }
         break;
+      }
       case '}':
-        inGroup = false;
-        tokens.push(')');
+        if (inGroup) {
+          inGroup = false;
+          tokens.push(')');
+        } else {
+          tokens.push('\\}');
+        }
         break;
       case ',':
         if (inGroup) {

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -114,6 +114,15 @@ it('should work with glob', async () => {
   expect(globToRegex('[a-z]')).toEqual(/^\[a-z\]$/);
   expect(globToRegex('$^+.\\*()|\\?\\{\\}\\[\\]')).toEqual(/^\$\^\+\.\*\(\)\|\?\{\}\[\]$/);
 
+  // unbalanced braces must be treated as literals, not produce invalid regexes
+  expect(globToRegex('{foo').test('{foo')).toBeTruthy();
+  expect(globToRegex('{foo').test('foo')).toBeFalsy();
+  expect(globToRegex('foo}').test('foo}')).toBeTruthy();
+  expect(globToRegex('foo}').test('foo')).toBeFalsy();
+  expect(globToRegex('**/*.png?{').test('https://localhost:8080/c.png?{')).toBeTruthy();
+  expect(globToRegex('**/*.png?{').test('https://localhost:8080/c.png?')).toBeFalsy();
+  expect(globToRegex('}foo{').test('}foo{')).toBeTruthy();
+
   expect(urlMatches(undefined, 'http://playwright.dev/', 'http://playwright.dev')).toBeTruthy();
   expect(urlMatches(undefined, 'http://playwright.dev/?a=b', 'http://playwright.dev?a=b')).toBeTruthy();
   expect(urlMatches(undefined, 'http://playwright.dev/', 'h*://playwright.dev')).toBeTruthy();


### PR DESCRIPTION
## Summary

- An unmatched `{` emitted an unclosed regex group `(`, and an unmatched `}` emitted an unmatched `)` — both produce `SyntaxError` when the regex is compiled at match time, silently aborting the intercepted request with `ERR_ABORTED`
- Fix: look ahead for a closing `}` before emitting the group opener; only close the group when actually inside one
- Unbalanced braces are now treated as literals, consistent with how most glob libraries behave

Fixes #40422