### PR TITLE
fix(mcp): prevent unhandled rejection in test op queue

### DIFF
--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -108,7 +108,7 @@ export class TestContext {
 
   private async _enqueue<T>(fn: () => Promise<T>): Promise<T> {
     const next = this._testOpQueue.then(fn);
-    this._testOpQueue = next.then(() => {});
+    this._testOpQueue = next.then(() => {}, () => {});
     return await next;
   }
 


### PR DESCRIPTION
## Summary
- Fix unhandled promise rejection in `_enqueue` that crashes the MCP server on Windows CI
- Add no-op rejection handler to `_testOpQueue` so the queue always resolves

The error still propagates to callers via `return await next` — this only prevents the serialization queue from becoming permanently broken.

Fixes flaky `test_run should stop when aborted` on Windows (introduced in #40582).