### PR TITLE
docs(release-1.59): rename Playwright MCP Bridge to Playwright Extension and fix links

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -283,7 +283,7 @@ Connect to your existing browser tabs instead of launching a new browser:
 playwright-cli open --extension
 ```
 
-This requires the [Playwright MCP Bridge browser extension](https://github.com/user-attachments/packages/extension) to be installed.
+This requires the [Playwright Extension](https://github.com/user-attachments/packages/extension) to be installed.
 
 ## Quick Reference
 

--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -283,7 +283,7 @@ Connect to your existing browser tabs instead of launching a new browser:
 playwright-cli open --extension
 ```
 
-This requires the [Playwright Extension](https://github.com/user-attachments/packages/extension) to be installed.
+This requires the [Playwright Extension](https://github.com/microsoft/playwright/blob/main/packages/extension/README.md) to be installed.
 
 ## Quick Reference
 

--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -175,7 +175,7 @@ Playwright MCP supports three profile modes:
 
 -   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-profile` in your platform's cache directory. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
--   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/user-attachments/packages/extension). Pass `--extension` to enable.
+-   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/microsoft/playwright/blob/main/packages/extension/README.md). Pass `--extension` to enable.
 
 ### Configuration file
 
@@ -185,7 +185,7 @@ For advanced configuration, use a JSON config file:
 npx @playwright/mcp@latest --config path/to/config.json
 ```
 
-The config file supports browser options, context options, network rules, timeouts, and more. See the [Playwright MCP repository](https://github.com/microsoft/playwright-mcp/blob/main/packages/playwright-mcp/config.d.ts) for the full schema.
+The config file supports browser options, context options, network rules, timeouts, and more. See the [Playwright MCP repository](https://github.com/microsoft/playwright-mcp/blob/main/config.d.ts) for the full schema.
 
 ### Standalone server
 

--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -175,7 +175,7 @@ Playwright MCP supports three profile modes:
 
 -   **Persistent (default)**: Login state and cookies are preserved between sessions. The profile is stored in `ms-playwright/mcp-{channel}-profile` in your platform's cache directory. Override with `--user-data-dir`.
 -   **Isolated**: Each session starts fresh. Pass `--isolated` to enable. You can load initial state with `--storage-state`.
--   **Browser extension**: Connect to your existing browser tabs with the [Playwright MCP Bridge extension](https://github.com/user-attachments/packages/extension). Pass `--extension` to enable.
+-   **Browser extension**: Connect to your existing browser tabs with the [Playwright Extension](https://github.com/user-attachments/packages/extension). Pass `--extension` to enable.
 
 ### Configuration file
 


### PR DESCRIPTION
## Summary
- Cherry-pick docs portion of #40259: rename "Playwright MCP Bridge" → "Playwright Extension".
- Cherry-pick #40571: fix broken Playwright Extension and MCP repository links.