### PR TITLE
chore: attempt at fixing win cli tests

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1507,7 +1507,7 @@ export function findChromiumChannelBestEffort(sdkLanguage: string): string | und
   for (const name of ['chromium', 'chrome', 'msedge']) {
     try {
       registry.findExecutable(name)!.executablePathOrDie(sdkLanguage);
-      channel = name === 'chromium' ? undefined : name;
+      channel = name === 'chromium' ? 'chrome-for-testing' : name;
       break;
     } catch (e) {
     }

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -33,7 +33,6 @@ import { minimist } from './minimist';
 import type { ListData, ListedBrowser, Output } from './output';
 import type { ClientInfo, SessionFile } from './registry';
 import type { MinimistArgs } from './minimist';
-import type { Readable } from 'stream';
 
 type GlobalOptions = {
   help?: boolean;
@@ -118,7 +117,8 @@ export async function program(options?: { embedderVersion?: string}) {
 
   switch (commandName) {
     case 'list': {
-      const data = await collectList(registry, clientInfo, !!args.all);
+      const checkAlive = args['check-alive'] !== false;
+      const data = await collectList(registry, clientInfo, !!args.all, checkAlive);
       output.list(data);
       return;
     }
@@ -230,34 +230,11 @@ export async function program(options?: { embedderVersion?: string}) {
       const foreground = args.port !== undefined;
       const child = spawn(process.execPath, daemonArgs, {
         detached: !foreground,
-        stdio: foreground ? 'inherit' : ['ignore', 'ignore', 'ignore', 'pipe'],
+        stdio: foreground ? 'inherit' : 'ignore',
       });
       if (foreground) {
         await new Promise<void>(resolve => child.on('exit', () => resolve()));
         return;
-      }
-      const readyStream = (child.stdio as unknown as Readable[])[3];
-      try {
-        await new Promise<void>((resolve, reject) => {
-          const settle = (err?: Error) => {
-            clearTimeout(timer);
-            readyStream.destroy();
-            if (err)
-              reject(err);
-            else
-              resolve();
-          };
-          const timer = setTimeout(() => settle(new Error('Dashboard daemon did not spin up within 60s, killing it')), 60_000);
-          readyStream.once('data', () => settle());
-          readyStream.once('error', err => settle(err));
-          child.once('exit', (code, signal) => settle(new Error(`Dashboard daemon exited (code=${code}, signal=${signal}) before signaling READY`)));
-        });
-      } catch (err) {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill('SIGKILL');
-          await new Promise<void>(resolve => child.once('exit', () => resolve()));
-        }
-        throw err;
       }
       child.unref();
       output.show(sessionName, child.pid);
@@ -383,29 +360,29 @@ async function killAllDaemons(): Promise<number[]> {
   return killed;
 }
 
-async function collectList(registry: Registry, clientInfo: ClientInfo, all: boolean): Promise<ListData> {
+async function collectList(registry: Registry, clientInfo: ClientInfo, all: boolean, checkAlive: boolean): Promise<ListData> {
   const browsers: ListedBrowser[] = [];
   const entries = registry.entryMap();
 
-  // List early to GC.
-  const serverEntries = await serverRegistry.list();
   const key = clientKey(clientInfo);
   for (const [workspaceKey, list] of entries) {
     if (!all && workspaceKey !== key)
       continue;
     for (const entry of list) {
       const session = new Session(entry);
-      const canConnect = await session.canConnect();
-      if (!canConnect) {
-        await session.deleteSessionConfig();
-        continue;
+      if (checkAlive) {
+        const canConnect = await session.canConnect();
+        if (!canConnect) {
+          await session.deleteSessionConfig();
+          continue;
+        }
       }
       const config = session.config;
       const channel = config.browser?.launchOptions.channel ?? config.browser?.browserName;
       browsers.push({
         name: session.name,
         workspace: workspaceKey,
-        status: canConnect ? 'open' : 'closed',
+        status: 'open',
         browserType: channel,
         userDataDir: config.browser?.userDataDir ?? null,
         headed: config.browser ? !config.browser.launchOptions.headless : undefined,
@@ -420,6 +397,7 @@ async function collectList(registry: Registry, clientInfo: ClientInfo, all: bool
   if (!all)
     return { all, browsers };
 
+  const serverEntries = await serverRegistry.list();
   const servers = [...serverEntries.values()].flat();
   return { all, browsers, servers, channelSessions: await listChannelSessions() };
 }

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -1022,7 +1022,8 @@ const sessionList = declareCommand({
   category: 'browsers',
   args: z.object({}),
   options: z.object({
-    all: z.boolean().optional().describe('List all browser sessions across all workspaces'),
+    'all': z.boolean().optional().describe('List all browser sessions across all workspaces'),
+    'check-alive': z.boolean().optional().describe('Probe each session to verify it is reachable, dropping unreachable ones (default: true). Use --no-check-alive to list registry entries without connecting.'),
   }),
   toolName: '',
   toolParams: () => ({}),

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import path from 'path';
 import { Writable } from 'stream';
 
@@ -420,6 +421,14 @@ export function formatFailure(screen: Screen, config: FullConfig, test: TestCase
       if (attachment.name === 'error-context' && attachment.path) {
         resultLines.push('');
         resultLines.push(screen.colors.dim(`    Error Context: ${relativeFilePath(screen, config, attachment.path)}`));
+        if (process.env.CI) {
+          try {
+            const content = fs.readFileSync(attachment.path, 'utf8');
+            for (const line of content.split('\n'))
+              resultLines.push(screen.colors.dim(`    ${line}`));
+          } catch {
+          }
+        }
         continue;
       }
 

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -64,7 +64,7 @@ export const test = baseTest.extend<{
     await use(async (bindTitle: string) => {
       let endpoint = '';
       await expect(async () => {
-        const { output } = await cli('list', '--all', '--json');
+        const { output } = await cli('list', '--all', '--json', '--no-check-alive');
         const { servers } = JSON.parse(output);
         const server = servers.find(s => s.title === bindTitle);
         endpoint = server.endpoint;


### PR DESCRIPTION
## Summary

- Add `--check-alive` (default true) to `playwright-cli list`; `--no-check-alive` lists registry entries without probing each session via `canConnect()`.