### PR TITLE
feat(codegen): add xUnit target for .NET C#

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -60,7 +60,7 @@ export function decorateProgram(program: Command) {
   commandWithOpenOptions('codegen [url]', 'open page and generate code for user actions',
       [
         ['-o, --output <file name>', 'saves the generated script to a file'],
-        ['--target <language>', `language to generate, one of javascript, playwright-test, python, python-async, python-pytest, csharp, csharp-mstest, csharp-nunit, java, java-junit`, codegenId()],
+        ['--target <language>', `language to generate, one of javascript, playwright-test, python, python-async, python-pytest, csharp, csharp-mstest, csharp-nunit, csharp-xunit, java, java-junit`, codegenId()],
         ['--test-id-attribute <attributeName>', 'use the specified attribute to generate data test ID selectors'],
       ]).action(async function(url, options) {
     await codegen(options, url);

--- a/packages/playwright-core/src/server/codegen/csharp.ts
+++ b/packages/playwright-core/src/server/codegen/csharp.ts
@@ -23,7 +23,7 @@ import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './ty
 import type { BrowserContextOptions } from '../../..';
 import type * as actions from '@recorder/actions';
 
-type CSharpLanguageMode = 'library' | 'mstest' | 'nunit';
+type CSharpLanguageMode = 'library' | 'mstest' | 'nunit' | 'xunit';
 
 export class CSharpLanguageGenerator implements LanguageGenerator {
   id: string;
@@ -42,6 +42,9 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
     } else if (mode === 'nunit') {
       this.name = 'NUnit';
       this.id = 'csharp-nunit';
+    } else if (mode === 'xunit') {
+      this.name = 'xUnit';
+      this.id = 'csharp-xunit';
     } else {
       throw new Error(`Unknown C# language mode: ${mode}`);
     }
@@ -196,13 +199,16 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
 
   generateTestRunnerHeader(options: LanguageGeneratorOptions): string {
     const formatter = new CSharpFormatter(0);
+    const playwrightNamespace = this._mode === 'nunit' ? 'NUnit' : this._mode === 'xunit' ? 'Xunit' : 'MSTest';
+    const classAttributes = this._mode === 'nunit' ? `[Parallelizable(ParallelScope.Self)]
+      [TestFixture]
+      ` : this._mode === 'mstest' ? `[TestClass]
+      ` : '';
     formatter.add(`
-      using Microsoft.Playwright.${this._mode === 'nunit' ? 'NUnit' : 'MSTest'};
-      using Microsoft.Playwright;
+      using Microsoft.Playwright.${playwrightNamespace};
+      using Microsoft.Playwright;${this._mode === 'xunit' ? `\n      using Xunit;` : ''}
 
-      ${this._mode === 'nunit' ? `[Parallelizable(ParallelScope.Self)]
-      [TestFixture]` : '[TestClass]'}
-      public class Tests : PageTest
+      ${classAttributes}public class Tests : PageTest
       {`);
     const formattedContextOptions = formatContextOptions(options.contextOptions, options.deviceName);
     if (formattedContextOptions) {
@@ -212,7 +218,8 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
       }`);
       formatter.newLine();
     }
-    formatter.add(`    [${this._mode === 'nunit' ? 'Test' : 'TestMethod'}]
+    const testAttribute = this._mode === 'nunit' ? 'Test' : this._mode === 'xunit' ? 'Fact' : 'TestMethod';
+    formatter.add(`    [${testAttribute}]
     public async Task MyTest()
     {`);
     if (options.contextOptions.recordHar) {

--- a/packages/playwright-core/src/server/codegen/languages.ts
+++ b/packages/playwright-core/src/server/codegen/languages.ts
@@ -31,6 +31,7 @@ export function languageSet() {
     new PythonLanguageGenerator(/* isAsync */true,  /* isPytest */false),
     new CSharpLanguageGenerator('mstest'),
     new CSharpLanguageGenerator('nunit'),
+    new CSharpLanguageGenerator('xunit'),
     new CSharpLanguageGenerator('library'),
     new JavaLanguageGenerator('junit'),
     new JavaLanguageGenerator('library'),

--- a/tests/library/inspector/cli-codegen-csharp.spec.ts
+++ b/tests/library/inspector/cli-codegen-csharp.spec.ts
@@ -198,7 +198,7 @@ test('should work with --save-har and --save-har-glob', async ({ runCLI }, testI
   expect(json.log.creator.name).toBe('Playwright');
 });
 
-for (const testFramework of ['nunit', 'mstest'] as const) {
+for (const testFramework of ['nunit', 'mstest', 'xunit'] as const) {
   test(`should not print context options method override in ${testFramework} if no options were passed`, async ({ runCLI, server }) => {
     const cli = runCLI([`--target=csharp-${testFramework}`, server.EMPTY_PAGE]);
     await cli.waitFor(`Page.GotoAsync("${server.EMPTY_PAGE}")`);
@@ -287,6 +287,32 @@ public class Tests : PageTest
     }
 
     [Test]
+    public async Task MyTest()
+    {
+        await Page.GotoAsync("${server.EMPTY_PAGE}");
+    }
+}`;
+  expect(await cli.text()).toContain(expected);
+});
+
+test(`should print a valid basic program in xunit`, async ({ runCLI, server }) => {
+  const cli = runCLI([`--target=csharp-xunit`, '--color-scheme=dark', server.EMPTY_PAGE]);
+  await cli.waitFor(`Page.GotoAsync("${server.EMPTY_PAGE}")`);
+  const expected = `using Microsoft.Playwright.Xunit;
+using Microsoft.Playwright;
+using Xunit;
+
+public class Tests : PageTest
+{
+    public override BrowserNewContextOptions ContextOptions()
+    {
+        return new()
+        {
+            ColorScheme = ColorScheme.Dark,
+        };
+    }
+
+    [Fact]
     public async Task MyTest()
     {
         await Page.GotoAsync("${server.EMPTY_PAGE}");

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -42,6 +42,7 @@ const codegenLang2Id: Map<string, string> = new Map([
   ['C#', 'csharp'],
   ['C# NUnit', 'csharp-nunit'],
   ['C# MSTest', 'csharp-mstest'],
+  ['C# xUnit', 'csharp-xunit'],
   ['Playwright Test', 'playwright-test'],
 ]);
 const codegenLangId2lang = new Map([...codegenLang2Id.entries()].map(([lang, langId]) => [langId, lang]));


### PR DESCRIPTION
## Summary
- Adds `csharp-xunit` codegen target alongside `csharp-mstest` / `csharp-nunit`.
- Emits `using Microsoft.Playwright.Xunit;` + `using Xunit;` and uses the `[Fact]` attribute.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3237