### PR TITLE
fix(tracing): mkdir tracesDir before live .stacks writes

### DIFF
--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -205,6 +205,9 @@ export async function tracingStarted(progress: Progress, stackSessions: Map<stri
   if (!params.tracesDir)
     tmpDir = await progress.race(fs.promises.mkdtemp(path.join(os.tmpdir(), 'playwright-tracing-')));
   const traceStacksFile = path.join(params.tracesDir || tmpDir!, params.traceName + '.stacks');
+  // Ensure the directory exists before addStackToTracingNoReply races ahead of
+  // the tracing recorder's own (separately queued) mkdir.
+  await progress.race(fs.promises.mkdir(path.dirname(traceStacksFile), { recursive: true }));
   stackSessions.set(traceStacksFile, { callStacks: [], file: traceStacksFile, writer: Promise.resolve(), tmpDir, live: params.live });
   return { stacksId: traceStacksFile };
 }


### PR DESCRIPTION
Fixes a race in live tracing.

`localUtils.tracingStarted` returns a stacksId at `<tracesDir>/<traceName>.stacks`, and `addStackToTracingNoReply` writes to that file directly. The recorder’s `Tracing` enqueues a recursive mkdir of `<tracesDir>/resources` through its own `SerializedFS` queue — separate from the per-session writer chain in `localUtils`, so there’s no happens-before guarantee between them.

When the SerializedFS worker hasn’t drained the mkdir yet and a stack write fires (live mode + an action like `page.goto`), the write fails with ENOENT.

Surfaces as a flake on `mcp-windows-latest-firefox` via `tests/mcp/tracing.spec.ts:54` (`browser_stop_tracing` returns `result: undefined` because tracing.stop bubbled the ENOENT).

Fix: precreate `path.dirname(traceStacksFile)` in `tracingStarted`, so the contract is self-contained for any caller.

https://mspwblobreport.z1.web.core.windows.net/run-25561393525-1-d8c56b0253640b9f180ee09093c38892d31661d7/index.html#?testId=39a796cef0e6f5869c06-d52e545eb08e8dd5c09c7