### PR TITLE
fix(dashboard): interactive clicks with remote browsers 

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -447,12 +447,12 @@ class AttachedPage {
   }
 
   private async _startScreencast(page: api.Page) {
+    const vp = await this._viewportSize();
     await page.screencast.start({
       onFrame: ({ data }: { data: Buffer }) => {
         if (this._disposed)
           return;
-        const vp = page.viewportSize();
-        this._owner.emitFrame(data.toString('base64'), vp?.width ?? 0, vp?.height ?? 0);
+        this._owner.emitFrame(data.toString('base64'), vp.width, vp.height);
       },
       size: { width: 1280, height: 800 },
       ...(this._recordingPath ? { path: this._recordingPath } : {}),


### PR DESCRIPTION
## Bug 1: Interactive clicks don't work with remote browsers

**Summary:** Dashboard interactive clicks go to (0,0) instead of intended coordinates when using `connectOverCDP()`, Android, or iOS remote debugging.

**Root Cause:** Remote browsers intentionally set `viewport: null` to avoid interfering with the browser's natural viewport. When Dashboard calls `page.viewportSize()`, it returns `null`, causing the coordinate mapping function `clientToViewport()` to receive `0×0` dimensions and always map clicks to the top-left corner.

**Reproduction Steps:**
1. Start a Chrome/Edge browser with remote debugging enabled:
```bash
chrome --remote-debugging-port=9222
```

2.Run Playwright Dashboard and connect over CDP:
```bash 
npx playwright open --headed --browser chromium --remote-debugging-port=9222
```


Open Dashboard in interactive mode
Try to click any element on the page
Expected: Click happens at the clicked location
Actual: Click always happens at (0,0) - top-left corner

User impact:

Interactive mode features fail: generate locator, hover, highlight, mouse events, keyboard events, fill, type, check, uncheck, select
Only scrolling works (doesn't require coordinate transformation)
Workaround: Manually resizing the viewport makes it work temporarily


Change: Modified the _startScreencast() method to detect viewport size once before streaming starts.