### PR TITLE
fix(dashboard): close server in singleton handler on shutdown

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -280,7 +280,9 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     const server = net.createServer();
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code !== 'EADDRINUSE')
+      const isInUse = err.code === 'EADDRINUSE'
+          || (process.platform === 'win32' && (err.code === 'EACCES' || err.code === 'EBUSY'));
+      if (!isInUse)
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -281,7 +281,7 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
       const isInUse = err.code === 'EADDRINUSE'
-          || (process.platform === 'win32' && (err.code === 'EACCES' || err.code === 'EBUSY'));
+          || (process.platform === 'win32' && err.code === 'EBUSY');
       if (!isInUse)
         return reject(err);
       const client = net.connect(socketPath, () => {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -350,6 +350,7 @@ export async function openDashboardApp() {
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
         } else if (parsed.kill) {
+          server?.close();
           socket.end();
           gracefullyProcessExitDoNotHang(0);
         } else {


### PR DESCRIPTION
## Symptom

`dashboard.spec.ts` flakes on Windows CI. The acquirer would time out waiting for the new daemon's bind-title to appear in the registry, with errors like `No server with title "..." in list` or `Cannot read properties of undefined (reading 'endpoint')` from `cli-fixtures.ts`.

## Root cause

When a daemon receives `--kill` it calls `gracefullyProcessExitDoNotHang(0)`, which can take up to 30s before the process actually exits. During that window:

1. The daemon's listening socket stayed open (we never called `server.close()`).
2. A racing `acquireSingleton()` in another process did `listen()` -> fail -> `connect()` -> **succeed** (server was still up) -> treat the dying daemon as "already running" and silently return.
3. The dying daemon then exited, and the new test never got its dashboard.

There is also a Windows-specific second leg: even after we close the listener, libuv on Windows named pipes maps the brief rebind window during a peer's `close()` drain to `EACCES` / `EBUSY` rather than `EADDRINUSE`, so the existing `acquireSingleton` retry guard rejected on the first listen error instead of falling through to the connect/retry path.

## Fix

Two surgical changes in `dashboardApp.ts`:

1. Call `server?.close()` in the --kill handler, before draining the in-flight RPC. New connections are refused immediately so a racing acquirer sees a connect error rather than `already running`.
2. Treat `EACCES` / `EBUSY` as "in use" alongside `EADDRINUSE`, but only on Windows -- POSIX stays strict so genuine permission errors still surface.
