### PR TITLE
chore(ci): bump create-github-app-token and azure/login to Node 24 majors

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -40,7 +40,7 @@ jobs:
         WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_BLOB_REPORTS_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_BLOB_REPORTS_TENANT_ID }}

--- a/.github/workflows/pr_check_client_side_changes.yml
+++ b/.github/workflows/pr_check_client_side_changes.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'microsoft/playwright'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PLAYWRIGHT_APP_ID }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -54,7 +54,7 @@ jobs:
       run: utils/publish_all_packages.sh --release
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_PW_CDN_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_PW_CDN_TENANT_ID }}
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: 20
-    - uses: actions/create-github-app-token@v2
+    - uses: actions/create-github-app-token@v3
       id: app-token
       with:
         app-id: ${{ vars.PLAYWRIGHT_APP_ID }}

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -30,7 +30,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_DOCKER_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_DOCKER_TENANT_ID }}

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -52,7 +52,7 @@ jobs:
         git add .
         git commit -m "feat(${BROWSER}): roll to r${REVISION}"
         git push origin $BRANCH_NAME --force
-    - uses: actions/create-github-app-token@v2
+    - uses: actions/create-github-app-token@v3
       id: app-token
       with:
         app-id: ${{ vars.PLAYWRIGHT_APP_ID }}

--- a/.github/workflows/roll_nodejs.yml
+++ b/.github/workflows/roll_nodejs.yml
@@ -33,7 +33,7 @@ jobs:
           git add .
           git commit -m "chore: roll driver/Dockerfile to recent Node.js LTS version"
           git push origin $BRANCH_NAME
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PLAYWRIGHT_APP_ID }}

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -38,7 +38,7 @@ jobs:
           git add .
           git commit -m "test: roll stable-test-runner to ${{ steps.bump.outputs.VERSION }}"
           git push origin $BRANCH_NAME
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PLAYWRIGHT_APP_ID }}

--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Azure Login
       if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_BLOB_REPORTS_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_BLOB_REPORTS_TENANT_ID }}

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: "trigger"
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/create-github-app-token@v2
+    - uses: actions/create-github-app-token@v3
       id: app-token
       with:
         app-id: ${{ vars.PLAYWRIGHT_APP_ID }}


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token@v2` → `@v3` (6 workflows) and `azure/login@v2` → `@v3` (4 workflows). Both `@v2` majors run on Node.js 20; the new majors run on Node.js 24.
- GitHub is forcing JavaScript actions to Node 24 by default on 2026-06-02 and removing Node 20 from runners on 2026-09-16.
- This PR does **not** touch the test matrices' `node-version: 20/22/24` — those remain deliberately set as the supported-Node test floor.

Files touched (10 references):
- `actions/create-github-app-token@v2` → `@v3`: pr_check_client_side_changes.yml, roll_browser_into_playwright.yml, publish_release.yml, roll_nodejs.yml, trigger_tests.yml, roll_stable_test_runner.yml
- `azure/login@v2` → `@v3`: tests_bidi.yml, publish_release.yml, create_test_report.yml, publish_release_docker.yml
