### PR TITLE
fix(server): use fs.promises.rm to delete temp upload directories

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -527,7 +527,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
   }
 
   private async _deleteAllTempDirs(): Promise<void> {
-    await Promise.all(this._tempDirs.map(async dir => await fs.promises.unlink(dir).catch(e => {})));
+    await Promise.all(this._tempDirs.map(async dir => await fs.promises.rm(dir, { recursive: true, force: true }).catch(e => {})));
   }
 
   setCustomCloseHandler(handler: (() => Promise<any>) | undefined) {


### PR DESCRIPTION
## Summary

- `_deleteAllTempDirs` uses `fs.promises.unlink` which cannot remove directories (returns EISDIR on Linux, EPERM on Windows)
- The error is silently caught via `.catch(e => {})`, so temp upload directories and their contents are never cleaned up
- Use `fs.promises.rm` with `recursive` and `force` options instead

**Failure scenario:** Every file upload via `setInputFiles` creates a temp directory (`upload-<guid>`) in the artifacts dir. On context close, `_deleteAllTempDirs` attempts `unlink` on these directories, which always fails silently. The directories and uploaded files accumulate on disk indefinitely.

**Origin:** `_deleteAllTempDirs` was introduced in [#12860](https://github.com/microsoft/playwright/pull/12860) (2022-03-18) when temp entries were files. [#31165](https://github.com/microsoft/playwright/pull/31165) (2024-06-12) added folder uploads which pushes directories into `_tempDirs`, but the cleanup method was not updated.

**Same pattern in this repo:**
- [#40751](https://github.com/microsoft/playwright/pull/40751) -- same `fs.promises.rm` fix for dashboard recording temp dir (open)