### PR TITLE
fix(har): preserve cookie values containing '=' in API request HAR recording

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -303,7 +303,9 @@ export abstract class APIRequestContext extends SdkObject {
     await this._updateRequestCookieHeader(progress, url, options.headers);
 
     const requestCookies = getHeader(options.headers, 'cookie')?.split(';').map(p => {
-      const [name, value] = p.split('=').map(v => v.trim());
+      const indexOfEquals = p.indexOf('=');
+      const name = indexOfEquals !== -1 ? p.substring(0, indexOfEquals).trim() : p.trim();
+      const value = indexOfEquals !== -1 ? p.substring(indexOfEquals + 1).trim() : '';
       return { name, value };
     }) || [];
     const requestEvent: APIRequestEvent = {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -826,6 +826,19 @@ it('should include API request', async ({ contextFactory, server }, testInfo) =>
   expect(entry._serverPort).toEqual(server.PORT);
 });
 
+it('should correctly record API request cookies with equals sign in value', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  const url = server.PREFIX + '/simple.json';
+  await page.request.get(url, {
+    headers: { cookie: 'token=abc=xyz; other=val' },
+  });
+  const log = await getLog();
+  expect(log.entries[0].request.cookies).toEqual([
+    { name: 'token', value: 'abc=xyz' },
+    { name: 'other', value: 'val' },
+  ]);
+});
+
 it('should respect minimal mode for API Requests', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo, { mode: 'minimal' });
   const url = server.PREFIX + '/simple.json';


### PR DESCRIPTION
## Summary

- `fetch.ts` parsed the `cookie` header with `split('=')`, splitting on every `=` instead of only the first one
- Cookie values containing `=` (Base64 tokens, JWT padding, etc.) were truncated in HAR recordings for API requests
- Fix uses `indexOf('=')` to match the logic already used in `harTracer.ts parseCookie()`

Fixes https://github.com/microsoft/playwright/issues/40639