### PR TITLE
feat(electron): add timeout option to electronApp.close()

### DIFF
--- a/docs/src/electron-api/class-electronapplication.md
+++ b/docs/src/electron-api/class-electronapplication.md
@@ -85,6 +85,14 @@ Page to retrieve the window for.
 
 Closes Electron application.
 
+### option: ElectronApplication.close.timeout
+* since: v1.52
+- `timeout` ?<[float]>
+
+Maximum time in milliseconds to wait for the application to close gracefully. If the timeout is exceeded, the
+application process is forcefully terminated. Pass `0` to disable timeout (default). When no timeout is specified,
+`close()` waits indefinitely for the application to exit.
+
 ## method: ElectronApplication.context
 * since: v1.9
 - returns: <[BrowserContext]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -17076,8 +17076,16 @@ export interface ElectronApplication {
 
   /**
    * Closes Electron application.
+   * @param options
    */
-  close(): Promise<void>;
+  close(options?: {
+    /**
+     * Maximum time in milliseconds to wait for the application to close gracefully. If the timeout is exceeded, the
+     * application process is forcefully terminated. Pass `0` to disable timeout (default). When no timeout is specified,
+     * `close()` waits indefinitely for the application to exit.
+     */
+    timeout?: number;
+  }): Promise<void>;
 
   /**
    * This method returns browser context that can be used for setting up context-wide routing, etc.

--- a/packages/playwright-core/src/electron/electron.ts
+++ b/packages/playwright-core/src/electron/electron.ts
@@ -180,7 +180,7 @@ export class Electron implements api.Electron {
       const chromeMatch = await Promise.race([chromeMatchPromise, waitForXserverError]);
       const browser = await chromium.connectOverCDP(chromeMatch[1], { timeout: progress.timeUntilDeadline(), isLocal: true });
 
-      app = new ElectronApplication(worker, browser, launchedProcess);
+      app = new ElectronApplication(worker, browser, launchedProcess, kill);
       await progress.race(app._initialize());
       return app;
     } catch (error) {
@@ -198,8 +198,9 @@ export class ElectronApplication extends EventEmitter implements api.ElectronApp
   private _windows = new Map<Page, JSHandle<BrowserWindow> | undefined>();
   private _appHandlePromise = new ManualPromise<JSHandle<ElectronAppType>>();
   private _closedPromise: Promise<void> | undefined;
+  private _kill: () => Promise<void>;
 
-  constructor(worker: Worker, browser: Browser, process: childProcess.ChildProcess) {
+  constructor(worker: Worker, browser: Browser, process: childProcess.ChildProcess, kill: () => Promise<void>) {
     super();
 
     this._worker = worker;
@@ -214,6 +215,7 @@ export class ElectronApplication extends EventEmitter implements api.ElectronApp
     this._context.close = () => this.close();
 
     this._process = process;
+    this._kill = kill;
   }
 
   _onClose() {
@@ -249,7 +251,7 @@ export class ElectronApplication extends EventEmitter implements api.ElectronApp
     await this.close();
   }
 
-  async close() {
+  async close(options?: { timeout?: number }) {
     if (!this._closedPromise) {
       this._closedPromise = new Promise<void>(f => this.once(Events.ElectronApplication.Close, f));
       await this._browser.close();
@@ -257,7 +259,17 @@ export class ElectronApplication extends EventEmitter implements api.ElectronApp
       await appHandle.evaluate(({ app }) => app.quit()).catch(() => {});
       await this._worker._disconnect();
     }
-    await this._closedPromise;
+
+    if (options?.timeout) {
+      const timer = setTimeout(() => this._kill().catch(() => {}), options.timeout);
+      try {
+        await this._closedPromise;
+      } finally {
+        clearTimeout(timer);
+      }
+    } else {
+      await this._closedPromise;
+    }
   }
 
   async waitForEvent(event: string, optionsOrPredicate: Function | { timeout?: number, predicate?: Function } = {}): Promise<any> {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17076,8 +17076,16 @@ export interface ElectronApplication {
 
   /**
    * Closes Electron application.
+   * @param options
    */
-  close(): Promise<void>;
+  close(options?: {
+    /**
+     * Maximum time in milliseconds to wait for the application to close gracefully. If the timeout is exceeded, the
+     * application process is forcefully terminated. Pass `0` to disable timeout (default). When no timeout is specified,
+     * `close()` waits indefinitely for the application to exit.
+     */
+    timeout?: number;
+  }): Promise<void>;
 
   /**
    * This method returns browser context that can be used for setting up context-wide routing, etc.

--- a/tests/electron/electron-app-hang-on-close.js
+++ b/tests/electron/electron-app-hang-on-close.js
@@ -1,0 +1,13 @@
+const assert = require('node:assert/strict');
+const { app } = require('electron');
+
+assert(process.env.PWTEST_ELECTRON_USER_DATA_DIR, 'PWTEST_ELECTRON_USER_DATA_DIR env var is not set');
+app.setPath('appData', process.env.PWTEST_ELECTRON_USER_DATA_DIR);
+
+app.on('window-all-closed', e => e.preventDefault());
+
+// Prevent quit — simulates an app that hangs on close
+// (e.g. due to IPC handlers, child processes, or beforeunload).
+app.on('before-quit', e => {
+  e.preventDefault();
+});

--- a/tests/electron/electron-app.spec.ts
+++ b/tests/electron/electron-app.spec.ts
@@ -343,6 +343,33 @@ test('should detach debugger on app-initiated exit', async ({ launchElectronApp 
   await closePromise;
 });
 
+test('should force-kill app when close timeout is exceeded', async ({ launchElectronApp }) => {
+  const electronApp = await launchElectronApp('electron-app-hang-on-close.js');
+  const events: string[] = [];
+  electronApp.on('close', () => events.push('application(close)'));
+  electronApp.process().on('exit', () => events.push('process(exit)'));
+
+  // This app prevents quit via before-quit handler, so close() without
+  // timeout would hang indefinitely. With a timeout, it should force-kill.
+  await electronApp.close({ timeout: 3000 });
+
+  events.sort();
+  expect(events).toEqual(['application(close)', 'process(exit)']);
+});
+
+test('should not force-kill when app closes within timeout', async ({ launchElectronApp }) => {
+  const electronApp = await launchElectronApp('electron-app.js');
+  const events: string[] = [];
+  electronApp.on('close', () => events.push('application(close)'));
+  electronApp.process().on('exit', () => events.push('process(exit)'));
+
+  // Normal app should close well within the timeout.
+  await electronApp.close({ timeout: 30000 });
+
+  events.sort();
+  expect(events).toEqual(['application(close)', 'process(exit)']);
+});
+
 test('should run pre-ready apis', async ({ launchElectronApp }) => {
   await launchElectronApp('electron-app-pre-ready.js');
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `timeout` option to `electronApp.close()` that force-kills the Electron process when the graceful shutdown exceeds the specified deadline.

Fixes #40586

## Motivation

`electronApp.close()` waits indefinitely for the process to exit. If the application prevents shutdown (via `before-quit` handlers, leaky IPC, or lingering child processes), `close()` hangs until the test-level timeout fires. This is a recurring issue in CI environments:

- #12189 — `app.quit()` called but process sticks around
- #27523 — Electron tests freeze 30s on close
- #39248 — Leaky IPC handlers cause hangs
- #13874 — Electron hangs closing context

PR #11336 correctly removed the old hardcoded 30s timeout, but left no way to opt into a grace period with force-kill escalation.

## API

```js
// Default: unchanged — waits indefinitely
await electronApp.close();

// With timeout: force-kills if app does not exit within 10s
await electronApp.close({ timeout: 10_000 });
```

## Implementation

Minimal change — wires the existing `kill` function from `processLauncher` into `ElectronApplication`:

1. **`electron.ts`**: `ElectronApplication` constructor now receives the `kill` function from `launchProcess`
2. **`close()`**: When `timeout` is set, starts a timer that calls `kill()` (SIGKILL on Unix, `taskkill /T /F` on Windows). If the process exits gracefully before the timer, `clearTimeout` cancels the force-kill. No new kill logic — reuses existing infrastructure in `processLauncher.ts`.
3. **Backward compatible**: Without `timeout`, behavior is identical to before.

**Key difference from the removed PR #11336 behavior:**
- Old: hardcoded 30s timeout that *threw an error* and left the process running
- New: opt-in timeout that *force-kills and waits for cleanup* — the caller always gets a clean exit

## Test Plan

- **`should force-kill app when close timeout is exceeded`** — Uses a test app with a `before-quit` handler that prevents shutdown. Verifies `close({ timeout: 3000 })` successfully kills the process and emits all expected events.
- **`should not force-kill when app closes within timeout`** — Verifies a normal app closes gracefully when a generous timeout is specified.

## Files Changed

| File | Change |
|------|--------|
| `packages/playwright-core/src/electron/electron.ts` | Pass `kill` to constructor, add `timeout` option to `close()` |
| `docs/src/electron-api/class-electronapplication.md` | Document the new `timeout` option |
| `packages/playwright-core/types/types.d.ts` | Auto-generated from docs |
| `packages/playwright-client/types/types.d.ts` | Auto-generated from docs |
| `tests/electron/electron-app-hang-on-close.js` | Test fixture: Electron app that prevents quit |
| `tests/electron/electron-app.spec.ts` | Two new tests for timeout behavior |