### PR TITLE
fix(extension): update Chrome Web Store URL and README link

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -12,7 +12,7 @@ The Playwright Chrome Extension allows you to connect to pages in your existing 
 
 ### Install the Extension
 
-Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
+Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
 
 ### Configure Playwright MCP server
 

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -20,7 +20,7 @@ import path from 'path';
 // Also pinned via the "key" field in packages/extension/manifest.json.
 export const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
-export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-mcp-bridge/${playwrightExtensionId}`;
+export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-extension/${playwrightExtensionId}`;
 
 export async function isPlaywrightExtensionInstalled(userDataDir: string): Promise<boolean> {
   // Chrome stores profiles as `Default` and `Profile <N>` subdirs of the user data dir;


### PR DESCRIPTION
Updates outdated Chrome Web Store URL to the canonical link and fixes broken README link.

Ensures consistency across the codebase and avoids relying on redirects.

Closes #40598
Follow-up from #40574 - https://github.com/microsoft/playwright/pull/40574#discussion_r3182695472