### PR TITLE
refactor(server): introduce SdkObject._type and DispatcherConnection.dispatcherFor

### DIFF
--- a/packages/playwright-core/src/cli/DEPS.list
+++ b/packages/playwright-core/src/cli/DEPS.list
@@ -4,6 +4,7 @@
 ../inprocess.ts
 ../package.ts
 ../server/
+../server/dispatchers/
 ../server/registry/
 ../remote/
 ../server/trace/viewer/

--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -25,6 +25,7 @@ import { packageRoot } from '../package';
 import { playwright } from '../inprocess';
 import { PlaywrightServer } from '../remote/playwrightServer';
 import { DispatcherConnection, PlaywrightDispatcher, RootDispatcher, createPlaywright } from '../server';
+import { populateBuiltinDispatcherFactories } from '../server/dispatchers/builtinFactories';
 
 import type { BrowserType } from '../client/browserType';
 import type { LaunchServerOptions } from '../client/types';
@@ -36,6 +37,7 @@ export function printApiJson() {
 
 export function runDriver() {
   const dispatcherConnection = new DispatcherConnection();
+  populateBuiltinDispatcherFactories(dispatcherConnection);
   new RootDispatcher(dispatcherConnection, async (rootScope, { sdkLanguage }) => {
     const playwright = createPlaywright({ sdkLanguage });
     return new PlaywrightDispatcher(rootScope, playwright);

--- a/packages/playwright-core/src/inprocess.ts
+++ b/packages/playwright-core/src/inprocess.ts
@@ -19,6 +19,7 @@ import { AndroidServerLauncherImpl } from './androidServerImpl';
 import { BrowserServerLauncherImpl } from './browserServerImpl';
 import { Electron } from './electron/electron';
 import { DispatcherConnection, PlaywrightDispatcher, RootDispatcher, createPlaywright } from './server';
+import { populateBuiltinDispatcherFactories } from './server/dispatchers/builtinFactories';
 import { Connection } from './client/connection';
 import { packageRoot } from './package';
 
@@ -30,6 +31,7 @@ export function createInProcessPlaywright(): PlaywrightAPI {
   const clientConnection = new Connection(nodePlatform(packageRoot));
   clientConnection.useRawBuffers();
   const dispatcherConnection = new DispatcherConnection(true /* local */);
+  populateBuiltinDispatcherFactories(dispatcherConnection);
 
   // Dispatch synchronously at first.
   dispatcherConnection.onmessage = message => clientConnection.dispatch(message);

--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -19,6 +19,7 @@ import { debugLogger } from '@utils/debugLogger';
 import { monotonicTime } from '@isomorphic/time';
 import { Semaphore } from '@isomorphic/semaphore';
 import { DispatcherConnection, PlaywrightDispatcher, RootDispatcher } from '../server';
+import { populateBuiltinDispatcherFactories } from '../server/dispatchers/builtinFactories';
 import { AndroidDevice } from '../server/android/android';
 import { Browser } from '../server/browser';
 import { DebugControllerDispatcher } from '../server/dispatchers/debugControllerDispatcher';
@@ -50,6 +51,7 @@ export class PlaywrightConnection {
     const lock = this._semaphore.acquire();
 
     this._dispatcherConnection = new DispatcherConnection();
+    populateBuiltinDispatcherFactories(this._dispatcherConnection);
     this._dispatcherConnection.onmessage = async message => {
       await lock;
       if (!transport.isClosed()) {

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -68,7 +68,7 @@ export class Android extends SdkObject {
   private _devices = new Map<string, AndroidDevice>();
 
   constructor(parent: SdkObject, backend: Backend) {
-    super(parent, 'android');
+    super(parent, 'Android', 'android');
     this._backend = backend;
   }
 
@@ -115,7 +115,7 @@ export class AndroidDevice extends SdkObject {
   private _isClosed = false;
 
   constructor(android: Android, backend: DeviceBackend, model: string, options: channels.AndroidDevicesOptions) {
-    super(android, 'android-device');
+    super(android, 'AndroidDevice', 'android-device');
     this._android = android;
     this._backend = backend;
     this.model = model;

--- a/packages/playwright-core/src/server/artifact.ts
+++ b/packages/playwright-core/src/server/artifact.ts
@@ -37,7 +37,7 @@ export class Artifact extends SdkObject {
   private _failureErrorValue: Error | undefined;
 
   constructor(parent: SdkObject, localPath: string, unaccessibleErrorMessage?: string, cancelCallback?: CancelCallback) {
-    super(parent, 'artifact');
+    super(parent, 'Artifact', 'artifact');
     this._localPath = localPath;
     this._unaccessibleErrorMessage = unaccessibleErrorMessage;
     this._cancelCallback = cancelCallback;

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -83,7 +83,7 @@ export abstract class Browser extends SdkObject {
   private _server: BrowserServer;
 
   constructor(parent: SdkObject, options: BrowserOptions) {
-    super(parent, 'browser');
+    super(parent, 'Browser', 'browser');
     this.attribution.browser = this;
     this.options = options;
     this.instrumentation.onBrowserOpen(this);

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -116,7 +116,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
   private _consoleApiExposed = false;
 
   constructor(browser: Browser, options: types.BrowserContextOptions, browserContextId: string | undefined) {
-    super(browser, 'browser-context');
+    super(browser, 'BrowserContext', 'browser-context');
     this.attribution.context = this;
     this._browser = browser;
     this._options = options;

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -50,7 +50,7 @@ export abstract class BrowserType extends SdkObject {
   private _name: BrowserName;
 
   constructor(parent: SdkObject, browserName: BrowserName) {
-    super(parent, 'browser-type');
+    super(parent, 'BrowserType', 'browser-type');
     this.attribution.browserType = this;
     this._name = browserName;
     this.logName = 'browser';

--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -53,7 +53,7 @@ export class CRConnection extends SdkObject {
   _closed = false;
 
   constructor(parent: SdkObject, transport: ConnectionTransport, protocolLogger: ProtocolLogger, browserLogsCollector: RecentLogsCollector) {
-    super(parent, 'cr-connection');
+    super(parent, 'CRConnection', 'cr-connection');
     this.setMaxListeners(0);
     this._transport = transport;
     this._protocolLogger = protocolLogger;
@@ -116,7 +116,7 @@ export class CRSession extends SdkObject<Protocol.EventMap & ConnectionEventMap>
   private _closed = false;
 
   constructor(connection: CRConnection, parentSession: CRSession | null, sessionId: string, eventListener?: SessionEventListener) {
-    super(connection, 'cr-session');
+    super(connection, 'CRSession', 'cr-session');
     this.setMaxListeners(0);
     this._connection = connection;
     this._parentSession = parentSession;
@@ -207,7 +207,7 @@ export class CDPSession extends SdkObject {
   private _listeners: RegisteredListener[] = [];
 
   constructor(parentSession: CRSession, sessionId: string) {
-    super(parentSession, 'cdp-session');
+    super(parentSession, 'CDPSession', 'cdp-session');
     this._session = parentSession.createChildSession(sessionId, (method, params) => this.emit(CDPSession.Events.Event, { method, params }));
     this._listeners = [eventsHelper.addEventListener(parentSession, 'Target.detachedFromTarget', (event: Protocol.Target.detachedFromTargetPayload) => {
       if (event.sessionId === sessionId)

--- a/packages/playwright-core/src/server/debugController.ts
+++ b/packages/playwright-core/src/server/debugController.ts
@@ -48,7 +48,7 @@ export class DebugController extends SdkObject {
   _generateAutoExpect = false;
 
   constructor(playwright: Playwright) {
-    super({ attribution: { isInternalPlaywright: true }, instrumentation: createInstrumentation() } as any, undefined, 'DebugController');
+    super({ attribution: { isInternalPlaywright: true }, instrumentation: createInstrumentation() } as any, 'DebugController', undefined, 'DebugController');
     this._playwright = playwright;
   }
 

--- a/packages/playwright-core/src/server/debugger.ts
+++ b/packages/playwright-core/src/server/debugger.ts
@@ -39,7 +39,7 @@ export class Debugger extends SdkObject implements InstrumentationListener {
   private _muted = false;
 
   constructor(context: BrowserContext) {
-    super(context, 'debugger');
+    super(context, 'Debugger', 'debugger');
     this._context = context;
     (this._context as any)[symbol] = this;
     context.instrumentation.addListener(this, context);

--- a/packages/playwright-core/src/server/dialog.ts
+++ b/packages/playwright-core/src/server/dialog.ts
@@ -28,16 +28,16 @@ export type DialogType = 'alert' | 'beforeunload' | 'confirm' | 'prompt';
 
 export class Dialog extends SdkObject {
   private _page: Page;
-  private _type: DialogType;
+  private _dialogType: DialogType;
   private _message: string;
   private _onHandle: OnHandle;
   private _handled = false;
   private _defaultValue: string;
 
   constructor(page: Page, type: DialogType, message: string, onHandle: OnHandle, defaultValue?: string) {
-    super(page, 'dialog');
+    super(page, 'Dialog', 'dialog');
     this._page = page;
-    this._type = type;
+    this._dialogType = type;
     this._message = message;
     this._onHandle = onHandle;
     this._defaultValue = defaultValue || '';
@@ -56,7 +56,7 @@ export class Dialog extends SdkObject {
   }
 
   type(): string {
-    return this._type;
+    return this._dialogType;
   }
 
   message(): string {
@@ -82,7 +82,7 @@ export class Dialog extends SdkObject {
   }
 
   async _close() {
-    if (this._type === 'beforeunload')
+    if (this._dialogType === 'beforeunload')
       await this._accept();
     else
       await this._dismiss();

--- a/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/androidDispatcher.ts
@@ -29,7 +29,7 @@ export class AndroidDispatcher extends Dispatcher<Android, channels.AndroidChann
   _type_Android = true;
   private readonly _denyLaunch: boolean;
   constructor(scope: RootDispatcher, android: Android, denyLaunch: boolean) {
-    super(scope, android, 'Android', {});
+    super(scope, android, {});
     this._denyLaunch = denyLaunch;
   }
 
@@ -53,7 +53,7 @@ export class AndroidDeviceDispatcher extends Dispatcher<AndroidDevice, channels.
   }
 
   constructor(scope: AndroidDispatcher, device: AndroidDevice) {
-    super(scope, device, 'AndroidDevice', {
+    super(scope, device, {
       model: device.model,
       serial: device.serial,
     });
@@ -181,7 +181,7 @@ class SocketSdkObject extends SdkObject implements SocketBackend {
   private _eventListeners;
 
   constructor(parent: SdkObject, socket: SocketBackend) {
-    super(parent, 'socket');
+    super(parent, 'AndroidSocket', 'socket');
     this._socket = socket;
     this._eventListeners = [
       eventsHelper.addEventListener(socket, 'data', data => this.emit('data', data)),
@@ -205,7 +205,7 @@ export class AndroidSocketDispatcher extends Dispatcher<SocketSdkObject, channel
   _type_AndroidSocket = true;
 
   constructor(scope: AndroidDeviceDispatcher, socket: SocketSdkObject) {
-    super(scope, socket, 'AndroidSocket', {});
+    super(scope, socket, {});
     this.addObjectListener('data', (data: Buffer) => this._dispatchEvent('data', { data }));
     this.addObjectListener('close', () => {
       this._dispatchEvent('close');

--- a/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
@@ -40,7 +40,7 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
   }
 
   private constructor(scope: DispatcherScope, artifact: Artifact) {
-    super(scope, artifact, 'Artifact', {
+    super(scope, artifact, {
       absolutePath: artifact.localPath(),
     });
   }

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -73,7 +73,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     const requestContext = APIRequestContextDispatcher.from(parentScope as BrowserContextDispatcher, context.fetchRequest);
     const tracing = TracingDispatcher.from(parentScope as BrowserContextDispatcher, context.tracing);
 
-    super(parentScope, context, 'BrowserContext', {
+    super(parentScope, context, {
       debugger: debugger_,
       requestContext,
       tracing,

--- a/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserDispatcher.ts
@@ -41,7 +41,7 @@ export class BrowserDispatcher extends Dispatcher<Browser, channels.BrowserChann
   private _isolatedContexts = new Set<BrowserContext>();
 
   constructor(scope: BrowserTypeDispatcher, browser: Browser, options: BrowserDispatcherOptions = {}) {
-    super(scope, browser, 'Browser', { version: browser.version(), name: browser.options.name, browserName: browser.options.browserType });
+    super(scope, browser, { version: browser.version(), name: browser.options.name, browserName: browser.options.browserType });
     this._options = options;
 
     if (!options.isolateContexts) {

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -28,7 +28,7 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
   _type_BrowserType = true;
   private readonly _denyLaunch: boolean;
   constructor(scope: RootDispatcher, browserType: BrowserType, denyLaunch: boolean) {
-    super(scope, browserType, 'BrowserType', {
+    super(scope, browserType, {
       executablePath: browserType.executablePath(),
       name: browserType.name()
     });

--- a/packages/playwright-core/src/server/dispatchers/builtinFactories.ts
+++ b/packages/playwright-core/src/server/dispatchers/builtinFactories.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ArtifactDispatcher } from './artifactDispatcher';
+import { BrowserContextDispatcher } from './browserContextDispatcher';
+import { DebuggerDispatcher } from './debuggerDispatcher';
+import { ElementHandleDispatcher } from './elementHandlerDispatcher';
+import { FrameDispatcher } from './frameDispatcher';
+import { APIRequestContextDispatcher, RequestDispatcher, ResponseDispatcher } from './networkDispatchers';
+import { PageDispatcher } from './pageDispatcher';
+import { TracingDispatcher } from './tracingDispatcher';
+
+import type { Artifact } from '../artifact';
+import type { BrowserContext } from '../browserContext';
+import type { Debugger } from '../debugger';
+import type { ElementHandle } from '../dom';
+import type { Frame } from '../frames';
+import type { APIRequestContext } from '../fetch';
+import type { Request, Response } from '../network';
+import type { Page } from '../page';
+import type { Tracing } from '../trace/recorder/tracing';
+import type { DispatcherConnection } from './dispatcher';
+
+export function populateBuiltinDispatcherFactories(connection: DispatcherConnection) {
+  connection.registerDispatcherFactories({
+    Artifact: (scope, obj) => ArtifactDispatcher.from(scope, obj as Artifact),
+    BrowserContext: (scope, obj) => BrowserContextDispatcher.from(scope, obj as BrowserContext),
+    Debugger: (scope, obj) => DebuggerDispatcher.from(scope as BrowserContextDispatcher, obj as Debugger),
+    ElementHandle: (scope, obj) => ElementHandleDispatcher.from(scope as FrameDispatcher, obj as ElementHandle),
+    Frame: (scope, obj) => FrameDispatcher.from(scope as BrowserContextDispatcher, obj as Frame),
+    APIRequestContext: (scope, obj) => APIRequestContextDispatcher.from(scope as BrowserContextDispatcher, obj as APIRequestContext),
+    Request: (scope, obj) => RequestDispatcher.from(scope as BrowserContextDispatcher, obj as Request),
+    Response: (scope, obj) => ResponseDispatcher.from(scope as BrowserContextDispatcher, obj as Response),
+    Page: (scope, obj) => PageDispatcher.from(scope as BrowserContextDispatcher, obj as Page),
+    Tracing: (scope, obj) => TracingDispatcher.from(scope as BrowserContextDispatcher, obj as Tracing),
+  });
+}

--- a/packages/playwright-core/src/server/dispatchers/cdpSessionDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/cdpSessionDispatcher.ts
@@ -26,7 +26,7 @@ export class CDPSessionDispatcher extends Dispatcher<CDPSession, channels.CDPSes
   _type_CDPSession = true;
 
   constructor(scope: BrowserDispatcher | BrowserContextDispatcher, cdpSession: CDPSession) {
-    super(scope, cdpSession, 'CDPSession', {});
+    super(scope, cdpSession, {});
     this.addObjectListener(CDPSession.Events.Event, ({ method, params }) => this._dispatchEvent('event', { method, params }));
     this.addObjectListener(CDPSession.Events.Closed, () => {
       this._dispatchEvent('close');

--- a/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/debugControllerDispatcher.ts
@@ -29,7 +29,7 @@ export class DebugControllerDispatcher extends Dispatcher<DebugController, chann
   private _listeners: RegisteredListener[];
 
   constructor(connection: DispatcherConnection, debugController: DebugController) {
-    super(connection, debugController, 'DebugController', {});
+    super(connection, debugController, {});
     this._type_DebugController = true;
     this._listeners = [
       eventsHelper.addEventListener(this._object, DebugController.Events.StateChanged, params => {

--- a/packages/playwright-core/src/server/dispatchers/debuggerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/debuggerDispatcher.ts
@@ -32,7 +32,7 @@ export class DebuggerDispatcher extends Dispatcher<Debugger, channels.DebuggerCh
   }
 
   constructor(scope: BrowserContextDispatcher, debugger_: Debugger) {
-    super(scope, debugger_, 'Debugger', {});
+    super(scope, debugger_, {});
     this.addObjectListener(Debugger.Events.PausedStateChanged, () => {
       this._dispatchEvent('pausedStateChanged', { pausedDetails: this._serializePausedDetails() });
     });

--- a/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dialogDispatcher.ts
@@ -28,7 +28,7 @@ export class DialogDispatcher extends Dispatcher<Dialog, channels.DialogChannel,
   constructor(scope: BrowserContextDispatcher, dialog: Dialog) {
     const page = PageDispatcher.fromNullable(scope, dialog.page().initializedOrUndefined());
     // Prefer scoping to the page, unless we don't have one.
-    super(page || scope, dialog, 'Dialog', {
+    super(page || scope, dialog, {
       page,
       type: dialog.type(),
       message: dialog.message(),

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -61,7 +61,7 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
   readonly _gcBucket: string;
   _object: Type;
 
-  constructor(parent: ParentScopeType | DispatcherConnection, object: Type, type: string, initializer: channels.InitializerTraits<ChannelType>, gcBucket?: string) {
+  constructor(parent: ParentScopeType | DispatcherConnection, object: Type, initializer: channels.InitializerTraits<ChannelType>, gcBucket?: string) {
     super();
 
     this.connection = parent instanceof DispatcherConnection ? parent : parent.connection;
@@ -69,9 +69,9 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
 
     const guid = object.guid;
     this._guid = guid;
-    this._type = type;
+    this._type = object._type;
     this._object = object;
-    this._gcBucket = gcBucket ?? type;
+    this._gcBucket = gcBucket ?? this._type;
 
     this.connection.registerDispatcher(this);
     if (this._parent) {
@@ -80,7 +80,7 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
     }
 
     if (this._parent)
-      this.connection.sendCreate(this._parent, type, guid, initializer);
+      this.connection.sendCreate(this._parent, this._type, guid, initializer);
     this.connection.maybeDisposeStaleDispatchers(this._gcBucket);
   }
 
@@ -177,12 +177,13 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
 }
 
 export type DispatcherScope = Dispatcher<SdkObject, any, any>;
+export type DispatcherFactory = (scope: DispatcherScope, object: SdkObject) => DispatcherScope;
 
 export class RootDispatcher extends Dispatcher<SdkObject, any, any> {
   private _initialized = false;
 
   constructor(connection: DispatcherConnection, private readonly createPlaywright?: (scope: RootDispatcher, options: channels.RootInitializeParams) => Promise<PlaywrightDispatcher>) {
-    super(connection, createRootSdkObject(), 'Root', {});
+    super(connection, createRootSdkObject(), {});
   }
 
   async initialize(params: channels.RootInitializeParams, progress: Progress): Promise<channels.RootInitializeResult> {
@@ -200,12 +201,28 @@ export class DispatcherConnection {
   readonly _dispatcherByGuid = new Map<string, DispatcherScope>();
   readonly _dispatcherByObject = new Map<any, DispatcherScope>();
   readonly _dispatchersByBucket = new Map<string, Set<string>>();
+  private _dispatcherFactories = new Map<string, DispatcherFactory>();
   onmessage = (message: object) => {};
   private _waitOperations = new Map<string, CallMetadata>();
   private _isLocal: boolean;
 
   constructor(isLocal?: boolean) {
     this._isLocal = !!isLocal;
+  }
+
+  registerDispatcherFactories(factories: Record<string, DispatcherFactory>) {
+    for (const [type, factory] of Object.entries(factories))
+      this._dispatcherFactories.set(type, factory);
+  }
+
+  dispatcherFor<T = DispatcherScope>(object: SdkObject, scope: DispatcherScope): T {
+    const existing = this.existingDispatcher<T>(object);
+    if (existing)
+      return existing;
+    const factory = this._dispatcherFactories.get(object._type);
+    if (!factory)
+      throw new Error(`No dispatcher factory registered for type ${object._type}`);
+    return factory(scope, object) as T;
   }
 
   sendEvent(dispatcher: DispatcherScope, event: string, params: any) {

--- a/packages/playwright-core/src/server/dispatchers/disposableDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/disposableDispatcher.ts
@@ -25,7 +25,7 @@ export class DisposableDispatcher extends Dispatcher<DisposableObject, channels.
   _type_Disposable = true;
 
   constructor(scope: DispatcherScope, disposable: DisposableObject) {
-    super(scope, disposable, 'Disposable', {});
+    super(scope, disposable, {});
   }
 
   async dispose(_: any, progress: Progress) {

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -50,7 +50,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
     // Note: we cannot check parentFrame() here because it may be null after the frame has been detached.
     const gcBucket = frame._page.mainFrame() === frame ? 'MainFrame' : 'Frame';
     const pageDispatcher = scope.connection.existingDispatcher<PageDispatcher>(frame._page);
-    super(pageDispatcher || scope, frame, 'Frame', {
+    super(pageDispatcher || scope, frame, {
       url: frame.url(),
       name: frame.name(),
       parentFrame: FrameDispatcher.fromNullable(scope, frame.parentFrame()),

--- a/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsHandleDispatcher.ts
@@ -35,7 +35,7 @@ export class JSHandleDispatcher<ParentScope extends JSHandleDispatcherParentScop
 
   protected constructor(scope: ParentScope, jsHandle: js.JSHandle) {
     // Do not call this directly, use createHandle() instead.
-    super(scope, jsHandle, jsHandle.asElement() ? 'ElementHandle' : 'JSHandle', {
+    super(scope, jsHandle, {
       preview: jsHandle.toString(),
     });
     jsHandle._setPreviewCallback(preview => this._dispatchEvent('previewUpdated', { preview }));

--- a/packages/playwright-core/src/server/dispatchers/jsonPipeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/jsonPipeDispatcher.ts
@@ -24,7 +24,7 @@ import type { Progress } from '@protocol/progress';
 export class JsonPipeDispatcher extends Dispatcher<SdkObject, channels.JsonPipeChannel, LocalUtilsDispatcher> implements channels.JsonPipeChannel {
   _type_JsonPipe = true;
   constructor(scope: LocalUtilsDispatcher) {
-    super(scope, new SdkObject(scope._object, 'jsonPipe'), 'JsonPipe', {});
+    super(scope, new SdkObject(scope._object, 'JsonPipe', 'jsonPipe'), {});
   }
 
   async send(params: channels.JsonPipeSendParams, progress: Progress): Promise<channels.JsonPipeSendResult> {

--- a/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/localUtilsDispatcher.ts
@@ -41,11 +41,11 @@ export class LocalUtilsDispatcher extends Dispatcher<SdkObject, channels.LocalUt
   private _stackSessions = new Map<string, localUtils.StackSession>();
 
   constructor(scope: RootDispatcher, playwright: Playwright) {
-    const localUtils = new SdkObject(playwright, 'localUtils', 'localUtils');
+    const localUtils = new SdkObject(playwright, 'LocalUtils', 'localUtils', 'localUtils');
     localUtils.logName = 'browser';
     const deviceDescriptors = Object.entries(descriptors)
         .map(([name, descriptor]) => ({ name, descriptor }));
-    super(scope, localUtils, 'LocalUtils', {
+    super(scope, localUtils, {
       deviceDescriptors,
     });
     this._type_LocalUtils = true;

--- a/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
+++ b/packages/playwright-core/src/server/dispatchers/networkDispatchers.ts
@@ -49,7 +49,7 @@ export class RequestDispatcher extends Dispatcher<Request, channels.RequestChann
     const page = request.frame()?._page;
     const pageDispatcher = page ? scope.connection.existingDispatcher<PageDispatcher>(page) : null;
     const frameDispatcher = FrameDispatcher.fromNullable(scope, frame);
-    super(pageDispatcher || frameDispatcher || scope, request, 'Request', {
+    super(pageDispatcher || frameDispatcher || scope, request, {
       frame: frameDispatcher,
       serviceWorker: WorkerDispatcher.fromNullable(scope, request.serviceWorker()),
       url: request.url(),
@@ -89,7 +89,7 @@ export class ResponseDispatcher extends Dispatcher<Response, channels.ResponseCh
   }
 
   private constructor(scope: RequestDispatcher, response: Response) {
-    super(scope, response, 'Response', {
+    super(scope, response, {
       // TODO: responses in popups can point to non-reported requests.
       request: scope,
       url: response.url(),
@@ -132,7 +132,7 @@ export class RouteDispatcher extends Dispatcher<Route, channels.RouteChannel, Re
   private _handled = false;
 
   constructor(scope: RequestDispatcher, route: Route) {
-    super(scope, route, 'Route', {
+    super(scope, route, {
       // Context route can point to a non-reported request, so we send the request in the initializer.
       request: scope
     });
@@ -179,7 +179,7 @@ export class WebSocketDispatcher extends Dispatcher<WebSocket, channels.WebSocke
   _type_WebSocket = true;
 
   constructor(scope: PageDispatcher, webSocket: WebSocket) {
-    super(scope, webSocket, 'WebSocket', {
+    super(scope, webSocket, {
       url: webSocket.url(),
     });
     this.addObjectListener(WebSocket.Events.FrameSent, (event: { opcode: number, data: string }) => this._dispatchEvent('frameSent', event));
@@ -205,7 +205,7 @@ export class APIRequestContextDispatcher extends Dispatcher<APIRequestContext, c
     // We will reparent these to the context below.
     const tracing = TracingDispatcher.from(parentScope as any as APIRequestContextDispatcher, request.tracing());
 
-    super(parentScope, request, 'APIRequestContext', {
+    super(parentScope, request, {
       tracing,
     });
 

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -85,7 +85,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     // We will reparent it to the page below using adopt.
     const mainFrame = FrameDispatcher.from(parentScope, page.mainFrame());
 
-    super(parentScope, page, 'Page', {
+    super(parentScope, page, {
       mainFrame,
       viewportSize: page.emulatedSize()?.viewport,
       isClosed: page.isClosed(),
@@ -502,7 +502,7 @@ export class WorkerDispatcher extends Dispatcher<Worker, channels.WorkerChannel,
   }
 
   constructor(scope: PageDispatcher | BrowserContextDispatcher | BrowserTypeDispatcher, worker: Worker) {
-    super(scope, worker, 'Worker', {
+    super(scope, worker, {
       url: worker.url
     });
     this.addObjectListener(Worker.Events.Console, (message: ConsoleMessage) => {
@@ -548,7 +548,7 @@ export class BindingCallDispatcher extends Dispatcher<SdkObject, channels.Bindin
 
   constructor(scope: PageDispatcher, name: string, source: { context: BrowserContext, page: Page, frame: Frame }, args: any[]) {
     const frameDispatcher = FrameDispatcher.from(scope.parentScope(), source.frame);
-    super(scope, new SdkObject(scope._object, 'bindingCall'), 'BindingCall', {
+    super(scope, new SdkObject(scope._object, 'BindingCall', 'bindingCall'), {
       frame: frameDispatcher,
       name,
       args: args.map(serializeResult),

--- a/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/playwrightDispatcher.ts
@@ -76,7 +76,7 @@ export class PlaywrightDispatcher extends Dispatcher<Playwright, channels.Playwr
     if (options.preLaunchedAndroidDevice)
       initializer.preConnectedAndroidDevice = new AndroidDeviceDispatcher(android, options.preLaunchedAndroidDevice);
 
-    super(scope, playwright, 'Playwright', initializer);
+    super(scope, playwright, initializer);
     this._type_Playwright = true;
     this._browserDispatcher = browserDispatcher;
     this._denyLaunch = denyLaunch;
@@ -101,7 +101,7 @@ class SocksSupportDispatcher extends Dispatcher<SdkObject, channels.SocksSupport
   private _socksListeners: RegisteredListener[];
 
   constructor(scope: RootDispatcher, parent: SdkObject, socksProxy: SocksProxy) {
-    super(scope, new SdkObject(parent, 'socksSupport'), 'SocksSupport', {});
+    super(scope, new SdkObject(parent, 'SocksSupport', 'socksSupport'), {});
     this._type_SocksSupport = true;
     this._socksProxy = socksProxy;
     this._socksListeners = [

--- a/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
@@ -27,7 +27,7 @@ class StreamSdkObject extends SdkObject {
   readonly stream: stream.Readable;
 
   constructor(parent: SdkObject, stream: stream.Readable) {
-    super(parent, 'stream');
+    super(parent, 'Stream', 'stream');
     this.stream = stream;
   }
 }
@@ -37,7 +37,7 @@ export class StreamDispatcher extends Dispatcher<StreamSdkObject, channels.Strea
   private _ended: boolean = false;
 
   constructor(scope: ArtifactDispatcher, stream: stream.Readable) {
-    super(scope, new StreamSdkObject(scope._object, stream), 'Stream', {});
+    super(scope, new StreamSdkObject(scope._object, stream), {});
     // In Node v12.9.0+ we can use readableEnded.
     stream.once('end', () => this._ended =  true);
     stream.once('error', () => this._ended =  true);

--- a/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts
@@ -35,7 +35,7 @@ export class TracingDispatcher extends Dispatcher<Tracing, channels.TracingChann
   }
 
   constructor(scope: BrowserContextDispatcher | APIRequestContextDispatcher, tracing: Tracing) {
-    super(scope, tracing, 'Tracing', {});
+    super(scope, tracing, {});
   }
 
   async tracingStart(params: channels.TracingTracingStartParams, progress: Progress): Promise<channels.TracingTracingStartResult> {

--- a/packages/playwright-core/src/server/dispatchers/webSocketRouteDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/webSocketRouteDispatcher.ts
@@ -38,7 +38,7 @@ export class WebSocketRouteDispatcher extends Dispatcher<SdkObject, channels.Web
   private static _idToDispatcher = new Map<string, WebSocketRouteDispatcher>();
 
   constructor(scope: PageDispatcher | BrowserContextDispatcher, id: string, url: string, protocols: string[], frame: Frame) {
-    super(scope, new SdkObject(scope._object, 'webSocketRoute'), 'WebSocketRoute', { url, protocols });
+    super(scope, new SdkObject(scope._object, 'WebSocketRoute', 'webSocketRoute'), { url, protocols });
     this._id = id;
     this._frame = frame;
     this._eventListeners.push(

--- a/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
@@ -28,7 +28,7 @@ class WritableStreamSdkObject extends SdkObject {
   readonly lastModifiedMs: number | undefined;
 
   constructor(parent: SdkObject, streamOrDirectory: fs.WriteStream | string, lastModifiedMs: number | undefined) {
-    super(parent, 'stream');
+    super(parent, 'WritableStream', 'stream');
     this.streamOrDirectory = streamOrDirectory;
     this.lastModifiedMs = lastModifiedMs;
   }
@@ -38,7 +38,7 @@ export class WritableStreamDispatcher extends Dispatcher<WritableStreamSdkObject
   _type_WritableStream = true;
 
   constructor(scope: BrowserContextDispatcher, streamOrDirectory: fs.WriteStream | string, lastModifiedMs?: number) {
-    super(scope, new WritableStreamSdkObject(scope._object, streamOrDirectory, lastModifiedMs), 'WritableStream', {});
+    super(scope, new WritableStreamSdkObject(scope._object, streamOrDirectory, lastModifiedMs), {});
   }
 
   async write(params: channels.WritableStreamWriteParams, progress: Progress): Promise<channels.WritableStreamWriteResult> {

--- a/packages/playwright-core/src/server/disposable.ts
+++ b/packages/playwright-core/src/server/disposable.ts
@@ -27,7 +27,7 @@ export abstract class DisposableObject extends SdkObject implements Disposable {
   readonly parent: Page | BrowserContext;
 
   constructor(parent: Page | BrowserContext) {
-    super(parent, 'disposable');
+    super(parent, 'Disposable', 'disposable');
     this.parent = parent;
   }
 

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -123,7 +123,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   readonly _frame: frames.Frame;
 
   constructor(context: FrameExecutionContext, objectId: string) {
-    super(context, 'node', undefined, objectId);
+    super(context, 'node', undefined, objectId, undefined, 'ElementHandle');
     this._page = context.frame._page;
     this._frame = context.frame;
     this._initializePreview().catch(e => {});
@@ -784,11 +784,11 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async type(progress: Progress, text: string, options: { delay?: number } & types.StrictOptions): Promise<void> {
     await this._markAsTargetElement(progress);
-    const result = await this._type(progress, text, options);
+    const result = await this._typeText(progress, text, options);
     return assertDone(throwRetargetableDOMError(result));
   }
 
-  async _type(progress: Progress, text: string, options: { delay?: number } & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
+  async _typeText(progress: Progress, text: string, options: { delay?: number } & types.StrictOptions): Promise<'error:notconnected' | 'done'> {
     progress.log(`elementHandle.type("${text}")`);
     await this._beforeNonPointerAction(progress);
     const result = await this._focus(progress, true /* resetSelectionIfNotFocused */);

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -116,7 +116,7 @@ export abstract class APIRequestContext extends SdkObject {
   }
 
   constructor(parent: SdkObject) {
-    super(parent, 'request-context');
+    super(parent, 'APIRequestContext', 'request-context');
     APIRequestContext.allInstances.add(this);
   }
 

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -483,7 +483,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   readonly selectors: FrameSelectors;
 
   constructor(page: Page, id: string, parentFrame: Frame | null) {
-    super(page, 'frame');
+    super(page, 'Frame', 'frame');
     this.attribution.frame = this;
     this.seq = page.frameManager._allocateFrameSeq();
     this._id = id;
@@ -1433,7 +1433,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async type(progress: Progress, selector: string, text: string, options: { delay?: number, noAutoWaiting?: boolean } & types.StrictOptions) {
-    return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options, (progress, handle) => handle._type(progress, text, options)));
+    return dom.assertDone(await this._retryWithProgressIfNotConnected(progress, selector, options, (progress, handle) => handle._typeText(progress, text, options)));
   }
 
   async press(progress: Progress, selector: string, key: string, options: { delay?: number, noWaitAfter?: boolean, noAutoWaiting?: boolean } & types.StrictOptions) {

--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -46,13 +46,15 @@ export type Attribution = {
 export type EventMap = Record<string | symbol, any[]>;
 
 export class SdkObject<EM extends EventMap = EventMap> extends EventEmitter<EM> {
+  readonly _type: string;
   guid: string;
   attribution: Attribution;
   instrumentation: Instrumentation;
   logName?: LogName;
 
-  constructor(parent: SdkObject, guidPrefix?: string, guid?: string) {
+  constructor(parent: SdkObject, type: string, guidPrefix?: string, guid?: string) {
     super();
+    this._type = type;
     this.guid = guid || `${guidPrefix || ''}@${createGuid()}`;
     this.setMaxListeners(0);
     this.attribution = { ...parent.attribution };
@@ -74,7 +76,7 @@ export class SdkObject<EM extends EventMap = EventMap> extends EventEmitter<EM> 
 
 export function createRootSdkObject() {
   const fakeParent = { attribution: {}, instrumentation: createInstrumentation() };
-  const root = new SdkObject(fakeParent as any);
+  const root = new SdkObject(fakeParent as any, 'Root');
   root.guid = '';
   return root;
 }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -62,7 +62,7 @@ export class ExecutionContext extends SdkObject {
   readonly worldNameForTest: string;
 
   constructor(parent: SdkObject, delegate: ExecutionContextDelegate, worldNameForTest: string) {
-    super(parent, 'execution-context');
+    super(parent, 'ExecutionContext', 'execution-context');
     this.worldNameForTest = worldNameForTest;
     this.delegate = delegate;
   }
@@ -128,8 +128,8 @@ export class JSHandle<T = any> extends SdkObject {
   protected _preview: string;
   private _previewCallback: ((preview: string) => void) | undefined;
 
-  constructor(context: ExecutionContext, type: string, preview: string | undefined, objectId?: string, value?: any) {
-    super(context, 'handle');
+  constructor(context: ExecutionContext, type: string, preview: string | undefined, objectId?: string, value?: any, sdkType: string = 'JSHandle') {
+    super(context, sdkType, 'handle');
     this._context = context;
     this._objectId = objectId;
     this._value = value;

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -197,7 +197,7 @@ export class Request extends SdkObject {
 
   constructor(context: contexts.BrowserContext, frame: frames.Frame | null, serviceWorker: pages.Worker | null, redirectedFrom: Request | null, documentId: string | undefined,
     url: string, resourceType: ResourceType, method: string, postData: Buffer | null, headers: HeadersArray) {
-    super(frame || context, 'request');
+    super(frame || context, 'Request', 'request');
     assert(!url.startsWith('data:'), 'Data urls should not fire requests');
     this._context = context;
     this._frame = frame;
@@ -342,7 +342,7 @@ export class Route extends SdkObject {
   private _futureHandlers: RouteHandler[] = [];
 
   constructor(request: Request, delegate: RouteDelegate) {
-    super(request._frame || request._context, 'route');
+    super(request._frame || request._context, 'Route', 'route');
     this._request = request;
     this._delegate = delegate;
     this._request._context.addRouteInFlight(this);
@@ -524,7 +524,7 @@ export class Response extends SdkObject {
   private _responseHeadersSizePromise = new ManualPromise<number | null>();
 
   constructor(request: Request, status: number, statusText: string, headers: HeadersArray, timing: ResourceTiming, getResponseBodyCallback: GetResponseBodyCallback, fromServiceWorker: boolean) {
-    super(request.frame() || request._context, 'response');
+    super(request.frame() || request._context, 'Response', 'response');
     this._request = request;
     this._timing = timing;
     this._status = status;
@@ -727,7 +727,7 @@ export class WebSocket extends SdkObject {
   };
 
   constructor(parent: SdkObject, url: string) {
-    super(parent, 'ws');
+    super(parent, 'WebSocket', 'ws');
     this._url = url;
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -203,7 +203,7 @@ export class Page extends SdkObject<PageEventMap> {
   _closeReason: string | undefined;
 
   constructor(delegate: PageDelegate, browserContext: BrowserContext) {
-    super(browserContext, 'page');
+    super(browserContext, 'Page', 'page');
     this.attribution.page = this;
     this.delegate = delegate;
     this.browserContext = browserContext;
@@ -950,7 +950,7 @@ export class Worker extends SdkObject<WorkerEventMap> {
   _closeReason: string | undefined;
 
   constructor(parent: SdkObject, url: string, onDisconnect?: () => Promise<void>) {
-    super(parent, 'worker');
+    super(parent, 'Worker', 'worker');
     this.attribution.worker = this;
     this.url = url;
     this._onDisconnect = onDisconnect;

--- a/packages/playwright-core/src/server/playwright.ts
+++ b/packages/playwright-core/src/server/playwright.ts
@@ -46,7 +46,7 @@ export class Playwright extends SdkObject {
   private _allBrowsers = new Set<Browser>();
 
   constructor(options: PlaywrightOptions) {
-    super(createRootSdkObject(), undefined, 'Playwright');
+    super(createRootSdkObject(), 'Playwright', undefined, 'Playwright');
     this.options = options;
     this.attribution.playwright = this;
     this.instrumentation.addListener({

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -100,7 +100,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
   readonly harRecorders = new Map<string, HarRecorder>();
 
   constructor(context: BrowserContext | APIRequestContext, tracesDir: string | undefined) {
-    super(context, 'tracing');
+    super(context, 'Tracing', 'tracing');
     this._context = context;
     this._precreatedTracesDir = tracesDir;
     this._harTracer = new HarTracer(context, null, this, {


### PR DESCRIPTION
## Summary

- Move the protocol channel type from a `Dispatcher` constructor argument to a field on `SdkObject` (`_type`), so it has a single source of truth.
- Add a string-keyed factory registry on `DispatcherConnection`: `registerDispatcherFactories({ Type: factory, ... })` and `dispatcherFor(object, scope)`. Built-ins are wired via `populateBuiltinDispatcherFactories(connection)` from `inprocess.ts`, `cli/driver.ts`, and `playwrightConnection.ts`.
- Lets plugin dispatchers wrap an `SdkObject` without importing concrete sibling dispatcher classes.
- Side renames to free the `_type` name: `Dialog._type` → `_dialogType`; `ElementHandle._type` method → `_typeText`.

No behavior change.