### PR TITLE
chore(test-runner): replace TestInfoError.matcherResult with errorContext

### DIFF
--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -22,18 +22,11 @@ Error message. Set when [Error] (or its subclass) has been thrown.
 
 Error stack. Set when [Error] (or its subclass) has been thrown.
 
-## property: TestInfoError.matcherResult
+## property: TestInfoError.errorContext
 * since: v1.60
-- type: ?<[Object]>
-  - `name` <[string]> Matcher name (e.g. `toBeVisible`).
-  - `pass` <[boolean]> Whether the matcher passed.
-  - `expected` ?<[any]> Expected value.
-  - `actual` ?<[any]> Received value.
-  - `log` ?<[Array]<[string]>> Matcher log lines, if any.
-  - `timeout` ?<[int]> Matcher timeout in milliseconds, set when the matcher timed out.
-  - `ariaSnapshot` ?<[string]> Aria snapshot of the receiver at the time of failure, if available.
+- type: ?<[string]>
 
-Structured information about a matcher failure. Set when the error originated from an `expect(...)` matcher; unset otherwise.
+Additional context for the error, such as the aria snapshot of the receiver at the time of an `expect(...)` matcher failure.
 
 ## property: TestInfoError.value
 * since: v1.10

--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -62,12 +62,11 @@ export function buildErrorContext(options: {
           stripAnsiEscapes(error.message || ''),
           '```',
       );
-      const ariaSnapshot = error.matcherResult?.ariaSnapshot;
-      if (ariaSnapshot) {
+      if (error.errorContext) {
         lines.push(
             '',
             '```yaml',
-            ariaSnapshot,
+            error.errorContext,
             '```',
         );
       }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -728,7 +728,7 @@ class ArtifactsRecorder {
       return;
     if (this._testInfo.errors.length === 0)
       return;
-    if (this._testInfo.errors.some(e => e.matcherResult?.ariaSnapshot))
+    if (this._testInfo.errors.some(e => e.errorContext))
       return;
     if (this._pageSnapshot)
       return;
@@ -776,7 +776,7 @@ class ArtifactsRecorder {
       await this._takePageSnapshot(context);
 
     if (this._testInfo.errors.length > 0) {
-      const hasMatcherAriaSnapshot = this._testInfo.errors.some(e => e.matcherResult?.ariaSnapshot);
+      const hasMatcherAriaSnapshot = this._testInfo.errors.some(e => e.errorContext);
       const errorContextContent = buildErrorContext({
         titlePath: this._testInfo.titlePath,
         location: { file: this._testInfo.file, line: this._testInfo.line, column: this._testInfo.column },

--- a/packages/playwright/src/worker/util.ts
+++ b/packages/playwright/src/worker/util.ts
@@ -22,22 +22,7 @@ import type { MatcherResultProperty } from '../matchers/matcherHint';
 export function testInfoError(error: Error | any): TestInfoError {
   const result = serializeError(error);
   const matcherResult = (error instanceof Error ? (error as any).matcherResult : undefined) as MatcherResultProperty | undefined;
-  if (matcherResult) {
-    const serialized: NonNullable<TestInfoError['matcherResult']> = {
-      name: matcherResult.name,
-      pass: matcherResult.pass,
-    };
-    if (matcherResult.expected !== undefined)
-      serialized.expected = matcherResult.expected;
-    if (matcherResult.actual !== undefined)
-      serialized.actual = matcherResult.actual;
-    if (matcherResult.log !== undefined)
-      serialized.log = matcherResult.log;
-    if (matcherResult.timeout !== undefined)
-      serialized.timeout = matcherResult.timeout;
-    if (matcherResult.ariaSnapshot !== undefined)
-      serialized.ariaSnapshot = matcherResult.ariaSnapshot;
-    result.matcherResult = serialized;
-  }
+  if (matcherResult?.ariaSnapshot !== undefined)
+    result.errorContext = matcherResult.ariaSnapshot;
   return result;
 }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -10012,45 +10012,10 @@ export interface TestInfoError {
   cause?: TestInfoError;
 
   /**
-   * Structured information about a matcher failure. Set when the error originated from an `expect(...)` matcher; unset
-   * otherwise.
+   * Additional context for the error, such as the aria snapshot of the receiver at the time of an `expect(...)` matcher
+   * failure.
    */
-  matcherResult?: {
-    /**
-     * Matcher name (e.g. `toBeVisible`).
-     */
-    name: string;
-
-    /**
-     * Whether the matcher passed.
-     */
-    pass: boolean;
-
-    /**
-     * Expected value.
-     */
-    expected?: any;
-
-    /**
-     * Received value.
-     */
-    actual?: any;
-
-    /**
-     * Matcher log lines, if any.
-     */
-    log?: Array<string>;
-
-    /**
-     * Matcher timeout in milliseconds, set when the matcher timed out.
-     */
-    timeout?: number;
-
-    /**
-     * Aria snapshot of the receiver at the time of failure, if available.
-     */
-    ariaSnapshot?: string;
-  };
+  errorContext?: string;
 
   /**
    * Error message. Set when [Error] (or its subclass) has been thrown.


### PR DESCRIPTION
## Summary
- Drop `TestInfoError.matcherResult` from the serialized error.
- Add `TestInfoError.errorContext: string` carrying the aria snapshot of the receiver at matcher-failure time.
- Runtime `ExpectError.matcherResult` (custom matcher API) is unchanged.