### PR TITLE
fix(server): advertise bound IP literal in wsEndpoint and URL prefix

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/http.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/http.ts
@@ -22,6 +22,7 @@ import crypto from 'crypto';
 import debug from 'debug';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { urlHostFromAddress } from '@utils/httpServer';
 import { createHttpServer, startHttpServer } from '@utils/network';
 
 import * as mcpServer from './server';
@@ -49,7 +50,7 @@ export function addressToString(address: string | net.AddressInfo | null, option
   assert(address, 'Could not bind server socket');
   if (typeof address === 'string')
     throw new Error('Unexpected address type: ' + address);
-  let host = address.family === 'IPv4' ? address.address : `[${address.address}]`;
+  let host = urlHostFromAddress(address);
   if (options.normalizeLoopback && (host === '0.0.0.0' || host === '[::]' || host === '[::1]' || host === '127.0.0.1'))
     host = 'localhost';
   return `${options.protocol}://${host}:${address.port}`;

--- a/packages/utils/httpServer.ts
+++ b/packages/utils/httpServer.ts
@@ -169,8 +169,7 @@ export class HttpServer {
       this._urlPrefixHumanReadable = address;
     } else {
       this._port = address.port;
-      const resolvedHost = address.family === 'IPv4' ? address.address : `[${address.address}]`;
-      this._urlPrefixPrecise = `http://${resolvedHost}:${address.port}`;
+      this._urlPrefixPrecise = `http://${urlHostFromAddress(address)}:${address.port}`;
       this._urlPrefixHumanReadable = `http://${host ?? 'localhost'}:${address.port}`;
       this._allowedHosts = computeAllowedHosts(host, address.address);
     }
@@ -301,6 +300,11 @@ export function computeAllowedHosts(requested: string | undefined, bound: string
   if (!isLoopback(bound) && requested === undefined)
     return null;
   return new Set(['localhost', '127.0.0.1', '[::1]']);
+}
+
+// Bracket IPv6 literals so they can be used as the host part of a URL.
+export function urlHostFromAddress(address: { address: string, family: string }): string {
+  return address.family === 'IPv6' ? `[${address.address}]` : address.address;
 }
 
 export function hostnameFromHostHeader(host: string): string {

--- a/packages/utils/wsServer.ts
+++ b/packages/utils/wsServer.ts
@@ -15,7 +15,7 @@
  */
 
 import { WebSocketServer as wsServer } from 'ws';
-import { computeAllowedHosts, hostnameFromHostHeader } from './httpServer';
+import { computeAllowedHosts, hostnameFromHostHeader, urlHostFromAddress } from './httpServer';
 import { createHttpServer } from './network';
 import { debugLogger } from './debugLogger';
 
@@ -78,11 +78,15 @@ export class WSServer {
           reject(new Error('Could not bind server socket'));
           return;
         }
-        const urlHost = hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
-        const wsEndpoint = typeof address === 'string' ? `${address}${path}` : `ws://${urlHost}:${address.port}${path}`;
-        if (typeof address !== 'string')
-          this._allowedHosts = computeAllowedHosts(hostname, address.address);
-        resolve(wsEndpoint);
+        if (typeof address === 'string') {
+          resolve(`${address}${path}`);
+          return;
+        }
+        // Advertise the bound IP literal in the wsEndpoint so the client connects to
+        // the same address family the server bound to. Otherwise the client and
+        // server resolvers can disagree on what 'localhost' means (see #40605).
+        this._allowedHosts = computeAllowedHosts(hostname, address.address);
+        resolve(`ws://${urlHostFromAddress(address)}:${address.port}${path}`);
       }).on('error', reject);
     });
 

--- a/tests/library/browser-server.spec.ts
+++ b/tests/library/browser-server.spec.ts
@@ -65,7 +65,7 @@ it('should write descriptor on start and remove on stop', async ({ browser }) =>
 
 it('should start ws server with host/port and produce well-formed endpoint', async ({ browserType, browser }) => {
   const serverInfo = await browser.bind('default', { host: 'localhost', port: 0 });
-  expect(serverInfo.endpoint).toMatch(/^ws:\/\/localhost:\d+\/[a-f0-9]+$/);
+  expect(serverInfo.endpoint).toMatch(/^ws:\/\/(127\.0\.0\.1|\[::1\]):\d+\/[a-f0-9]+$/);
 
   const browser2 = await browserType.connect(serverInfo.endpoint);
   const page = await browser2.newPage();


### PR DESCRIPTION
net.Server.listen('localhost') can bind ::1, but http/net clients call dns.lookup which (since Node 17, verbatim:true) uses getaddrinfo with AI_ADDRCONFIG and resolves localhost only to 127.0.0.1 when no global IPv6 route exists. The client then fails with ECONNREFUSED while the server is listening on ::1.

Advertise the actual bound address (bracketing IPv6 literals) in the wsEndpoint and HTTP url prefix so the client connects to the same family the server bound to.

Fixes: https://github.com/microsoft/playwright/issues/40605
Closes: https://github.com/microsoft/playwright-browsers/pull/2226