### PR TITLE
fix(dashboard): fix Windows named pipe race on daemon shutdown

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -22,6 +22,7 @@ import http from 'http';
 import { HttpServer } from '@utils/httpServer';
 import { makeSocketPath } from '@utils/fileUtils';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
+import { monotonicTime } from '@isomorphic/time';
 import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
@@ -387,34 +388,29 @@ export async function openDashboardForContext(context: api.BrowserContext): Prom
 
 async function runKillClient(): Promise<void> {
   const socketPath = dashboardSocketPath();
-  let pid: number;
-  try {
-    pid = await new Promise<number>((resolve, reject) => {
-      const client = net.connect(socketPath);
-      let data = '';
-      client.once('connect', () => {
-        client.write(JSON.stringify({ kill: true }) + '\n');
-      });
-      client.on('data', chunk => { data += chunk; });
-      client.once('end', () => {
-        let pid: number | undefined;
-        try { pid = JSON.parse(data.trim()).pid; } catch { }
-        if (pid === undefined)
-          reject(new Error('Dashboard did not return its PID'));
-        else
-          resolve(pid);
-      });
-      client.once('error', () => reject(new Error('no dashboard running')));
+  const pid = await new Promise<number | undefined>((resolve, reject) => {
+    const client = net.connect(socketPath);
+    let data = '';
+    client.once('connect', () => {
+      client.write(JSON.stringify({ kill: true }) + '\n');
     });
-  } catch (e: any) {
-    if (e?.message === 'no dashboard running')
-      return;
-    throw e;
-  }
+    client.on('data', chunk => { data += chunk; });
+    client.once('end', () => {
+      let pid: number | undefined;
+      try { pid = JSON.parse(data.trim()).pid; } catch { }
+      if (pid === undefined)
+        reject(new Error('Dashboard did not return its PID'));
+      else
+        resolve(pid);
+    });
+    client.once('error', () => resolve(undefined));
+  });
+  if (pid === undefined)
+    return;
   // Poll until the daemon process exits — at that point the OS has released all
   // its handles, including the named pipe, so the next acquisition won't see a stale pipe.
-  const deadline = Date.now() + 35000;
-  while (Date.now() < deadline) {
+  const deadline = monotonicTime() + 35000;
+  while (monotonicTime() < deadline) {
     try {
       process.kill(pid, 0);
     } catch {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -280,9 +280,7 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     const server = net.createServer();
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      const isInUse = err.code === 'EADDRINUSE'
-          || (process.platform === 'win32' && err.code === 'EBUSY');
-      if (!isInUse)
+      if (err.code !== 'EADDRINUSE')
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');
@@ -345,16 +343,21 @@ export async function openDashboardApp() {
         socket.end();
         return;
       }
+      if (parsed.kill) {
+        // Write our PID so the kill client can wait for the process to fully exit,
+        // which guarantees the named pipe is released (especially on Windows).
+        // Start graceful shutdown only after the socket data has been flushed, so the
+        // kill client is guaranteed to receive the PID before we begin tearing down.
+        server?.close();
+        socket.end(JSON.stringify({ pid: process.pid }) + '\n', () => gracefullyProcessExitDoNotHang(0));
+        return;
+      }
       void statePromise.then(({ page, server: dashboard }) => {
         if (parsed.annotate) {
           page?.bringToFront().catch(() => {});
           dashboard.reveal(parsed);
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
-        } else if (parsed.kill) {
-          server?.close();
-          socket.end();
-          gracefullyProcessExitDoNotHang(0);
         } else {
           page?.bringToFront().catch(() => {});
           dashboard.reveal(parsed);
@@ -384,14 +387,42 @@ export async function openDashboardForContext(context: api.BrowserContext): Prom
 
 async function runKillClient(): Promise<void> {
   const socketPath = dashboardSocketPath();
-  await new Promise<void>(resolve => {
-    const client = net.connect(socketPath);
-    client.once('connect', () => {
-      client.write(JSON.stringify({ kill: true }) + '\n');
+  let pid: number;
+  try {
+    pid = await new Promise<number>((resolve, reject) => {
+      const client = net.connect(socketPath);
+      let data = '';
+      client.once('connect', () => {
+        client.write(JSON.stringify({ kill: true }) + '\n');
+      });
+      client.on('data', chunk => { data += chunk; });
+      client.once('end', () => {
+        let pid: number | undefined;
+        try { pid = JSON.parse(data.trim()).pid; } catch { }
+        if (pid === undefined)
+          reject(new Error('Dashboard did not return its PID'));
+        else
+          resolve(pid);
+      });
+      client.once('error', () => reject(new Error('no dashboard running')));
     });
-    client.once('end', () => resolve());
-    client.once('error', () => resolve());
-  });
+  } catch (e: any) {
+    if (e?.message === 'no dashboard running')
+      return;
+    throw e;
+  }
+  // Poll until the daemon process exits — at that point the OS has released all
+  // its handles, including the named pipe, so the next acquisition won't see a stale pipe.
+  const deadline = Date.now() + 35000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise(r => setTimeout(r, 50));
+  }
+  throw new Error(`Dashboard process ${pid} did not exit within the deadline`);
 }
 
 async function runAnnotateClient(options: DashboardOptions): Promise<void> {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -60,7 +60,7 @@ export const test = baseTest.extend<{
       return page;
     });
   },
-  connectToDashboard: async ({ cli, playwright }, use) => {
+  connectToDashboard: [async ({ cli, playwright }, use) => {
     await use(async (bindTitle: string) => {
       let endpoint = '';
       await expect(async () => {
@@ -72,7 +72,7 @@ export const test = baseTest.extend<{
       return await playwright.chromium.connect(endpoint);
     });
     await cli('show', '--kill');
-  },
+  }, { timeout: 60000 }],
 
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
     await fs.promises.mkdir(test.info().outputPath('.playwright'), { recursive: true });


### PR DESCRIPTION
## Summary

Fixes a Windows CI flake where dashboard tests sporadically failed with `Cannot read properties of undefined (reading 'endpoint')`.

The root cause: after `--kill`, Windows keeps the named pipe connectable during `gracefullyCloseAll`. The next test could connect to the dying daemon, get rejected mid-handshake, and see `server.endpoint` as undefined — cascading failures across many tests.

**Daemon side** (`dashboardApp.ts`): move the `kill` handler before `statePromise.then()` so it fires immediately. Send the daemon PID in `socket.end(data, callback)` and only call `gracefullyProcessExitDoNotHang` inside the flush callback, ensuring the client receives the PID before teardown begins.

**Client side** (`runKillClient`): after receiving the daemon PID, poll `process.kill(pid, 0)` until `ESRCH` (up to 35 s). This guarantees the named pipe is fully released before the next test tries to acquire the singleton.

**Test fixture** (`cli-fixtures.ts`): give `connectToDashboard` a 60 s fixture timeout.

Also reverts f536e37aa2 (added `EBUSY` check + `server.close` in singleton handler) which was a previous incomplete attempt at fixing this.

Fixes #40626