### PR TITLE
test(dashboard): bump timeout for in-flight Submit re-enable assertion

### DIFF
--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -204,8 +204,10 @@ test('user-initiated annotate downloads zip with feedback.md', async ({ connectT
   await expect(dashboard.locator('.annotate-sidebar')).toBeVisible();
   await expect(dashboard.locator('.annotate-sidebar-thumb')).toHaveCount(1);
   // Wait until the in-flight (aborted) submit fully resolves and the button is re-enabled,
-  // otherwise installing the next picker mid-flight would race.
-  await expect(dashboard.getByRole('button', { name: 'Submit', exact: true })).toBeEnabled();
+  // otherwise installing the next picker mid-flight would race. The on-page work
+  // (PNG render + zip build + picker reject) can take longer than the default 5s
+  // poll on slow CI shards — see https://github.com/microsoft/playwright/actions/runs/25559486702.
+  await expect(dashboard.getByRole('button', { name: 'Submit', exact: true })).toBeEnabled({ timeout: 15000 });
 
   // Now install a capturing picker and submit for real.
   const awaitZipBytes = await installSaveFilePickerMock(dashboard);


### PR DESCRIPTION
## Summary

Experiment to test the hypothesis that the in-flight submit pipeline can outlast the default 5s expect-poll on slow CI, leaving the Submit button stuck on "Submitting…" when the assertion fires.

Seen in https://github.com/microsoft/playwright/actions/runs/25559486702 — error-context aria snapshot at timeout shows `button "Submitting…" [disabled]`.

Draft to see if the bump alone makes this shard happy; if so, real fix is to await the in-flight work (or match both labels) rather than carry a longer timeout.
