### PR TITLE
fix(mcp): forward browser-level CDP commands in extension mode

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserModel.ts
+++ b/packages/playwright-core/src/tools/mcp/browserModel.ts
@@ -150,6 +150,21 @@ export class BrowserModel {
     return this._findTabSession(s => s.sessionId === sessionId)?.targetInfo;
   }
 
+  // Forward a browser-level CDP command (Storage.*, Browser.*, etc.) that is
+  // not associated with a specific tab. chrome.debugger.sendCommand requires a
+  // target, so we route through any attached tab; the command itself is
+  // browser-scoped and returns the same result regardless of which tab is used.
+  async sendBrowserCommand(method: string, params: any): Promise<any> {
+    const tabSession = this._tabSessions.values().next().value;
+    if (!tabSession)
+      throw new Error(`No attached tab to forward browser-level command: ${method}`);
+    return await this._sendToExtension('chrome.debugger.sendCommand', [
+      { tabId: tabSession.tabId },
+      method,
+      params,
+    ]);
+  }
+
   // Forward a CDP command from Playwright to the tab its sessionId resolves to.
   async sendCommand(sessionId: string, method: string, params: any): Promise<any> {
     // Two cases:

--- a/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelayV2.ts
@@ -106,8 +106,9 @@ export class ExtensionProtocolV2 implements ExtensionProtocolHandler {
   }
 
   async forwardToExtension(method: string, params: any, sessionId: string | undefined): Promise<any> {
+    // Browser-level commands (Storage.*, Browser.*) have no sessionId.
     if (!sessionId)
-      throw new Error(`Unsupported command without sessionId: ${method}`);
+      return await this._model.sendBrowserCommand(method, params);
     return await this._model.sendCommand(sessionId, method, params);
   }
 }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs/promises';
 
-import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, startWithExtensionFlag } from './extension-fixtures';
+import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, connectAndNavigate, startWithExtensionFlag } from './extension-fixtures';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 
 const { defaultUserDataDirForChannel } = utils;
@@ -287,6 +287,36 @@ test(`--browser <channel> selects channel-specific userDataDir`, {
   })).toHaveResponse({
     error: expect.stringContaining(`Playwright Extension not found in "${expectedUserDataDir}"`),
     isError: true,
+  });
+});
+
+test(`browser_cookie_list and browser_cookie_set work in extension mode`, {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40687' },
+}, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+  const { client } = await startClient({
+    args: [`--extension`],
+    config: { capabilities: ['storage'] },
+    env: {
+      PWTEST_EXTENSION_USER_DATA_DIR: browserWithExtension.userDataDir,
+    },
+  });
+
+  await connectAndNavigate(browserContext, client, server.HELLO_WORLD);
+
+  // Storage.setCookie / Storage.getCookies are browser-level CDP commands
+  // (no sessionId) and used to be rejected outright by the v2 relay.
+  await client.callTool({
+    name: 'browser_cookie_set',
+    arguments: { name: 'extCookie', value: 'extValue' },
+  });
+  const result = await client.callTool({
+    name: 'browser_cookie_list',
+    arguments: {},
+  });
+
+  expect(result).toHaveResponse({
+    result: expect.stringContaining('extCookie=extValue'),
   });
 });
 


### PR DESCRIPTION
## Summary
- v2 relay rejected browser-level CDP commands (Storage.*, Browser.*) because they carry no sessionId. Route them through any attached tab's chrome.debugger session — the command is browser-scoped, so any tab works.
- This unblocks `cookie-list`, `cookie-set`, `state-save`, etc. in extension mode.

Fixes https://github.com/microsoft/playwright/issues/40687