### PR TITLE
fix(tracing): add missing error handlers in zip repack path

### DIFF
--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -101,7 +101,26 @@ export async function zip(progress: Progress, stackSessions: Map<string, StackSe
       return;
     }
     assert(inZipFile);
+    inZipFile.on('error', error => promise.reject(error));
     let pendingEntries = inZipFile.entryCount;
+
+    const finalizeRepack = () => {
+      zipFile.end(undefined, () => {
+        zipFile.outputStream.pipe(fs.createWriteStream(params.zipFile))
+            .on('close', () => {
+              fs.promises.unlink(tempFile).then(() => {
+                promise.resolve();
+              }).catch(error => promise.reject(error));
+            })
+            .on('error', error => promise.reject(error));
+      });
+    };
+
+    if (pendingEntries === 0) {
+      finalizeRepack();
+      return;
+    }
+
     inZipFile.on('entry', entry => {
       inZipFile.openReadStream(entry, (err, readStream) => {
         if (err) {
@@ -109,15 +128,8 @@ export async function zip(progress: Progress, stackSessions: Map<string, StackSe
           return;
         }
         zipFile.addReadStream(readStream!, entry.fileName);
-        if (--pendingEntries === 0) {
-          zipFile.end(undefined, () => {
-            zipFile.outputStream.pipe(fs.createWriteStream(params.zipFile)).on('close', () => {
-              fs.promises.unlink(tempFile).then(() => {
-                promise.resolve();
-              }).catch(error => promise.reject(error));
-            });
-          });
-        }
+        if (--pendingEntries === 0)
+          finalizeRepack();
       });
     });
   });


### PR DESCRIPTION
## Summary

The zip repack path (appending entries to an existing trace zip) has three error handling gaps:

1. **No \`.on('error')\` on the yauzl \`ZipFile\`** - a corrupt input zip emits an unhandled error event that can crash the process.
2. **No \`.on('error')\` on the output \`createWriteStream\`** - a write failure (disk full, permissions) leaves the promise unsettled, hanging until progress timeout. The write path on line 87 of the same function correctly has this handler; the repack path did not.
3. **No guard for \`entryCount === 0\`** - if the input zip has zero entries, no \`entry\` events fire and the promise hangs forever.

## Origin

The repack code was introduced in [#10815](https://github.com/microsoft/playwright/pull/10815) (2021-12-09). The write path added in the same commit correctly handles errors (line 87: \`.on('error', error => promise.reject(error))\`), but the repack path was not given the same treatment. The yauzl \`.on('error')\` handler was also omitted, unlike the yazl \`ZipFile\` which has one (line 47).