### PR TITLE
feat(github-reporter): emit failure annotations as tests finish

### DIFF
--- a/packages/playwright/src/reporters/github.ts
+++ b/packages/playwright/src/reporters/github.ts
@@ -22,7 +22,7 @@ import { msToString } from '@isomorphic/formatUtils';
 import { TerminalReporter, formatResultFailure, formatRetry } from './base';
 import { stripAnsiEscapes } from '../util';
 
-import type { FullResult, TestCase, TestError } from '../../types/testReporter';
+import type { FullResult, TestCase, TestError, TestResult } from '../../types/testReporter';
 
 type GitHubLogType = 'debug' | 'notice' | 'warning' | 'error';
 
@@ -64,6 +64,7 @@ class GitHubLogger {
 
 export class GitHubReporter extends TerminalReporter {
   githubLogger = new GitHubLogger();
+  private _failedTestCount = 0;
 
   constructor(options: { omitFailures?: boolean } = {}) {
     super(options);
@@ -72,6 +73,29 @@ export class GitHubReporter extends TerminalReporter {
 
   printsToStdio() {
     return false;
+  }
+
+  override onTestEnd(test: TestCase, result: TestResult) {
+    super.onTestEnd(test, result);
+    if (this.willRetry(test))
+      return;
+    if (!this._shouldPrintFailureAnnotations(test))
+      return;
+    this._failedTestCount++;
+    for (const r of test.results)
+      this._printFailureAnnotation(test, r, this._failedTestCount);
+  }
+
+  private _shouldPrintFailureAnnotations(test: TestCase): boolean {
+    switch (test.outcome()) {
+      case 'unexpected':
+      case 'flaky':
+        return true;
+      case 'skipped':
+        return test.results.some(r => r.status === 'interrupted') && test.results.some(r => !!r.error);
+      default:
+        return false;
+    }
   }
 
   override async onEnd(result: FullResult) {
@@ -87,8 +111,6 @@ export class GitHubReporter extends TerminalReporter {
   private _printAnnotations() {
     const summary = this.generateSummary();
     const summaryMessage = this.generateSummaryMessage(summary);
-    if (summary.failuresToPrint.length)
-      this._printFailureAnnotations(summary.failuresToPrint);
     this._printSlowTestAnnotations();
     this._printSummaryAnnotation(summaryMessage);
   }
@@ -109,26 +131,22 @@ export class GitHubReporter extends TerminalReporter {
     });
   }
 
-  private _printFailureAnnotations(failures: TestCase[]) {
-    failures.forEach((test, index) => {
-      const title = this.formatTestTitle(test);
-      const header = this.formatTestHeader(test, { indent: '  ', index: index + 1, mode: 'error' });
-      for (const result of test.results) {
-        const errors = formatResultFailure(this.screen, test, result, '    ');
-        for (const error of errors) {
-          const options: GitHubLogOptions = {
-            file: workspaceRelativePath(error.location?.file || test.location.file),
-            title,
-          };
-          if (error.location) {
-            options.line = error.location.line;
-            options.col = error.location.column;
-          }
-          const message = [header, ...formatRetry(this.screen, result), error.message].join('\n');
-          this.githubLogger.error(message, options);
-        }
+  private _printFailureAnnotation(test: TestCase, result: TestResult, index: number) {
+    const title = this.formatTestTitle(test);
+    const header = this.formatTestHeader(test, { indent: '  ', index, mode: 'error' });
+    const errors = formatResultFailure(this.screen, test, result, '    ');
+    for (const error of errors) {
+      const options: GitHubLogOptions = {
+        file: workspaceRelativePath(error.location?.file || test.location.file),
+        title,
+      };
+      if (error.location) {
+        options.line = error.location.line;
+        options.col = error.location.column;
       }
-    });
+      const message = [header, ...formatRetry(this.screen, result), error.message].join('\n');
+      this.githubLogger.error(message, options);
+    }
   }
 }
 

--- a/tests/playwright-test/reporter-github.spec.ts
+++ b/tests/playwright-test/reporter-github.spec.ts
@@ -97,5 +97,23 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(text).toContain('::error ::Error: Oh my!%0A%0A');
       expect(result.exitCode).toBe(1);
     });
+
+    test('emit GitHub failure annotation before run summary', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          test('failing', async ({}) => {
+            expect(1 + 1).toBe(3);
+          });
+          test.skip('marker', async ({}) => {});
+        `
+      }, { workers: 1, reporter: 'github' }, { GITHUB_WORKSPACE: process.cwd() });
+      const text = result.output;
+      const errorIndex = text.indexOf('::error');
+      const summaryIndex = text.indexOf('🎭 Playwright Run Summary');
+      expect(errorIndex).toBeGreaterThanOrEqual(0);
+      expect(summaryIndex).toBeGreaterThan(errorIndex);
+      expect(result.exitCode).toBe(1);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Emit GitHub failure annotations as tests finish, instead of buffering them until the run summary at the end. This way, timed-out or cancelled CI jobs still preserve `::error` annotations for tests that already failed.

Slow-test annotations and the run summary still emit at the end, since they need aggregated data.

Behavior of the existing failure annotations is preserved:
- Deferred until a test will not retry again (via `willRetry`).
- Same filtering as `generateSummary`'s `failuresToPrint` (`unexpected`, `flaky`, or `skipped`-with-interrupted-error).
- Per-test index shared across all retries of the same test.

Fixes https://github.com/microsoft/playwright/issues/40524