### PR TITLE
fix(trace-viewer): sanitize snapshot renderer against XSS from crafted traces

### DIFF
--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -99,6 +99,10 @@ export class SnapshotRenderer {
         }
       } else if (isNodeNameAttributesChildNodesSnapshot(n)) {
         const [name, nodeAttrs, ...children] = n;
+        // Filter SCRIPT elements. The capture side already strips these, but a
+        // crafted trace file could include them to achieve XSS.
+        if (name.toUpperCase() === 'SCRIPT')
+          return;
         // Element node.
         // Note that <noscript> will not be rendered by default in the trace viewer, because
         // JS is enabled. So rename it to <x-noscript>.
@@ -156,7 +160,10 @@ export class SnapshotRenderer {
     const snapshot = this._snapshot;
     const html = this._htmlCache.getOrCompute(this, () => {
       visit(snapshot.html, this._index, undefined, undefined);
-      const prefix = snapshot.doctype ? `<!DOCTYPE ${snapshot.doctype}>` : '';
+      // Sanitize doctype to prevent injection from crafted trace files.
+      // Valid doctype names (from document.doctype.name) only contain alphanumeric characters.
+      const safeDoctype = snapshot.doctype?.replace(/[^a-zA-Z0-9]/g, '');
+      const prefix = safeDoctype ? `<!DOCTYPE ${safeDoctype}>` : '';
       const html = prefix + [
         // Hide the document in order to prevent flickering. We will unhide once script has processed shadow.
         '<style>*,*::before,*::after { visibility: hidden }</style>',


### PR DESCRIPTION
## Summary

- The snapshot renderer did not filter SCRIPT elements or sanitize the doctype field. A crafted trace file could inject `["SCRIPT", {}, "alert(1)"]` into snapshot JSON or use a malicious doctype value to break out of the DOCTYPE declaration and execute arbitrary JavaScript in the trace viewer context.
- The capture side (`snapshotterInjected.ts`) already strips SCRIPT elements and sanitizes attributes, but trace files are untrusted input and the renderer must not rely on the capture side for safety.
- Trace files are routinely shared between team members for debugging and can be opened on [trace.playwright.dev](https://trace.playwright.dev), a public website. The XSS executes automatically when a snapshot renders, with no user interaction beyond opening the trace.
- Skip SCRIPT elements in the renderer (mirrors `snapshotterInjected.ts:364`)
- Sanitize doctype to alphanumeric only (valid doctype names are always alphanumeric)

Follows the same defense-in-depth pattern as #40115 and #14325.