### PR TITLE
feat(keyboard): add pressSequence() for batched key presses

### DIFF
--- a/docs/src/api/class-keyboard.md
+++ b/docs/src/api/class-keyboard.md
@@ -299,6 +299,64 @@ Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
 
 Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
+## async method: Keyboard.pressSequence
+* since: v1.61
+
+Presses each key in the [`param: keys`] array sequentially. Each key press is equivalent to calling
+[`method: Keyboard.press`] for that key. When [`option: delay`] is specified, there is a pause between
+consecutive key presses.
+
+Unlike calling [`method: Keyboard.press`] in a loop, this method sends the entire sequence in a single
+protocol message, reducing round-trip overhead when multiple keys need to be pressed in quick succession.
+
+[`param: keys`] entries follow the same format as [`method: Keyboard.press`], including modifier shortcuts
+like `"Control+A"`.
+
+**Usage**
+
+```js
+// Keyboard-based drag: grab, move down twice, drop
+await page.keyboard.pressSequence(['Space', 'ArrowDown', 'ArrowDown', 'Space'], { delay: 100 });
+
+// Select all and delete
+await page.keyboard.pressSequence(['ControlOrMeta+A', 'Backspace']);
+```
+
+```java
+// Keyboard-based drag: grab, move down twice, drop
+page.keyboard().pressSequence(Arrays.asList("Space", "ArrowDown", "ArrowDown", "Space"),
+    new Keyboard.PressSequenceOptions().setDelay(100));
+```
+
+```python async
+# Keyboard-based drag: grab, move down twice, drop
+await page.keyboard.press_sequence(["Space", "ArrowDown", "ArrowDown", "Space"], delay=100)
+```
+
+```python sync
+# Keyboard-based drag: grab, move down twice, drop
+page.keyboard.press_sequence(["Space", "ArrowDown", "ArrowDown", "Space"], delay=100)
+```
+
+```csharp
+// Keyboard-based drag: grab, move down twice, drop
+await page.Keyboard.PressSequenceAsync(
+    new[] { "Space", "ArrowDown", "ArrowDown", "Space" },
+    new() { Delay = 100 });
+```
+
+### param: Keyboard.pressSequence.keys
+* since: v1.61
+- `keys` <[Array]<[string]>>
+
+Array of key names to press sequentially. Each key follows the same format as [`method: Keyboard.press`].
+
+### option: Keyboard.pressSequence.delay
+* since: v1.61
+- `delay` <[float]>
+
+Time to wait between consecutive key presses in milliseconds. Defaults to 0.
+
 ## async method: Keyboard.type
 * since: v1.8
 

