### PR TITLE
feat(dashboard): add Overview mode showing all tabs as a live grid

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -19,6 +19,7 @@ import './dashboard.css';
 import { ChevronLeftIcon, ChevronRightIcon, LockIcon, LockOpenIcon, ReloadIcon, ScreenshotRegionIcon } from './icons';
 import { AnnotateModal } from './annotations';
 import { clientToViewport, getImageLayout } from './imageLayout';
+import { OverviewGrid } from './overviewGrid';
 import { Recording } from './recording';
 
 import type { Annotation } from './annotations';
@@ -67,7 +68,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ model }) => {
   const [, setRevision] = React.useState(0);
   React.useEffect(() => model.subscribe(() => setRevision(r => r + 1)), [model]);
 
-  const { tabs, mode, recording, liveFrame, annotateFrame, annotateInitiator, pendingAnnotate } = model.state;
+  const { tabs, mode, recording, liveFrame, annotateFrame, annotateInitiator, pendingAnnotate, overview } = model.state;
   const interactive = mode === 'interactive';
 
   const [flashTick, setFlashTick] = React.useState(0);
@@ -244,7 +245,15 @@ export const Dashboard: React.FC<DashboardProps> = ({ model }) => {
   const isRecording = recording?.phase === 'recording';
   const showAnnotateModal = !!annotateFrame;
   const showRecording = recording?.phase === 'stopped';
-  const modeLabel = showAnnotateModal ? 'Dashboard: annotate' : isRecording ? 'Dashboard: record' : 'Dashboard';
+  const modeLabel = overview ? 'Dashboard: overview' : showAnnotateModal ? 'Dashboard: annotate' : isRecording ? 'Dashboard: record' : 'Dashboard';
+
+  if (overview) {
+    return (
+      <main className='dashboard-view dashboard-view-overview' aria-label={modeLabel}>
+        <OverviewGrid model={model} />
+      </main>
+    );
+  }
 
   return (
     <main className={'dashboard-view' + (interactive ? ' interactive' : '')} aria-label={modeLabel}>

--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -35,7 +35,7 @@ export type AnnotationData = { x: number; y: number; width: number; height: numb
 export type DashboardChannelEvents = {
   sessions: { sessions: SessionStatus[]; clientInfo: ClientInfo };
   tabs: { tabs: Tab[] };
-  frame: { data: string; viewportWidth: number; viewportHeight: number };
+  frame: { page: string; data: string; viewportWidth: number; viewportHeight: number };
   annotate: {};
   cancelAnnotate: {};
 };
@@ -48,6 +48,7 @@ export interface DashboardChannel {
   newTab(params: { browser: string; context: string }): Promise<void>;
   closeSession(params: { browser: string }): Promise<void>;
   setVisible(params: { visible: boolean }): Promise<void>;
+  setOverview(params: { enabled: boolean }): Promise<void>;
 
   navigate(params: { url: string }): Promise<void>;
   back(): Promise<void>;

--- a/packages/dashboard/src/dashboardModel.ts
+++ b/packages/dashboard/src/dashboardModel.ts
@@ -37,6 +37,8 @@ export type DashboardState = {
   // Dashboard / page state.
   tabs: Tab[] | null;
   liveFrame: DashboardChannelEvents['frame'] | undefined;
+  liveFrames: Map<string, DashboardChannelEvents['frame']>;
+  overview: boolean;
   annotateFrame: AnnotateFrame | undefined;
   pendingAnnotate: { initiator: 'cli' | 'user' } | null;
   annotateInitiator: 'cli' | 'user' | null;
@@ -52,6 +54,8 @@ const initialState: DashboardState = {
   loadingSessions: true,
   tabs: null,
   liveFrame: undefined,
+  liveFrames: new Map(),
+  overview: false,
   annotateFrame: undefined,
   pendingAnnotate: null,
   annotateInitiator: null,
@@ -71,10 +75,32 @@ export class DashboardModel {
   constructor(client: DashboardChannel) {
     this._client = client;
     client.on('sessions', params => this._emit({ sessions: params.sessions, clientInfo: params.clientInfo, loadingSessions: false }));
-    client.on('tabs', params => this._emit({ tabs: params.tabs }));
-    client.on('frame', params => this._emit({ liveFrame: params }));
+    client.on('tabs', params => this._onTabs(params.tabs));
+    client.on('frame', params => this._onFrame(params));
     client.on('annotate', () => this.enterAnnotate('cli'));
     client.on('cancelAnnotate', () => this.cancelAnnotate());
+  }
+
+  private _onFrame(params: DashboardChannelEvents['frame']) {
+    const liveFrames = new Map(this.state.liveFrames);
+    liveFrames.set(params.page, params);
+    const selectedPage = this.state.tabs?.find(t => t.selected)?.page;
+    const partial: Partial<DashboardState> = { liveFrames };
+    if (selectedPage === params.page)
+      partial.liveFrame = params;
+    this._emit(partial);
+  }
+
+  private _onTabs(tabs: Tab[]) {
+    const validIds = new Set(tabs.map(t => t.page));
+    const liveFrames = new Map<string, DashboardChannelEvents['frame']>();
+    for (const [id, frame] of this.state.liveFrames) {
+      if (validIds.has(id))
+        liveFrames.set(id, frame);
+    }
+    const selectedPage = tabs.find(t => t.selected)?.page;
+    const liveFrame = selectedPage ? liveFrames.get(selectedPage) : undefined;
+    this._emit({ tabs, liveFrames, liveFrame });
   }
 
   subscribe(listener: Listener): () => void {
@@ -96,9 +122,36 @@ export class DashboardModel {
     void this._client.setVisible({ visible });
   }
 
+  toggleOverview() {
+    void this.setOverview(!this.state.overview);
+  }
+
+  async setOverview(enabled: boolean) {
+    if (this.state.overview === enabled)
+      return;
+    if (enabled)
+      await this._cleanupOnModeSwitch();
+    this._emit({ overview: enabled });
+    try {
+      await this._client.setOverview({ enabled });
+    } catch {
+      // best-effort; revert on failure
+      this._emit({ overview: !enabled });
+    }
+  }
+
   // Tab actions.
 
   selectTab(tab: Tab) {
+    if (this.state.tabs) {
+      const optimisticTabs = this.state.tabs.map(t => ({
+        ...t,
+        selected: t.page === tab.page,
+      }));
+      this._onTabs(optimisticTabs);
+    }
+    if (this.state.overview)
+      void this.setOverview(false);
     void this._client.selectTab({ browser: tab.browser, context: tab.context, page: tab.page });
   }
 

--- a/packages/dashboard/src/icons.tsx
+++ b/packages/dashboard/src/icons.tsx
@@ -120,6 +120,15 @@ export const ReloadIcon: React.FC = () => (
   </svg>
 );
 
+export const GridIcon: React.FC = () => (
+  <svg width='14' height='14' viewBox='0 0 16 16' fill='none' stroke='currentColor' strokeWidth='1.5' aria-hidden='true'>
+    <rect x='1.75' y='1.75' width='5' height='5' rx='1.25'/>
+    <rect x='9.25' y='1.75' width='5' height='5' rx='1.25'/>
+    <rect x='1.75' y='9.25' width='5' height='5' rx='1.25'/>
+    <rect x='9.25' y='9.25' width='5' height='5' rx='1.25'/>
+  </svg>
+);
+
 export const InspectorPanelIcon: React.FC = () => (
   <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
     <rect x='3' y='3' width='18' height='18' rx='2'/>

--- a/packages/dashboard/src/overviewGrid.css
+++ b/packages/dashboard/src/overviewGrid.css
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.overview-grid {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  padding: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  align-content: start;
+}
+
+.overview-empty {
+  grid-column: 1 / -1;
+  color: var(--color-fg-subtle);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+
+.overview-tile {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.1s ease, transform 0.1s ease;
+}
+
+.overview-tile:hover {
+  border-color: var(--color-accent-fg);
+  transform: translateY(-1px);
+}
+
+.overview-tile:focus-visible {
+  outline: 2px solid var(--color-accent-fg);
+  outline-offset: 2px;
+}
+
+.overview-tile-chrome {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  height: 32px;
+  min-height: 32px;
+  padding: 0 8px;
+  background: var(--color-canvas-subtle);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+:root:not(.light-mode) .overview-tile-chrome {
+  background: var(--color-canvas-overlay);
+}
+
+.overview-tile-omnibox {
+  flex: 1;
+  min-width: 0;
+  height: 22px;
+  line-height: 22px;
+  padding: 0 10px;
+  font-size: 12px;
+  color: var(--color-fg-default);
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+:root:not(.light-mode) .overview-tile-omnibox {
+  background: var(--color-canvas-inset);
+}
+
+.overview-tile-screen {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  min-height: 160px;
+  background: var(--color-canvas-subtle);
+  overflow: hidden;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.overview-tile-screen img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.overview-tile-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 160px;
+  background: linear-gradient(135deg, var(--color-canvas-subtle) 25%, var(--color-canvas-overlay) 50%, var(--color-canvas-subtle) 75%);
+  background-size: 400% 400%;
+  animation: overview-shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes overview-shimmer {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}

--- a/packages/dashboard/src/overviewGrid.tsx
+++ b/packages/dashboard/src/overviewGrid.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import './overviewGrid.css';
+
+import type { Tab } from './dashboardChannel';
+import type { DashboardModel } from './dashboardModel';
+
+type OverviewGridProps = {
+  model: DashboardModel;
+};
+
+export const OverviewGrid: React.FC<OverviewGridProps> = ({ model }) => {
+  const { tabs, liveFrames } = model.state;
+  const items = tabs ?? [];
+  return (
+    <div className='overview-grid' role='list' aria-label='All tabs overview'>
+      {items.length === 0 && (
+        <div className='overview-empty' role='status' aria-live='polite'>No open tabs.</div>
+      )}
+      {items.map(tab => (
+        <OverviewTile
+          key={tab.page}
+          tab={tab}
+          frame={liveFrames.get(tab.page)}
+          onClick={() => model.selectTab(tab)}
+        />
+      ))}
+    </div>
+  );
+};
+
+type OverviewTileProps = {
+  tab: Tab;
+  frame: { data: string } | undefined;
+  onClick: () => void;
+};
+
+const OverviewTile: React.FC<OverviewTileProps> = ({ tab, frame, onClick }) => {
+  return (
+    <button
+      className='overview-tile'
+      role='listitem'
+      onClick={onClick}
+      title={tab.title || tab.url}
+    >
+      <div className='overview-tile-chrome'>
+        <div className='overview-tile-omnibox'>{tab.url || 'about:blank'}</div>
+      </div>
+      <div className='overview-tile-screen'>
+        {frame
+          ? <img alt='' src={'data:image/jpeg;base64,' + frame.data} />
+          : <div className='overview-tile-placeholder' aria-hidden='true' />}
+      </div>
+    </button>
+  );
+};

--- a/packages/dashboard/src/sessionSidebar.css
+++ b/packages/dashboard/src/sessionSidebar.css
@@ -43,6 +43,25 @@
   letter-spacing: 0.03em;
 }
 
+.dashboard-overview-toggle.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
+  height: 24px;
+}
+
+.dashboard-overview-toggle.toolbar-button.toggled {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground, var(--color-fg-default));
+}
+
+.dashboard-overview-toggle-label {
+  line-height: 1;
+}
+
 .dashboard-shell-sidebar-content {
   flex: 1;
   overflow: auto;

--- a/packages/dashboard/src/sessionSidebar.tsx
+++ b/packages/dashboard/src/sessionSidebar.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import './sessionSidebar.css';
 import { SettingsButton } from './settingsView';
-import { BrowserIcon } from './icons';
+import { BrowserIcon, GridIcon } from './icons';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { ListView } from '@web/components/listView';
 
@@ -77,7 +77,7 @@ const TabRow: React.FC<{ tab: Tab; model: DashboardModel }> = ({ tab, model }) =
 };
 
 export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model }) => {
-  const { sessions, clientInfo, loadingSessions, tabs: allTabs } = model.state;
+  const { sessions, clientInfo, loadingSessions, tabs: allTabs, overview } = model.state;
   const openSessions = sessions;
 
   const tabsByBrowserAndContext = React.useMemo(() => {
@@ -123,7 +123,15 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model }) => {
 
   return <nav className='dashboard-shell-sidebar' aria-label='Sessions'>
     <div className='dashboard-shell-sidebar-header'>
-      <h2 className='dashboard-shell-sidebar-title'>Sessions</h2>
+      <ToolbarButton
+        className='dashboard-overview-toggle'
+        title={model.state.overview ? 'Exit overview' : 'Show overview of all tabs'}
+        toggled={model.state.overview}
+        onClick={() => model.toggleOverview()}
+      >
+        <GridIcon />
+        <span className='dashboard-overview-toggle-label'>Overview</span>
+      </ToolbarButton>
       <SettingsButton />
     </div>
     <div className='dashboard-shell-sidebar-content'>
@@ -148,7 +156,8 @@ export const SessionSidebar: React.FC<SessionSidebarProps> = ({ model }) => {
                   ? [{ contextGuid: null, tabs: [] }]
                   : contextEntries.map(([contextGuid, tabs]) => ({ contextGuid, tabs }));
             return rows.map((row, rowIdx) => {
-              const activeTab = row.tabs?.find(t => t.context === activeContext && t.selected);
+              const realActiveTab = row.tabs?.find(t => t.context === activeContext && t.selected);
+              const activeTab = overview ? undefined : realActiveTab;
               const rowKey = `${guid}-${row.contextGuid ?? `placeholder-${rowIdx}`}`;
               return <section
                 key={rowKey}

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -37,6 +37,8 @@ export class DashboardConnection implements Transport {
 
   private _provider: SessionProvider;
   private _attachedPage: AttachedPage | undefined;
+  private _overviewPages: Map<string, OverviewPage> = new Map();
+  private _overviewEnabled = false;
   private _onclose: () => void;
   private _onconnected?: () => void;
   private _onAnnotationSubmit?: (base64Png: string | undefined, ariaSnapshot: string, annotations: AnnotationData[]) => void;
@@ -60,12 +62,24 @@ export class DashboardConnection implements Transport {
     this._provider.on(SessionProviderEvent.SessionsChanged, () => {
       this._pushSessions();
       void this._tryRevealPending();
+      if (this._overviewEnabled)
+        void this._syncOverview();
     });
-    this._provider.on(SessionProviderEvent.TabsChanged, () => this._pushTabs());
+    this._provider.on(SessionProviderEvent.TabsChanged, () => {
+      this._pushTabs();
+      if (this._overviewEnabled)
+        void this._syncOverview();
+    });
     this._provider.on(SessionProviderEvent.ContextClosed, context => {
       if (this._attachedPage?.page.context() === context) {
         this._attachedPage.dispose();
         this._attachedPage = undefined;
+      }
+      for (const [id, op] of this._overviewPages) {
+        if (op.page.context() === context) {
+          op.dispose();
+          this._overviewPages.delete(id);
+        }
       }
     });
     this._provider.on(SessionProviderEvent.AttachRequested, page => { void this._switchAttachedTo(page); });
@@ -77,6 +91,9 @@ export class DashboardConnection implements Transport {
     this._provider.dispose();
     this._attachedPage?.dispose();
     this._attachedPage = undefined;
+    for (const op of this._overviewPages.values())
+      op.dispose();
+    this._overviewPages.clear();
     for (const stream of this._streams.values()) {
       void stream.handle.close()
           .catch(() => {})
@@ -131,6 +148,56 @@ export class DashboardConnection implements Transport {
       return;
     this._visible = params.visible;
     await this._attachedPage?.setScreencastActive(params.visible);
+    for (const op of this._overviewPages.values())
+      await op.setScreencastActive(params.visible);
+  }
+
+  async setOverview(params: { enabled: boolean }) {
+    if (this._overviewEnabled === params.enabled)
+      return;
+    this._overviewEnabled = params.enabled;
+    if (params.enabled) {
+      await this._syncOverview();
+    } else {
+      for (const op of this._overviewPages.values())
+        op.dispose();
+      this._overviewPages.clear();
+    }
+  }
+
+  private async _syncOverview() {
+    if (!this._overviewEnabled)
+      return;
+    const attachedPageObj = this._attachedPage?.page;
+    const wantedPages = new Map<string, api.Page>();
+    for (const { context } of this._provider.contextEntries()) {
+      for (const page of context.pages()) {
+        // The primary attached page already streams its own frames via
+        // AttachedPage.startScreencast; skip it here to avoid double-attach.
+        if (page === attachedPageObj)
+          continue;
+        wantedPages.set(pageId(page), page);
+      }
+    }
+    for (const [id, op] of this._overviewPages) {
+      if (!wantedPages.has(id) || wantedPages.get(id) !== op.page) {
+        op.dispose();
+        this._overviewPages.delete(id);
+      }
+    }
+    for (const [id, page] of wantedPages) {
+      if (this._overviewPages.has(id))
+        continue;
+      const op = new OverviewPage(this, page, id);
+      this._overviewPages.set(id, op);
+      try {
+        if (this._visible)
+          await op.setScreencastActive(true);
+      } catch {
+        op.dispose();
+        this._overviewPages.delete(id);
+      }
+    }
   }
 
   revealSession(sessionName: string, workspaceDir?: string) {
@@ -208,8 +275,8 @@ export class DashboardConnection implements Transport {
     this.sendEvent?.('tabs', { tabs });
   }
 
-  emitFrame(data: string, viewportWidth: number, viewportHeight: number) {
-    this.sendEvent?.('frame', { data, viewportWidth, viewportHeight });
+  emitFrame(pageId: string, data: string, viewportWidth: number, viewportHeight: number) {
+    this.sendEvent?.('frame', { page: pageId, data, viewportWidth, viewportHeight });
   }
 
   emitAnnotate() {
@@ -297,6 +364,8 @@ export class DashboardConnection implements Transport {
       this._annotateWaitingForAttach = false;
       this.sendEvent?.('annotate', {});
     }
+    if (this._overviewEnabled)
+      await this._syncOverview();
   }
 
   _handleAttachedPageClose(context: api.BrowserContext) {
@@ -452,7 +521,7 @@ class AttachedPage {
         if (this._disposed)
           return;
         const vp = page.viewportSize();
-        this._owner.emitFrame(data.toString('base64'), vp?.width ?? 0, vp?.height ?? 0);
+        this._owner.emitFrame(pageId(page), data.toString('base64'), vp?.width ?? 0, vp?.height ?? 0);
       },
       size: { width: 1280, height: 800 },
       ...(this._recordingPath ? { path: this._recordingPath } : {}),
@@ -462,6 +531,54 @@ class AttachedPage {
   private async _restartScreencast(page: api.Page) {
     await page.screencast.stop().catch(() => {});
     await this._startScreencast(page);
+  }
+}
+
+class OverviewPage {
+  private _owner: DashboardConnection;
+  private _page: api.Page;
+  private _pageId: string;
+  private _running = false;
+  private _disposed = false;
+
+  constructor(owner: DashboardConnection, page: api.Page, id: string) {
+    this._owner = owner;
+    this._page = page;
+    this._pageId = id;
+  }
+
+  get page(): api.Page { return this._page; }
+
+  async setScreencastActive(active: boolean) {
+    if (this._disposed)
+      return;
+    if (active && !this._running) {
+      this._running = true;
+      try {
+        await this._page.screencast.start({
+          onFrame: ({ data }: { data: Buffer }) => {
+            if (this._disposed)
+              return;
+            const vp = this._page.viewportSize();
+            this._owner.emitFrame(this._pageId, data.toString('base64'), vp?.width ?? 0, vp?.height ?? 0);
+          },
+          size: { width: 640, height: 400 },
+        });
+      } catch (e) {
+        this._running = false;
+        throw e;
+      }
+    } else if (!active && this._running) {
+      this._running = false;
+      await this._page.screencast.stop().catch(() => {});
+    }
+  }
+
+  dispose() {
+    this._disposed = true;
+    if (this._running)
+      this._page.screencast.stop().catch(() => {});
+    this._running = false;
   }
 }
 

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -496,3 +496,44 @@ test('save recording streams WebM bytes to the chosen file', async ({ cli, serve
   // WebM files start with the EBML magic bytes.
   expect(bytes.subarray(0, 4)).toEqual(Buffer.from([0x1a, 0x45, 0xdf, 0xa3]));
 });
+
+test('overview mode shows a grid tile for every tab and selecting one exits overview', async ({ boundBrowser, server, startDashboardServer }) => {
+  const contextA = await boundBrowser.newContext();
+  const pageA = await contextA.newPage();
+  await pageA.goto(server.EMPTY_PAGE);
+
+  const contextB = await boundBrowser.newContext();
+  const pageB = await contextB.newPage();
+  await pageB.goto(server.PREFIX + '/title.html');
+
+  const dashboard = await startDashboardServer();
+  await expect(dashboard.getByRole('region', { name: /^Session / })).toHaveCount(2);
+
+  // Toggle overview on.
+  await dashboard.getByRole('button', { name: /overview/i }).click();
+
+  await expect(dashboard.getByRole('main', { name: 'Dashboard: overview' })).toBeVisible();
+  // No tab is selected in the sidebar while overview is active.
+  await expect(dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option', { selected: true })).toHaveCount(0);
+  const grid = dashboard.getByRole('list', { name: 'All tabs overview' });
+  await expect(grid).toBeVisible();
+  const tiles = grid.getByRole('listitem');
+  await expect(tiles).toHaveCount(2);
+
+  // The toolbar (interactive / annotate / record buttons) is not shown in overview.
+  await expect(dashboard.getByRole('button', { name: /interactive mode/i })).toHaveCount(0);
+
+  // Clicking a tile exits overview and selects that tab.
+  await tiles.first().click();
+  await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
+  await expect(dashboard.locator('img#display')).toBeVisible();
+  const sessions = dashboard.getByRole('navigation', { name: 'Sessions' });
+  await expect(sessions.getByRole('option', { selected: true })).toHaveCount(1);
+
+  // Toggling overview on then off restores the previous selection (display-only).
+  const toggle = dashboard.getByRole('button', { name: /overview/i });
+  await toggle.click();
+  await expect(sessions.getByRole('option', { selected: true })).toHaveCount(0);
+  await toggle.click();
+  await expect(sessions.getByRole('option', { selected: true })).toHaveCount(1);
+});


### PR DESCRIPTION
Stashed for now — team likes the UI but wants to validate customer need and perf characteristics before pursuing. Closing immediately so the diff is preserved for future reference.

## Summary
- New "Overview" toggle in the sidebar header replaces the "Sessions" header
- When toggled on, the main pane shows a live grid of screencast tiles for every tab across all sessions
- Clicking a tile selects that tab and exits overview
- Sidebar selection is hidden (display-only) while overview is on; toggling off restores it
