### PR TITLE
fix(server): destroy stream in StreamDispatcher._onDispose

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
@@ -65,6 +65,10 @@ export class StreamDispatcher extends Dispatcher<StreamSdkObject, channels.Strea
     return { binary: buffer || Buffer.from('') };
   }
 
+  override _onDispose() {
+    this._object.stream.destroy();
+  }
+
   async close(params: channels.StreamCloseParams, progress: Progress): Promise<void> {
     this._object.stream.destroy();
   }


### PR DESCRIPTION
## Summary

- `StreamDispatcher` does not override `_onDispose()`, so when the dispatcher hierarchy is torn down (client disconnect, page close), the underlying `Readable` stream from `fs.createReadStream` is never destroyed, leaking a file descriptor per open artifact stream.
- Every other resource-holding dispatcher overrides `_onDispose()` for cleanup: `TracingDispatcher`, `PageDispatcher`, `DebugControllerDispatcher`, `WebSocketRouteDispatcher`.

## Origin

`StreamDispatcher` was introduced in [#2733](https://github.com/microsoft/playwright/pull/2733) (2020-06-26). The `_onDispose()` pattern was established later in [#19572](https://github.com/microsoft/playwright/pull/19572) (2022-12-19) by dgozman, which added `_onDispose()` to page, context, and tracing dispatchers, but missed `StreamDispatcher`. A subsequent stream fix in [#27291](https://github.com/microsoft/playwright/pull/27291) addressed event listener leaks in the same file but not the missing `_onDispose()`.