--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -268,6 +268,7 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['Page.keyboardInsertText', { title: 'Insert "{text}"', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.keyboardType', { title: 'Type "{text}"', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.keyboardPress', { title: 'Press "{key}"', slowMo: true, snapshot: true, pause: true, input: true, }],
+  ['Page.keyboardPressSequence', { title: 'Press sequence', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseMove', { title: 'Mouse move', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseDown', { title: 'Mouse down', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseUp', { title: 'Mouse up', slowMo: true, snapshot: true, pause: true, input: true, }],

--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -268,7 +268,7 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['Page.keyboardInsertText', { title: 'Insert "{text}"', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.keyboardType', { title: 'Type "{text}"', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.keyboardPress', { title: 'Press "{key}"', slowMo: true, snapshot: true, pause: true, input: true, }],
-  ['Page.keyboardPressSequence', { title: 'Press sequence', slowMo: true, snapshot: true, pause: true, input: true, }],
+  ['Page.keyboardPressSequence', { title: 'Press key sequence', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseMove', { title: 'Mouse move', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseDown', { title: 'Mouse down', slowMo: true, snapshot: true, pause: true, input: true, }],
   ['Page.mouseUp', { title: 'Mouse up', slowMo: true, snapshot: true, pause: true, input: true, }],

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -19606,6 +19606,43 @@ export interface Keyboard {
   }): Promise<void>;
 
   /**
+   * Presses each key in the
+   * [`keys`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-keys) array sequentially.
+   * Each key press is equivalent to calling
+   * [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press) for that key. When
+   * [`delay`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-delay) is specified, there
+   * is a pause between consecutive key presses.
+   *
+   * Unlike calling [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press) in a
+   * loop, this method sends the entire sequence in a single protocol message, reducing round-trip overhead when
+   * multiple keys need to be pressed in quick succession.
+   *
+   * [`keys`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-keys) entries follow the
+   * same format as [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press),
+   * including modifier shortcuts like `"Control+A"`.
+   *
+   * **Usage**
+   *
+   * ```js
+   * // Keyboard-based drag: grab, move down twice, drop
+   * await page.keyboard.pressSequence(['Space', 'ArrowDown', 'ArrowDown', 'Space'], { delay: 100 });
+   *
+   * // Select all and delete
+   * await page.keyboard.pressSequence(['ControlOrMeta+A', 'Backspace']);
+   * ```
+   *
+   * @param keys Array of key names to press sequentially. Each key follows the same format as
+   * [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press).
+   * @param options
+   */
+  pressSequence(keys: ReadonlyArray<string>, options?: {
+    /**
+     * Time to wait between consecutive key presses in milliseconds. Defaults to 0.
+     */
+    delay?: number;
+  }): Promise<void>;
+
+  /**
    * **NOTE** In most cases, you should use
    * [locator.fill(value[, options])](https://playwright.dev/docs/api/class-locator#locator-fill) instead. You only need
    * to press keys one by one if there is special keyboard handling on the page - in this case use

--- a/packages/playwright-core/src/client/input.ts
+++ b/packages/playwright-core/src/client/input.ts
@@ -45,6 +45,10 @@ export class Keyboard implements api.Keyboard {
   async press(key: string, options: channels.PageKeyboardPressOptions = {}) {
     await this._page._channel.keyboardPress({ key, ...options });
   }
+
+  async pressSequence(keys: string[], options: channels.PageKeyboardPressSequenceOptions = {}) {
+    await this._page._channel.keyboardPressSequence({ keys, ...options });
+  }
 }
 
 export class Mouse implements api.Mouse {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2387,6 +2387,11 @@ scheme.PageKeyboardPressParams = tObject({
   delay: tOptional(tFloat),
 });
 scheme.PageKeyboardPressResult = tOptional(tObject({}));
+scheme.PageKeyboardPressSequenceParams = tObject({
+  keys: tArray(tString),
+  delay: tOptional(tFloat),
+});
+scheme.PageKeyboardPressSequenceResult = tOptional(tObject({}));
 scheme.PageMouseMoveParams = tObject({
   x: tFloat,
   y: tFloat,

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -284,6 +284,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     await this._page.keyboard.apiPress(progress, params.key, params);
   }
 
+  async keyboardPressSequence(params: channels.PageKeyboardPressSequenceParams, progress: Progress): Promise<void> {
+    await this._page.keyboard.apiPressSequence(progress, params.keys, params);
+  }
+
   async clearConsoleMessages(params: channels.PageClearConsoleMessagesParams, progress: Progress): Promise<channels.PageClearConsoleMessagesResult> {
     this._page.clearConsoleMessages();
   }

--- a/packages/playwright-core/src/server/input.ts
+++ b/packages/playwright-core/src/server/input.ts
@@ -126,6 +126,20 @@ export class Keyboard {
     await this.press(progress, key, options);
   }
 
+  async apiPressSequence(progress: Progress, keys: string[], options: { delay?: number } = {}) {
+    await progress.race(this._page.instrumentation.onBeforeInputAction(this._page, progress.metadata));
+    await this.pressSequence(progress, keys, options);
+  }
+
+  async pressSequence(progress: Progress, keys: string[], options: { delay?: number } = {}) {
+    const delay = options.delay || undefined;
+    for (let i = 0; i < keys.length; i++) {
+      await this.press(progress, keys[i]);
+      if (delay && i < keys.length - 1)
+        await progress.wait(delay);
+    }
+  }
+
   async press(progress: Progress, key: string, options: { delay?: number } = {}) {
     function split(keyString: string) {
       const keys = [];

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19606,6 +19606,43 @@ export interface Keyboard {
   }): Promise<void>;
 
   /**
+   * Presses each key in the
+   * [`keys`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-keys) array sequentially.
+   * Each key press is equivalent to calling
+   * [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press) for that key. When
+   * [`delay`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-delay) is specified, there
+   * is a pause between consecutive key presses.
+   *
+   * Unlike calling [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press) in a
+   * loop, this method sends the entire sequence in a single protocol message, reducing round-trip overhead when
+   * multiple keys need to be pressed in quick succession.
+   *
+   * [`keys`](https://playwright.dev/docs/api/class-keyboard#keyboard-press-sequence-option-keys) entries follow the
+   * same format as [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press),
+   * including modifier shortcuts like `"Control+A"`.
+   *
+   * **Usage**
+   *
+   * ```js
+   * // Keyboard-based drag: grab, move down twice, drop
+   * await page.keyboard.pressSequence(['Space', 'ArrowDown', 'ArrowDown', 'Space'], { delay: 100 });
+   *
+   * // Select all and delete
+   * await page.keyboard.pressSequence(['ControlOrMeta+A', 'Backspace']);
+   * ```
+   *
+   * @param keys Array of key names to press sequentially. Each key follows the same format as
+   * [keyboard.press(key[, options])](https://playwright.dev/docs/api/class-keyboard#keyboard-press).
+   * @param options
+   */
+  pressSequence(keys: ReadonlyArray<string>, options?: {
+    /**
+     * Time to wait between consecutive key presses in milliseconds. Defaults to 0.
+     */
+    delay?: number;
+  }): Promise<void>;
+
+  /**
    * **NOTE** In most cases, you should use
    * [locator.fill(value[, options])](https://playwright.dev/docs/api/class-locator#locator-fill) instead. You only need
    * to press keys one by one if there is special keyboard handling on the page - in this case use

--- a/packages/protocol/spec/page.yml
+++ b/packages/protocol/spec/page.yml
@@ -318,7 +318,7 @@ Page:
         input: true
 
     keyboardPressSequence:
-      title: Press sequence
+      title: Press key sequence
       parameters:
         keys:
           type: array

--- a/packages/protocol/spec/page.yml
+++ b/packages/protocol/spec/page.yml
@@ -317,6 +317,19 @@ Page:
         pause: true
         input: true
 
+    keyboardPressSequence:
+      title: Press sequence
+      parameters:
+        keys:
+          type: array
+          items: string
+        delay: float?
+      flags:
+        slowMo: true
+        snapshot: true
+        pause: true
+        input: true
+
     mouseMove:
       title: Mouse move
       parameters:

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -3845,6 +3845,7 @@ export interface PageChannel extends PageEventTarget, EventTargetChannel {
   keyboardInsertText(params: PageKeyboardInsertTextParams, progress?: Progress): Promise<PageKeyboardInsertTextResult>;
   keyboardType(params: PageKeyboardTypeParams, progress?: Progress): Promise<PageKeyboardTypeResult>;
   keyboardPress(params: PageKeyboardPressParams, progress?: Progress): Promise<PageKeyboardPressResult>;
+  keyboardPressSequence(params: PageKeyboardPressSequenceParams, progress?: Progress): Promise<PageKeyboardPressSequenceResult>;
   mouseMove(params: PageMouseMoveParams, progress?: Progress): Promise<PageMouseMoveResult>;
   mouseDown(params: PageMouseDownParams, progress?: Progress): Promise<PageMouseDownResult>;
   mouseUp(params: PageMouseUpParams, progress?: Progress): Promise<PageMouseUpResult>;
@@ -4212,6 +4213,14 @@ export type PageKeyboardPressOptions = {
   delay?: number,
 };
 export type PageKeyboardPressResult = void;
+export type PageKeyboardPressSequenceParams = {
+  keys: string[],
+  delay?: number,
+};
+export type PageKeyboardPressSequenceOptions = {
+  delay?: number,
+};
+export type PageKeyboardPressSequenceResult = void;
 export type PageMouseMoveParams = {
   x: number,
   y: number,

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -820,6 +820,11 @@ it('pressSequence should handle modifier combinations', async ({ page }) => {
   expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('def');
 });
 
+it('pressSequence should throw on invalid key', async ({ page }) => {
+  const error = await page.keyboard.pressSequence(['a', 'FakeKeyThatDoesNotExist', 'b']).catch(e => e);
+  expect(error.message).toContain('Unknown key');
+});
+
 it('pressSequence should produce correct key events', async ({ page }) => {
   await page.evaluate(() => {
     const textarea = document.createElement('textarea');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -757,3 +757,83 @@ it('should close dialog on Escape key press in contenteditable', {
   await expect(dialog).toHaveJSProperty('open', false);
   await expect(widget).not.toBeVisible();
 });
+
+it('pressSequence should press keys in order', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+  });
+  await page.keyboard.type('Hello World!');
+  // Select all and delete using pressSequence
+  await page.keyboard.pressSequence(['ControlOrMeta+A', 'Backspace']);
+  expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('');
+});
+
+it('pressSequence should respect delay between keys', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+  });
+  await page.keyboard.type('Hello');
+  const startTime = Date.now();
+  await page.keyboard.pressSequence(['ArrowLeft', 'ArrowLeft', 'ArrowLeft'], { delay: 100 });
+  const elapsed = Date.now() - startTime;
+  // 3 keys with delay=100 between them means 2 delays = at least 200ms
+  expect(elapsed).toBeGreaterThanOrEqual(150);
+  await page.keyboard.type('_');
+  expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('He_llo');
+});
+
+it('pressSequence should work with empty array', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+  });
+  await page.keyboard.type('Hello');
+  // Empty array should be a no-op
+  await page.keyboard.pressSequence([]);
+  expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('Hello');
+});
+
+it('pressSequence should work with single key', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+  });
+  await page.keyboard.pressSequence(['a']);
+  expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('a');
+});
+
+it('pressSequence should handle modifier combinations', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+  });
+  await page.keyboard.type('abcdef');
+  // Move to beginning, select 3 chars, delete
+  await page.keyboard.pressSequence(['Home', 'Shift+ArrowRight', 'Shift+ArrowRight', 'Shift+ArrowRight', 'Backspace']);
+  expect(await page.evaluate(() => document.querySelector('textarea')!.value)).toBe('def');
+});
+
+it('pressSequence should produce correct key events', async ({ page }) => {
+  await page.evaluate(() => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    (window as any).events = [];
+    textarea.addEventListener('keydown', e => (window as any).events.push('down:' + e.key));
+    textarea.addEventListener('keyup', e => (window as any).events.push('up:' + e.key));
+  });
+  await page.keyboard.pressSequence(['a', 'b', 'c']);
+  const events = await page.evaluate(() => (window as any).events);
+  expect(events).toEqual([
+    'down:a', 'up:a',
+    'down:b', 'up:b',
+    'down:c', 'up:c',
+  ]);
+});


### PR DESCRIPTION
## Summary

- Add `keyboard.pressSequence(keys, options)` to press an array of named keys in a single protocol round-trip
- Follows the same server-side batching pattern as the existing `keyboard.type()` for characters

## Motivation

`keyboard.type("hello")` batches character-level key presses into a single protocol message, with all character events processed server-side. There is no equivalent for named keys (`Space`, `ArrowDown`, `Enter`, etc.).

When automating keyboard-driven interactions like drag-and-drop via accessibility patterns (Space to grab, Arrow keys to move, Space to drop) or multi-step form navigation, each `keyboard.press()` call requires a separate protocol round-trip:

```js
// Current: 5 protocol round-trips
await page.keyboard.press('Space');
await page.keyboard.press('ArrowDown');
await page.keyboard.press('ArrowDown');
await page.keyboard.press('ArrowDown');
await page.keyboard.press('Space');
```

```js
// New: 1 protocol round-trip
await page.keyboard.pressSequence(['Space', 'ArrowDown', 'ArrowDown', 'ArrowDown', 'Space'], { delay: 100 });
```

This is particularly relevant for:

- **Keyboard-based drag-and-drop**: Mouse-based `dragTo()` does not work with popular DnD libraries like react-beautiful-dnd and dnd-kit ([#13855](https://github.com/microsoft/playwright/issues/13855), [#35749](https://github.com/microsoft/playwright/issues/35749)). The common workaround is keyboard-based reordering (Space/Arrow/Space), which requires multiple sequential `keyboard.press()` calls.

- **AI browser agents**: Tools like [browser-use](https://github.com/browser-use/browser-use), Playwright MCP, and other automation agents rely heavily on keyboard sequences for form navigation. Each `keyboard.press()` call incurs protocol serialization + WebSocket frame + async scheduling overhead, which compounds in tight loops. See [browser-use#4683](https://github.com/browser-use/browser-use/issues/4683) for a related request about faster input clearing.

- **Remote automation**: When Playwright connects to a remote browser via `connect()` or `connect_over_cdp()`, network latency amplifies per-call overhead from ~5-10ms locally to 50-200ms per call. A 5-key drag sequence goes from ~250ms to ~1s of pure overhead.

Unlike `evaluateAll` alternatives, this cannot be replicated with `page.evaluate()`: CDP keyboard events go through the browser's native input pipeline (`Input.dispatchKeyEvent`), triggering IME, contenteditable, autocomplete, and framework-specific event handlers that synthetic `dispatchEvent()` calls do not.

## API

```ts
// Press keys sequentially with optional delay between presses
await page.keyboard.pressSequence(['Space', 'ArrowDown', 'Space'], { delay: 100 });

// Supports modifier combinations (same format as keyboard.press)
await page.keyboard.pressSequence(['ControlOrMeta+A', 'Backspace']);

// Empty array is a no-op
await page.keyboard.pressSequence([]);
```

## Implementation

Follows the standard 6-step API addition process: docs, client, protocol, dispatcher, server, tests. The server-side `pressSequence()` method iterates the key array and delegates each press to the existing `press()` method, applying the delay between consecutive presses. 7 tests covering: basic sequencing, delay timing, empty/single arrays, modifier combos, event ordering, and invalid key error handling.