### PR TITLE
test(bidi): update unnamed cookie expectations

### DIFF
--- a/tests/library/browsercontext-add-cookies.spec.ts
+++ b/tests/library/browsercontext-add-cookies.spec.ts
@@ -423,7 +423,7 @@ it('should set cookies for a frame', async ({ context, page, server }) => {
   expect(await page.frames()[1].evaluate('document.cookie')).toBe('frame-cookie=value');
 });
 
-it('should allow unnamed cookies', async ({ page, context, server, browserName, platform }) => {
+it('should allow unnamed cookies', async ({ page, context, server, browserName, platform, isBidi }) => {
   server.setRoute('/cookies', (req, res) => {
     res.write(req.headers.cookie ?? 'undefined-on-server');
     res.end();
@@ -435,7 +435,7 @@ it('should allow unnamed cookies', async ({ page, context, server, browserName, 
   }]);
   // Round-trip behavior
   const resp = await page.goto(server.PREFIX + '/cookies');
-  if (browserName === 'webkit' && platform === 'darwin') {
+  if ((browserName === 'webkit' && platform === 'darwin') || (browserName === 'firefox' && isBidi)) {
     expect.soft(await resp!.text()).toBe('undefined-on-server');
     expect.soft(await page.evaluate('document.cookie')).toBe('');
   } else {
@@ -446,7 +446,7 @@ it('should allow unnamed cookies', async ({ page, context, server, browserName, 
   await page.goto(server.EMPTY_PAGE);
   await page.evaluate(() => document.cookie = '=unnamed-via-js;');
   await context.addCookies(await context.cookies());
-  if (browserName === 'webkit' && platform === 'darwin')
+  if ((browserName === 'webkit' && platform === 'darwin') || (browserName === 'firefox' && isBidi))
     expect.soft(await page.evaluate('document.cookie')).toBe('');
   else
     expect.soft(await page.evaluate('document.cookie')).toBe('unnamed-via-js');


### PR DESCRIPTION
Firefox [recently changed](https://bugzilla.mozilla.org/show_bug.cgi?id=2026913) to not allow unnamed cookies, aligning with Safari.