### PR TITLE
feat(tracing): add live option to startHar

### DIFF
--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -380,6 +380,13 @@ A glob or regex pattern to filter requests that are stored in the HAR. Defaults 
 Only used together with `content: 'attach'`. When set, response bodies are placed in this directory instead of next to
 the HAR file. Not compatible with a `.zip` HAR file.
 
+### option: Tracing.startHar.live
+* since: v1.60
+* langs: js
+- `live` <[boolean]>
+
+When set to `true`, the HAR file is rewritten on disk every time a network request finishes, so that the file can be read while recording. The file is finalized on [`method: Tracing.stopHar`]. Not compatible with a `.zip` HAR file or with remote connections.
+
 ## async method: Tracing.group
 * since: v1.49
 - returns: <[Disposable]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -22163,6 +22163,14 @@ export interface Tracing {
     content?: "omit"|"embed"|"attach";
 
     /**
+     * When set to `true`, the HAR file is rewritten on disk every time a network request finishes, so that the file can
+     * be read while recording. The file is finalized on
+     * [tracing.stopHar()](https://playwright.dev/docs/api/class-tracing#tracing-stop-har). Not compatible with a `.zip`
+     * HAR file or with remote connections.
+     */
+    live?: boolean;
+
+    /**
      * When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
      */

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -96,18 +96,23 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     });
   }
 
-  async startHar(path: string, options: { content?: 'embed' | 'attach' | 'omit', mode?: 'full' | 'minimal', urlFilter?: string | RegExp, resourcesDir?: string } = {}) {
+  async startHar(path: string, options: { content?: 'embed' | 'attach' | 'omit', mode?: 'full' | 'minimal', urlFilter?: string | RegExp, resourcesDir?: string, live?: boolean } = {}) {
     await this._wrapApiCall(async () => {
       if (this._harId)
         throw new Error('HAR recording has already been started');
       if (options.resourcesDir && path.endsWith('.zip'))
         throw new Error('resourcesDir option is not compatible with a .zip har file');
+      if (options.live && path.endsWith('.zip'))
+        throw new Error('live option is not compatible with a .zip har file');
+      if (options.live && this._connection.isRemote())
+        throw new Error('live option is not supported for remote connections');
       const defaultContent = path.endsWith('.zip') ? 'attach' : 'embed';
       this._harId = await this._recordIntoHAR(path, null, {
         url: options.urlFilter,
         updateContent: options.content ?? defaultContent,
         updateMode: options.mode ?? 'full',
         resourcesDir: options.resourcesDir,
+        live: options.live,
       });
     });
     return new DisposableStub(() => this.stopHar());
@@ -123,7 +128,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     });
   }
 
