### PR TITLE
chore(bidi): fix support for downloads

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -255,7 +255,7 @@ export class BidiPage implements PageDelegate {
     if (!originPage)
       return;
 
-    this._browserContext._browser.downloadCreated(originPage, event.navigation, event.url, event.suggestedFilename);
+    this._browserContext._browser.downloadCreated(originPage, event.navigation, event.url, event.suggestedFilename, event.suggestedFilename);
   }
 
   private _onDownloadEnded(event: bidi.BrowsingContext.DownloadEndParams) {

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import path from 'path';
-
 import { assert } from '@isomorphic/assert';
+import { resolveWithinRoot } from '@utils/fileUtils';
 import { Page } from './page';
 import { Artifact } from './artifact';
 
@@ -29,7 +28,9 @@ export class Download {
 
   constructor(page: Page, downloadsPath: string, uuid: string, url: string, suggestedFilename?: string, downloadFilename?: string) {
     const unaccessibleErrorMessage = page.browserContext._options.acceptDownloads === 'deny' ? 'Pass { acceptDownloads: true } when you are creating your browser context.' : undefined;
-    const downloadPath = path.join(downloadsPath, downloadFilename ?? uuid);
+    const downloadPath = resolveWithinRoot(downloadsPath, downloadFilename ?? uuid);
+    if (!downloadPath)
+      throw new Error(`Download filename '${downloadFilename}' escapes download directory`);
     this.artifact = new Artifact(page, downloadPath, unaccessibleErrorMessage, () => this.cancel());
     this._page = page;
     this.url = url;


### PR DESCRIPTION
This PR:
- uses the `suggestedFilename` for downloads with Bidi
- uses `resolveWithinRoot()` instead of `path.join()` in the Download constructor to ensure downloads can't escape the download folder

Fixes #40513 and the following tests:
- `library/browsertype-connect.spec.ts`:
  - "launchServer > should save download"
  - "run-server > should save download"
- `library/defaultbrowsercontext-1.spec.ts`:
  - "should support acceptDownloads option"
- `library/download.spec.ts`:
  - "download event > should report download when navigation turns into download"
  - "download event > should work with Cross-Origin-Opener-Policy"
  - "download event > should report downloads with acceptDownloads: true"
  - "download event > should report downloads for download attribute"
  - "download event > should save to user-specified path without updating original path"
  - "download event > should save to two different paths with multiple saveAs calls"
  - "download event > should save to overwritten filepath"
  - "download event > should create subdirectories when saving to non-existent user-specified path"
  - "download event > should report non-navigation downloads"
  - "download event > should report download path within page.on('download', …) handler for Files"
  - "download event > should delete file"
  - "download event > should expose stream"
  - "download event > should delete downloads on context destruction"
  - "download event > should delete downloads on browser gone"
  - "download event > should download large binary.zip"
  - "download event > should not fail explicitly to cancel a download even if that is already finished"
  - "download event > should report downloads with interception"
  - "download event > should emit download event from nested iframes"
  - "should be able to download a PDF file"
  - "should be able to download a inline PDF file via response interception"
  - "should save to user-specified path"
- `library/downloads-path.spec.ts`:
  - "downloads path > should delete downloads when context closes"
  - "downloads path > should delete downloads when persistent context closes"
