### PR TITLE
fix(dashboard): clean up temp recording directory on close

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -84,6 +84,7 @@ export class DashboardConnection implements Transport {
           .catch(() => {});
     }
     this._streams.clear();
+    void fs.promises.rm(this._recordingDir, { recursive: true, force: true }).catch(() => {});
     this._onclose();
   }
 


### PR DESCRIPTION
## Summary

- `DashboardConnection` creates a temp directory for recordings via `mkdtempSync` but never removes it when the connection closes
- Clean up the directory in `onclose` to avoid orphaned temp files

**Failure scenario:** Each dashboard WebSocket connection creates a `playwright-recordings-*` temp directory. When the connection closes, individual stream files are cleaned up but the directory itself persists. On long-running servers with many dashboard sessions, this accumulates orphaned directories in the system temp folder.

**Origin:** The recording directory was introduced in [#40279](https://github.com/microsoft/playwright/pull/40279) (2026-04-17) by Pavel Feldman.