### PR TITLE
Revert "feat(firefox): roll to r1518"

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1518",
+      "revision": "1515",
       "installByDefault": true,
       "browserVersion": "149.0",
       "title": "Firefox"

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -520,7 +520,6 @@ export namespace Protocol {
         width: number;
         height: number;
       }|null;
-      deviceScaleFactor?: number;
     };
     export type setViewportSizeReturnValue = void;
     export type setZoomParameters = {


### PR DESCRIPTION
Reverts microsoft/playwright#40538

Breaks a dozen of MCP tests on Windows: https://github.com/microsoft/playwright/actions/runs/25311072586/job/74197829103

```
    [firefox] › tests\mcp\cli-devtools.spec.ts:217:5 › video-start-stop ────────────────────────────
    [firefox] › tests\mcp\cli-devtools.spec.ts:231:5 › video-chapter ───────────────────────────────
    [firefox] › tests\mcp\cli-session.spec.ts:70:5 › delete-data ───────────────────────────────────
    [firefox] › tests\mcp\dashboard.spec.ts:124:5 › daemon show: closing page exits the process ────
    [firefox] › tests\mcp\dashboard.spec.ts:165:5 › should capture annotations via show --annotate ─
    [firefox] › tests\mcp\dashboard.spec.ts:186:5 › should start dashboard and annotate when no dashboard is running 
    [firefox] › tests\mcp\dashboard.spec.ts:208:5 › should enter annotate mode on fresh dashboard.tsx mount with annotate 
    [firefox] › tests\mcp\dashboard.spec.ts:232:5 › should annotate via direct browser_annotate MCP call 
    [firefox] › tests\mcp\dashboard.spec.ts:265:5 › should annotate when context has no fixed viewport 
    [firefox] › tests\mcp\dashboard.spec.ts:302:5 › should cancel browser_annotate when the MCP request is aborted 
    [firefox] › tests\mcp\dashboard.spec.ts:333:5 › should cancel browser_annotate when the MCP client disconnects 
    [firefox] › tests\mcp\dashboard.spec.ts:362:5 › should switch screencast to -s session on show --annotate 
    [firefox] › tests\mcp\dashboard.spec.ts:411:5 › should disengage annotate mode when --annotate client disconnects 
    [firefox] › tests\mcp\dashboard.spec.ts:478:5 › save recording streams WebM bytes to the chosen file 
```