### PR TITLE
fix(mcp): resolve explicit output filenames under output dir

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -79,11 +79,7 @@ export class Response {
   }
 
   async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
-    let fileName: string;
-    if (template.suggestedFilename)
-      fileName = await this.resolveClientFilename(template.suggestedFilename);
-    else
-      fileName = await this._context.outputFile(template, { origin: 'llm' });
+    const fileName = await this._context.outputFile(template, { origin: 'llm' });
     const relativeName = this._computeRelativeTo(fileName);
     const printableLink = `- [${title}](${relativeName})`;
     return { fileName, relativeName, printableLink };

--- a/tests/mcp/cli-storage.spec.ts
+++ b/tests/mcp/cli-storage.spec.ts
@@ -54,7 +54,7 @@ test('state-save saves to custom filename', async ({ cli, server }, testInfo) =>
   const { output } = await cli('state-save', 'my-state.json');
   expect(output).toContain('my-state.json');
 
-  const stateFile = testInfo.outputPath('my-state.json');
+  const stateFile = testInfo.outputPath('.playwright-cli', 'my-state.json');
   expect(await fs.promises.stat(stateFile).catch(() => null)).not.toBeNull();
 });
 
@@ -117,7 +117,7 @@ test('state-save and state-load roundtrip', async ({ cli, server, mcpBrowser }, 
   expect(clearedResult).toContain('|null');
 
   // Restore storage state
-  await cli('state-load', testInfo.outputPath('roundtrip-state.json'));
+  await cli('state-load', testInfo.outputPath('.playwright-cli', 'roundtrip-state.json'));
 
   // Reload to pick up cookies
   await cli('goto', server.EMPTY_PAGE);

--- a/tests/mcp/pdf.spec.ts
+++ b/tests/mcp/pdf.spec.ts
@@ -78,9 +78,9 @@ test('save as pdf (filename: output.pdf)', async ({ startClient, mcpBrowser, ser
     code: expect.stringContaining(`await page.pdf(`),
   });
 
-  const files = [...fs.readdirSync(testInfo.outputPath())];
+  const files = [...fs.readdirSync(testInfo.outputPath('.playwright-mcp'))];
 
-  expect(fs.existsSync(testInfo.outputPath())).toBeTruthy();
+  expect(fs.existsSync(testInfo.outputPath('.playwright-mcp'))).toBeTruthy();
   const pdfFiles = files.filter(f => f.endsWith('.pdf'));
   expect(pdfFiles).toHaveLength(1);
   expect(pdfFiles[0]).toMatch(/^output.pdf$/);

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 
 import { test, expect } from './fixtures';
 import { jpegjs, PNG } from '../../packages/playwright-core/lib/utilsBundle';
@@ -94,6 +95,29 @@ test('--output-dir should work', async ({ startClient, server }, testInfo) => {
   const files = [...fs.readdirSync(outputDir)].filter(f => f.endsWith('.png'));
   expect(files).toHaveLength(1);
   expect(files[0]).toMatch(/^page-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.png$/);
+});
+
+test('--output-dir should work with explicit filename', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    code: expect.stringContaining(`page.goto('http://localhost`),
+  });
+
+  await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: {
+      filename: 'output.png',
+    },
+  });
+
+  expect(fs.existsSync(path.join(outputDir, 'output.png'))).toBeTruthy();
+  expect(fs.existsSync(testInfo.outputPath('output.png'))).toBeFalsy();
 });
 
 for (const type of ['png', 'jpeg']) {
@@ -246,7 +270,7 @@ test('browser_take_screenshot (filename: "output.png")', async ({ client, server
     ],
   });
 
-  const files = [...fs.readdirSync(testInfo.outputPath())].filter(f => f.endsWith('.png'));
+  const files = [...fs.readdirSync(testInfo.outputPath('.playwright-mcp'))].filter(f => f.endsWith('.png'));
   expect(files).toHaveLength(1);
   expect(files[0]).toMatch(/^output\.png$/);
 });

--- a/tests/mcp/snapshot-mode.spec.ts
+++ b/tests/mcp/snapshot-mode.spec.ts
@@ -113,5 +113,5 @@ test('should respect snapshot[filename]', async ({ client, server }, testInfo) =
     },
   })).toHaveTextResponse(expect.stringContaining('snapshot1.yml'));
 
-  expect(await fs.promises.readFile(path.join(testInfo.outputPath(), 'snapshot1.yml'), 'utf8')).toContain(`- button "Button 1" [ref=e2]`);
+  expect(await fs.promises.readFile(path.join(testInfo.outputPath('.playwright-mcp'), 'snapshot1.yml'), 'utf8')).toContain(`- button "Button 1" [ref=e2]`);
 });

--- a/tests/mcp/storage.spec.ts
+++ b/tests/mcp/storage.spec.ts
@@ -100,7 +100,7 @@ test('browser_storage_state saves to custom filename', async ({ startClient, ser
     result: expect.stringContaining('my-state.json'),
   });
 
-  const stateFile = testInfo.outputPath('my-state.json');
+  const stateFile = testInfo.outputPath('.playwright-mcp', 'my-state.json');
   expect(await fs.promises.stat(stateFile).catch(() => null)).not.toBeNull();
 });
 
@@ -243,7 +243,7 @@ test('browser_storage_state and browser_set_storage_state roundtrip', async ({ s
   // Restore storage state
   await client.callTool({
     name: 'browser_set_storage_state',
-    arguments: { filename: testInfo.outputPath('roundtrip-state.json') },
+    arguments: { filename: testInfo.outputPath('.playwright-mcp', 'roundtrip-state.json') },
   });
 
   // Reload to pick up cookies


### PR DESCRIPTION
## Summary
- resolve explicit MCP output artifact filenames through the configured output directory
- keep workspace filename resolution for tools that read client-provided files
- update MCP screenshot, PDF, snapshot, and storage coverage for explicit output filenames

Fixes https://github.com/microsoft/playwright-mcp/issues/1595