### PR TITLE
chore: bump version to v1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-internal",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-internal",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -9600,10 +9600,10 @@
       "version": "0.0.0"
     },
     "packages/playwright": {
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9617,11 +9617,11 @@
     },
     "packages/playwright-browser-chromium": {
       "name": "@playwright/browser-chromium",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "engines": {
         "node": ">=18"
@@ -9629,11 +9629,11 @@
     },
     "packages/playwright-browser-firefox": {
       "name": "@playwright/browser-firefox",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "engines": {
         "node": ">=18"
@@ -9641,22 +9641,22 @@
     },
     "packages/playwright-browser-webkit": {
       "name": "@playwright/browser-webkit",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "packages/playwright-chromium": {
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9676,14 +9676,14 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "packages/playwright-core": {
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9694,11 +9694,11 @@
     },
     "packages/playwright-ct-core": {
       "name": "@playwright/experimental-ct-core",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-next",
-        "playwright-core": "1.60.0-next",
+        "playwright": "1.60.0",
+        "playwright-core": "1.60.0",
         "vite": "^6.4.1"
       },
       "engines": {
@@ -9707,10 +9707,10 @@
     },
     "packages/playwright-ct-react": {
       "name": "@playwright/experimental-ct-react",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@playwright/experimental-ct-core": "1.60.0-next",
+        "@playwright/experimental-ct-core": "1.60.0",
         "@vitejs/plugin-react": "^4.2.1"
       },
       "bin": {
@@ -9722,10 +9722,10 @@
     },
     "packages/playwright-ct-react17": {
       "name": "@playwright/experimental-ct-react17",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@playwright/experimental-ct-core": "1.60.0-next",
+        "@playwright/experimental-ct-core": "1.60.0",
         "@vitejs/plugin-react": "^4.2.1"
       },
       "bin": {
@@ -9737,10 +9737,10 @@
     },
     "packages/playwright-ct-vue": {
       "name": "@playwright/experimental-ct-vue",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@playwright/experimental-ct-core": "1.60.0-next",
+        "@playwright/experimental-ct-core": "1.60.0",
         "@vitejs/plugin-vue": "^5.2.0"
       },
       "bin": {
@@ -9762,11 +9762,11 @@
       }
     },
     "packages/playwright-firefox": {
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9777,10 +9777,10 @@
     },
     "packages/playwright-test": {
       "name": "@playwright/test",
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-next"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9790,11 +9790,11 @@
       }
     },
     "packages/playwright-webkit": {
-      "version": "1.60.0-next",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-next"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-internal",
   "private": true,
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",

--- a/packages/playwright-browser-chromium/package.json
+++ b/packages/playwright-browser-chromium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-chromium",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright package that automatically installs Chromium",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-browser-firefox/package.json
+++ b/packages/playwright-browser-firefox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-firefox",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright package that automatically installs Firefox",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-browser-webkit/package.json
+++ b/packages/playwright-browser-webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-webkit",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright package that automatically installs WebKit",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-chromium",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate Chromium",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-client/package.json
+++ b/packages/playwright-client/package.json
@@ -30,6 +30,6 @@
     "watch": "npm run esbuild -- --watch"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-core",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",

--- a/packages/playwright-ct-core/package.json
+++ b/packages/playwright-ct-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/experimental-ct-core",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright Component Testing Helpers",
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
     }
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next",
+    "playwright-core": "1.60.0",
     "vite": "^6.4.1",
-    "playwright": "1.60.0-next"
+    "playwright": "1.60.0"
   }
 }

--- a/packages/playwright-ct-react/package.json
+++ b/packages/playwright-ct-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/experimental-ct-react",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright Component Testing for React",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@playwright/experimental-ct-core": "1.60.0-next",
+    "@playwright/experimental-ct-core": "1.60.0",
     "@vitejs/plugin-react": "^4.2.1"
   },
   "bin": {

--- a/packages/playwright-ct-react17/package.json
+++ b/packages/playwright-ct-react17/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/experimental-ct-react17",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright Component Testing for React",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@playwright/experimental-ct-core": "1.60.0-next",
+    "@playwright/experimental-ct-core": "1.60.0",
     "@vitejs/plugin-react": "^4.2.1"
   },
   "bin": {

--- a/packages/playwright-ct-vue/package.json
+++ b/packages/playwright-ct-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/experimental-ct-vue",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "Playwright Component Testing for Vue",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@playwright/experimental-ct-core": "1.60.0-next",
+    "@playwright/experimental-ct-core": "1.60.0",
     "@vitejs/plugin-vue": "^5.2.0"
   },
   "bin": {

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-firefox",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate Firefox",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/test",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
   },
   "scripts": {},
   "dependencies": {
-    "playwright": "1.60.0-next"
+    "playwright": "1.60.0"
   }
 }

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-webkit",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate WebKit",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "1.60.0-next",
+  "version": "1.60.0",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
@@ -53,7 +53,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "playwright-core": "1.60.0-next"
+    "playwright-core": "1.60.0"
   },
   "optionalDependencies": {
     "fsevents": "2.3.2"


### PR DESCRIPTION
## Summary
- Bump all package versions from `1.60.0-next` to `1.60.0`

Reference: https://github.com/microsoft/playwright-internal/issues/288