### PR TITLE
docs(api): extract repeated alias structures into params.md mixins

### DIFF
--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -55,13 +55,8 @@ Disposes the body of this response. If not called then the body will stay in mem
 
 An object with all the response HTTP headers associated with this response.
 
-## method: APIResponse.headersArray
+## method: APIResponse.headersArray = %%-return-headers-array-%%
 * since: v1.16
-- returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
-  - `name` <[string]> Name of the header.
-  - `value` <[string]> Value of the header.
 
 An array with all the response HTTP headers associated with this response. Header names are not lower-cased.
 Headers with multiple entries, such as `Set-Cookie`, appear in the array multiple times.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -766,12 +766,8 @@ await page.GetByRole(AriaRole.Button).ClickAsync();
 
 Name of the function on the window object.
 
-### param: BrowserContext.exposeBinding.callback
+### param: BrowserContext.exposeBinding.callback = %%-expose-binding-callback-%%
 * since: v1.8
-- `callback` <[function]>
-  - alias-java: BindingCallback
-
-Callback function that will be called in the Playwright's context.
 
 ## async method: BrowserContext.exposeFunction
 * since: v1.8
@@ -958,12 +954,8 @@ class BrowserContextExamples
 
 Name of the function on the window object.
 
-### param: BrowserContext.exposeFunction.callback
+### param: BrowserContext.exposeFunction.callback = %%-expose-function-callback-%%
 * since: v1.8
-- `callback` <[function]>
-  - alias-java: FunctionCallback
-
-Callback function that will be called in the Playwright's context.
 
 ## async method: BrowserContext.grantPermissions
 * since: v1.8

--- a/docs/src/api/class-formdata.md
+++ b/docs/src/api/class-formdata.md
@@ -114,22 +114,14 @@ Field name.
 
 ### param: FormData.append.value
 * since: v1.44
-- `value` <[string]|[boolean]|[int]|[Path]|[Object]>
-  - alias: FilePayload
-  - `name` <[string]> File name
-  - `mimeType` <[string]> File type
-  - `buffer` <[Buffer]> File content
+- `value` <[string]|[boolean]|[int]|[Path]|[Object]> = %%-file-payload-fields-%%
 
 Field value.
 
 ### param: FormData.append.value
 * since: v1.44
 * langs: csharp
-- `value` <[string]|[boolean]|[int]|[Object]>
-  - alias-csharp: FilePayload
-  - `name` <[string]> File name
-  - `mimeType` <[string]> File type
-  - `buffer` <[Buffer]> File content
+- `value` <[string]|[boolean]|[int]|[Object]> = %%-file-payload-fields-%%
 
 Field value.
 
@@ -215,21 +207,13 @@ Field name.
 
 ### param: FormData.set.value
 * since: v1.18
-- `value` <[string]|[boolean]|[int]|[Path]|[Object]>
-  - alias: FilePayload
-  - `name` <[string]> File name
-  - `mimeType` <[string]> File type
-  - `buffer` <[Buffer]> File content
+- `value` <[string]|[boolean]|[int]|[Path]|[Object]> = %%-file-payload-fields-%%
 
 Field value.
 
 ### param: FormData.set.value
 * since: v1.18
 * langs: csharp
-- `value` <[string]|[boolean]|[int]|[Object]>
-  - alias-csharp: FilePayload
-  - `name` <[string]> File name
-  - `mimeType` <[string]> File type
-  - `buffer` <[Buffer]> File content
+- `value` <[string]|[boolean]|[int]|[Object]> = %%-file-payload-fields-%%
 
 Field value.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1826,12 +1826,8 @@ class PageExamples
 
 Name of the function on the window object.
 
-### param: Page.exposeBinding.callback
+### param: Page.exposeBinding.callback = %%-expose-binding-callback-%%
 * since: v1.8
-- `callback` <[function]>
-  - alias-java: BindingCallback
-
-Callback function that will be called in the Playwright's context.
 
 ## async method: Page.exposeFunction
 * since: v1.8
@@ -2020,12 +2016,8 @@ class PageExamples
 
 Name of the function on the window object
 
-### param: Page.exposeFunction.callback
+### param: Page.exposeFunction.callback = %%-expose-function-callback-%%
 * since: v1.8
-- `callback` <[function]>
-  - alias-java: FunctionCallback
-
-Callback function which will be called in Playwright's context.
 
 ## async method: Page.fill
 * since: v1.8

