### PR TITLE
fix(trace): replay sub-resources from archive in trace snapshot CLI

### DIFF
--- a/packages/playwright-core/src/tools/trace/traceSnapshot.ts
+++ b/packages/playwright-core/src/tools/trace/traceSnapshot.ts
@@ -99,10 +99,61 @@ async function serveTraceSnapshot(storage: SnapshotStorage, loader: TraceLoader,
     return true;
   });
 
+  httpServer.routePath('/__pwsnapshot/sw.js', (_request: any, response: any) => {
+    response.statusCode = 200;
+    response.setHeader('Content-Type', 'application/javascript');
+    response.setHeader('Service-Worker-Allowed', '/');
+    response.end(`
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
+self.addEventListener('fetch', e => {
+  const reqUrl = new URL(e.request.url);
+  if (reqUrl.origin === self.location.origin)
+    return;
+  e.respondWith((async () => {
+    const client = e.clientId ? await self.clients.get(e.clientId) : null;
+    if (!client)
+      return new Response('No client', { status: 500 });
+    const params = new URLSearchParams({
+      frame: client.url,
+      url: e.request.url,
+      method: e.request.method,
+    });
+    return fetch('/__pwsnapshot/resource?' + params.toString());
+  })());
+});
+`);
+    return true;
+  });
+
+  httpServer.routePath('/__pwsnapshot/resource', (request: any, response: any) => {
+    const url = new URL('http://localhost' + request.url!);
+    const frame = new URL(url.searchParams.get('frame')!);
+    const snapshotUrl = 'http://localhost' + frame.pathname + frame.search;
+    const requestUrl = url.searchParams.get('url')!;
+    const method = url.searchParams.get('method')!;
+    snapshotServer.serveResource([requestUrl], method, snapshotUrl).then(async resp => {
+      response.statusCode = resp.status;
+      resp.headers.forEach((value: string, key: string) => response.appendHeader(key, value));
+      response.end(Buffer.from(await resp.arrayBuffer()));
+    }).catch(() => {
+      response.statusCode = 500;
+      response.end();
+    });
+    return true;
+  });
+
+  const startTime = Date.now();
   httpServer.routePrefix('/', (_request: any, response: any) => {
-    response.statusCode = 302;
-    response.setHeader('Location', `/snapshot/${pageId}?name=${encodeURIComponent(snapshotKey)}`);
-    response.end();
+    response.statusCode = 200;
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.end(`<!DOCTYPE html><html><body><script>(async () => {
+  await navigator.serviceWorker.register('/__pwsnapshot/sw.js?v=${startTime}', { scope: '/' });
+  await navigator.serviceWorker.ready;
+  if (!navigator.serviceWorker.controller)
+    await new Promise(r => navigator.serviceWorker.addEventListener('controllerchange', r, { once: true }));
+  location.replace(${JSON.stringify(`/snapshot/${pageId}?name=${encodeURIComponent(snapshotKey)}`)});
+})();</script></body></html>`);
     return true;
   });
 
