### PR TITLE
fix(trace): await pending stack writer before deleting stack session

### DIFF
--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -129,6 +129,7 @@ async function deleteStackSession(progress: Progress, stackSessions: Map<string,
   const session = stacksId ? stackSessions.get(stacksId) : undefined;
   if (!session)
     return;
+  await progress.race(session.writer);
   stackSessions.delete(stacksId!);
   if (session.tmpDir)
     await progress.race(removeFolders([session.tmpDir]));


### PR DESCRIPTION
## Summary

Fixes a race that produces intermittent missing-`.stacks` (and sometimes `.network`) failures in the MCP tracing tests on CI, e.g.:

https://github.com/microsoft/playwright/actions/runs/25439080489/job/74625000623#step:3:799

```
- StringMatching /trace-\d+\.stacks/,
- StringMatching /trace-\d+\.trace/,
+ "trace-1778076470380.trace",
```

### The race

When tracing is started in `live: true` mode, every API call schedules an `addStackToTracingNoReply` over the `LocalUtils` channel. On the server, those writes are chained onto `session.writer`:

```ts
session.writer = session.writer.then(() => {
  const buffer = Buffer.from(JSON.stringify(serializeClientSideCallMetadata(session.callStacks)));
  return fs.promises.writeFile(session.file, buffer);
});
```

The client side fires those calls and forgets (`.catch(() => {})`).

When a chunk is *discarded* (which is what mcp's `browser_stop_tracing` does — it calls `tracing.stop()` with no path, taking the discard branch in `_doStopChunk`), the client invokes `traceDiscarded` → `deleteStackSession`. The server previously deleted the session from the map and removed the tmp dir without awaiting the in-flight `session.writer`. So the final `.stacks` write could land on disk *after* the test (or the next tool) inspected the traces directory, producing the flake.

### Fix

`deleteStackSession` now awaits `session.writer` (via `progress.race`) before removing the session, matching the existing pattern in `zip()`.
