### PR TITLE
fix(extension): update remaining install URLs to correct repository path

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -12,7 +12,7 @@ The Playwright Chrome Extension allows you to connect to pages in your existing 
 
 ### Install the Extension
 
-Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
+Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
 
 ### Configure Playwright MCP server
 

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -20,7 +20,7 @@ import path from 'path';
 // Also pinned via the "key" field in packages/extension/manifest.json.
 export const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
-export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-mcp-bridge/${playwrightExtensionId}`;
+export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-extension/${playwrightExtensionId}`;
 
 export async function isPlaywrightExtensionInstalled(userDataDir: string): Promise<boolean> {
   // Chrome stores profiles as `Default` and `Profile <N>` subdirs of the user data dir;


### PR DESCRIPTION
## Summary
- Follow-up to 067e9cfee5 which only updated `connect.tsx`. This updates the two remaining places that still pointed to `playwright-mcp-bridge`: `packages/extension/README.md` and `packages/playwright-core/src/tools/utils/extension.ts`.