### PR TITLE
test(mcp): use 1 worker on CI to reduce flakiness

### DIFF
--- a/tests/mcp/playwright.config.ts
+++ b/tests/mcp/playwright.config.ts
@@ -51,7 +51,7 @@ export default defineConfig<TestOptions>({
   testDir: rootTestDir,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  workers: undefined,
+  workers: process.env.CI ? 1 : undefined,
   reporter: reporters(),
   tag: process.env.PW_TAG,
   projects: [


### PR DESCRIPTION
- Run MCP tests with 1 worker on CI (was defaulting to CPU count ~2) to reduce flakiness from parallel test interference