### PR TITLE
docs(aria-snapshot): clarify boxes coordinates are viewport-relative

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -248,7 +248,7 @@ When specified, limits the depth of the snapshot.
 * since: v1.60
 - `boxes` <[boolean]>
 
-When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are relative to the viewport, as returned by [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect). Defaults to `false`.
 
 ## async method: Locator.blur
 * since: v1.28

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4257,7 +4257,7 @@ When specified, limits the depth of the snapshot.
 * since: v1.60
 - `boxes` <[boolean]>
 
-When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are relative to the viewport, as returned by [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect). Defaults to `false`.
 
 ## async method: Page.tap
 * since: v1.8

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2052,7 +2052,10 @@ export interface Page {
    */
   ariaSnapshot(options?: {
     /**
-     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+     * relative to the viewport, as returned by
+     * [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+     * Defaults to `false`.
      */
     boxes?: boolean;
 
@@ -13050,7 +13053,10 @@ export interface Locator {
    */
   ariaSnapshot(options?: {
     /**
-     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+     * relative to the viewport, as returned by
+     * [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+     * Defaults to `false`.
      */
     boxes?: boolean;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2052,7 +2052,10 @@ export interface Page {
    */
   ariaSnapshot(options?: {
     /**
-     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+     * relative to the viewport, as returned by
+     * [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+     * Defaults to `false`.
      */
     boxes?: boolean;
 
@@ -13050,7 +13053,10 @@ export interface Locator {
    */
   ariaSnapshot(options?: {
     /**
-     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Defaults to `false`.
+     * When `true`, appends each element's bounding box as `[box=x,y,width,height]` to the snapshot. Coordinates are
+     * relative to the viewport, as returned by
+     * [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+     * Defaults to `false`.
      */
     boxes?: boolean;
 


### PR DESCRIPTION
## Summary
- Clarify that the `boxes` option on `Page.ariaSnapshot` / `Locator.ariaSnapshot` returns viewport-relative coordinates (as from `Element.getBoundingClientRect()`).