### PR TITLE
feat(api): unify WebError and ConsoleMessage location

### DIFF
--- a/docs/src/api/class-consolemessage.md
+++ b/docs/src/api/class-consolemessage.md
@@ -115,8 +115,10 @@ List of arguments passed to a `console` function call. See also [`event: Page.co
 * langs: js, python
 - returns: <[Object]>
   - `url` <[string]> URL of the resource.
-  - `lineNumber` <[int]> 0-based line number in the resource.
-  - `columnNumber` <[int]> 0-based column number in the resource.
+  - `line` <[int]> 0-based line number in the resource.
+  - `column` <[int]> 0-based column number in the resource.
+  - `lineNumber` <[int]> 0-based line number in the resource. Deprecated, use `line` instead.
+  - `columnNumber` <[int]> 0-based column number in the resource. Deprecated, use `column` instead.
 
 ## method: ConsoleMessage.location
 * since: v1.8

--- a/docs/src/api/class-weberror.md
+++ b/docs/src/api/class-weberror.md
@@ -68,15 +68,8 @@ Unhandled error that was thrown.
 
 ## method: WebError.location
 * since: v1.60
-* langs: js, python
 - returns: <[Object]>
+  - alias: WebErrorLocation
   - `url` <[string]> URL of the resource.
   - `line` <[int]> 0-based line number in the resource.
   - `column` <[int]> 0-based column number in the resource.
-
-## method: WebError.location
-* since: v1.60
-* langs: csharp, java
-- returns: <[string]>
-
-URL of the resource followed by 0-based line and column numbers in the resource formatted as `URL:line:column`.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -19716,10 +19716,20 @@ export interface ConsoleMessage {
     /**
      * 0-based line number in the resource.
      */
-    lineNumber: number;
+    line: number;
 
     /**
      * 0-based column number in the resource.
+     */
+    column: number;
+
+    /**
+     * 0-based line number in the resource. Deprecated, use `line` instead.
+     */
+    lineNumber: number;
+
+    /**
+     * 0-based column number in the resource. Deprecated, use `column` instead.
      */
     columnNumber: number;
   };

--- a/packages/playwright-core/src/client/consoleMessage.ts
+++ b/packages/playwright-core/src/client/consoleMessage.ts
@@ -22,8 +22,6 @@ import type * as channels from '@protocol/channels';
 import type { Page } from './page';
 import type { Worker } from './worker';
 
-type ConsoleMessageLocation = channels.BrowserContextConsoleEvent['location'];
-
 export class ConsoleMessage implements api.ConsoleMessage {
 
   private _page: Page | null;
@@ -58,8 +56,9 @@ export class ConsoleMessage implements api.ConsoleMessage {
     return this._event.args.map(JSHandle.from);
   }
 
-  location(): ConsoleMessageLocation {
-    return this._event.location;
+  location(): ReturnType<api.ConsoleMessage['location']> {
+    const { url, lineNumber, columnNumber } = this._event.location;
+    return { url, line: lineNumber, column: columnNumber, lineNumber, columnNumber };
   }
 
   timestamp(): number {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19716,10 +19716,20 @@ export interface ConsoleMessage {
     /**
      * 0-based line number in the resource.
      */
-    lineNumber: number;
+    line: number;
 
     /**
      * 0-based column number in the resource.
+     */
+    column: number;
+
+    /**
+     * 0-based line number in the resource. Deprecated, use `line` instead.
+     */
+    lineNumber: number;
+
+    /**
+     * 0-based column number in the resource. Deprecated, use `column` instead.
      */
     columnNumber: number;
   };

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -148,11 +148,11 @@ it('should have location for console API calls', async ({ page, server }) => {
     page.goto(server.PREFIX + '/consolelog.html'),
   ]);
   expect(message.type()).toBe('log');
-  const location = message.location();
   // Engines have different column notion.
-  delete location.columnNumber;
-  expect(location).toEqual({
+  const { url, line, lineNumber } = message.location();
+  expect({ url, line, lineNumber }).toEqual({
     url: server.PREFIX + '/consolelog.html',
+    line: 7,
     lineNumber: 7,
   });
 });


### PR DESCRIPTION
## Summary
- `WebError.location` now returns an Object with `url`/`line`/`column` in all languages (was a string in java/csharp).
- `ConsoleMessage.location()` exposes `line`/`column`; `lineNumber`/`columnNumber` are kept as deprecated aliases.