@@ -115,6 +166,7 @@ async function runCommandOnSnapshot(server: { url: string, stop: () => Promise<v
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.url);
+  await page.waitForURL(url => new URL(url).pathname.startsWith('/snapshot/'));
 
   const backend = new BrowserBackend({
     snapshot: { mode: 'full' },

--- a/packages/playwright-core/src/tools/trace/traceSnapshot.ts
+++ b/packages/playwright-core/src/tools/trace/traceSnapshot.ts
@@ -103,26 +103,7 @@ async function serveTraceSnapshot(storage: SnapshotStorage, loader: TraceLoader,
     response.statusCode = 200;
     response.setHeader('Content-Type', 'application/javascript');
     response.setHeader('Service-Worker-Allowed', '/');
-    response.end(`
-self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
-self.addEventListener('fetch', e => {
-  const reqUrl = new URL(e.request.url);
-  if (reqUrl.origin === self.location.origin)
-    return;
-  e.respondWith((async () => {
-    const client = e.clientId ? await self.clients.get(e.clientId) : null;
-    if (!client)
-      return new Response('No client', { status: 500 });
-    const params = new URLSearchParams({
-      frame: client.url,
-      url: e.request.url,
-      method: e.request.method,
-    });
-    return fetch('/__pwsnapshot/resource?' + params.toString());
-  })());
-});
-`);
+    response.end(`(${snapshotServiceWorker.toString()})();`);
     return true;
   });
 
@@ -144,21 +125,60 @@ self.addEventListener('fetch', e => {
   });
 
   const startTime = Date.now();
+  const snapshotUrl = `/snapshot/${pageId}?name=${encodeURIComponent(snapshotKey)}`;
   httpServer.routePrefix('/', (_request: any, response: any) => {
     response.statusCode = 200;
     response.setHeader('Content-Type', 'text/html; charset=utf-8');
-    response.end(`<!DOCTYPE html><html><body><script>(async () => {
-  await navigator.serviceWorker.register('/__pwsnapshot/sw.js?v=${startTime}', { scope: '/' });
-  await navigator.serviceWorker.ready;
-  if (!navigator.serviceWorker.controller)
-    await new Promise(r => navigator.serviceWorker.addEventListener('controllerchange', r, { once: true }));
-  location.replace(${JSON.stringify(`/snapshot/${pageId}?name=${encodeURIComponent(snapshotKey)}`)});
-})();</script></body></html>`);
+    response.end(`<!DOCTYPE html><html><body><script>(${bootstrapSnapshotPage.toString()})(${JSON.stringify(`/__pwsnapshot/sw.js?v=${startTime}`)}, ${JSON.stringify(snapshotUrl)});</script></body></html>`);
     return true;
   });
 
   await httpServer.start({ preferredPort: 0 });
   return { url: httpServer.urlPrefix('human-readable'), stop: () => httpServer.stop() };
+}
+
+function snapshotServiceWorker() {
+  type Client = { url: string };
+  type FetchEvent = {
+    request: Request;
+    clientId: string | null;
+    respondWith(response: Promise<Response>): void;
+  };
+  type ServiceWorkerGlobalScope = {
+    location: { origin: string };
+    addEventListener(event: 'install' | 'activate', listener: (event: any) => void): void;
+    addEventListener(event: 'fetch', listener: (event: FetchEvent) => void): void;
+    clients: { claim(): Promise<void>; get(id: string): Promise<Client | undefined> };
+    skipWaiting(): Promise<void>;
+  };
+  const sw = self as unknown as ServiceWorkerGlobalScope;
+
+  sw.addEventListener('install', () => sw.skipWaiting());
+  sw.addEventListener('activate', event => event.waitUntil(sw.clients.claim()));
+  sw.addEventListener('fetch', event => {
+    const requestUrl = new URL(event.request.url);
+    if (requestUrl.origin === sw.location.origin)
+      return;
+    event.respondWith((async () => {
+      const client = event.clientId ? await sw.clients.get(event.clientId) : null;
+      if (!client)
+        return new Response('No client', { status: 500 });
+      const params = new URLSearchParams({
+        frame: client.url,
+        url: event.request.url,
+        method: event.request.method,
+      });
+      return fetch('/__pwsnapshot/resource?' + params.toString());
+    })());
+  });
+}
+
+async function bootstrapSnapshotPage(swUrl: string, snapshotUrl: string) {
+  await navigator.serviceWorker.register(swUrl, { scope: '/' });
+  await navigator.serviceWorker.ready;
+  if (!navigator.serviceWorker.controller)
+    await new Promise(resolve => navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true }));
+  location.replace(snapshotUrl);
 }
 
 async function runCommandOnSnapshot(server: { url: string, stop: () => Promise<void> }, browserArgs: string[]) {

--- a/tests/mcp/trace-cli-fixtures.ts
+++ b/tests/mcp/trace-cli-fixtures.ts
@@ -44,15 +44,21 @@ export const test = baseTest
         const page = await context.newPage();
         server.setContent('/', `
           <html>
-            <head><title>Test Page</title></head>
+            <head>
+              <title>Test Page</title>
+              <link rel="stylesheet" href="/style.css">
+            </head>
             <body>
               <h1>Hello World</h1>
               <button id="btn">Click me</button>
               <input id="search" type="text" placeholder="Search..." />
               <a href="/page2">Go to page 2</a>
+              <div id="styled">Styled text</div>
             </body>
           </html>
         `, 'text/html');
+
+        server.setContent('/style.css', '#styled { color: rgb(255, 0, 0); }', 'text/css');
 
         server.setContent('/page2', `
           <html>
@@ -113,6 +119,10 @@ export const test = baseTest
         const tracePath = path.join(tmpDir, 'trace.zip');
         await context.tracing.stop({ path: tracePath });
         await browser.close();
+
+        // Drop the recorded routes so trace replay tests can't accidentally fetch sub-resources
+        // from the still-running test server — they should come from the trace archive.
+        server.reset();
 
         await use(tracePath);
 

--- a/tests/mcp/trace-cli-fixtures.ts
+++ b/tests/mcp/trace-cli-fixtures.ts
@@ -120,8 +120,6 @@ export const test = baseTest
         await context.tracing.stop({ path: tracePath });
         await browser.close();
 
-        // Drop the recorded routes so trace replay tests can't accidentally fetch sub-resources
-        // from the still-running test server — they should come from the trace archive.
         server.reset();
 
         await use(tracePath);

--- a/tests/mcp/trace-cli.spec.ts
+++ b/tests/mcp/trace-cli.spec.ts
@@ -186,10 +186,6 @@ test('trace snapshot resolves inner frames', async ({ runTraceCli }) => {
 });
 
 test('trace snapshot replays sub-resource stylesheets from the archive', async ({ runTraceCli }) => {
-  // The CLI snapshot HTTP server only handles `/snapshot/...` directly. Sub-resource requests
-  // (the snapshot HTML's <base href> points at the recorded origin) are intercepted via
-  // BrowserContext.route in serveTraceSnapshot's decorateContext, mirroring the trace-viewer
-  // service worker's `snapshotServer.serveResource(...)` logic.
   const { stdout: listOutput } = await runTraceCli(['actions', '--grep', 'Click']);
   const match = listOutput.match(/^\s+(\d+)\.\s/m);
   expect(match).toBeTruthy();

--- a/tests/mcp/trace-cli.spec.ts
+++ b/tests/mcp/trace-cli.spec.ts
@@ -15,9 +15,9 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 
 import { test, expect } from './trace-cli-fixtures';
-import path from 'path';
 
 test.skip(({ mcpBrowser }) => mcpBrowser !== 'chrome', 'Chrome-only');
 
@@ -183,6 +183,24 @@ test('trace snapshot resolves inner frames', async ({ runTraceCli }) => {
 
   const { stdout } = await runTraceCli(['snapshot', '--name', 'after', anchorClickOrdinal]);
   expect(stdout).toContain('Innermost');
+});
+
+test('trace snapshot replays sub-resource stylesheets from the archive', async ({ runTraceCli }) => {
+  // The CLI snapshot HTTP server only handles `/snapshot/...` directly. Sub-resource requests
+  // (the snapshot HTML's <base href> points at the recorded origin) are intercepted via
+  // BrowserContext.route in serveTraceSnapshot's decorateContext, mirroring the trace-viewer
+  // service worker's `snapshotServer.serveResource(...)` logic.
+  const { stdout: listOutput } = await runTraceCli(['actions', '--grep', 'Click']);
+  const match = listOutput.match(/^\s+(\d+)\.\s/m);
+  expect(match).toBeTruthy();
+  const ordinal = match![1];
+
+  const { stdout, exitCode } = await runTraceCli([
+    'snapshot', '--name', 'before', ordinal,
+    '--', 'eval', 'el => getComputedStyle(el).color', '#styled',
+  ]);
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('rgb(255, 0, 0)');
 });
 
 test('trace screenshot saves image file', async ({ runTraceCli }, testInfo) => {


### PR DESCRIPTION
## Summary
- The `trace snapshot` CLI (and `trace serve`) only replayed the recorded HTML; sub-resources fetched live from the original origin, so snapshots rendered unstyled whenever that origin was unreachable.
- Serve sub-resources from the trace archive via a small inline service worker on a bootstrap page. Cross-origin fetches forward to a `/__pwsnapshot/resource` endpoint that delegates to `SnapshotServer.serveResource`. Same path works for both `trace snapshot` and `trace serve`.