--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -111,13 +111,8 @@ An object with the request HTTP headers. The header names are lower-cased.
 Note that this method does not return security-related headers, including cookie-related ones.
 You can use [`method: Request.allHeaders`] for complete list of headers that include `cookie` information.
 
-## async method: Request.headersArray
+## async method: Request.headersArray = %%-return-headers-array-%%
 * since: v1.15
-- returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
-  - `name` <[string]> Name of the header.
-  - `value` <[string]> Value of the header.
 
 An array with all the request HTTP headers associated with this request. Unlike [`method: Request.allHeaders`], header names are NOT lower-cased.
 Headers with multiple entries, such as `Set-Cookie`, appear in the array multiple times.

--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -46,13 +46,8 @@ An object with the response HTTP headers. The header names are lower-cased.
 Note that this method does not return security-related headers, including cookie-related ones.
 You can use [`method: Response.allHeaders`] for complete list of headers that include `cookie` information.
 
-## async method: Response.headersArray
+## async method: Response.headersArray = %%-return-headers-array-%%
 * since: v1.15
-- returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
-  - `name` <[string]> Name of the header.
-  - `value` <[string]> Value of the header.
 
 An array with all the request HTTP headers associated with this response. Unlike [`method: Response.allHeaders`], header names are NOT lower-cased.
 Headers with multiple entries, such as `Set-Cookie`, appear in the array multiple times.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -127,12 +127,7 @@ and Linux and to "Meta" on macOS.
 Defaults to `left`.
 
 ## input-files
-- `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
-  - alias-csharp: FilePayload
-  - alias-java: FilePayload
-  - `name` <[string]> File name
-  - `mimeType` <[string]> File type
-  - `buffer` <[Buffer]> File content
+- `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>> = %%-file-payload-fields-%%
 
 ## drop-payload
 - `payload` <[Object]>
@@ -1302,6 +1297,32 @@ Specify the color of the overlay box for masked elements, in [CSS color format](
 
 When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to
 `false`.
+
+## return-headers-array
+- returns: <[Array]<[Object]>>
+  - alias-csharp: Header
+  - alias-java: HttpHeader
+  - `name` <[string]> Name of the header.
+  - `value` <[string]> Value of the header.
+
+## file-payload-fields
+- alias-csharp: FilePayload
+- alias-java: FilePayload
+- `name` <[string]> File name
+- `mimeType` <[string]> File type
+- `buffer` <[Buffer]> File content
+
+## expose-binding-callback
+- `callback` <[function]>
+  - alias-java: BindingCallback
+
+Callback function that will be called in the Playwright's context.
+
+## expose-function-callback
+- `callback` <[function]>
+  - alias-java: FunctionCallback
+
+Callback function that will be called in the Playwright's context.
 
 ## screenshot-option-clip
 - `clip` <[Object]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2665,7 +2665,7 @@ export interface Page {
    * ```
    *
    * @param name Name of the function on the window object
-   * @param callback Callback function which will be called in Playwright's context.
+   * @param callback Callback function that will be called in the Playwright's context.
    */
   exposeFunction(name: string, callback: Function): Promise<Disposable>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2665,7 +2665,7 @@ export interface Page {
    * ```
    *
    * @param name Name of the function on the window object
-   * @param callback Callback function which will be called in Playwright's context.
+   * @param callback Callback function that will be called in the Playwright's context.
    */
   exposeFunction(name: string, callback: Function): Promise<Disposable>;
 

--- a/utils/doclint/api_parser.js
+++ b/utils/doclint/api_parser.js
@@ -322,6 +322,8 @@ function applyTemplates(body, params) {
       const template = paramsMap.get(key);
       if (!template)
         throw new Error('Bad template: ' + key);
+      if (!node.children)
+        node.children = [];
       // Insert right after all metadata options like "* since",
       // keeping any additional text like **Usage** below the template.
       let index = node.children.findIndex(child => child.type !== 'li');


### PR DESCRIPTION
## Summary
- Extract three structures with identical sub-fields and identical aliases that were duplicated across class docs into `params.md` mixins:
  - `return-headers-array` — used by `APIResponse.headersArray`, `Request.headersArray`, `Response.headersArray` (csharp:`Header`, java:`HttpHeader`)
  - `expose-binding-callback` — used by `BrowserContext.exposeBinding`, `Page.exposeBinding` (java:`BindingCallback`)
  - `expose-function-callback` — used by `BrowserContext.exposeFunction`, `Page.exposeFunction` (java:`FunctionCallback`)
- `Page.exposeFunction.callback` wording is normalized to match `BrowserContext.exposeFunction.callback` (equivalent meaning, slightly different wording).