### PR TITLE
test(mcp): mark test_run abort test as slow

### DIFF
--- a/tests/mcp/test-run.spec.ts
+++ b/tests/mcp/test-run.spec.ts
@@ -124,6 +124,7 @@ Running 2 tests using 1 worker
 });
 
 test('test_run should stop when aborted', async ({ startClient }) => {
+  test.slow(true, 'Drives two full test-runner lifecycles (abort + restart)');
   await writeFiles({
     'slow.test.ts': `
       import { test } from '@playwright/test';


### PR DESCRIPTION
## Summary
- `tests/mcp/test-run.spec.ts:126` (`test_run should stop when aborted`) drives two full Playwright test-runner lifecycles in one test body (aborted run + follow-up run), while sibling tests only do one. On Windows CI under parallel load it occasionally exceeds the 30s timeout and fails with `MCP error -32000: Connection closed` (teardown symptom, root cause is timeout).
- Mark it `test.slow()` to give it 3× headroom, matching the pattern at `tests/library/browsertype-connect.spec.ts:75`.