### PR TITLE
fix(reporter): strip ansi from test stdout when colors are disabled

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -15,6 +15,7 @@
  */
 
 import path from 'path';
+import { Writable } from 'stream';
 
 import realColors from 'colors/safe';
 import { noColors } from '@isomorphic/colors';
@@ -77,6 +78,19 @@ const originalProcessStdout = process.stdout;
 // eslint-disable-next-line no-restricted-properties
 const originalProcessStderr = process.stderr;
 
+class StripAnsiStream extends Writable {
+  private _target: NodeJS.WriteStream;
+
+  constructor(target: NodeJS.WriteStream) {
+    super();
+    this._target = target;
+  }
+
+  override _write(chunk: any, encoding: any, callback: any) {
+    this._target.write(stripAnsiEscapes(chunk.toString()), callback);
+  }
+}
+
 // Output goes to terminal.
 export const terminalScreen: TerminalScreen = (() => {
   let isTTY = !!originalProcessStdout.isTTY;
@@ -120,8 +134,8 @@ export const terminalScreen: TerminalScreen = (() => {
     ttyWidth,
     ttyHeight,
     colors,
-    stdout: originalProcessStdout,
-    stderr: originalProcessStderr,
+    stdout: useColors ? originalProcessStdout : new StripAnsiStream(originalProcessStdout) as unknown as NodeJS.WriteStream,
+    stderr: useColors ? originalProcessStderr : new StripAnsiStream(originalProcessStderr) as unknown as NodeJS.WriteStream,
   };
 })();
 

--- a/tests/playwright-test/reporter-list.spec.ts
+++ b/tests/playwright-test/reporter-list.spec.ts
@@ -553,6 +553,21 @@ Running 1 test using 1 worker
   });
 });
 
+test('strips ansi from test stdout when FORCE_COLOR=0', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passes', async ({}) => {
+        console.log('\\u001b[31mRED\\u001b[39mWHITE');
+        process.stderr.write('GREEN\\u001b[32mDOT\\u001b[39mEND\\n');
+      });
+    `,
+  }, { reporter: 'list' }, { FORCE_COLOR: '0', PLAYWRIGHT_FORCE_TTY: '80' });
+  expect(result.exitCode).toBe(0);
+  expect(result.rawOutput).toContain('REDWHITE');
+  expect(result.rawOutput).toContain('GREENDOTEND');
+});
+
 function simpleAnsiRenderer(text, ttyWidth) {
   let lineNumber = 0;
   let columnNumber = 0;


### PR DESCRIPTION
## Summary
- Wraps the reporter's `stdout`/`stderr` with a `Writable` that strips ANSI escapes when `useColors` is false (e.g. `FORCE_COLOR=0`), so user-printed ANSI sequences and reporter cursor codes don't leak into non-color output.

Fixes https://github.com/microsoft/playwright/issues/40683