### PR TITLE
test(mcp): capture debug logs around cli show / connectToDashboard (do-not-merge)

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -230,7 +230,10 @@ export async function program(options?: { embedderVersion?: string}) {
       const foreground = args.port !== undefined;
       const child = spawn(process.execPath, daemonArgs, {
         detached: !foreground,
-        stdio: daemonStdio(foreground ? 'inherit' : 'ignore', 'dashboard', sessionName),
+        // Foreground mode pipes the daemon's stdout up to the caller (tests
+        // wait for "Listening on ..." on stdout); only redirect to log files
+        // when the daemon is detached and would otherwise drop output.
+        stdio: foreground ? 'inherit' : daemonStdio('ignore', 'dashboard', sessionName),
       });
       if (foreground) {
         await new Promise<void>(resolve => child.on('exit', () => resolve()));

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -31,6 +31,8 @@ import { libPath } from '../../package';
 import { serverRegistry } from '../../serverRegistry';
 import { minimist } from './minimist';
 
+import type { ChildProcess, StdioOptions } from 'child_process';
+import type { Readable } from 'stream';
 import type { ListData, ListedBrowser, Output } from './output';
 import type { ClientInfo, SessionFile } from './registry';
 import type { MinimistArgs } from './minimist';
@@ -228,17 +230,27 @@ export async function program(options?: { embedderVersion?: string}) {
         return;
       }
       const foreground = args.port !== undefined;
+      const detachedStdio = daemonStdio('ignore', 'dashboard', sessionName);
+      // Append a 'pipe' for fd 3 so the detached daemon can signal READY back
+      // once the dashboard server is listening, the browser is launched and
+      // bound, and the dashboard page has finished navigating. Without this,
+      // `cli show` would return before the dashboard is usable, leaving
+      // callers (tests, scripts) to race against startup.
+      const stdioWithReady: StdioOptions = Array.isArray(detachedStdio)
+        ? [...detachedStdio, 'pipe']
+        : [detachedStdio, detachedStdio, detachedStdio, 'pipe'];
       const child = spawn(process.execPath, daemonArgs, {
         detached: !foreground,
         // Foreground mode pipes the daemon's stdout up to the caller (tests
         // wait for "Listening on ..." on stdout); only redirect to log files
         // when the daemon is detached and would otherwise drop output.
-        stdio: foreground ? 'inherit' : daemonStdio('ignore', 'dashboard', sessionName),
+        stdio: foreground ? 'inherit' : stdioWithReady,
       });
       if (foreground) {
         await new Promise<void>(resolve => child.on('exit', () => resolve()));
         return;
       }
+      await waitForDaemonReady(child);
       child.unref();
       output.show(sessionName, child.pid);
       return;
@@ -318,6 +330,44 @@ function daemonStdio(fallback: 'ignore' | 'inherit', label: string, sessionName:
   } catch {
     return fallback;
   }
+}
+
+// Wait for the detached dashboard daemon (spawned by `cli show`) to signal
+// READY on its fd 3. The child writes after the dashboard server is listening,
+// the browser is launched and bound, and the dashboard page navigation is
+// complete. Times out after 60s. Rejects if the child exits before signaling.
+function waitForDaemonReady(child: ChildProcess): Promise<void> {
+  // child.stdio is typed as a 3-tuple, but we passed a 4-entry stdio array so
+  // index 3 exists at runtime. Cast through unknown to access it without
+  // resorting to `any`.
+  const readyStream = (child.stdio as unknown as Array<Readable | null>)[3];
+  if (!readyStream)
+    return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      readyStream.removeListener('data', onData);
+      readyStream.removeListener('end', onEnd);
+      readyStream.removeListener('error', onError);
+      child.removeListener('exit', onExit);
+    };
+    const settle = (err?: Error) => {
+      cleanup();
+      // Destroy the parent's read end so Windows can reap the pipe handle
+      // before we unref() the child. On POSIX this is a no-op.
+      try { readyStream.destroy(); } catch { /* noop */ }
+      err ? reject(err) : resolve();
+    };
+    const onData = () => settle();
+    const onEnd = () => settle(new Error('Dashboard daemon closed ready pipe before signaling READY'));
+    const onError = (err: Error) => settle(err);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => settle(new Error(`Dashboard daemon exited (code=${code}, signal=${signal}) before signaling READY`));
+    const timer = setTimeout(() => settle(new Error('Dashboard daemon did not signal READY within 60s')), 60_000);
+    readyStream.once('data', onData);
+    readyStream.once('end', onEnd);
+    readyStream.once('error', onError);
+    child.once('exit', onExit);
+  });
 }
 
 async function installBrowser() {

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -19,6 +19,7 @@
 import { execSync, spawn } from 'child_process';
 
 import crypto from 'crypto';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -213,7 +214,7 @@ export async function program(options?: { embedderVersion?: string}) {
         daemonArgs.push(`--host=${args.host as string}`);
       if (args.kill) {
         daemonArgs.push(`--kill`);
-        const child = spawn(process.execPath, daemonArgs, { stdio: 'ignore' });
+        const child = spawn(process.execPath, daemonArgs, { stdio: daemonStdio('ignore', 'dashboard-kill', sessionName) });
         await new Promise<void>(resolve => child.on('exit', () => resolve()));
         return;
       }
@@ -229,7 +230,7 @@ export async function program(options?: { embedderVersion?: string}) {
       const foreground = args.port !== undefined;
       const child = spawn(process.execPath, daemonArgs, {
         detached: !foreground,
-        stdio: foreground ? 'inherit' : 'ignore',
+        stdio: daemonStdio(foreground ? 'inherit' : 'ignore', 'dashboard', sessionName),
       });
       if (foreground) {
         await new Promise<void>(resolve => child.on('exit', () => resolve()));
@@ -295,6 +296,25 @@ async function runInitWorkspace(args: MinimistArgs, output: Output) {
         reject(new Error(`Workspace initialization failed with exit code ${code}`));
     });
   });
+}
+
+// When PWTEST_CLI_LOG_DIR is set (test-only), redirect a spawned daemon's
+// stdout/stderr to log files in that directory so flakiness around `cli show`
+// is debuggable. Returns the input fallback ('ignore' | 'inherit') in
+// production.
+function daemonStdio(fallback: 'ignore' | 'inherit', label: string, sessionName: string): 'ignore' | 'inherit' | ('ignore' | number)[] {
+  const dir = process.env.PWTEST_CLI_LOG_DIR;
+  if (!dir)
+    return fallback;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const stamp = `${Date.now()}-${process.pid}`;
+    const outFd = fs.openSync(path.join(dir, `${label}-${sessionName}-${stamp}.out.log`), 'w');
+    const errFd = fs.openSync(path.join(dir, `${label}-${sessionName}-${stamp}.err.log`), 'w');
+    return ['ignore', outFd, errFd];
+  } catch {
+    return fallback;
+  }
 }
 
 async function installBrowser() {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -321,6 +321,21 @@ export async function openDashboardApp() {
     return;
   }
   const statePromise = innerOpenDashboardApp(options);
+  // Once the dashboard is fully started (server listening, browser launched
+  // + bound, page navigated), signal READY back to the parent process via
+  // fd 3. `cli show` in program.ts spawns this entry with a fourth 'pipe'
+  // stdio entry and blocks until it sees this byte. The try/catch handles
+  // EPIPE (parent closed early, e.g. timeout) and the developer-debug case
+  // of running `node dashboardApp.js` directly without an fd 3 attached.
+  void statePromise.then(() => {
+    try {
+      fs.writeSync(3, 'READY\n');
+      fs.closeSync(3);
+    } catch {
+      // No fd 3 attached, parent already closed it, or write failed - the
+      // dashboard is up regardless; nothing to do.
+    }
+  });
   server?.on('connection', socket => {
     let buffer = '';
     socket.on('data', data => {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -277,9 +277,7 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     const server = net.createServer();
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      const isInUse = err.code === 'EADDRINUSE'
-          || (process.platform === 'win32' && err.code === 'EBUSY');
-      if (!isInUse)
+      if (err.code !== 'EADDRINUSE')
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');
@@ -349,7 +347,6 @@ export async function openDashboardApp() {
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
         } else if (parsed.kill) {
-          server?.close();
           socket.end();
           gracefullyProcessExitDoNotHang(0);
         } else {

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -22,7 +22,6 @@ import http from 'http';
 import { HttpServer } from '@utils/httpServer';
 import { makeSocketPath } from '@utils/fileUtils';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
-import { monotonicTime } from '@isomorphic/time';
 import { libPath } from '../../package';
 import { playwright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
@@ -278,7 +277,9 @@ async function acquireSingleton(options: DashboardOptions): Promise<net.Server> 
     const server = net.createServer();
     server.listen(socketPath, () => resolve(server));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code !== 'EADDRINUSE')
+      const isInUse = err.code === 'EADDRINUSE'
+          || (process.platform === 'win32' && err.code === 'EBUSY');
+      if (!isInUse)
         return reject(err);
       const client = net.connect(socketPath, () => {
         client.write(JSON.stringify(options) + '\n');
@@ -341,21 +342,16 @@ export async function openDashboardApp() {
         socket.end();
         return;
       }
-      if (parsed.kill) {
-        // Write our PID so the kill client can wait for the process to fully exit,
-        // which guarantees the named pipe is released (especially on Windows).
-        // Start graceful shutdown only after the socket data has been flushed, so the
-        // kill client is guaranteed to receive the PID before we begin tearing down.
-        server?.close();
-        socket.end(JSON.stringify({ pid: process.pid }) + '\n', () => gracefullyProcessExitDoNotHang(0));
-        return;
-      }
       void statePromise.then(({ page, server: dashboard }) => {
         if (parsed.annotate) {
           page?.bringToFront().catch(() => {});
           dashboard.reveal(parsed);
           dashboard.triggerAnnotate();
           dashboard.registerAnnotateWaiter(socket);
+        } else if (parsed.kill) {
+          server?.close();
+          socket.end();
+          gracefullyProcessExitDoNotHang(0);
         } else {
           page?.bringToFront().catch(() => {});
           dashboard.reveal(parsed);
@@ -385,37 +381,14 @@ export async function openDashboardForContext(context: api.BrowserContext): Prom
 
 async function runKillClient(): Promise<void> {
   const socketPath = dashboardSocketPath();
-  const pid = await new Promise<number | undefined>((resolve, reject) => {
+  await new Promise<void>(resolve => {
     const client = net.connect(socketPath);
-    let data = '';
     client.once('connect', () => {
       client.write(JSON.stringify({ kill: true }) + '\n');
     });
-    client.on('data', chunk => { data += chunk; });
-    client.once('end', () => {
-      let pid: number | undefined;
-      try { pid = JSON.parse(data.trim()).pid; } catch { }
-      if (pid === undefined)
-        reject(new Error('Dashboard did not return its PID'));
-      else
-        resolve(pid);
-    });
-    client.once('error', () => resolve(undefined));
+    client.once('end', () => resolve());
+    client.once('error', () => resolve());
   });
-  if (pid === undefined)
-    return;
-  // Poll until the daemon process exits — at that point the OS has released all
-  // its handles, including the named pipe, so the next acquisition won't see a stale pipe.
-  const deadline = monotonicTime() + 35000;
-  while (monotonicTime() < deadline) {
-    try {
-      process.kill(pid, 0);
-    } catch {
-      return;
-    }
-    await new Promise(r => setTimeout(r, 50));
-  }
-  throw new Error(`Dashboard process ${pid} did not exit within the deadline`);
 }
 
 async function runAnnotateClient(options: DashboardOptions): Promise<void> {

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -82,7 +82,10 @@ export const test = baseTest.extend<{
     await use(async (...args: string[]) => {
       const cliArgs = args.filter(arg => typeof arg === 'string');
       const cliOptions = args.findLast(arg => typeof arg === 'object') || {};
-      const result = await runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless });
+      const result = await test.step(
+          `cli ${cliArgs.join(' ')}`,
+          () => runCli(childProcess, cliArgs, cliOptions, { mcpBrowser, mcpHeadless })
+      );
       if (result.daemonPid)
         allPids.push(result.daemonPid);
       if (result.dashboardPid)

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -60,7 +60,7 @@ export const test = baseTest.extend<{
       return page;
     });
   },
-  connectToDashboard: [async ({ cli, playwright }, use) => {
+  connectToDashboard: async ({ cli, playwright }, use) => {
     await use(async (bindTitle: string) => {
       let endpoint = '';
       await expect(async () => {
@@ -72,7 +72,7 @@ export const test = baseTest.extend<{
       return await playwright.chromium.connect(endpoint);
     });
     await cli('show', '--kill');
-  }, { timeout: 60000 }],
+  },
 
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
     await fs.promises.mkdir(test.info().outputPath('.playwright'), { recursive: true });

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -76,6 +76,7 @@ export const test = baseTest.extend<{
 
   cli: async ({ mcpBrowser, mcpHeadless, childProcess }, use) => {
     await fs.promises.mkdir(test.info().outputPath('.playwright'), { recursive: true });
+    await fs.promises.mkdir(test.info().outputPath('cli-logs'), { recursive: true });
     const allPids: number[] = [];
 
     await use(async (...args: string[]) => {
@@ -99,6 +100,13 @@ export const test = baseTest.extend<{
         continue;
       }
     }
+
+    // Surface debug logs as test artifacts unconditionally (pass and fail) so
+    // we can diff a passing run vs. a flaky run when investigating cross-test
+    // contamination of the registry, sockets, or dashboard daemon.
+    await attachLogDir(test.info().outputPath('cli-logs'), 'cli-logs');
+    await attachLogDir(daemonDir, 'daemon', name => name.endsWith('.err') || name.endsWith('.session') || name.endsWith('.out'));
+    await attachLogDir(test.info().outputPath('registry'), 'registry');
   },
   boundBrowser: async ({ mcpBrowser, playwright }, use) => {
     const browserName = (mcpBrowser === 'chrome' || mcpBrowser === 'msedge') ? 'chromium' : mcpBrowser;
@@ -121,6 +129,15 @@ function cliEnv() {
     PLAYWRIGHT_DAEMON_SESSION_DIR: test.info().outputPath('daemon'),
     PLAYWRIGHT_SOCKETS_DIR: path.join(os.tmpdir(), 'ds-' + crypto.createHash('sha1').update(test.info().outputDir).digest('hex').slice(0, 16)),
     PWTEST_CLI_CHANNEL_SCAN_DISABLED_FOR_TEST: '1',
+    // Capture playwright debug logs from spawned daemons / dashboard so we
+    // can diagnose flakiness around `cli show` and `connectToDashboard`.
+    // The `debug` package writes to stderr by default; spawned processes
+    // redirect their stderr to <PWTEST_CLI_LOG_DIR>/*.err.log (see program.ts
+    // daemonStdio()) and to <daemon>/<session>.err (see session.ts).
+    DEBUG: 'pw:*',
+    DEBUG_COLORS: '0',
+    DEBUG_HIDE_DATE: '0',
+    PWTEST_CLI_LOG_DIR: test.info().outputPath('cli-logs'),
   };
 }
 
@@ -170,6 +187,44 @@ function parseJsonPid(stdout: string) {
     return JSON.parse(stdout).pid;
   } catch {
   }
+}
+
+async function attachLogDir(dir: string, prefix: string, filter?: (basename: string) => boolean) {
+  const testInfo = test.info();
+  const walk = async (current: string, rel: string) => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      const relName = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(full, relName);
+        continue;
+      }
+      if (!entry.isFile())
+        continue;
+      if (filter && !filter(entry.name))
+        continue;
+      try {
+        const stat = await fs.promises.stat(full);
+        if (stat.size === 0) {
+          // Overwrite the empty file with a marker so it shows up in the
+          // attachments/ folder (path-based attachments) instead of being
+          // hidden inside the JSON report (body attachments). This makes
+          // "process produced no output" trivially distinguishable from
+          // "log file was missing entirely".
+          await fs.promises.writeFile(full, '<empty>');
+        }
+        await testInfo.attach(`${prefix}/${relName}`, { path: full, contentType: 'text/plain' });
+      } catch {
+      }
+    }
+  };
+  await walk(dir, '');
 }
 
 function loadAttachments(output: string) {

--- a/tests/mcp/playwright.config.ts
+++ b/tests/mcp/playwright.config.ts
@@ -54,6 +54,10 @@ export default defineConfig<TestOptions>({
   workers: undefined,
   reporter: reporters(),
   tag: process.env.PW_TAG,
+  timeout: process.platform === 'win32' ? 60000 : 30000,
+  expect: {
+    timeout: process.platform === 'win32' ? 10000 : 5000,
+  },
   projects: [
     { name: 'chrome', metadata: { ...metadata, browserName: 'chromium', channel: 'chrome' }, testDir },
     { name: 'chromium', use: { mcpBrowser: 'chromium' }, metadata: { ...metadata, browserName: 'chromium' }, testDir },


### PR DESCRIPTION
Spec branch to flush out flakiness around `cli show` and `connectToDashboard` in dashboard/annotate tests.

- Adds opt-in `PWTEST_CLI_LOG_DIR` log capture for the detached `cli show` daemon (`packages/playwright-core/src/tools/cli-client/program.ts`).
- Turns it on plus `DEBUG=pw:*` for every MCP test in `tests/mcp/cli-fixtures.ts`; the cli fixture teardown surfaces every file from `cli-logs/`, `daemon/`, and `registry/` as a test attachment on every run (pass or fail).
- **Reverts https://github.com/microsoft/playwright/pull/40642 and https://github.com/microsoft/playwright/pull/40626** so CI exercises the original flaky paths.

Do not merge — diagnostic branch only.