### PR TITLE
fix(android): reject pending callbacks on device close

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -265,6 +265,9 @@ export class AndroidDevice extends SdkObject {
       clearTimeout(this._pollingWebViews);
     for (const connection of this._browserConnections)
       await connection.close();
+    for (const callback of this._callbacks.values())
+      callback.reject(new Error('Device closed'));
+    this._callbacks.clear();
     if (this._driverPromise) {
       const driver = await this._driver();
       driver?.close();

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -245,7 +245,7 @@ export class AndroidDevice extends SdkObject {
       delete params.androidSelector;
     }
     const driver = await this._driver();
-    if (!driver)
+    if (!driver || this._isClosed)
       throw new Error('Device is closed');
     const id = ++this._lastId;
     const result = new Promise((fulfill, reject) => this._callbacks.set(id, { fulfill, reject }));


### PR DESCRIPTION
## Summary

- Reject all pending `_callbacks` when `AndroidDevice._close()` is called, preventing in-flight `_send()` calls from hanging forever
- Add a synchronous `_isClosed` guard after the `await` in `_send()` to prevent a race condition where `_close()` clears the callback map during the microtask yield

## Problem

`AndroidDevice._close()` tears down the driver, backend, and browser connections, but never rejects the pending entries in `_callbacks`. Any in-flight `_send()` call that is awaiting a response when the device closes will hang indefinitely because its promise is never resolved or rejected.

All four browser protocol sessions (CR, FF, WK, Bidi) already handle this correctly:

```typescript
// crConnection.ts:187-197
dispose() {
  this._closed = true;
  for (const callback of this._callbacks.values()) {
    callback.error.setMessage('Internal server error, session closed.');
    callback.reject(callback.error);
  }
  this._callbacks.clear();
}
```

The Android device uses the same callback map pattern (`_callbacks: Map<number, { fulfill, reject }>`) but was missing the cleanup loop.

Additionally, `_send()` has a race condition: it `await`s `this._driver()` before checking `_isClosed` and adding to the callback map. A concurrent `_close()` can clear the map during that yield, leaving the new callback orphaned.

### Related issues

- [#21510](https://github.com/microsoft/playwright/issues/21510): Android script gets stuck on `context.newPage()` / `launchBrowser()`
- [#38424](https://github.com/microsoft/playwright/issues/38424): `webview.page()` hangs forever on hidden/detached WebViews
- [#35104](https://github.com/microsoft/playwright/issues/35104): Android server stops unexpectedly before starting test
- [#21049](https://github.com/microsoft/playwright/issues/21049): `launchBrowser()` stuck on Oppo/Xiaomi devices
- [#31474](https://github.com/microsoft/playwright/issues/31474): Cancel inflight promises on page/context close

These issues all involve Android operations hanging or becoming unresponsive. While this fix does not address the root cause of each one (often device-specific firmware issues), it ensures that when the device does close, all pending operations fail cleanly instead of hanging the test process.

Comparable fix in Appium: [appium/appium#6562](https://github.com/appium/appium/issues/6562) (hanging after clicking button that closes Android WebView, caused by pending callbacks not cleaned up).

## Fix

1. In `_close()`: iterate `_callbacks`, reject each with `Error('Device closed')`, then clear the map. Placed before driver/backend teardown so callbacks are rejected while the transport is still valid.
2. In `_send()`: add `this._isClosed` check after `await this._driver()` to close the race window.

## Changes

- `packages/playwright-core/src/server/android/android.ts`: 4 lines added