### PR TITLE
chore: compute call title once and stash it on Progress

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -17,6 +17,7 @@
 import { EventEmitter } from 'events';
 
 import { getMetainfo } from '@isomorphic/protocolMetainfo';
+import { renderTitleForCall } from '@isomorphic/protocolFormatter';
 import { eventsHelper } from '@utils/eventsHelper';
 import { isUnderTest } from '@utils/debug';
 import { assert } from '@isomorphic/assert';
@@ -102,8 +103,8 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
     this.connection.sendAdopt(this, child);
   }
 
-  async _runCommand(callMetadata: CallMetadata, method: string, validParams: any) {
-    const controller = ProgressController.createForSdkObject(this._object, callMetadata);
+  async _runCommand(callMetadata: CallMetadata, method: string, validParams: any, title: string) {
+    const controller = ProgressController.createForSdkObject(this._object, callMetadata, title);
     this._activeProgressControllers.add(controller);
     try {
       return await controller.run(progress => (this as any)[method](validParams, progress), validParams?.timeout);
@@ -378,7 +379,7 @@ export class DispatcherConnection {
       // If the dispatcher has been disposed while running the instrumentation call, error out.
       if (this._dispatcherByGuid.get(guid) !== dispatcher)
         throw new TargetClosedError(sdkObject.closeReason());
-      const result = await dispatcher._runCommand(callMetadata, method, validParams);
+      const result = await dispatcher._runCommand(callMetadata, method, validParams, renderTitleForCall(callMetadata));
       const validator = findValidator(dispatcher._type, method, 'Result');
       response.result = validator(result, '', this._validatorToWireContext());
       callMetadata.result = result;

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -23,7 +23,6 @@ import { asLocator } from '@isomorphic/locatorGenerators';
 import { assert } from '@isomorphic/assert';
 import { constructURLBasedOnBaseURL } from '@isomorphic/urlMatch';
 import { makeWaitForNextTask } from '@utils/task';
-import { renderTitleForCall } from '@isomorphic/protocolFormatter';
 import { BrowserContext } from './browserContext';
 import * as dom from './dom';
 import { TimeoutError } from './errors';
@@ -1453,7 +1452,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async expect(progress: Progress, selector: string | undefined, options: FrameExpectParams): Promise<ExpectResult> {
-    progress.log(`${renderTitleForCall(progress.metadata)}${options.timeoutForLogs ? ` with timeout ${options.timeoutForLogs}ms` : ''}`);
+    progress.log(`${progress.title}${options.timeoutForLogs ? ` with timeout ${options.timeoutForLogs}ms` : ''}`);
     const lastIntermediateResult: { received?: ExpectReceived, isSet: boolean, errorMessage?: string } = { isSet: false };
     const fixupMetadataError = (result: ExpectResult) => {
       // Library mode special case for the expect errors which are return values, not exceptions.

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -22,7 +22,6 @@ import { getComparator } from '@utils/comparators';
 import { debugLogger } from '@utils/debugLogger';
 import { LongStandingScope } from '@isomorphic/manualPromise';
 import { assert } from '@isomorphic/assert';
-import { renderTitleForCall } from '@isomorphic/protocolFormatter';
 import { trimStringWithEllipsis } from '@isomorphic/stringUtils';
 import { asLocator } from '@isomorphic/locatorGenerators';
 import { BrowserContext } from './browserContext';
@@ -739,7 +738,7 @@ export class Page extends SdkObject<PageEventMap> {
       let actual: Buffer | undefined;
       let previous: Buffer | undefined;
       const pollIntervals = [0, 100, 250, 500];
-      progress.log(`${renderTitleForCall(progress.metadata)}${options.timeout ? ` with timeout ${options.timeout}ms` : ''}`);
+      progress.log(`${progress.title}${options.timeout ? ` with timeout ${options.timeout}ms` : ''}`);
       if (options.expected)
         progress.log(`  verifying given screenshot expectation`);
       else

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -32,18 +32,20 @@ export class ProgressController {
   private _onCallLog?: (message: string) => void;
 
   readonly metadata: CallMetadata;
+  readonly title: string;
   private _controller: AbortController;
 
-  constructor(metadata?: CallMetadata, onCallLog?: (message: string) => void) {
+  constructor(metadata?: CallMetadata, title?: string, onCallLog?: (message: string) => void) {
     this.metadata = metadata || { id: '', startTime: 0, endTime: 0, type: 'Internal', method: '', params: {}, log: [], internal: true };
+    this.title = title ?? '';
     this._onCallLog = onCallLog;
     this._forceAbortPromise.catch(e => null);  // Prevent unhandled promise rejection.
     this._controller = new AbortController();
   }
 
-  static createForSdkObject(sdkObject: SdkObject, callMetadata: CallMetadata) {
+  static createForSdkObject(sdkObject: SdkObject, callMetadata: CallMetadata, title?: string) {
     const logName = sdkObject.logName || 'api';
-    return new ProgressController(callMetadata, message => {
+    return new ProgressController(callMetadata, title, message => {
       // Note: "attribution.playwright" is undefined in DebugController. Unfortunate!
       if (logName === 'api' && sdkObject.attribution.playwright?.options.isInternalPlaywright)
         return;
@@ -85,6 +87,7 @@ export class ProgressController {
         this._onCallLog?.(message);
       },
       metadata: this.metadata,
+      title: this.title,
       setAllowConcurrentOrNestedRaces: (allow: boolean) => {
         allowConcurrent = allow;
       },
@@ -186,5 +189,6 @@ export const nullProgress: Progress = {
     log: [],
     internal: true,
   },
+  title: '',
   setAllowConcurrentOrNestedRaces() { },
 };

--- a/packages/protocol/src/progress.d.ts
+++ b/packages/protocol/src/progress.d.ts
@@ -39,5 +39,9 @@ export interface Progress {
   wait(timeout: number): Promise<void>; // timeout = 0 here means "wait 0 ms", not forever.
   signal: AbortSignal;
   metadata: CallMetadata;
+  // Resolved title for the call (already format-substituted), used when logging.
+  // Computed once at dispatch time so server code does not need to look up
+  // protocol metainfo / substitute params on every log line.
+  title: string;
   setAllowConcurrentOrNestedRaces(allow: boolean): void;
 }


### PR DESCRIPTION
## Summary
- Resolve the call title once at dispatch time and place it on `Progress.title`.
- `frame.expect` and `page._expectScreenshot` now log via `progress.title` instead of calling `renderTitleForCall(metadata)` per log line.
- `renderTitleForCall` stays put for the trace viewer and the three remaining metadata-only consumers (screencast / debugger event / recorder call log).