### PR TITLE
docs: alias drop-payload Object types and dedupe identical aliases

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -128,15 +128,16 @@ Defaults to `left`.
 
 ## input-files
 - `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
-  - alias-csharp: FilePayload
-  - alias-java: FilePayload
+  - alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 
 ## drop-payload
 - `payload` <[Object]>
+  - alias: DropPayload
   - `files` ?<[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
+    - alias: FilePayload
     - `name` <[string]> File name
     - `mimeType` <[string]> File type
     - `buffer` <[Buffer]> File content


### PR DESCRIPTION
## Summary

The `## drop-payload` block in `docs/src/api/params.md` was missing the
language alias annotations that `## input-files` carries, so language ports
that need a concrete type for the inline `[Object]` fall back to ambiguous
generated names (e.g. Java's generator was emitting `Files.java` / `Payload.java`
duplicating the existing `FilePayload` and using a generic `Payload` name).

Adds:
- `alias: DropPayload` on the outer payload Object.
- `alias: FilePayload` on the inner `files` field's Object union.

While at it, dedupe `alias-csharp: X` + `alias-java: X` pairs to a single
`alias: X` where the values are identical (the api parser maps the bare
`alias:` to the `default` key, which language generators consume as a
fallback). Affects `input-files` and the new `drop-payload` block.

No api shape change — this only adds/normalizes type names for the inline
Object types.

## Test plan
- [x] `API_JSON_MODE=1 node utils/doclint/generateApiJson.js` — parses cleanly
- [x] regenerated api.json picks up the aliases (verified `langAliases.default`
      is present on `Locator.drop.payload`, the inner `files` Object, and
      `setInputFiles.files` Object)