### PR TITLE
fix(mcp): resolve extension channel/executablePath from CLI and env

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -25,7 +25,7 @@ import { outputDir } from '../backend/context';
 import { createExtensionBrowser } from './extensionContextFactory';
 import { connectToBrowserAcrossVersions } from '../utils/connect';
 import { serverRegistry } from '../../serverRegistry';
-import { resolveChannelForExtension } from './config';
+import { resolveExtensionOptions } from './config';
 // eslint-disable-next-line no-restricted-imports
 import { connectToBrowser } from '../../client/connect';
 
@@ -59,8 +59,8 @@ export async function createBrowserWithInfo(config: FullConfig, clientInfo: Clie
     canBind = true;
     ownership = 'own';
   } else if (config.extension) {
-    const channel = resolveChannelForExtension(cliOptions);
-    browser = await createExtensionBrowser(channel, clientInfo.clientName);
+    const { channel, executablePath } = resolveExtensionOptions(cliOptions);
+    browser = await createExtensionBrowser(channel, executablePath, clientInfo.clientName);
     ownership = 'attached';
   } else {
     browser = await createPersistentBrowser(config, clientInfo);

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -62,7 +62,6 @@ type CDPResponse = CDPMessage;
 export class CDPRelayServer {
   private _wsHost: string;
   private _browserChannel: string;
-  private _userDataDir?: string;
   private _executablePath?: string;
   private _cdpPath: string;
   private _extensionPath: string;
@@ -73,10 +72,9 @@ export class CDPRelayServer {
   private _handler: ExtensionProtocolHandler;
   private _extensionConnectionPromise = new ManualPromise<void>();
 
-  constructor(server: http.Server, browserChannel: string, userDataDir?: string, executablePath?: string) {
+  constructor(server: http.Server, browserChannel: string, executablePath?: string) {
     this._wsHost = addressToString(server.address(), { protocol: 'ws' });
     this._browserChannel = browserChannel;
-    this._userDataDir = userDataDir;
     this._executablePath = executablePath;
     this._protocolVersion = parseInt(process.env.PLAYWRIGHT_EXTENSION_PROTOCOL ?? protocol.DEFAULT_VERSION.toString(), 10);
 
@@ -145,8 +143,9 @@ export class CDPRelayServer {
     }
 
     const args: string[] = [];
-    if (this._userDataDir)
-      args.push(`--user-data-dir=${this._userDataDir}`);
+    const userDataDir = process.env.PWTEST_EXTENSION_USER_DATA_DIR;
+    if (userDataDir)
+      args.push(`--user-data-dir=${userDataDir}`);
     if (os.platform() === 'linux' && channel === 'chromium')
       args.push('--no-sandbox');
     args.push(href);

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -194,10 +194,11 @@ export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionN
   return { ...result, browser, configFile, skillMode: true };
 }
 
-export function resolveChannelForExtension(cliOptions: CLIOptions): string {
+export function resolveExtensionOptions(cliOptions: CLIOptions): { channel: string, executablePath?: string } {
   const browser = cliOptions.browser ?? envToString(process.env.PLAYWRIGHT_MCP_BROWSER);
   const { channel } = resolveBrowserParam(browser);
-  return channel ?? 'chrome';
+  const executablePath = cliOptions.executablePath ?? envToString(process.env.PLAYWRIGHT_MCP_EXECUTABLE_PATH);
+  return { channel: channel ?? 'chrome', executablePath };
 }
 
 async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<FullConfig['browser']> {

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -25,14 +25,17 @@ import type * as playwrightTypes from '../../..';
 
 const debugLogger = debug('pw:mcp:relay');
 
-export async function createExtensionBrowser(channel: string, clientName: string): Promise<playwrightTypes.Browser> {
-  const userDataDir = process.env.PWTEST_EXTENSION_USER_DATA_DIR ?? defaultUserDataDirForChannel(channel);
-  if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir))
-    throw new Error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
+export async function createExtensionBrowser(channel: string, executablePath: string | undefined, clientName: string): Promise<playwrightTypes.Browser> {
+  // Custom executablePath may target a browser in a different filesystem (e.g. Windows chrome.exe from WSL2), so the local profile path is not meaningful.
+  if (!executablePath) {
+    const userDataDir = process.env.PWTEST_EXTENSION_USER_DATA_DIR ?? defaultUserDataDirForChannel(channel);
+    if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir))
+      throw new Error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
+  }
 
   const httpServer = createHttpServer();
   await startHttpServer(httpServer, {});
-  const relay = new CDPRelayServer(httpServer, channel, userDataDir);
+  const relay = new CDPRelayServer(httpServer, channel, executablePath);
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);
 
   try {

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs/promises';
+
 import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 
@@ -229,6 +231,28 @@ test(`extension needs update`, async ({ startExtensionClient, server }) => {
 
   const confirmationPage = await confirmationPagePromise;
   await expect(confirmationPage.locator('.status-banner')).toContainText(`Playwright client trying to connect requires newer extension version`);
+});
+
+test(`custom executablePath skips local extension check`, {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1590' },
+}, async ({ startClient, server }) => {
+  const executablePath = test.info().outputPath('echo.sh');
+  await fs.writeFile(executablePath, '#!/bin/bash\necho "Custom exec args: $@" > "$(dirname "$0")/output.txt"', { mode: 0o755 });
+
+  // Empty profile would normally fail the extension-installed check; it is skipped when executablePath is set.
+  const { client } = await startClient({
+    args: [`--extension`, `--executable-path=${executablePath}`],
+    env: { PWTEST_EXTENSION_USER_DATA_DIR: test.info().outputPath('empty-profile') },
+  });
+
+  client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  }).catch(() => {});
+  await expect(async () => {
+    const output = await fs.readFile(test.info().outputPath('output.txt'), 'utf8');
+    expect(output).toMatch(new RegExp(`Custom exec args.*chrome-extension://${extensionId}/connect\\.html\\?`));
+  }).toPass();
 });
 
 test(`fails when extension is missing in custom userDataDir`, async ({ startClient, server }) => {


### PR DESCRIPTION
## Summary
- Restores `--executable-path` / `PLAYWRIGHT_MCP_EXECUTABLE_PATH` support for extension mode (regressed in 5ec1b3f81).
- Resolves both channel and executablePath from CLI options + env (not the merged config), matching the existing pattern.
- Skips the local extension-installed check when a custom executablePath is provided, since the browser may live in a different filesystem (e.g. Windows `chrome.exe` launched from WSL2).

Fixes https://github.com/microsoft/playwright-mcp/issues/1590