### PR TITLE
fix(runner): force-kill worker that hangs on stop

### DIFF
--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -252,6 +252,10 @@ export class Dispatcher {
       for (const error of params.fatalErrors)
         this._testRun.reporter.onError?.(error, workerInfo);
     });
+    worker.on('processError', (error: TestError) => {
+      this._testRun.hasWorkerErrors = true;
+      this._testRun.reporter.onError?.(error);
+    });
     worker.on('exit', () => {
       const producedEnv = this._producedEnvByProjectId.get(testGroup.projectId) || {};
       this._producedEnvByProjectId.set(testGroup.projectId, { ...producedEnv, ...worker.producedEnv() });

--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -19,7 +19,8 @@ import { EventEmitter } from 'events';
 
 import debug from 'debug';
 import { assert } from '@isomorphic/assert';
-import { timeOrigin } from '@isomorphic/time';
+import { monotonicTime, timeOrigin } from '@isomorphic/time';
+import { raceAgainstDeadline } from '@isomorphic/timeoutRunner';
 
 import type { ipc, processRunner } from '../common';
 
@@ -165,8 +166,30 @@ export class ProcessHost extends EventEmitter {
       this.send({ method: '__stop__' });
       this._didSendStop = true;
     }
-    if (!this._didExitAndRanOnExit)
-      await new Promise(f => this.once('exit', f));
+    if (this._didExitAndRanOnExit)
+      return;
+    const exitPromise = new Promise<void>(f => this.once('exit', () => f()));
+    const timeout = +(process.env.PWTEST_CHILD_PROCESS_TIMEOUT || 5 * 60 * 1000);
+    const result = await raceAgainstDeadline(() => exitPromise, monotonicTime() + timeout);
+    if (result.timedOut) {
+      this.emit('processError', { message: `Error: ${this._processName} process did not exit within ${timeout}ms after stop, force-killed it` });
+      this._forceKill();
+      await exitPromise;
+    }
+  }
+
+  private _forceKill() {
+    const pid = this.process?.pid;
+    if (!pid)
+      return;
+    try {
+      if (process.platform === 'win32')
+        child_process.spawnSync(`taskkill /pid ${pid} /T /F`, { shell: true });
+      else
+        process.kill(pid, 'SIGKILL');
+    } catch {
+      // The process may have already exited.
+    }
   }
 
   didSendStop() {

--- a/tests/playwright-test/exit-code.spec.ts
+++ b/tests/playwright-test/exit-code.spec.ts
@@ -207,3 +207,26 @@ test('should exit with code 1 when config is not found', async ({ runInlineTest 
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain(`foo.config.js does not exist`);
 });
+
+test('should force-kill a worker that does not exit on stop', async ({ runInlineTest }) => {
+  const now = monotonicTime();
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        hangOnExit: [async ({}, use) => {
+          await use();
+          // Disable graceful exit to simulate a worker that cannot self-terminate.
+          process.exit = (() => {}) as any;
+          setInterval(() => {}, 1000);
+        }, { scope: 'worker' }],
+      });
+      test('passes', async ({ hangOnExit }) => {});
+    `,
+  }, undefined, { PWTEST_CHILD_PROCESS_TIMEOUT: '2000' });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(1);
+  expect(result.output).toContain('process did not exit within 2000ms after stop, force-killed it');
+  // Should complete well within a minute thanks to the watchdog.
+  expect(monotonicTime() - now).toBeLessThan(60000);
+});


### PR DESCRIPTION
## Summary
- Watchdog around `__stop__`: if the worker process does not exit within 5 min (overridable via `PWTEST_CHILD_PROCESS_TIMEOUT` for tests), it is force-killed (`taskkill /T /F` on Windows, SIGKILL elsewhere).
- Force-kill emits a new `processError` event that the dispatcher reports via `reporter.onError`, so a hung worker fails the run.

Fixes https://github.com/microsoft/playwright/issues/39753