### PR TITLE
fix(chromium): close file descriptor on protocol stream save error

### DIFF
--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -55,7 +55,7 @@ export async function saveProtocolStream(client: CRSession, handle: string, path
       await fd.write(buf);
     }
   } finally {
-    await fd.close();
+    await fd.close().catch(() => {});
     await client.send('IO.close', { handle }).catch(() => {});
   }
 }
@@ -63,13 +63,16 @@ export async function saveProtocolStream(client: CRSession, handle: string, path
 export async function readProtocolStream(client: CRSession, handle: string): Promise<Buffer> {
   let eof = false;
   const chunks = [];
-  while (!eof) {
-    const response = await client.send('IO.read', { handle });
-    eof = response.eof;
-    const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
-    chunks.push(buf);
+  try {
+    while (!eof) {
+      const response = await client.send('IO.read', { handle });
+      eof = response.eof;
+      const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
+      chunks.push(buf);
+    }
+  } finally {
+    await client.send('IO.close', { handle }).catch(() => {});
   }
-  await client.send('IO.close', { handle });
   return Buffer.concat(chunks);
 }
 

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -56,8 +56,8 @@ export async function saveProtocolStream(client: CRSession, handle: string, path
     }
   } finally {
     await fd.close();
+    await client.send('IO.close', { handle }).catch(() => {});
   }
-  await client.send('IO.close', { handle });
 }
 
 export async function readProtocolStream(client: CRSession, handle: string): Promise<Buffer> {

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -56,23 +56,20 @@ export async function saveProtocolStream(client: CRSession, handle: string, path
     }
   } finally {
     await fd.close().catch(() => {});
-    await client.send('IO.close', { handle }).catch(() => {});
   }
+  await client.send('IO.close', { handle });
 }
 
 export async function readProtocolStream(client: CRSession, handle: string): Promise<Buffer> {
   let eof = false;
   const chunks = [];
-  try {
-    while (!eof) {
-      const response = await client.send('IO.read', { handle });
-      eof = response.eof;
-      const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
-      chunks.push(buf);
-    }
-  } finally {
-    await client.send('IO.close', { handle }).catch(() => {});
+  while (!eof) {
+    const response = await client.send('IO.read', { handle });
+    eof = response.eof;
+    const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
+    chunks.push(buf);
   }
+  await client.send('IO.close', { handle });
   return Buffer.concat(chunks);
 }
 

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -47,13 +47,16 @@ export async function saveProtocolStream(client: CRSession, handle: string, path
   let eof = false;
   await mkdirIfNeeded(path);
   const fd = await fs.promises.open(path, 'w');
-  while (!eof) {
-    const response = await client.send('IO.read', { handle });
-    eof = response.eof;
-    const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
-    await fd.write(buf);
+  try {
+    while (!eof) {
+      const response = await client.send('IO.read', { handle });
+      eof = response.eof;
+      const buf = Buffer.from(response.data, response.base64Encoded ? 'base64' : undefined);
+      await fd.write(buf);
+    }
+  } finally {
+    await fd.close();
   }
-  await fd.close();
   await client.send('IO.close', { handle });
 }
 


### PR DESCRIPTION
## Summary

- `saveProtocolStream` opens a write fd but does not close it when `client.send('IO.read')` throws, leaking one file descriptor per failed stream save
- `readProtocolStream` has the same pattern: `IO.close` is not called if `IO.read` throws
- Wrap read loops in try/finally to ensure both the local fd and the server-side IO handle are always closed

**Failure scenario:** When Chromium's IO.read fails mid-stream (e.g., browser crash, session disconnect), the file descriptor opened at `fs.promises.open(path, 'w')` is never closed. Each failed save leaks one OS file descriptor. Under sustained failures, this can exhaust the process file descriptor limit.

**Origin:** The fd-based stream saving was introduced in [#24414](https://github.com/microsoft/playwright/pull/24414) (2023-07-26) by Pavel Feldman. The original code assumed IO.read would always succeed through EOF.