### PR TITLE
docs: fix broken link to test configuration

### DIFF
--- a/docs/src/test-retries-js.md
+++ b/docs/src/test-retries-js.md
@@ -5,7 +5,7 @@ title: "Retries"
 
 ## Introduction
 
-Test retries are a way to automatically re-run a test when it fails. This is useful when a test is flaky and fails intermittently. Test retries are configured in the [configuration file](./test-configuration.md).
+Test retries are a way to automatically re-run a test when it fails. This is useful when a test is flaky and fails intermittently. Test retries are configured in the [configuration file](./test-configuration-js.md).
 
 ## Failures
 


### PR DESCRIPTION
Update link to point to test-configuration-js.md instead of the non-existent test-configuration.md.