### PR TITLE
fix(mcp): propagate --browser channel on --extension path

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -43,11 +43,6 @@ type BrowserWithInfo = {
   ownership: 'attached' | 'own',
 };
 
-export async function createBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {
-  const { browser } = await createBrowserWithInfo(config, clientInfo, {});
-  return browser;
-}
-
 export async function createBrowserWithInfo(config: FullConfig, clientInfo: ClientInfo, cliOptions: CLIOptions): Promise<BrowserWithInfo> {
   if (config.browser.remoteEndpoint)
     return await createRemoteBrowser(config);

--- a/packages/playwright-core/src/tools/mcp/index.ts
+++ b/packages/playwright-core/src/tools/mcp/index.ts
@@ -16,7 +16,7 @@
 
 import { resolveConfig } from './config';
 import { filteredTools } from '../backend/tools';
-import { createBrowser } from './browserFactory';
+import { createBrowserWithInfo } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
 import { createServer } from '../utils/mcp/server';
 import { packageJSON } from '../../package';
@@ -35,7 +35,9 @@ export async function createConnection(userConfig: Config = {}, contextGetter?: 
     version: packageJSON.version,
     toolSchemas: tools.map(tool => tool.schema),
     create: async (clientInfo: ClientInfo) => {
-      const browser = contextGetter ? new SimpleBrowser(await contextGetter()) : await createBrowser(config, clientInfo);
+      const browser = contextGetter
+        ? new SimpleBrowser(await contextGetter())
+        : (await createBrowserWithInfo(config, clientInfo, {})).browser;
       const context = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
       return new BrowserBackend(config, context, tools);
     },

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -18,7 +18,7 @@ import { Option as ProgramOption } from 'commander';
 import * as mcpServer from '../utils/mcp/server';
 import { commaSeparatedList, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
 import { setupExitWatchdog } from './watchdog';
-import { createBrowser, createBrowserWithInfo } from './browserFactory';
+import { createBrowserWithInfo } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
 import { filteredTools } from '../backend/tools';
 import { testDebug } from './log';
@@ -101,7 +101,7 @@ export function decorateMCPCommand(command: Command) {
             version,
             toolSchemas: tools.map(tool => tool.schema),
             create: async (clientInfo: ClientInfo) => {
-              const browser = await createBrowser(config, clientInfo);
+              const { browser } = await createBrowserWithInfo(config, clientInfo, options);
               const browserContext = browser.contexts()[0];
               return new BrowserBackend(config, browserContext, tools);
             },

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -94,23 +94,6 @@ export function decorateMCPCommand(command: Command) {
 
         const config = await resolveCLIConfigForMCP(options);
         const tools = filteredTools(config);
-        if (config.extension) {
-          const serverBackendFactory: mcpServer.ServerBackendFactory = {
-            name: 'Playwright w/ extension',
-            nameInConfig: 'playwright-extension',
-            version,
-            toolSchemas: tools.map(tool => tool.schema),
-            create: async (clientInfo: ClientInfo) => {
-              const { browser } = await createBrowserWithInfo(config, clientInfo, options);
-              const browserContext = browser.contexts()[0];
-              return new BrowserBackend(config, browserContext, tools);
-            },
-            disposed: async () => { }
-          };
-          await mcpServer.start(serverBackendFactory, config.server);
-          return;
-        }
-
         const useSharedBrowser = config.sharedBrowserContext || config.browser.isolated;
         let sharedBrowser: playwright.Browser | undefined;
         let clientCount = 0;

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -15,6 +15,9 @@
  */
 
 import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { utils } from '../../packages/playwright-core/lib/coreBundle';
+
+const { defaultUserDataDirForChannel } = utils;
 
 test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   const { browserContext, client } = await startExtensionClient();
@@ -241,6 +244,25 @@ test(`fails when extension is missing in custom userDataDir`, async ({ startClie
     arguments: { url: server.HELLO_WORLD },
   })).toHaveResponse({
     error: expect.stringContaining(`Playwright Extension not found in "${userDataDir}"`),
+    isError: true,
+  });
+});
+
+test(`--browser <channel> selects channel-specific userDataDir`, {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1589' },
+}, async ({ startClient, server }) => {
+  const expectedUserDataDir = defaultUserDataDirForChannel('chrome-dev')!;
+
+  const { client } = await startClient({
+    args: [`--extension`, `--browser=chrome-dev`],
+    omitArgs: [`--browser=chromium`],
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    error: expect.stringContaining(`Playwright Extension not found in "${expectedUserDataDir}"`),
     isError: true,
   });
 });

--- a/tests/mcp/cli-cdp.spec.ts
+++ b/tests/mcp/cli-cdp.spec.ts
@@ -22,28 +22,28 @@ test.describe.configure({
 });
 
 test('connect by channel name error', async ({ cli }) => {
-  const { error } = await cli('attach', '--cdp=chrome-canary');
-  expect(error).toContain('Could not connect to chrome-canary');
+  const { error } = await cli('attach', '--cdp=chrome-dev');
+  expect(error).toContain('Could not connect to chrome-dev');
   expect(error).toContain('chrome://inspect/#remote-debugging');
 });
 
 test('attach --cdp=<channel> defaults session name to the channel', async ({ cli }) => {
   // Connection fails, but the daemon writes its err log under the resolved session name.
-  await cli('attach', '--cdp=chrome-canary');
+  await cli('attach', '--cdp=chrome-dev');
   const folder = await daemonFolder();
   expect(folder).toBeTruthy();
   const files = await fs.promises.readdir(folder!);
-  expect(files).toContain('chrome-canary.err');
+  expect(files).toContain('chrome-dev.err');
   expect(files).not.toContain('default.err');
 });
 
 test('explicit --session wins over --cdp=<channel>', async ({ cli }) => {
-  await cli('attach', '--cdp=chrome-canary', '-s=explicit');
+  await cli('attach', '--cdp=chrome-dev', '-s=explicit');
   const folder = await daemonFolder();
   expect(folder).toBeTruthy();
   const files = await fs.promises.readdir(folder!);
   expect(files).toContain('explicit.err');
-  expect(files).not.toContain('chrome-canary.err');
+  expect(files).not.toContain('chrome-dev.err');
 });
 
 test('attach via cdp URL keeps the default session', async ({ cdpServer, cli, server }) => {


### PR DESCRIPTION
## Summary
- The extension server backend called `createBrowser`, a thin wrapper that passed `{}` as `cliOptions` to `createBrowserWithInfo`. `resolveChannelForExtension({})` ignored `--browser` and fell back to `chrome`, so e.g. `--extension --browser chrome-beta` silently spawned regular Chrome with Chrome's user-data-dir.
- Inline the wrapper at the call sites so the extension path threads the actual `CLIOptions` through, and drop the now-redundant extension-specific server backend in `program.ts` — the unified factory already does the right thing.
- Add a regression test asserting `--browser=chrome-dev --extension` resolves to the chrome-dev default user-data-dir (visible in the "Playwright Extension not found" error).

Fixes https://github.com/microsoft/playwright-mcp/issues/1589