### PR TITLE
Revert "fix(dashboard): close server in singleton handler on shutdown (#40626)"

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -280,9 +280,7 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     const server = net.createServer();
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      const isInUse = err.code === 'EADDRINUSE'
-          || (process.platform === 'win32' && err.code === 'EBUSY');
-      if (!isInUse)
+      if (err.code !== 'EADDRINUSE')
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');
@@ -352,7 +350,6 @@ export async function openDashboardApp() {
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
         } else if (parsed.kill) {
-          server?.close();
           socket.end();
           gracefullyProcessExitDoNotHang(0);
         } else {


### PR DESCRIPTION
Reverts #40626 — the EBUSY check and `server?.close()` in the kill handler added there are not needed. The real fix for the Windows named pipe race is in #40642.