### PR TITLE
fix(transport): add timeout to closeAndWait to prevent hangs

### DIFF
--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -193,12 +193,13 @@ export class WebSocketTransport implements ConnectionTransport {
     this._ws.close();
   }
 
-  async closeAndWait() {
+  async closeAndWait(timeoutMs: number = 30000) {
     if (this._ws.readyState === ws.CLOSED)
       return;
-    const promise = new Promise(f => this._ws.once('close', f));
+    const closePromise = new Promise(f => this._ws.once('close', f));
     this.close();
-    await promise; // Make sure to await the actual disconnect.
+    const timeout = new Promise(f => setTimeout(f, timeoutMs));
+    await Promise.race([closePromise, timeout]);
   }
 }
 

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -193,13 +193,15 @@ export class WebSocketTransport implements ConnectionTransport {
     this._ws.close();
   }
 
-  async closeAndWait(timeoutMs: number = 30000) {
+  async closeAndWait() {
     if (this._ws.readyState === ws.CLOSED)
       return;
     const closePromise = new Promise(f => this._ws.once('close', f));
     this.close();
-    const timeout = new Promise(f => setTimeout(f, timeoutMs));
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise(f => timer = setTimeout(f, 30000));
     await Promise.race([closePromise, timeout]);
+    clearTimeout(timer!);
   }
 }
 

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -193,13 +193,13 @@ export class WebSocketTransport implements ConnectionTransport {
     this._ws.close();
   }
 
-  async closeAndWait() {
+  async closeAndWait(timeoutMs = 30000) {
     if (this._ws.readyState === ws.CLOSED)
       return;
     const closePromise = new Promise(f => this._ws.once('close', f));
     this.close();
     let timer: NodeJS.Timeout;
-    const timeout = new Promise(f => timer = setTimeout(f, 30000));
+    const timeout = new Promise(f => timer = setTimeout(f, timeoutMs));
     await Promise.race([closePromise, timeout]);
     clearTimeout(timer!);
   }

--- a/tests/library/transport.spec.ts
+++ b/tests/library/transport.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { playwrightTest as test, expect } from '../config/browserTest';
+import { WebSocketServer } from 'ws';
+import { server as coreServer } from '../../packages/playwright-core/lib/coreBundle';
+
+const { WebSocketTransport } = coreServer;
+
+test('closeAndWait should not hang when server does not send close frame', async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  const port = (wss.address() as { port: number }).port;
+
+  // Server accepts but never closes its end of the connection.
+  wss.on('connection', () => {});
+
+  const transport = await WebSocketTransport.connect(undefined, `ws://localhost:${port}`);
+  const start = Date.now();
+  await transport.closeAndWait(1000);
+  const elapsed = Date.now() - start;
+
+  expect(elapsed).toBeLessThan(5000);
+  wss.close();
+});
+
+test('closeAndWait should return immediately when already closed', async () => {
+  const wss = new WebSocketServer({ port: 0 });
+  const port = (wss.address() as { port: number }).port;
+
+  wss.on('connection', ws => {
+    ws.on('close', () => ws.close());
+  });
+
+  const transport = await WebSocketTransport.connect(undefined, `ws://localhost:${port}`);
+  await transport.closeAndWait();
+
+  const start = Date.now();
+  await transport.closeAndWait();
+  const elapsed = Date.now() - start;
+
+  expect(elapsed).toBeLessThan(100);
+  wss.close();
+});


### PR DESCRIPTION
## Summary

- `closeAndWait` awaits the WebSocket close event with no deadline; if the remote end never sends a close frame, the caller hangs indefinitely
- Add a 30-second timeout via `Promise.race` so the close path always completes
- Clear the timer after resolution to avoid keeping the event loop alive

**Failure scenario:** Called in the error cleanup path of `WebSocketTransport._connect()` (line 128). If the initial connection fails but the WebSocket never emits a close event (e.g., network partition, unresponsive remote), `closeAndWait` blocks forever, preventing the connection error from propagating to the caller.

**Origin:** `closeAndWait` was introduced in [#2350](https://github.com/microsoft/playwright/pull/2350) (2020-05-29) by Dmitry Gozman as part of the Progress concept.