### PR TITLE
test(mcp): simplify PLAYWRIGHT_SOCKETS_DIR to hash of outputDir

### DIFF
--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -119,11 +119,7 @@ function cliEnv() {
     PLAYWRIGHT_SERVER_REGISTRY: test.info().outputPath('registry'),
     PWTEST_DASHBOARD_SETTINGS_FILE: test.info().outputPath('dashboard.settings.json'),
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
-    // Include a short hash of outputDir so that concurrent runs from different
-    // checkouts use different socket directories, while runs within the same
-    // checkout share them (which helps surface race conditions and cleanup
-    // issues). The hash is kept short to stay clear of socket path length limits.
-    PLAYWRIGHT_SOCKETS_DIR: path.join(os.tmpdir(), 'ds' + String(test.info().workerIndex) + '-' + crypto.createHash('sha1').update(test.info().outputDir).digest('hex').slice(0, 8)),
+    PLAYWRIGHT_SOCKETS_DIR: path.join(os.tmpdir(), 'ds-' + crypto.createHash('sha1').update(test.info().outputDir).digest('hex').slice(0, 16)),
     PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST: '1',
   };
 }


### PR DESCRIPTION
- Drop `workerIndex` prefix — hashing `outputDir` alone gives both cross-test and cross-worktree isolation, since `outputDir` is unique per test and includes the checkout path
- Expand hash from 8 → 16 hex chars (64 bits) now that we're not constrained by the extra `workerIndex` prefix length