### PR TITLE
docs: fix broken Playwright Extension and MCP repository links

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -284,7 +284,7 @@ Connect to your existing browser tabs instead of launching a new browser:
 playwright-cli attach --extension
 ```
 
-This requires the [Playwright Extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md) to be installed.
+This requires the [Playwright Extension](https://github.com/microsoft/playwright/blob/main/packages/extension/README.md) to be installed.
 
 ## Quick Reference
 

--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -175,7 +175,7 @@ Playwright MCP supports three profile modes:
 
 -   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-{workspace-hash}` in your platform's cache directory, so different projects get separate profiles automatically. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
--   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). Pass `--extension` to enable.
+-   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/microsoft/playwright/blob/main/packages/extension/README.md). Pass `--extension` to enable.
 
 ### Configuration file
 
@@ -185,7 +185,7 @@ For advanced configuration, use a JSON config file:
 npx @playwright/mcp@latest --config path/to/config.json
 ```
 
-The config file supports browser options, context options, network rules, timeouts, and more. See the [Playwright MCP repository](https://github.com/microsoft/playwright-mcp/blob/main/packages/playwright-mcp/config.d.ts) for the full schema.
+The config file supports browser options, context options, network rules, timeouts, and more. See the [Playwright MCP repository](https://github.com/microsoft/playwright-mcp/blob/main/config.d.ts) for the full schema.
 
 ### Standalone server
 


### PR DESCRIPTION
The documentation now points to the correct locations for the Playwright Extension and the config schema in the microsoft/playwright repository instead of the outdated microsoft/playwright-mcp repository.

Fixes broken links in `getting-started-cli.md` and `getting-started-mcp.md`.

Closes #40570