### PR TITLE
fix(server): validate file paths in createTempFiles

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 import { deserializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
 import { createGuid } from '@utils/crypto';
-import { isPathInside } from '@utils/fileUtils';
+import { resolveWithinRoot } from '@utils/fileUtils';
 import { BrowserContext } from '../browserContext';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { DebuggerDispatcher } from './debuggerDispatcher';
@@ -233,8 +233,8 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     return {
       rootDir: params.rootDirName ? new WritableStreamDispatcher(this, tempDirWithRootName) : undefined,
       writableStreams: await Promise.all(params.items.map(async item => {
-        const itemPath = path.join(tempDirWithRootName, item.name);
-        if (!isPathInside(tempDirWithRootName, itemPath))
+        const itemPath = resolveWithinRoot(tempDirWithRootName, item.name);
+        if (!itemPath)
           throw new Error(`Invalid file name: ${item.name}`);
         await progress.race(fs.promises.mkdir(path.dirname(itemPath), { recursive: true }));
         const file = fs.createWriteStream(itemPath);

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 import { deserializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
 import { createGuid } from '@utils/crypto';
-import { resolveWithinRoot } from '@utils/fileUtils';
+import { throwingResolveWithinRoot } from '@utils/fileUtils';
 import { BrowserContext } from '../browserContext';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { DebuggerDispatcher } from './debuggerDispatcher';
@@ -233,9 +233,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     return {
       rootDir: params.rootDirName ? new WritableStreamDispatcher(this, tempDirWithRootName) : undefined,
       writableStreams: await Promise.all(params.items.map(async item => {
-        const itemPath = resolveWithinRoot(tempDirWithRootName, item.name);
-        if (!itemPath)
-          throw new Error(`Invalid file name: ${item.name}`);
+        const itemPath = throwingResolveWithinRoot(tempDirWithRootName, item.name);
         await progress.race(fs.promises.mkdir(path.dirname(itemPath), { recursive: true }));
         const file = fs.createWriteStream(itemPath);
         return new WritableStreamDispatcher(this, file, item.lastModifiedMs);

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -19,6 +19,7 @@ import path from 'path';
 
 import { deserializeURLMatch, urlMatches } from '@isomorphic/urlMatch';
 import { createGuid } from '@utils/crypto';
+import { isPathInside } from '@utils/fileUtils';
 import { BrowserContext } from '../browserContext';
 import { CDPSessionDispatcher } from './cdpSessionDispatcher';
 import { DebuggerDispatcher } from './debuggerDispatcher';
@@ -232,8 +233,11 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     return {
       rootDir: params.rootDirName ? new WritableStreamDispatcher(this, tempDirWithRootName) : undefined,
       writableStreams: await Promise.all(params.items.map(async item => {
-        await progress.race(fs.promises.mkdir(path.dirname(path.join(tempDirWithRootName, item.name)), { recursive: true }));
-        const file = fs.createWriteStream(path.join(tempDirWithRootName, item.name));
+        const itemPath = path.join(tempDirWithRootName, item.name);
+        if (!isPathInside(tempDirWithRootName, itemPath))
+          throw new Error(`Invalid file name: ${item.name}`);
+        await progress.race(fs.promises.mkdir(path.dirname(itemPath), { recursive: true }));
+        const file = fs.createWriteStream(itemPath);
         return new WritableStreamDispatcher(this, file, item.lastModifiedMs);
       }))
     };

--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -93,6 +93,13 @@ export function resolveWithinRoot(root: string, fileName: string): string | null
   return isPathInside(root, resolvedFile) ? resolvedFile : null;
 }
 
+export function throwingResolveWithinRoot(root: string, fileName: string): string {
+  const resolved = resolveWithinRoot(root, fileName);
+  if (!resolved)
+    throw new Error(`Path '${fileName}' escapes root directory`);
+  return resolved;
+}
+
 export function toPosixPath(aPath: string): string {
   return aPath.split(path.sep).join(path.posix.sep);
 }


### PR DESCRIPTION
## Summary

- `rootDirName` is sanitized with `path.basename()` but `item.name` is used raw in `path.join()`, allowing path components like `../` to escape the temp directory
- Add `isPathInside` check consistent with the existing `rootDirName` validation and other path checks in the codebase

**Failure scenario:** When using `browserType.connect()` to a shared Playwright server, a remote client sends RPC messages including `createTempFiles` with crafted `item.name` values containing `../../`. The `rootDirName` parameter is correctly sanitized with `path.basename()` on line 229, but `item.name` passes through `path.join()` unsanitized, resolving `../` components and allowing writes outside the temp directory.

**Origin:** Introduced in [#31165](https://github.com/microsoft/playwright/pull/31165) (2024-06-12).

**Related fixes in this repo:**
- [#40715](https://github.com/microsoft/playwright/pull/40715) -- path traversal in static file serving (merged)
- [#40623](https://github.com/microsoft/playwright/pull/40623) -- Zip Slip path traversal in harUnzip (merged)
- [#40555](https://github.com/microsoft/playwright/pull/40555) -- confine trace attachment reads to trace dir (merged)