### PR TITLE
fix(extension): update README URL to correct repository path

### DIFF
--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -217,7 +217,7 @@ const ConnectApp: React.FC = () => {
 
 const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensionVersion }) => {
   const readmeUrl = 'https://github.com/microsoft/playwright/blob/main/packages/extension/README.md';
-  const chromeWebStoreUrl = 'https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm';
+  const chromeWebStoreUrl = 'https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm';
   return (
     <div>
       Playwright client trying to connect requires newer extension version (current version: {extensionVersion}).{' '}

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -216,7 +216,7 @@ const ConnectApp: React.FC = () => {
 };
 
 const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensionVersion }) => {
-  const readmeUrl = 'https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md';
+  const readmeUrl = 'https://github.com/microsoft/playwright/blob/main/packages/extension/README.md';
   const chromeWebStoreUrl = 'https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm';
   return (
     <div>


### PR DESCRIPTION
The previous URL pointed to a non-existent location. This change ensures users are directed to the correct documentation for version mismatch errors.

Closes #40573