### PR TITLE
fix(server): guard JSON.parse in protocol message handlers

### DIFF
--- a/packages/playwright-core/src/remote/playwrightConnection.ts
+++ b/packages/playwright-core/src/remote/playwrightConnection.ts
@@ -64,7 +64,14 @@ export class PlaywrightConnection {
     transport.on('message', async (message: string) => {
       await lock;
       const messageString = Buffer.from(message).toString();
-      const jsonMessage = JSON.parse(messageString);
+      let jsonMessage: any;
+      try {
+        jsonMessage = JSON.parse(messageString);
+      } catch (e) {
+        debugLogger.log('server', `[${this._id}] failed to parse message: ${e}`);
+        this.close({ code: 1007, reason: 'Malformed message' });
+        return;
+      }
       if (debugLogger.isEnabled('server:channel'))
         debugLogger.log('server:channel', `[${this._id}] ${monotonicTime() * 1000} ◀ RECV ${messageString}`);
       if (debugLogger.isEnabled('server:metadata'))

--- a/packages/playwright-core/src/server/pipeTransport.ts
+++ b/packages/playwright-core/src/server/pipeTransport.ts
@@ -74,8 +74,15 @@ export class PipeTransport implements ConnectionTransport {
     this._pendingBuffers.push(buffer.slice(0, end));
     const message = Buffer.concat(this._pendingBuffers).toString();
     this._waitForNextTask(() => {
+      let parsedMessage;
+      try {
+        parsedMessage = JSON.parse(message);
+      } catch (e) {
+        debugLogger.log('error', `PipeTransport: failed to parse message: ${e}`);
+        return;
+      }
       if (this.onmessage)
-        this.onmessage.call(null, JSON.parse(message));
+        this.onmessage.call(null, parsedMessage);
     });
 
     let start = end + 1;
@@ -83,8 +90,15 @@ export class PipeTransport implements ConnectionTransport {
     while (end !== -1) {
       const message = buffer.toString(undefined, start, end);
       this._waitForNextTask(() => {
+        let parsedMessage;
+        try {
+          parsedMessage = JSON.parse(message);
+        } catch (e) {
+          debugLogger.log('error', `PipeTransport: failed to parse message: ${e}`);
+          return;
+        }
         if (this.onmessage)
-          this.onmessage.call(null, JSON.parse(message));
+          this.onmessage.call(null, parsedMessage);
       });
       start = end + 1;
       end = buffer.indexOf('\0', start);

--- a/packages/playwright-core/src/server/pipeTransport.ts
+++ b/packages/playwright-core/src/server/pipeTransport.ts
@@ -74,15 +74,8 @@ export class PipeTransport implements ConnectionTransport {
     this._pendingBuffers.push(buffer.slice(0, end));
     const message = Buffer.concat(this._pendingBuffers).toString();
     this._waitForNextTask(() => {
-      let parsedMessage;
-      try {
-        parsedMessage = JSON.parse(message);
-      } catch (e) {
-        debugLogger.log('error', `PipeTransport: failed to parse message: ${e}`);
-        return;
-      }
       if (this.onmessage)
-        this.onmessage.call(null, parsedMessage);
+        this.onmessage.call(null, JSON.parse(message));
     });
 
     let start = end + 1;
@@ -90,15 +83,8 @@ export class PipeTransport implements ConnectionTransport {
     while (end !== -1) {
       const message = buffer.toString(undefined, start, end);
       this._waitForNextTask(() => {
-        let parsedMessage;
-        try {
-          parsedMessage = JSON.parse(message);
-        } catch (e) {
-          debugLogger.log('error', `PipeTransport: failed to parse message: ${e}`);
-          return;
-        }
         if (this.onmessage)
-          this.onmessage.call(null, parsedMessage);
+          this.onmessage.call(null, JSON.parse(message));
       });
       start = end + 1;
       end = buffer.indexOf('\0', start);

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -158,6 +158,22 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       }
     });
 
+    test('should not crash on malformed json frame', async ({ connect, startRemoteServer }) => {
+      const remoteServer = await startRemoteServer(kind);
+      const ws = new WebSocket(remoteServer.wsEndpoint());
+      await new Promise<void>((resolve, reject) => {
+        ws.once('open', resolve);
+        ws.once('error', reject);
+      });
+      ws.send(']');
+      await new Promise<void>(resolve => ws.once('close', () => resolve()));
+      // Server should still be alive and accept new connections.
+      const browser = await connect(remoteServer.wsEndpoint());
+      const page = await browser.newPage();
+      expect(await page.evaluate('1 + 2')).toBe(3);
+      await browser.close();
+    });
+
     test('should be able to visit ipv6', async ({ connect, startRemoteServer, ipV6ServerPort, channel }) => {
       test.fail(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
       test.fail(channel === 'webkit-wsl', 'WebKit on WSL does not support IPv6: https://github.com/microsoft/WSL/issues/10803');


### PR DESCRIPTION
## Summary

- `PlaywrightConnection` and `PipeTransport` call `JSON.parse` on incoming messages without try-catch, unlike `WebSocketTransport` which already guards against this (#23689).
- In `PlaywrightConnection`, the parse runs inside an async event handler. The rejected Promise is unhandled (no global `unhandledRejection` handler in the remote server), crashing the process. A single malformed WebSocket frame takes down all connected clients.
- In `PipeTransport`, the parse runs inside a `setImmediate` callback, causing `uncaughtException` on corrupted browser output.
- Wrap both in try-catch to match the existing `WebSocketTransport` pattern. `PlaywrightConnection` closes the offending connection with WebSocket code 1007; `PipeTransport` logs and skips the malformed message.

The `PlaywrightConnection` fix is the same approach from #40121 (approved by @pavelfeldman but not merged). This PR also covers `PipeTransport`.

The unguarded `JSON.parse` in `PlaywrightConnection` was introduced in #28141 (2023-11-16). In `PipeTransport`, it has been unguarded since #1567 (2020-03-26).