### PR TITLE
docs(connectOverCDP): describe noDefaults via Playwright options

### DIFF
--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -225,15 +225,16 @@ Maximum time in milliseconds to wait for the connection to be established. Defau
 `30000` (30 seconds). Pass `0` to disable timeout.
 
 ### option: BrowserType.connectOverCDP.noDefaults
-* since: v1.53
+* since: v1.60
 - `noDefaults` <[boolean]>
 
-When true, Playwright will not send default overrides to the browser on the default context. This includes
-`Browser.setDownloadBehavior`, `Emulation.setFocusEmulationEnabled`, and `Emulation.setEmulatedMedia`.
-Useful when attaching to a user's daily-driver browser where these overrides would interfere with
-existing browser state. New contexts created via
-[browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context)
-are not affected. Defaults to `false`.
+When true, Playwright will not apply its default overrides to the existing default browser context.
+Specifically, [`option: Browser.newContext.acceptDownloads`] is left at the browser's setting, focus
+emulation is not enabled, and media emulation options (such as [`option: Browser.newContext.colorScheme`],
+[`option: Browser.newContext.reducedMotion`], [`option: Browser.newContext.forcedColors`], and
+[`option: Browser.newContext.contrast`]) are not applied. Useful when attaching to a user's daily-driver
+browser where these overrides would interfere with existing browser state. New contexts created via
+[`method: Browser.newContext`] are not affected. Defaults to `false`.
 
 
 ## method: BrowserType.executablePath

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -22899,10 +22899,15 @@ export interface ConnectOverCDPOptions {
   isLocal?: boolean;
 
   /**
-   * When true, Playwright will not send default overrides to the browser on the default context. This includes
-   * `Browser.setDownloadBehavior`, `Emulation.setFocusEmulationEnabled`, and `Emulation.setEmulatedMedia`. Useful when
-   * attaching to a user's daily-driver browser where these overrides would interfere with existing browser state. New
-   * contexts created via
+   * When true, Playwright will not apply its default overrides to the existing default browser context. Specifically,
+   * [`acceptDownloads`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-accept-downloads) is
+   * left at the browser's setting, focus emulation is not enabled, and media emulation options (such as
+   * [`colorScheme`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-color-scheme),
+   * [`reducedMotion`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-reduced-motion),
+   * [`forcedColors`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-forced-colors), and
+   * [`contrast`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-contrast)) are not applied.
+   * Useful when attaching to a user's daily-driver browser where these overrides would interfere with existing browser
+   * state. New contexts created via
    * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context) are not
    * affected. Defaults to `false`.
    */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -22899,10 +22899,15 @@ export interface ConnectOverCDPOptions {
   isLocal?: boolean;
 
   /**
-   * When true, Playwright will not send default overrides to the browser on the default context. This includes
-   * `Browser.setDownloadBehavior`, `Emulation.setFocusEmulationEnabled`, and `Emulation.setEmulatedMedia`. Useful when
-   * attaching to a user's daily-driver browser where these overrides would interfere with existing browser state. New
-   * contexts created via
+   * When true, Playwright will not apply its default overrides to the existing default browser context. Specifically,
+   * [`acceptDownloads`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-accept-downloads) is
+   * left at the browser's setting, focus emulation is not enabled, and media emulation options (such as
+   * [`colorScheme`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-color-scheme),
+   * [`reducedMotion`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-reduced-motion),
+   * [`forcedColors`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-forced-colors), and
+   * [`contrast`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-contrast)) are not applied.
+   * Useful when attaching to a user's daily-driver browser where these overrides would interfere with existing browser
+   * state. New contexts created via
    * [browser.newContext([options])](https://playwright.dev/docs/api/class-browser#browser-new-context) are not
    * affected. Defaults to `false`.
    */


### PR DESCRIPTION
## Summary
- Rephrase `BrowserType.connectOverCDP({ noDefaults })` to refer to Playwright API options (`acceptDownloads`, `colorScheme` / `reducedMotion` / `forcedColors` / `contrast`, focus emulation) instead of CDP commands (`Browser.setDownloadBehavior`, `Emulation.setFocusEmulationEnabled`, `Emulation.setEmulatedMedia`).
- Fix the `since` tag from v1.53 to v1.60.