### PR TITLE
test: roll stable-test-runner to 1.60.0-beta-1778191499000

### DIFF
--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.60.0-alpha-2026-05-04"
+        "@playwright/test": "^1.60.0-beta-1778191499000"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-alpha-2026-05-04",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-alpha-2026-05-04.tgz",
-      "integrity": "sha512-+eTFaLFs8y7PXhHbKWoURf+hDbH1NZ1okAIDc+k1YjuLAkd3JRD9mAPff8NzCiqp4OpCew/bnDp4PpoSRhsQPw==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-eJM7mWJvEfdJFLD9Hm+NZFeOliipw1mMLCtSX2HPeQoLw/jp58sxPQH2ldpchRTn0UMgDcuI0XKI24+8nLC1zA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-2026-05-04"
+        "playwright": "1.60.0-beta-1778191499000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-2026-05-04",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-2026-05-04.tgz",
-      "integrity": "sha512-a+gBaMH4U5r7bPUd3p3FjpWuB4lg7mFFcs68uUCpC65j/vaXqJ5dWJxCGv2w7SmKWjeOKzY7IzXYuUjMshwdDg==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-I4ZT4SFIrNdZAXmfDg8K67ya9uAs2ELqXfG0MA8ZcojDXyI6pWqIj2nnF/KqloGM++2ACvOa5MlII4Xa0c92/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-2026-05-04"
+        "playwright-core": "1.60.0-beta-1778191499000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-2026-05-04",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-2026-05-04.tgz",
-      "integrity": "sha512-mjOw2DkFyklXnafv7sj9I3i9NElF1xg6lOGc6UpCdHo23ZgxpZXjLAkmvJ3flijEzSwlFyzAnr7YgndxMDaiuQ==",
+      "version": "1.60.0-beta-1778191499000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778191499000.tgz",
+      "integrity": "sha512-rN9NcOjAXvVf1qexgevYfRK8h4YhVRtu72tRcfcoU7aisGPSRIeoeGxozFYMjNPFWsJJEVsr3kkBYXuwKRPt7g==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "^1.60.0-alpha-2026-05-04"
+    "@playwright/test": "^1.60.0-beta-1778191499000"
   }
 }


### PR DESCRIPTION
## Summary
- Roll stable-test-runner from `1.60.0-alpha-2026-05-04` to `1.60.0-beta-1778191499000`.

Part of https://github.com/microsoft/playwright-internal/issues/288.