### PR TITLE
fix(test-runner): race IPv4 and IPv6 webServer port checks

### DIFF
--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -221,7 +221,17 @@ async function isPortUsed(port: number): Promise<boolean> {
           resolve(true);
         });
   });
-  return await innerIsPortUsed('127.0.0.1') || await innerIsPortUsed('::1');
+  return new Promise<boolean>(resolve => {
+    let pending = 2;
+    const onResult = (result: boolean) => {
+      if (result)
+        resolve(true);
+      else if (--pending === 0)
+        resolve(false);
+    };
+    void innerIsPortUsed('127.0.0.1').then(onResult);
+    void innerIsPortUsed('::1').then(onResult);
+  });
 }
 
 async function waitFor(waitFn: () => Promise<boolean>, cancellationToken: { canceled: boolean }) {


### PR DESCRIPTION
## Summary
- Run the IPv4 and IPv6 port checks in parallel instead of sequentially, so a hanging check on one address doesn't block the other.
- Resolve `true` as soon as either check succeeds; resolve `false` only once both have failed.

Fixes https://github.com/microsoft/playwright/issues/40430