### PR TITLE
feat(dashboard): server mode parity for --annotate and show reveal

### DIFF
--- a/packages/dashboard/src/dashboardChannel.ts
+++ b/packages/dashboard/src/dashboardChannel.ts
@@ -49,6 +49,7 @@ export type DashboardChannelEvents = {
   frame: { data: string; viewportWidth: number; viewportHeight: number };
   annotate: {};
   cancelAnnotate: {};
+  focus: {};
 };
 
 export type MouseButton = 'left' | 'middle' | 'right';

--- a/packages/dashboard/src/dashboardModel.ts
+++ b/packages/dashboard/src/dashboardModel.ts
@@ -94,6 +94,7 @@ export class DashboardModel {
     client.on('frame', params => this._emit({ liveFrame: params }));
     client.on('annotate', () => this.enterAnnotate('cli'));
     client.on('cancelAnnotate', () => this.cancelAnnotate(false));
+    client.on('focus', () => window.focus());
   }
 
   subscribe(listener: Listener): () => void {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -42,7 +42,7 @@ declare const __PW_HMR__: boolean;
 
 type DashboardServer = {
   url: string;
-  reveal: (options: DashboardOptions) => void;
+  reveal: (options: DashboardOptions) => boolean;
   triggerAnnotate: () => void;
   registerAnnotateWaiter: (socket: net.Socket) => void;
   close: () => Promise<void>;
@@ -103,17 +103,18 @@ async function startDashboardServer(provider: SessionProvider, options: Dashboar
     attachDashboardStaticServer(httpServer, dashboardDir);
   await httpServer.start({ port: options.port, host: options.host });
 
-  const reveal = (next: DashboardOptions) => {
+  const reveal = (next: DashboardOptions): boolean => {
     currentReveal = next;
+    if (!connections.size)
+      return false;
     if (next.pageId) {
       for (const connection of connections)
         connection.revealPage(next.pageId);
-      return;
+    } else if (next.sessionName) {
+      for (const connection of connections)
+        connection.revealSession(next.sessionName, next.workspaceDir);
     }
-    if (!next.sessionName)
-      return;
-    for (const connection of connections)
-      connection.revealSession(next.sessionName, next.workspaceDir);
+    return true;
   };
 
   const triggerAnnotate = () => {
@@ -168,13 +169,6 @@ async function attachDashboardDevServer(httpServer: HttpServer) {
   });
 }
 // HMR end
-
-async function innerOpenDashboardApp(options: DashboardOptions): Promise<{ page: api.Page; server: DashboardServer }> {
-  const server = await startDashboardServer(new RegistrySessionProvider(), options);
-  const { page } = await launchApp('dashboard', { onClose: () => gracefullyProcessExitDoNotHang(0) });
-  await page.goto(server.url);
-  return { page, server };
-}
 
 async function launchApp(appName: string, options?: { onClose?: () => void }) {
   const channel = findChromiumChannelBestEffort('javascript');
@@ -282,6 +276,17 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');
+      });
+      let responseData = '';
+      client.on('data', chunk => { responseData += chunk.toString(); });
+      client.on('end', () => {
+        let parsed: { error?: string } | undefined;
+        try { parsed = JSON.parse(responseData.trim()); } catch {}
+        if (parsed?.error) {
+          // eslint-disable-next-line no-console
+          console.error(parsed.error);
+          gracefullyProcessExitDoNotHang(1);
+        }
         reject(new Error('already running'));
       });
       client.on('error', () => {
@@ -307,22 +312,33 @@ export async function openDashboardApp() {
     // eslint-disable-next-line no-console
     console.error('Unhandled promise rejection:', error);
   });
-  if (options.port !== undefined) {
-    const { url } = await startDashboardServer(new RegistrySessionProvider(), options);
-    // eslint-disable-next-line no-console
-    console.log(`Listening on ${url}`);
-    selfDestructOnParentGone();
-    return;
-  }
-  let server: net.Server | undefined;
-  process.on('exit', () => server?.close());
+  const isServerMode = options.port !== undefined;
+  let socketServer: net.Server | undefined;
+  process.on('exit', () => socketServer?.close());
   try {
-    server = await acquireSingleton(options);
+    socketServer = await acquireSingleton(options);
   } catch {
     return;
   }
-  const statePromise = innerOpenDashboardApp(options);
-  server?.on('connection', socket => {
+
+  const dashboardPromise = startDashboardServer(new RegistrySessionProvider(), options);
+  let pagePromise: Promise<api.Page | undefined>;
+  if (isServerMode) {
+    void dashboardPromise.then(({ url }) => {
+      // eslint-disable-next-line no-console
+      console.log(`Listening on ${url}`);
+      selfDestructOnParentGone();
+    });
+    pagePromise = Promise.resolve(undefined);
+  } else {
+    pagePromise = dashboardPromise.then(async dashboard => {
+      const { page } = await launchApp('dashboard', { onClose: () => gracefullyProcessExitDoNotHang(0) });
+      await page.goto(dashboard.url);
+      return page;
+    });
+  }
+
+  socketServer.on('connection', socket => {
     let buffer = '';
     socket.on('data', data => {
       buffer += data.toString();
@@ -341,30 +357,49 @@ export async function openDashboardApp() {
         socket.end();
         return;
       }
+
       if (parsed.kill) {
+        if (isServerMode) {
+          socket.end(JSON.stringify({ error: `Cannot kill a server-mode dashboard via --kill. Stop the process directly.` }) + '\n');
+          return;
+        }
         // Write our PID so the kill client can wait for the process to fully exit,
         // which guarantees the named pipe is released (especially on Windows).
         // Start graceful shutdown only after the socket data has been flushed, so the
         // kill client is guaranteed to receive the PID before we begin tearing down.
-        server?.close();
+        socketServer?.close();
         socket.end(JSON.stringify({ pid: process.pid }) + '\n', () => gracefullyProcessExitDoNotHang(0));
         return;
       }
-      void statePromise.then(({ page, server: dashboard }) => {
-        if (parsed.annotate) {
-          page?.bringToFront().catch(() => {});
-          dashboard.reveal(parsed);
+
+      // Cross-mode conflict: a server-mode launch attempt while app mode is running is rejected.
+      // A plain reveal (no port) is always allowed regardless of mode.
+      const incomingIsServer = parsed.port !== undefined;
+      if (!isServerMode && incomingIsServer) {
+        socket.end(JSON.stringify({ error: `Dashboard is already running in app mode. Use 'playwright show --kill' to stop it first.` }) + '\n');
+        return;
+      }
+
+      void Promise.all([dashboardPromise, pagePromise]).then(([dashboard, page]) => {
+        page?.bringToFront().catch(() => {});
+        if (parsed!.annotate) {
+          dashboard.reveal(parsed!);
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
         } else {
-          page?.bringToFront().catch(() => {});
-          dashboard.reveal(parsed);
-          socket.end();
+          const revealed = dashboard.reveal(parsed!);
+          if (isServerMode && !revealed) {
+            socket.end(JSON.stringify({ error: `Nobody is looking at the dashboard, cannot reveal session.` }) + '\n');
+            // TODO: queue the reveal for the next connecting client
+          } else {
+            socket.end();
+          }
         }
       });
     });
   });
-  await statePromise;
+
+  await Promise.all([dashboardPromise, pagePromise]);
 }
 
 export async function openDashboardForContext(context: api.BrowserContext): Promise<void> {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -43,6 +43,7 @@ export class DashboardConnection implements Transport {
   private _pushTabsScheduled = false;
   private _visible = true;
   private _pendingReveal: { sessionName?: string; workspaceDir?: string; pageId?: string } | undefined;
+  private _workspaceDir: string | undefined;
   private _annotateWaitingForAttach = false;
 
   _recordingDir: string;
@@ -54,6 +55,7 @@ export class DashboardConnection implements Transport {
     this._onconnected = onconnected;
     this._onAnnotationSubmit = onAnnotationSubmit;
     this._recordingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'playwright-recordings-'));
+    this._workspaceDir = createClientInfo().workspaceDir;
   }
 
   onconnect() {
@@ -135,6 +137,8 @@ export class DashboardConnection implements Transport {
 
   revealSession(sessionName: string, workspaceDir?: string) {
     this._pendingReveal = { sessionName, workspaceDir };
+    this._workspaceDir = workspaceDir;
+    this._pushSessions();
     void this._tryRevealPending();
   }
 
@@ -161,6 +165,7 @@ export class DashboardConnection implements Transport {
     this._pendingReveal = undefined;
     await this._switchAttachedTo(page);
     this._pushTabs();
+    this.emitFocus();
   }
 
   async submitAnnotation(params: { frames: SubmittedAnnotationFrame[]; feedback: string }) {
@@ -205,7 +210,7 @@ export class DashboardConnection implements Transport {
   }
 
   emitSessions(sessions: BrowserDescriptor[]) {
-    this.sendEvent?.('sessions', { sessions, clientInfo: createClientInfo() });
+    this.sendEvent?.('sessions', { sessions, clientInfo: { ...createClientInfo(), workspaceDir: this._workspaceDir } });
   }
 
   emitTabs(tabs: Tab[]) {
@@ -214,6 +219,10 @@ export class DashboardConnection implements Transport {
 
   emitFrame(data: string, viewportWidth: number, viewportHeight: number) {
     this.sendEvent?.('frame', { data, viewportWidth, viewportHeight });
+  }
+
+  emitFocus() {
+    this.sendEvent?.('focus', {});
   }
 
   emitAnnotate() {

--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -498,3 +498,20 @@ test('should disengage annotate mode when --annotate client disconnects', async 
 
   await expect(dashboard.getByRole('main', { name: 'Dashboard', exact: true })).toBeVisible();
 });
+
+test('should capture annotations via show --annotate with server-mode dashboard', async ({ startDashboardServer, cli, server }) => {
+  await cli('open', server.EMPTY_PAGE);
+  const dashboard = await startDashboardServer();
+  await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
+
+  const annotatePromise = cli('show', '--annotate');
+  let done = false;
+  void annotatePromise.finally(() => { done = true; });
+
+  await drawAndSubmitAnnotation(dashboard, 'server-mode');
+
+  const { output, exitCode } = await annotatePromise;
+  expect(done).toBe(true);
+  expect(exitCode).toBe(0);
+  verifyAnnotateOutput(output, 'server-mode', test.info().outputDir);
+});

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -17,6 +17,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import crypto from 'crypto';
 
 import { test, expect, installSaveFilePickerMock } from './cli-fixtures';
 
@@ -76,8 +77,10 @@ test('should show current workspace sessions first', async ({ cli, server, start
   await cli('open', server.EMPTY_PAGE, { cwd: wsA });
   await cli('open', server.EMPTY_PAGE, { cwd: wsB });
 
+  const dashboard = await startDashboardServer({ cwd: wsA });
+
   const checkOrder = async (first: string, second: string) => {
-    const dashboard = await startDashboardServer({ cwd: first });
+    await cli('show', { cwd: first });
     const workspaceGroups = dashboard.getByRole('region', { name: /^Workspace / });
     await expect(workspaceGroups).toHaveCount(2);
 
@@ -177,4 +180,29 @@ test('save recording streams WebM bytes to the chosen file', async ({ cli, serve
   const bytes = await awaitBytes();
   // WebM files start with the EBML magic bytes.
   expect(bytes.subarray(0, 4)).toEqual(Buffer.from([0x1a, 0x45, 0xdf, 0xa3]));
+});
+
+test('should error when server mode starts while app mode is running', async ({ cli, server }) => {
+  await cli('open', server.EMPTY_PAGE);
+  await cli('show', { bindTitle: `--playwright-internal--${crypto.randomUUID()}` });
+
+  const { error } = await cli('show', '--port=0');
+  expect(error).toContain('already running in app mode');
+});
+
+test('should focus browser and warn when no clients on server-mode reveal', async ({ cli, server, startDashboardServer }) => {
+  await cli('open', server.EMPTY_PAGE, '--session=my-session');
+  const dashboard = await startDashboardServer({ session: 'my-session' });
+
+  await test.step('focus is called when a browser has the dashboard open', async () => {
+    const focused = dashboard.evaluate(() => new Promise<void>(resolve => { window.focus = resolve; }));
+    await cli('show', '-s=my-session');
+    await focused;
+  });
+
+  await test.step('prints warning when no browser has the dashboard open', async () => {
+    await dashboard.goto('about:blank'); // disconnect WS client
+    const { error } = await cli('show', '--port=0', '-s=my-session');
+    expect(error).toContain('Nobody is looking');
+  });
 });


### PR DESCRIPTION
- Server mode (`--port`) now acquires the singleton socket, so `playwright show` and `playwright show --annotate` reach it the same way as app mode
- `window.focus()` is sent to connected browser clients when a session is revealed (via a new `focus` WS event)
- Cross-mode conflict: starting server mode while app mode is running is rejected with a clear error; plain reveals always forward regardless of mode
- `--kill` is rejected in server mode with a clear error
- `_workspaceDir` on `DashboardConnection` tracks the caller's workspace and updates on `revealSession` so session ordering reflects the last reveal target
- "Nobody is looking" error is returned over the socket so it surfaces in the CLI output of the calling process

Closes https://github.com/microsoft/playwright-cli/issues/325