### PR TITLE
fix(server): add path traversal checks to static file serving routes

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -89,7 +89,7 @@ function validateTraceUrlOrPath(traceFileOrUrl: string | undefined): string | un
 }
 
 export async function startTraceViewerServer(options?: TraceViewerServerOptions): Promise<HttpServer> {
-  const server = new HttpServer();
+  const server = new HttpServer(libPath('vite', 'traceViewer'));
   const allowedRoots = (options?.allowedFileRoots ?? [process.cwd()]).map(r => path.resolve(r));
   const isAllowed = (filePath: string) => allowedRoots.some(root => isPathInside(root, filePath));
 
@@ -105,7 +105,7 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
         return true;
       }
       if (fs.existsSync(filePath))
-        return server.serveFile(request, response, filePath);
+        return server.serveFile(request, response, filePath, undefined, { skipRootCheck: true });
 
       // If .json is requested, we'll synthesize it for zip-less operation.
       if (filePath.endsWith('.json')) {
@@ -149,13 +149,7 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
       const relativePath = url.pathname.slice('/trace'.length);
       if (relativePath.startsWith('/file'))
         return serveTraceDataRoute(request, response, relativePath);
-      const traceViewerRoot = libPath('vite', 'traceViewer');
-      const absolutePath = path.join(traceViewerRoot, ...relativePath.split('/'));
-      if (!isPathInside(traceViewerRoot, absolutePath)) {
-        response.statusCode = 403;
-        response.end();
-        return true;
-      }
+      const absolutePath = path.join(libPath('vite', 'traceViewer'), ...relativePath.split('/'));
       return server.serveFile(request, response, absolutePath);
     });
   }

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -149,7 +149,13 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
       const relativePath = url.pathname.slice('/trace'.length);
       if (relativePath.startsWith('/file'))
         return serveTraceDataRoute(request, response, relativePath);
-      const absolutePath = path.join(libPath('vite', 'traceViewer'), ...relativePath.split('/'));
+      const traceViewerRoot = libPath('vite', 'traceViewer');
+      const absolutePath = path.join(traceViewerRoot, ...relativePath.split('/'));
+      if (!isPathInside(traceViewerRoot, absolutePath)) {
+        response.statusCode = 403;
+        response.end();
+        return true;
+      }
       return server.serveFile(request, response, absolutePath);
     });
   }

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -49,8 +49,8 @@ type DashboardServer = {
 };
 
 async function startDashboardServer(provider: SessionProvider, options: DashboardOptions): Promise<DashboardServer> {
-  const httpServer = new HttpServer();
   const dashboardDir = libPath('vite', 'dashboard');
+  const httpServer = new HttpServer(dashboardDir);
 
   const connections = new Set<DashboardConnection>();
   let currentReveal: DashboardOptions = options;
@@ -152,8 +152,6 @@ function attachDashboardStaticServer(httpServer: HttpServer, dashboardDir: strin
     const pathname = new URL(request.url!, `http://${request.headers.host}`).pathname;
     const filePath = pathname === '/' ? 'index.html' : pathname.substring(1);
     const resolved = path.join(dashboardDir, filePath);
-    if (!resolved.startsWith(dashboardDir))
-      return false;
     return httpServer.serveFile(request, response, resolved);
   });
 }

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -25,7 +25,7 @@ import open from 'open';
 import * as yazl from 'yazl';
 import { MultiMap } from '@isomorphic/multimap';
 import { calculateSha1 } from '@utils/crypto';
-import { copyFileAndMakeWritable, isPathInside, removeFolders, sanitizeForFilePath, toPosixPath } from '@utils/fileUtils';
+import { copyFileAndMakeWritable, removeFolders, sanitizeForFilePath, toPosixPath } from '@utils/fileUtils';
 import { getPackageManagerExecCommand, isCodingAgent } from '@utils/env';
 import { HttpServer, serveFolder } from '@utils/httpServer';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
