### PR TITLE
docs(cli): document `&` URL escaping on Windows

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -231,6 +231,18 @@ playwright-cli -s=msedge detach
 playwright-cli delete-data
 ```
 
+## URLs with `&` on Windows
+
+On Windows, `cmd.exe` and PowerShell treat `&` as a command separator, so URLs with multiple query parameters get truncated before `playwright-cli` runs. Escape `&` with `^&` in `cmd.exe`, or use `--%` in PowerShell:
+
+```batch
+playwright-cli goto "https://example.com/?a=1^&b=2"
+```
+
+```powershell
+playwright-cli --% goto "https://example.com/?a=1&b=2"
+```
+
 ## Snapshots
 
 After each command, playwright-cli provides a snapshot of the current browser state.

--- a/tests/mcp/cli-core.spec.ts
+++ b/tests/mcp/cli-core.spec.ts
@@ -34,6 +34,12 @@ test('close', async ({ cli, server }) => {
   expect(output).toContain(`Browser 'default' closed`);
 });
 
+test('preserves URL with & query params', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-cli/issues/403' } }, async ({ cli, server }) => {
+  const url = `${server.HELLO_WORLD}?a=1&b=2`;
+  const { output } = await cli('open', url);
+  expect(output).toContain(`Page URL: ${url}`);
+});
+
 test('click button', async ({ cli, server }) => {
   server.setContent('/', `<button>Submit</button>`, 'text/html');
 


### PR DESCRIPTION
## Summary

- `cmd.exe` and PowerShell treat `&` as a command separator, so URLs with multiple query parameters get truncated before `playwright-cli` runs.
- Add escaping guidance (`^&` for cmd, `--%` for PowerShell) to the CLI SKILL.md.
- Add a regression test asserting the CLI preserves `&` in URL args when invoked directly.

Fixes https://github.com/microsoft/playwright-cli/issues/403