### PR TITLE
test(bidi): allow firefoxUserPrefs in Playwright's own tests

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -373,7 +373,7 @@ function filterLaunchOptions(options: LaunchOptionsWithTimeout, allowUnsafe: boo
     headless: options.headless,
     proxy: options.proxy,
     chromiumSandbox: allowUnsafe ? options.chromiumSandbox : undefined,
-    firefoxUserPrefs: allowUnsafe ? options.firefoxUserPrefs : undefined,
+    firefoxUserPrefs: (isUnderTest() || allowUnsafe) ? options.firefoxUserPrefs : undefined,
     slowMo: options.slowMo,
     executablePath: (isUnderTest() || allowUnsafe) ? options.executablePath : undefined,
     downloadsPath: allowUnsafe ? options.downloadsPath : undefined,


### PR DESCRIPTION
Fixes the following tests in `library/browsertype-connect.spec.ts`:
- "run-server > socks proxy > should proxy based on the pattern"
- "run-server > socks proxy > should proxy ipv6 localhost requests"
- "run-server > socks proxy > should proxy localhost requests"