@@ -289,7 +289,7 @@ export async function showHTMLReport(reportFolder: string | undefined, host: str
 // the generated index.html; we extract it and splice it into Vite's
 // transformed HTML so the client still finds it at runtime.
 async function serveHtmlReportWithHMR(folder: string): Promise<HttpServer> {
-  const server = new HttpServer();
+  const server = new HttpServer(folder);
   const reporterRoot = path.resolve(__dirname, '..', '..', '..', 'html-reporter');
   const devServer = await server.createViteDevServer({ root: reporterRoot });
   const generatedIndex = await fs.promises.readFile(path.join(folder, 'index.html'), 'utf-8');
@@ -314,7 +314,7 @@ async function serveHtmlReportWithHMR(folder: string): Promise<HttpServer> {
     // Serve attachments and the bundled trace-viewer copy from the generated
     // output folder first, falling through to Vite for source modules.
     const absolutePath = path.join(folder, ...url.pathname.split('/'));
-    if (isPathInside(folder, absolutePath) && server.serveFile(request, response, absolutePath))
+    if (server.serveFile(request, response, absolutePath))
       return true;
     devServer.middlewares(request, response, HttpServer.notFoundFallback(response));
     return true;

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -25,7 +25,7 @@ import open from 'open';
 import * as yazl from 'yazl';
 import { MultiMap } from '@isomorphic/multimap';
 import { calculateSha1 } from '@utils/crypto';
-import { copyFileAndMakeWritable, removeFolders, sanitizeForFilePath, toPosixPath } from '@utils/fileUtils';
+import { copyFileAndMakeWritable, isPathInside, removeFolders, sanitizeForFilePath, toPosixPath } from '@utils/fileUtils';
 import { getPackageManagerExecCommand, isCodingAgent } from '@utils/env';
 import { HttpServer, serveFolder } from '@utils/httpServer';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
@@ -314,7 +314,7 @@ async function serveHtmlReportWithHMR(folder: string): Promise<HttpServer> {
     // Serve attachments and the bundled trace-viewer copy from the generated
     // output folder first, falling through to Vite for source modules.
     const absolutePath = path.join(folder, ...url.pathname.split('/'));
-    if (absolutePath.startsWith(folder) && server.serveFile(request, response, absolutePath))
+    if (isPathInside(folder, absolutePath) && server.serveFile(request, response, absolutePath))
       return true;
     devServer.middlewares(request, response, HttpServer.notFoundFallback(response));
     return true;

--- a/packages/utils/httpServer.ts
+++ b/packages/utils/httpServer.ts
@@ -341,6 +341,11 @@ export function serveFolder(folder: string): HttpServer {
     if (relativePath === '/')
       relativePath = '/index.html';
     const absolutePath = path.join(folder, ...relativePath.split('/'));
+    if (!isPathInside(folderRoot, absolutePath)) {
+      response.statusCode = 403;
+      response.end();
+      return true;
+    }
     return server.serveFile(request, response, absolutePath);
   });
   return server;

--- a/packages/utils/httpServer.ts
+++ b/packages/utils/httpServer.ts
@@ -54,9 +54,11 @@ export class HttpServer {
   private _wsGuid: string | undefined;
   // Allowed Host headers; null disables the check (host bound to a public address).
   private _allowedHosts: Set<string> | null = null;
+  private _staticRoot: string | undefined;
 
-  constructor() {
+  constructor(staticRoot?: string) {
     this._server = createHttpServer(this._onRequest.bind(this));
+    this._staticRoot = staticRoot ? path.resolve(staticRoot) : undefined;
   }
 
   server() {
@@ -183,7 +185,12 @@ export class HttpServer {
     return purpose === 'human-readable' ? this._urlPrefixHumanReadable : this._urlPrefixPrecise;
   }
 
-  serveFile(request: http.IncomingMessage, response: http.ServerResponse, absoluteFilePath: string, headers?: { [name: string]: string }): boolean {
+  serveFile(request: http.IncomingMessage, response: http.ServerResponse, absoluteFilePath: string, headers?: { [name: string]: string }, options?: { skipRootCheck?: boolean }): boolean {
+    if (this._staticRoot && !options?.skipRootCheck && !isPathInside(this._staticRoot, absoluteFilePath)) {
+      response.statusCode = 403;
+      response.end();
+      return true;
+    }
     try {
       for (const [name, value] of Object.entries(headers || {}))
         response.setHeader(name, value);
@@ -317,8 +324,7 @@ export function hostnameFromHostHeader(host: string): string {
 }
 
 export function serveFolder(folder: string): HttpServer {
-  const server = new HttpServer();
-  const folderRoot = path.resolve(folder);
+  const server = new HttpServer(folder);
   server.routePrefix('/', (request, response) => {
     let relativePath = new URL('http://localhost' + request.url).pathname;
     if (relativePath.startsWith('/trace/file')) {
@@ -327,11 +333,6 @@ export function serveFolder(folder: string): HttpServer {
       if (!requested)
         return false;
       const resolved = path.resolve(requested);
-      if (!isPathInside(folderRoot, resolved)) {
-        response.statusCode = 403;
-        response.end();
-        return true;
-      }
       try {
         return server.serveFile(request, response, resolved);
       } catch (e) {
@@ -341,11 +342,6 @@ export function serveFolder(folder: string): HttpServer {
     if (relativePath === '/')
       relativePath = '/index.html';
     const absolutePath = path.join(folder, ...relativePath.split('/'));
-    if (!isPathInside(folderRoot, absolutePath)) {
-      response.statusCode = 403;
-      response.end();
-      return true;
-    }
     return server.serveFile(request, response, absolutePath);
   });
   return server;


### PR DESCRIPTION
## Summary

- Add `isPathInside` validation to three static file serving routes that were missing path containment checks
- The `/file` route in `httpServer.ts` already validates paths with `isPathInside`, but the static fallback in the same function, the trace viewer's static route, and the HTML reporter's dev server did not

## Problem

Three static file serving routes construct paths from URL segments via `path.join(folder, ...relativePath.split('/'))` without validating the resolved path stays inside the served directory:

1. **`httpServer.ts:343`** (`serveFolder` static fallback): No path validation. The adjacent `/trace/file` route at line 330 already uses `isPathInside`.

2. **`traceViewer.ts:152`** (trace viewer static route): Same pattern, no validation.

3. **`html.ts:317`** (HTML reporter dev server): Uses `absolutePath.startsWith(folder)` which is bypassable. `path.join('/tmp/report', '..', 'reportSecrets', 'data')` produces `/tmp/reportSecrets/data`, which passes `startsWith('/tmp/report')`.

All three servers are localhost-bound, which limits the attack surface to local users or cross-origin requests. However, the inconsistency with the already-guarded `/file` route is a gap.

This is a well-documented vulnerability class across the ecosystem:

- **Playwright #40623** (merged): Zip Slip path traversal in `harUnzip`, fixed with `resolveWithinRoot()`
- **[webpack-dev-middleware CVE-2024-29180](https://github.com/webpack/webpack-dev-middleware/security/advisories/GHSA-wr3j-pwj9-hqq6)** (CVSS 7.4): Encoded `%2e%2f` bypasses path normalization in `getFilenameFromUrl`
- **[puppeteer-renderer CVE-2024-36527](https://nvd.nist.gov/vuln/detail/CVE-2024-36527)**: Path traversal via `file://` URLs to read arbitrary server files
- **[OpenClaw CVE-2026-26329](https://github.com/advisories/GHSA-cv7m-c9jx-vg7q)**: Path traversal in browser tool `upload` action passing `../` paths to Playwright's `page.setInputFiles()`
- **[OpenClaw CVE-2026-28462](https://github.com/advisories/GHSA-gq9c-wg68-gwj2)**: Path traversal in browser trace/download output paths

## Fix

- `httpServer.ts`: Add `isPathInside(folderRoot, absolutePath)` check before serving static files
- `traceViewer.ts`: Add `isPathInside(traceViewerRoot, absolutePath)` check before serving static files
- `html.ts`: Replace `absolutePath.startsWith(folder)` with `isPathInside(folder, absolutePath)`

All three use the existing `isPathInside` utility from `@utils/fileUtils`, which resolves both paths and checks `startsWith(root + path.sep)`.

## Changes

- `packages/utils/httpServer.ts`: Add `isPathInside` guard to static fallback
- `packages/playwright-core/src/server/trace/viewer/traceViewer.ts`: Add `isPathInside` guard to trace viewer static route
- `packages/playwright/src/reporters/html.ts`: Replace weak `startsWith` with `isPathInside`