### PR TITLE
fix(ci): prevent shell injection via CI event data in gitCommitInfoPlugin

### DIFF
--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -124,12 +124,12 @@ async function gitCommitInfo(gitDir: string): Promise<GitCommitInfo | undefined>
     '%cn', // committer name
     '%ce', // committer email
     '%ct', // committer date, UNIX timestamp
-    '',    // branch
   ];
-  const output = await runGit(`git log -1 --pretty=format:"${tokens.join(separator)}" && git rev-parse --abbrev-ref HEAD`, gitDir);
-  if (!output)
+  const logOutput = await runGit(['log', '-1', `--pretty=format:${tokens.join(separator)}`], gitDir);
+  if (!logOutput)
     return undefined;
-  const [hash, shortHash, subject, body, authorName, authorEmail, authorTime, committerName, committerEmail, committerTime, branch] = output.split(separator);
+  const branchOutput = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], gitDir);
+  const [hash, shortHash, subject, body, authorName, authorEmail, authorTime, committerName, committerEmail, committerTime] = logOutput.split(separator);
 
   return {
     shortHash,
@@ -146,7 +146,7 @@ async function gitCommitInfo(gitDir: string): Promise<GitCommitInfo | undefined>
       email: committerEmail,
       time: +committerTime * 1000,
     },
-    branch: branch.trim(),
+    branch: branchOutput?.trim() ?? '',
   };
 }
 
@@ -154,8 +154,8 @@ async function gitDiff(gitDir: string, ci?: CIInfo): Promise<string | undefined>
   const diffLimit = 100_000;
   if (ci?.prBaseHash) {
     // https://git-scm.com/docs/git-fetch
-    await runGit(`git fetch origin ${ci.prBaseHash} --depth=1 --no-auto-maintenance --no-auto-gc --no-tags --no-recurse-submodules`, gitDir);
-    const diff = await runGit(`git diff ${ci.prBaseHash} HEAD`, gitDir);
+    await runGit(['fetch', 'origin', ci.prBaseHash, '--depth=1', '--no-auto-maintenance', '--no-auto-gc', '--no-tags', '--no-recurse-submodules'], gitDir);
+    const diff = await runGit(['diff', ci.prBaseHash, 'HEAD'], gitDir);
     if (diff)
       return diff.substring(0, diffLimit);
   }
@@ -165,7 +165,7 @@ async function gitDiff(gitDir: string, ci?: CIInfo): Promise<string | undefined>
     return;
 
   // Check dirty state first.
-  const uncommitted = await runGit('git diff', gitDir);
+  const uncommitted = await runGit(['diff'], gitDir);
   if (uncommitted === undefined) {
     // Failed to run git diff.
     return;
@@ -174,20 +174,20 @@ async function gitDiff(gitDir: string, ci?: CIInfo): Promise<string | undefined>
     return uncommitted.substring(0, diffLimit);
 
   // Assume non-shallow checkout on local.
-  const diff = await runGit('git diff HEAD~1', gitDir);
+  const diff = await runGit(['diff', 'HEAD~1'], gitDir);
   return diff?.substring(0, diffLimit);
 }
 
-async function runGit(command: string, cwd: string): Promise<string | undefined> {
-  debug(`running "${command}"`);
+async function runGit(args: string[], cwd: string): Promise<string | undefined> {
+  debug(`running "git ${args.join(' ')}"`);
   const start = monotonicTime();
   const result = await spawnAsync(
-      command,
-      [],
-      { stdio: 'pipe', cwd, timeout: GIT_OPERATIONS_TIMEOUT_MS, shell: true }
+      'git',
+      args,
+      { stdio: 'pipe', cwd, timeout: GIT_OPERATIONS_TIMEOUT_MS }
   );
   if (monotonicTime() - start > GIT_OPERATIONS_TIMEOUT_MS) {
-    print(`timeout of ${GIT_OPERATIONS_TIMEOUT_MS}ms exceeded while running "${command}"`);
+    print(`timeout of ${GIT_OPERATIONS_TIMEOUT_MS}ms exceeded while running "git ${args.join(' ')}"`);
     return;
   }
   if (result.code)


### PR DESCRIPTION
## Summary

- Replace `spawnAsync` with `shell: true` with shell-free argument arrays in `gitCommitInfoPlugin.ts`
- `prBaseHash` from the GitHub Actions event payload (`$GITHUB_EVENT_PATH`) was interpolated into shell commands, allowing arbitrary command execution in CI
- Follow-up to #40657 (same vulnerability class in `vcs.ts`, merged)

## Problem

The `gitCommitInfoPlugin` reads `pull_request.base.sha` from the GitHub Actions event JSON and passes it into shell commands via string interpolation:

```typescript
// gitCommitInfoPlugin.ts:157-158
await runGit(`git fetch origin ${ci.prBaseHash} --depth=1 ...`, gitDir);
const diff = await runGit(`git diff ${ci.prBaseHash} HEAD`, gitDir);

// runGit passes the string to spawnAsync with shell: true
spawnAsync(command, [], { shell: true, ... })
```

In a malicious PR, the event payload is attacker-influenced. While `base.sha` is typically a hex SHA, the value comes from a JSON file (`$GITHUB_EVENT_PATH`) that the workflow runner writes. Shell metacharacters in this value would be interpreted because `shell: true` invokes `/bin/sh -c`.

The `runGit` function also executed the `gitCommitInfo()` call as a chained shell command: `git log ... && git rev-parse ...`. This shell chaining is unnecessary and adds attack surface.

### Why this matters

This is the same vulnerability class ([CWE-78](https://cwe.mitre.org/data/definitions/78.html)) that has been found and fixed across the ecosystem:

- **Playwright #40657** (merged): Same `execSync` to `execFileSync` fix in `vcs.ts` for `--only-changed`
- **[OpenClaw CVE-2026-27487](https://github.com/openclaw/openclaw/security/advisories/GHSA-4564-pvr2-qq4h)** (CVSS 7.6): OAuth token injected into `execSync` shell command for macOS keychain write. Fixed with `execFileSync` + argument arrays. Same pattern, same fix.
- **[OpenClaw #68428](https://github.com/openclaw/openclaw/issues/68428)**: Template injection findings across CI workflows (zizmor scanner)
- **[create-react-app #12590](https://github.com/facebook/create-react-app/pull/12590)**: Shell injection via `execSync` in `openBrowser()`. Found by [GitHub Security Lab (GHSL-2021-070)](https://securitylab.github.com/advisories/GHSL-2021-070-react-dev-utils/).
- **Node.js docs** explicitly warn: "Never pass unsanitized user input to `exec`/`execSync`. Any input containing shell metacharacters may be used to trigger arbitrary command execution."

## Fix

- Change `runGit` to accept an argument array and pass `'git'` + `args` to `spawnAsync` without `shell: true`
- Split the chained `git log && git rev-parse` into two separate `runGit` calls
- Update all call sites (`gitCommitInfo`, `gitDiff`) to pass argument arrays

## Changes

- `packages/playwright/src/plugins/gitCommitInfoPlugin.ts`: 1 file, 15 insertions, 15 deletions