### PR TITLE
chore(registry): dedupe executables in resolveBrowsers

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1457,7 +1457,7 @@ export class Registry {
 
     if (faultyArguments.length)
       throw new Error(`Invalid installation targets: ${faultyArguments.map(name => `'${name}'`).join(', ')}. Expecting one of: ${this.suggestedBrowsersToInstall()}`);
-    return executables;
+    return [...new Set(executables)];
   }
 }
 


### PR DESCRIPTION
## Summary
- `resolveBrowsers` pushes ffmpeg once per browser argument, so callers that don't go through `install()`/`installDeps()` (e.g. `install --dry-run`) saw ffmpeg listed multiple times.
- Dedupe the array before returning.