### PR TITLE
fix(dashboard): retry singleton listen with backoff on Windows shutdown race

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -278,7 +278,12 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
 
   return await new Promise((resolve, reject) => {
     const server = net.createServer();
-    server.listen(socketPath, () => resolve(server));
+    let listenRetries = 0;
+
+    const tryListen = () => {
+      server.listen(socketPath, () => resolve(server));
+    };
+
     server.on('error', (err: NodeJS.ErrnoException) => {
       const isInUse = err.code === 'EADDRINUSE'
           || (process.platform === 'win32' && err.code === 'EBUSY');
@@ -291,9 +296,15 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
       client.on('error', () => {
         if (process.platform !== 'win32')
           fs.unlinkSync(socketPath);
-        server.listen(socketPath, () => resolve(server));
+        // On Windows the previous server may still be shutting down; retry with backoff.
+        if (listenRetries >= 5)
+          return reject(err);
+        const delay = Math.min(100 * (1 << listenRetries++), 3000);
+        setTimeout(tryListen, delay);
       });
     });
+
+    tryListen();
   });
 }
 


### PR DESCRIPTION
When the previous dashboard instance is mid-shutdown on Windows, `net.createServer().listen()` can fail with `EBUSY` even after a failed `net.connect()` (because the pipe name is still transiently held by the kernel). This causes the singleton acquisition to fail rather than waiting for the previous instance to finish closing.

- Retry `server.listen` with exponential backoff (100ms, 200ms, 400ms, 800ms, 1600ms) when the connect-then-listen path fails
- Give up and reject after 5 retries (~3.1s total)