### PR TITLE
fix(mcp): do not mark response as close when there are no tabs

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -251,8 +251,6 @@ export class Response {
         addSection('Open tabs', renderTabsMarkdown(tabHeaders));
       addSection('Page', renderTabMarkdown(tabHeaders.find(h => h.current) ?? tabHeaders[0]));
     }
-    if (this._context.tabs().length === 0)
-      this._isClose = true;
 
     // Handle modal states.
     if (tabSnapshot?.modalStates.length)


### PR DESCRIPTION
## Summary
- Fixes `ini config sets timeouts and console level` in `tests/mcp/config.ini.spec.ts`: tools like `browser_get_config` that don't open a tab were getting `isClose=true` set on the response.