### PR TITLE
fix(security): prevent Zip Slip path traversal in harUnzip

### DIFF
--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -25,7 +25,7 @@ import { serializeClientSideCallMetadata } from '@isomorphic/trace/traceUtils';
 import { assert } from '@isomorphic/assert';
 import { calculateSha1 } from '@utils/crypto';
 import { ZipFile } from '@utils/zipFile';
-import { removeFolders } from '@utils/fileUtils';
+import { removeFolders, resolveWithinRoot } from '@utils/fileUtils';
 import { HarBackend } from './harBackend';
 import type * as channels from '@protocol/channels';
 import type * as har from '@trace/har';
@@ -187,7 +187,10 @@ export async function harUnzip(progress: Progress, params: channels.LocalUtilsHa
           await progress.race(fs.promises.mkdir(resourcesDir, { recursive: true }));
           resourcesDirCreated = true;
         }
-        await progress.race(fs.promises.writeFile(path.join(resourcesDir, entry), buffer));
+        const outPath = resolveWithinRoot(resourcesDir, entry);
+        if (!outPath)
+          throw new Error(`HAR zip entry '${entry}' escapes output directory`);
+        await progress.race(fs.promises.writeFile(outPath, buffer));
       }
     }
     await progress.race(fs.promises.unlink(params.zipFile));


### PR DESCRIPTION
## Summary

Fixes #40622

The `harUnzip()` function in `packages/playwright-core/src/server/localUtils.ts` extracts zip entries using `path.join(resourcesDir, entry)` without validating that the resolved path stays inside `resourcesDir`. A crafted `.har.zip` file with entries containing path traversal sequences (e.g. `../../etc/cron.d/evil`) could write files to arbitrary locations on the filesystem.

## Fix

Added `resolveWithinRoot()` validation before writing each extracted zip entry, rejecting any entry whose resolved path escapes the target `resourcesDir`. This follows the exact same pattern already used in `extractTrace()` in `packages/playwright-core/src/tools/trace/traceParser.ts`:

```typescript
const outPath = resolveWithinRoot(resourcesDir, entry);
if (!outPath)
  throw new Error(`HAR zip entry '${entry}' escapes output directory`);
await progress.race(fs.promises.writeFile(outPath, buffer));
```

## Changes

- **`packages/playwright-core/src/server/localUtils.ts`**: Import `resolveWithinRoot` from `@utils/fileUtils` and add path containment check in `harUnzip()`.

## Test plan

The `resolveWithinRoot()` utility is already thoroughly tested via the existing `extractTrace()` codepath. The fix is a 3-line addition that rejects any zip entry with a relative path escaping the output directory (returns `null` for absolute paths and paths that resolve outside the root after normalization).