### PR TITLE
test(dashboard): wait for page load before asserting in annotate tests

### DIFF
--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -61,6 +61,7 @@ test('should capture multiple screenshots in one annotation', async ({ connectTo
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotatePromise = cli('show', '--annotate');
@@ -114,6 +115,7 @@ test('should abort annotation when last screenshot is removed', async ({ connect
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotatePromise = cli('show', '--annotate');
@@ -153,6 +155,7 @@ test('should abort MCP annotation when last screenshot is removed', async ({ con
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.locator('.annotate-sidebar-thumb')).toHaveCount(1);
 
     // Close the fullscreen overlay first so the sidebar remove button is accessible.
@@ -177,6 +180,7 @@ test('user-initiated annotate downloads zip with feedback.md', async ({ connectT
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   // Start with an aborting picker to verify cancellation keeps the session intact.
@@ -234,6 +238,7 @@ test('should capture annotations via show --annotate', async ({ connectToDashboa
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotatePromise = cli('show', '--annotate');
@@ -259,6 +264,7 @@ test('should start dashboard and annotate when no dashboard is running', async (
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await drawAndSubmitAnnotation(dashboard, 'hi');
   } finally {
     await browser.close().catch(() => {});
@@ -282,6 +288,7 @@ test('should enter annotate mode on fresh dashboard.tsx mount with -s --annotate
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
     await expect(activeSession(dashboard)).toHaveAccessibleName('Session second');
     await drawAndSubmitAnnotation(dashboard, 'fresh');
@@ -314,6 +321,7 @@ test('should annotate via direct browser_annotate MCP call', async ({ connectToD
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
     await drawAndSubmitAnnotation(dashboard, 'direct-mcp');
   } finally {
@@ -351,6 +359,7 @@ test('should annotate when context has no fixed viewport', async ({ connectToDas
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
     await drawAndSubmitAnnotation(dashboard, 'no-viewport');
   } finally {
@@ -383,6 +392,7 @@ test('should cancel browser_annotate when the MCP request is aborted', async ({ 
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
 
     controller.abort();
@@ -413,6 +423,7 @@ test('should cancel browser_annotate when the MCP client disconnects', async ({ 
   const browser = await connectToDashboard(bindTitle);
   try {
     const dashboard = browser.contexts()[0].pages()[0];
+    await dashboard.waitForLoadState('load');
     await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
 
     await client.close();
@@ -435,6 +446,7 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   await cli('-s=first', 'show', { bindTitle });
   const browser = await connectToDashboard(bindTitle);
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await expect(dashboard.locator('#display')).toBeVisible();
 
   const sampleCenter = () => dashboard.evaluate(() => {
@@ -480,6 +492,7 @@ test('should disengage annotate mode when --annotate client disconnects', async 
   const browser = await connectToDashboard(bindTitle);
 
   const dashboard = browser.contexts()[0].pages()[0];
+  await dashboard.waitForLoadState('load');
   await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
 
   const annotateClient = childProcess({


### PR DESCRIPTION
## Summary

Add `waitForLoadState('load')` after obtaining the dashboard page in all 13 annotate test sites. The tests grab the page via `browser.contexts()[0].pages()[0]` and immediately assert or click without waiting for the page to finish loading.

## Problem

The annotate tests are the dominant source of MCP CI failures on Windows. Every failing test shows the same error in CI logs:

```
Locator: getByRole('main', { name: 'Dashboard: annotate' })
Expected: visible
Received: undefined
Timeout: 5000ms
Call log:
  - waiting for "http://localhost:XXXXX/" navigation to finish...
```

The page hasn't finished navigating when the assertion starts. On Linux/macOS, the dashboard loads within the 5000ms default expect timeout. On Windows CI, it doesn't.

## CI failure statistics (last 14 MCP workflow runs)

Data from runs 25543907347 through 25579035284 (May 8, 2026):

| Metric | Value |
|--------|-------|
| MCP workflow runs analyzed | 14 failed + 1 passed + 5 cancelled/pending |
| Total individual test failures | 90 |
| Annotate test failures | **47 (52% of all failures)** |
| Runs with at least one annotate failure | **12 / 14 (86%)** |
| Runs with `navigation to finish` in logs | **9 / 14 (64%)** |
| Runs that would be fully green without annotate failures | 1 / 14 |

The annotate failures are spread across all Windows browser projects (chrome, chromium, msedge, webkit, firefox) and hit nearly every annotate test:

| Test | Failures across 14 runs |
|------|------------------------|
| `should abort MCP annotation when last screenshot is removed` | 6 |
| `should capture multiple screenshots in one annotation` | 5 |
| `should cancel browser_annotate when the MCP request is aborted` | 5 |
| `should enter annotate mode on fresh dashboard.tsx mount` | 5 |
| `user-initiated annotate downloads zip with feedback.md` | 5 |
| `should abort annotation when last screenshot is removed` | 4 |
| `should cancel browser_annotate when the MCP client disconnects` | 3 |
| `should annotate via direct browser_annotate MCP call` | 3 |
| `should annotate when context has no fixed viewport` | 3 |

## Root cause

Every annotate test follows this pattern:

```ts
const browser = await connectToDashboard(bindTitle);
const dashboard = browser.contexts()[0].pages()[0];
// Immediately assert or click without waiting for page load:
await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible();
```

`connectToDashboard` connects to the Playwright server but does not wait for any page to load. The test grabs the first page and immediately starts asserting. Playwright's `expect().toBeVisible()` retries within its 5000ms timeout, but if the page navigation itself hasn't completed (the dashboard is a React SPA that needs to load HTML, JS bundles, and render), the locator search fails because the DOM is empty.

The `McpError: Connection closed` errors reported alongside these failures are a consequence, not the cause: when the assertion times out and the test fails, the framework kills the MCP server during cleanup, which closes the connection on the pending `browser_annotate` call.

## Fix

Add `await dashboard.waitForLoadState('load')` after every `browser.contexts()[0].pages()[0]` call (13 sites). This ensures the page HTML and scripts have loaded before any assertions or interactions begin.

Related: [#40729](https://github.com/microsoft/playwright/pull/40729) (bumps timeout for one specific assertion), [#40348](https://github.com/microsoft/playwright/pull/40348) (fixes a different annotate race), [#40296](https://github.com/microsoft/playwright/pull/40296) (attempted IPC fix, closed).