### PR TITLE
chore(mcp): bump default extension protocol to v2

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -22,8 +22,8 @@
  * - /extension/guid - Extension connection
  *
  * Protocol version is controlled by PLAYWRIGHT_EXTENSION_PROTOCOL env variable:
- * - v1 (default): single-tab, extension manages debugger attachment
- * - v2: multi-tab, relay manages debugger via chrome.* APIs
+ * - v1: single-tab, extension manages debugger attachment
+ * - v2 (default): multi-tab, relay manages debugger via chrome.* APIs
  */
 
 import { spawn } from 'child_process';

--- a/packages/playwright-core/src/tools/mcp/protocol.ts
+++ b/packages/playwright-core/src/tools/mcp/protocol.ts
@@ -21,7 +21,7 @@ export const LATEST_VERSION = 2;
 
 // The protocol version used by default when PLAYWRIGHT_EXTENSION_PROTOCOL is
 // not set. May lag behind LATEST_VERSION while a new version is rolling out.
-export const DEFAULT_VERSION = 1;
+export const DEFAULT_VERSION = 2;
 
 // Structural mirrors of @types/chrome shapes used over the wire. The extension
 // imports the real chrome.* types and they are structurally compatible.

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -57,9 +57,9 @@ export const test = base.extend<TestFixtures, WorkerFixtures & ExtensionTestOpti
   protocolVersion: [2, { option: true, scope: 'worker' }],
 
   _protocolEnv: [async ({ protocolVersion }, use) => {
-    // Default is 1.
-    if (protocolVersion === 2)
-      process.env.PLAYWRIGHT_EXTENSION_PROTOCOL = '2';
+    // Default is 2.
+    if (protocolVersion === 1)
+      process.env.PLAYWRIGHT_EXTENSION_PROTOCOL = '1';
     else
       delete process.env.PLAYWRIGHT_EXTENSION_PROTOCOL;
     await use();

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -58,8 +58,7 @@ test(`connect.html protocolVersion search param matches fixture option`, async (
   expect(url.searchParams.get('protocolVersion')).toBe(String(protocolVersion));
 });
 
-test(`protocolVersion defaults to 1`, async ({ startExtensionClient, server, protocolVersion }) => {
-  // test.fail(true, 'Server default is currently 2; this test guards the expected default of 1');
+test(`protocolVersion defaults to 2`, async ({ startExtensionClient, server, protocolVersion }) => {
   const saved = process.env.PLAYWRIGHT_EXTENSION_PROTOCOL;
   delete process.env.PLAYWRIGHT_EXTENSION_PROTOCOL;
 
@@ -76,7 +75,7 @@ test(`protocolVersion defaults to 1`, async ({ startExtensionClient, server, pro
 
   const selectorPage = await confirmationPagePromise;
   const url = new URL(selectorPage.url());
-  expect(url.searchParams.get('protocolVersion')).toBe('1');
+  expect(url.searchParams.get('protocolVersion')).toBe('2');
 
   process.env.PLAYWRIGHT_EXTENSION_PROTOCOL = saved;
 });


### PR DESCRIPTION
## Summary
- Switch the cdpRelay's `DEFAULT_VERSION` from 1 to 2 — the extension already supports v2 (`SUPPORTED_PROTOCOL_VERSION = 2`), so clients without `PLAYWRIGHT_EXTENSION_PROTOCOL` set now get the multi-tab interface by default.
- Update extension test fixture to opt into v1 explicitly (instead of v2), and refresh the `protocolVersion defaults to ...` test.

Fixes https://github.com/microsoft/playwright-mcp/issues/1317
Fixes https://github.com/microsoft/playwright-cli/issues/373