### PR TITLE
chore(docs): include electron-api and mobile-api in render_release_notes

### DIFF
--- a/utils/render_release_notes.mjs
+++ b/utils/render_release_notes.mjs
@@ -37,7 +37,9 @@ let documentation = parseApi(path.join(documentationRoot, 'api'));
 if (language === 'js') {
   documentation = documentation
       .mergeWith(parseApi(path.join(documentationRoot, 'test-api'), path.join(documentationRoot, 'api', 'params.md')))
-      .mergeWith(parseApi(path.join(documentationRoot, 'test-reporter-api')));
+      .mergeWith(parseApi(path.join(documentationRoot, 'test-reporter-api')))
+      .mergeWith(parseApi(path.join(documentationRoot, 'electron-api'), path.join(documentationRoot, 'api', 'params.md')))
+      .mergeWith(parseApi(path.join(documentationRoot, 'mobile-api'), path.join(documentationRoot, 'api', 'params.md')));
 }
 
 documentation.setLinkRenderer(docsLinkRendererForLanguage(language, 'ReleaseNotesMd'));


### PR DESCRIPTION
## Summary
- Merge `electron-api/` and `mobile-api/` documentation into `render_release_notes.mjs`, matching what `utils/doclint/cli.js` already does.
- Without this, links like `[\`method: ElectronApplication.close\`]` or `[\`method: AndroidDevice.launchBrowser\`]` throw `Undefined member reference` when rendering release notes for GitHub.