### PR TITLE
test: forward NODE_OPTIONS to remote server child processes

### DIFF
--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -15,7 +15,6 @@
  */
 
 import path from 'path';
-import { inheritAndCleanEnv } from './utils';
 import type { BrowserType, Browser } from 'playwright-core';
 import type { CommonFixtures, TestChildProcess } from './commonFixtures';
 
@@ -36,7 +35,7 @@ export class RunServer implements PlaywrightServer {
       command.push(`--artifacts-dir=${options.artifactsDir}`);
     this._process = childProcess({
       command,
-      env: inheritAndCleanEnv(options?.env),
+      env: { NODE_OPTIONS: process.env.NODE_OPTIONS, ...options?.env },
     });
 
     let wsEndpointCallback: (value: string) => void;
@@ -108,6 +107,7 @@ export class RemoteServer implements PlaywrightServer {
     };
     this._process = childProcess({
       command: ['node', path.join(__dirname, 'remote-server-impl.js'), JSON.stringify(options)],
+      env: { NODE_OPTIONS: process.env.NODE_OPTIONS },
     });
 
     let index = 0;


### PR DESCRIPTION
The test fixture's `inheritAndCleanEnv` strips `NODE_OPTIONS` from spawned child processes. This makes it impossible to apply Node-level workarounds such as `--dns-result-order=ipv4first` or `--no-network-family-autoselection` to the WS server processes started by `RunServer` / `RemoteServer`, which hides issues like microsoft/playwright#40605 behind asymmetric DNS results between parent and child.

Pass `NODE_OPTIONS` explicitly so the child inherits it.

Refs https://github.com/microsoft/playwright/issues/40605