### PR TITLE
fix(mcp): anchor aria-ref regex in target resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Never add "Generated with" in commit message.
 Never add test plan to PR description. Keep PR description short — a few bullet points at most.
 Branch naming for issue fixes: `fix-<issue-number>`
 
+**Never amend commits.** Always create a new commit for follow-up changes, even when iterating on an open PR. Amending rewrites history and forces a force-push, losing the incremental review trail. Only amend if the user explicitly says so.
+
 **Never `git push` without an explicit instruction to push.** Applies even when a PR is already open for the branch — additional commits are immediately visible to reviewers. Commit locally, report what was committed, and wait. Only push when the user's message contains "push", "upload", "create PR", "ship it", or equivalent.
 
 ## Development Guides

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -444,7 +444,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async targetLocators(params: { element?: string, target: string }[]): Promise<{ locator: playwright.Locator, resolved: string }[]> {
     await this._initializedPromise;
     return Promise.all(params.map(async param => {
-      if (!param.target.match(/(f\d+)?(e\d+)/)) {
+      if (!param.target.match(/^(f\d+)?e\d+$/)) {
         const selector = locatorOrSelectorAsSelector('javascript', param.target, this.context.config.testIdAttribute || 'data-testid');
         const handle = await this.page.$(selector);
         if (!handle)

--- a/tests/mcp/click.spec.ts
+++ b/tests/mcp/click.spec.ts
@@ -202,3 +202,25 @@ test('browser_click (test id attribute)', async ({ startClient, server, mcpBrows
     code: `await page.getByTestId('submit').click();`,
   });
 });
+
+test('browser_click (locator target containing aria-ref-like substring)', async ({ client, server }) => {
+  server.setContent('/', `
+    <title>Title</title>
+    <button id="z2l9e43l3">Submit</button>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'Submit button',
+      target: '#z2l9e43l3',
+    },
+  })).toHaveResponse({
+    code: `await page.locator('#z2l9e43l3').click();`,
+  });
+});


### PR DESCRIPTION
## Summary
- Anchor the aria-ref detection regex so locators like `id=z2l9e43l3` (which contain `e\d+` substrings) are no longer misclassified as aria-refs.

Fixes https://github.com/microsoft/playwright-mcp/issues/1600