### PR TITLE
Pass saveVideo / PLAYWRIGHT_MCP_SAVE_VIDEO through to recordVideo

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -25,7 +25,7 @@ import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { libPath } from '../../package';
 import { startCliDaemonServer } from './daemon';
 import { setupExitWatchdog } from '../mcp/watchdog';
-import { createBrowserWithInfo } from '../mcp/browserFactory';
+import { browserContextOptionsFromConfig, createBrowserWithInfo } from '../mcp/browserFactory';
 import * as configUtils from '../mcp/config';
 import { createClientInfo } from '../cli-client/registry';
 import { registry as browserRegistry } from '../../server/registry/index';
@@ -62,7 +62,7 @@ export function decorateProgram(program: Command) {
           const { browser, browserInfo, canBind, ownership } = await createBrowserWithInfo(mcpConfig, mcpClientInfo, options);
           if (canBind)
             await browser.bind(sessionName, { workspaceDir: clientInfo.workspaceDir });
-          const browserContext = mcpConfig.browser.isolated ? await browser.newContext(mcpConfig.browser.contextOptions) : browser.contexts()[0];
+          const browserContext = mcpConfig.browser.isolated ? await browser.newContext(browserContextOptionsFromConfig(mcpConfig, mcpClientInfo)) : browser.contexts()[0];
           if (!browserContext)
             throw new Error('Error: unable to connect to a browser that does not have any contexts');
           const persistent = options.persistent || options.profile || mcpConfig.browser.userDataDir ? true : undefined;

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -76,6 +76,17 @@ export interface BrowserContextFactory {
   createContext(clientInfo: ClientInfo): Promise<playwrightTypes.BrowserContext>;
 }
 
+export function browserContextOptionsFromConfig(config: FullConfig, clientInfo: ClientInfo): playwrightTypes.BrowserContextOptions {
+  const result: playwrightTypes.BrowserContextOptions = { ...config.browser.contextOptions };
+  if (config.saveVideo && !result.recordVideo) {
+    result.recordVideo = {
+      dir: path.resolve(outputDir({ config, cwd: clientInfo.cwd }), 'videos'),
+      size: config.saveVideo,
+    };
+  }
+  return result;
+}
+
 function browserInfo(browser: playwrightTypes.Browser, config: FullConfig): BrowserInfo {
   return {
     // eslint-disable-next-line no-restricted-syntax
@@ -151,7 +162,7 @@ async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInf
   const launchOptions: playwrightTypes.LaunchOptions & playwrightTypes.BrowserContextOptions = {
     tracesDir,
     ...config.browser.launchOptions,
-    ...config.browser.contextOptions,
+    ...browserContextOptionsFromConfig(config, clientInfo),
     handleSIGINT: false,
     handleSIGTERM: false,
     ignoreDefaultArgs: configIgnoreDefaultArgs === true

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -138,6 +138,12 @@ export type Config = {
   saveSession?: boolean;
 
   /**
+   * Record video of the browser session at the given size, saved under
+   * `<outputDir>/videos`. When unset, video is not recorded automatically.
+   */
+  saveVideo?: { width: number; height: number };
+
+  /**
    * Reuse the same browser context between all connected HTTP clients.
    */
   sharedBrowserContext?: boolean;

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -64,6 +64,7 @@ export type CLIOptions = {
   proxyBypass?: string;
   proxyServer?: string;
   saveSession?: boolean;
+  saveVideo?: ViewportSize;
   secrets?: Record<string, string>;
   sharedBrowserContext?: boolean;
   snapshotMode?: 'full' | 'none';
@@ -350,6 +351,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
     allowUnrestrictedFileAccess: cliOptions.allowUnrestrictedFileAccess,
     codegen: cliOptions.codegen,
     saveSession: cliOptions.saveSession,
+    saveVideo: cliOptions.saveVideo,
     secrets: cliOptions.secrets,
     sharedBrowserContext: cliOptions.sharedBrowserContext,
     snapshot: cliOptions.snapshotMode ? { mode: cliOptions.snapshotMode } : undefined,
@@ -410,6 +412,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   options.userAgent = envToString(e.PLAYWRIGHT_MCP_USER_AGENT);
   options.userDataDir = envToString(e.PLAYWRIGHT_MCP_USER_DATA_DIR);
   options.viewportSize = resolutionParser('--viewport-size', e.PLAYWRIGHT_MCP_VIEWPORT_SIZE);
+  options.saveVideo = resolutionParser('--save-video', e.PLAYWRIGHT_MCP_SAVE_VIDEO);
   return configFromCLIOptions(options);
 }
 

--- a/packages/playwright-core/src/tools/mcp/index.ts
+++ b/packages/playwright-core/src/tools/mcp/index.ts
@@ -16,7 +16,7 @@
 
 import { resolveConfig } from './config';
 import { filteredTools } from '../backend/tools';
-import { createBrowserWithInfo } from './browserFactory';
+import { browserContextOptionsFromConfig, createBrowserWithInfo } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
 import { createServer } from '../utils/mcp/server';
 import { packageJSON } from '../../package';
@@ -38,7 +38,7 @@ export async function createConnection(userConfig: Config = {}, contextGetter?: 
       const browser = contextGetter
         ? new SimpleBrowser(await contextGetter())
         : (await createBrowserWithInfo(config, clientInfo, {})).browser;
-      const context = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
+      const context = config.browser.isolated ? await browser.newContext(browserContextOptionsFromConfig(config, clientInfo)) : browser.contexts()[0];
       return new BrowserBackend(config, context, tools);
     },
     disposed: async () => { }

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -18,7 +18,7 @@ import { Option as ProgramOption } from 'commander';
 import * as mcpServer from '../utils/mcp/server';
 import { commaSeparatedList, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
 import { setupExitWatchdog } from './watchdog';
-import { createBrowserWithInfo } from './browserFactory';
+import { browserContextOptionsFromConfig, createBrowserWithInfo } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
 import { filteredTools } from '../backend/tools';
 import { testDebug } from './log';
@@ -65,6 +65,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
       .option('--sandbox', 'enable the sandbox for all process types that are normally not sandboxed.')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
+      .option('--save-video <size>', 'record a video of the browser session at the given size, for example "800x600". Saved under <output-dir>/videos.', resolutionParser.bind(null, '--save-video'))
       .option('--secrets <path>', 'path to a file containing secrets in the dotenv format', dotenvFileLoader)
       .option('--shared-browser-context', 'reuse the same browser context between all connected HTTP clients.')
       .option('--snapshot-mode <mode>', 'when taking snapshots for responses, specifies the mode to use. Can be "full" or "none". Default is "full".')
@@ -124,7 +125,7 @@ export function decorateMCPCommand(command: Command) {
               const sessionName = count > 1 ? `${clientInfo.clientName} (${count})` : clientInfo.clientName;
               await browser.bind(sessionName, { workspaceDir: clientInfo.cwd });
             }
-            const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
+            const browserContext = config.browser.isolated ? await browser.newContext(browserContextOptionsFromConfig(config, clientInfo)) : browser.contexts()[0];
             return new BrowserBackend(config, browserContext, tools);
           },
           disposed: async backend => {

--- a/tests/mcp/video.spec.ts
+++ b/tests/mcp/video.spec.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import { test, expect } from './fixtures';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
@@ -40,6 +43,28 @@ for (const mode of ['isolated', 'persistent']) {
     await navigateToTestPage(client, server);
     await produceFrames(client);
     await closeBrowser(client);
+  });
+
+  test(`should record video via saveVideo (${mode})`, async ({ startClient, server }, testInfo) => {
+    const outputDir = testInfo.outputPath('output');
+
+    const { client } = await startClient({
+      config: {
+        outputDir,
+        saveVideo: { width: 800, height: 600 },
+      },
+      args: [
+        ...(mode === 'isolated' ? ['--isolated'] : []),
+      ],
+    });
+
+    await navigateToTestPage(client, server);
+    await produceFrames(client);
+    await closeBrowser(client);
+
+    const videosDir = path.join(outputDir, 'videos');
+    const files = await fs.promises.readdir(videosDir);
+    expect(files.some(f => f.endsWith('.webm'))).toBe(true);
   });
 }
 


### PR DESCRIPTION
The saveVideo config field and PLAYWRIGHT_MCP_SAVE_VIDEO env var had no effect: the field was missing from the Config type, the env var was not read, and nothing translated saveVideo into a recordVideo context option.

Add saveVideo to Config and CLIOptions, parse PLAYWRIGHT_MCP_SAVE_VIDEO and --save-video, and inject recordVideo: { dir: <outputDir>/videos, size } in browserContextOptionsFromConfig so videos are produced for both isolated and persistent context paths (MCP server, in-process API, and the playwright-cli daemon).