-  async _recordIntoHAR(har: string, page: Page | null, options: { url?: string | RegExp, updateContent?: 'attach' | 'embed' | 'omit', updateMode?: 'minimal' | 'full', resourcesDir?: string } = {}): Promise<string> {
+  async _recordIntoHAR(har: string, page: Page | null, options: { url?: string | RegExp, updateContent?: 'attach' | 'embed' | 'omit', updateMode?: 'minimal' | 'full', resourcesDir?: string, live?: boolean } = {}): Promise<string> {
     const isZip = har.endsWith('.zip');
     const { harId } = await this._channel.harStart({
       page: page?._channel,
@@ -135,6 +140,7 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
         mode: options.updateMode ?? 'minimal',
         harPath: isZip ? undefined : har,
         resourcesDir: options.resourcesDir,
+        live: options.live,
       },
     });
     this._harRecorders.set(harId, { path: har, resourcesDir: options.resourcesDir });

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -185,6 +185,7 @@ scheme.RecordHarOptions = tObject({
   urlRegexFlags: tOptional(tString),
   harPath: tOptional(tString),
   resourcesDir: tOptional(tString),
+  live: tOptional(tBoolean),
 });
 scheme.FormField = tObject({
   name: tString,

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -37,6 +37,8 @@ export class HarRecorder implements HarTracerDelegate {
   private _tracer: HarTracer;
   private _entries: har.Entry[] = [];
   private _writtenContentEntries = new Set<string>();
+  private _live: boolean;
+  private _harDirEnsured = false;
 
   constructor(context: BrowserContext | APIRequestContext, fallbackDir: string, harId: string, page: Page | null, options: channels.RecordHarOptions) {
     this._context = context;
@@ -50,6 +52,7 @@ export class HarRecorder implements HarTracerDelegate {
       this._resourcesDir = path.join(fallbackDir, `${harId}-resources`);
     const urlFilterRe = options.urlRegexSource !== undefined && options.urlRegexFlags !== undefined ? new RegExp(options.urlRegexSource, options.urlRegexFlags) : undefined;
     const content = options.content || 'embed';
+    this._live = !!options.live;
     this._tracer = new HarTracer(context, page, this, {
       content,
       slimMode: options.mode === 'minimal',
@@ -66,6 +69,17 @@ export class HarRecorder implements HarTracerDelegate {
   }
 
   onEntryFinished(entry: har.Entry) {
+    if (this._live)
+      this._writeLog(this._tracer._snapshot());
+  }
+
+  private _writeLog(log: har.Log) {
+    log.entries = this._entries;
+    if (!this._harDirEnsured) {
+      this._fs.mkdir(path.dirname(this._harFilePath));
+      this._harDirEnsured = true;
+    }
+    this._fs.writeFile(this._harFilePath, jsonStringify({ log }));
   }
 
   onContentBlob(sha1: string, buffer: Buffer) {
@@ -82,12 +96,7 @@ export class HarRecorder implements HarTracerDelegate {
       return;
     this._isFlushed = true;
     await this._tracer.flush();
-
-    const log = this._tracer.stop();
-    log.entries = this._entries;
-
-    this._fs.mkdir(path.dirname(this._harFilePath));
-    this._fs.writeFile(this._harFilePath, jsonStringify({ log }));
+    this._writeLog(this._tracer.stop());
   }
 
   async flush() {

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -532,13 +532,18 @@ export class HarTracer {
     await Promise.all(this._barrierPromises);
   }
 
-  stop() {
-    this._started = false;
-    eventsHelper.removeEventListeners(this._eventListeners);
-    this._barrierPromises.clear();
-
+  _snapshot(): har.Log {
     const context = this._context instanceof BrowserContext ? this._context : undefined;
-    const log: har.Log = {
+    const pages = this._pageEntries.size ? Array.from(this._pageEntries.values()).map(pageEntry => {
+      const copy = { ...pageEntry, pageTimings: { ...pageEntry.pageTimings } };
+      if (!this._options.omitTiming) {
+        const startDateTime = ((pageEntry as any)[startedDateSymbol] as Date).valueOf();
+        copy.pageTimings.onContentLoad = relativeTiming(copy.pageTimings.onContentLoad, startDateTime);
+        copy.pageTimings.onLoad = relativeTiming(copy.pageTimings.onLoad, startDateTime);
+      }
+      return copy;
+    }) : undefined;
+    return {
       version: '1.2',
       creator: {
         name: 'Playwright',
@@ -548,22 +553,16 @@ export class HarTracer {
         name: context?._browser.options.name || '',
         version: context?._browser.version() || ''
       },
-      pages: this._pageEntries.size ? Array.from(this._pageEntries.values()) : undefined,
+      pages,
       entries: [],
     };
-    if (!this._options.omitTiming) {
-      for (const pageEntry of log.pages || []) {
-        const startDateTime = ((pageEntry as any)[startedDateSymbol] as Date).valueOf();
-        if (typeof pageEntry.pageTimings.onContentLoad === 'number' && pageEntry.pageTimings.onContentLoad >= 0)
-          pageEntry.pageTimings.onContentLoad -= startDateTime;
-        else
-          pageEntry.pageTimings.onContentLoad = -1;
-        if (typeof pageEntry.pageTimings.onLoad === 'number' && pageEntry.pageTimings.onLoad >= 0)
-          pageEntry.pageTimings.onLoad -= startDateTime;
-        else
-          pageEntry.pageTimings.onLoad = -1;
-      }
-    }
+  }
+
+  stop() {
+    this._started = false;
+    eventsHelper.removeEventListeners(this._eventListeners);
+    this._barrierPromises.clear();
+    const log = this._snapshot();
     this._pageEntries.clear();
     return log;
   }
@@ -610,6 +609,10 @@ export class HarTracer {
     return result;
   }
 
+}
+
+function relativeTiming(value: number | undefined, startDateTime: number): number {
+  return typeof value === 'number' && value >= 0 ? value - startDateTime : -1;
 }
 
 function createHarEntry(pageRef: string | undefined, method: string, url: URL, frameref: string | undefined, options: HarTracerOptions): har.Entry {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -22163,6 +22163,14 @@ export interface Tracing {
     content?: "omit"|"embed"|"attach";
 
     /**
+     * When set to `true`, the HAR file is rewritten on disk every time a network request finishes, so that the file can
+     * be read while recording. The file is finalized on
+     * [tracing.stopHar()](https://playwright.dev/docs/api/class-tracing#tracing-stop-har). Not compatible with a `.zip`
+     * HAR file or with remote connections.
+     */
+    live?: boolean;
+
+    /**
      * When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page,
      * cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
      */

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -317,6 +317,7 @@ export type RecordHarOptions = {
   urlRegexFlags?: string,
   harPath?: string,
   resourcesDir?: string,
+  live?: boolean,
 };
 
 export type FormField = {

--- a/packages/protocol/src/protocol.yml
+++ b/packages/protocol/src/protocol.yml
@@ -326,6 +326,7 @@ RecordHarOptions:
     urlRegexFlags: string?
     harPath: string?
     resourcesDir: string?
+    live: boolean?
 
 
 FormField:

--- a/packages/utils/serializedFS.ts
+++ b/packages/utils/serializedFS.ts
@@ -101,6 +101,11 @@ export class SerializedFS {
       last.content += op.content;
       return;
     }
+    if (last?.op === 'writeFile' && op.op === 'writeFile' && last.file === op.file && !last.skipIfExists && !op.skipIfExists) {
+      // The latest write supersedes the previous one queued for the same file.
+      last.content = op.content;
+      return;
+    }
 
     this._operations.push(op);
     if (this._operationsDone.isDone())

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -972,4 +972,57 @@ it.describe('tracing.startHar', () => {
     await expect(context.tracing.startHar(harPath, { content: 'attach', resourcesDir })).rejects.toThrow(/resourcesDir option is not compatible with a \.zip har file/);
     await context.close();
   });
+
+  it('should write HAR live while recording', async ({ contextFactory, server }, testInfo) => {
+    let cssResponse: import('http').ServerResponse | undefined;
+    const cssRequested = new Promise<void>(resolve => {
+      server.setRoute('/one-style.css', (_, res) => {
+        cssResponse = res;
+        resolve();
+      });
+    });
+
+    const context = await contextFactory();
+    const harPath = testInfo.outputPath('tracing.har');
+    await context.tracing.startHar(harPath, { live: true });
+    const page = await context.newPage();
+    const navigation = page.goto(server.PREFIX + '/one-style.html');
+
+    await cssRequested;
+
+    const readEntries = () => {
+      try {
+        const log = JSON.parse(fs.readFileSync(harPath).toString()).log as Log;
+        return log.entries.map(e => ({ url: e.request.url, status: e.response.status }));
+      } catch {
+        return [];
+      }
+    };
+
+    // The HAR file is on disk before stopHar(), with the in-flight CSS entry shown as pending.
+    await expect.poll(readEntries).toEqual(expect.arrayContaining([
+      { url: server.PREFIX + '/one-style.html', status: 200 },
+      { url: server.PREFIX + '/one-style.css', status: -1 },
+    ]));
+
+    cssResponse!.setHeader('Content-Type', 'text/css');
+    cssResponse!.end('body { color: red; }');
+    await navigation;
+
+    await context.tracing.stopHar();
+    await context.close();
+
+    const log = JSON.parse(fs.readFileSync(harPath).toString()).log as Log;
+    expect(log.entries.map(e => ({ url: e.request.url, status: e.response.status }))).toEqual(expect.arrayContaining([
+      { url: server.PREFIX + '/one-style.html', status: 200 },
+      { url: server.PREFIX + '/one-style.css', status: 200 },
+    ]));
+  });
+
+  it('should reject live together with a .zip har file', async ({ contextFactory }, testInfo) => {
+    const context = await contextFactory();
+    const harPath = testInfo.outputPath('tracing.har.zip');
+    await expect(context.tracing.startHar(harPath, { live: true })).rejects.toThrow(/live option is not compatible with a \.zip har file/);
+    await context.close();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a `live: boolean` option to `tracing.startHar()` that rewrites the HAR file on disk every time a network request finishes, so it can be read while recording.
- Not compatible with a `.zip` output path or with remote connections.
- Coalesces consecutive same-path `writeFile` ops in `SerializedFS` so live recordings don't queue O(N) redundant disk writes.