### PR TITLE
fix(trace-viewer): neutralize object and embed tags in snapshot renderer

### DIFF
--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -140,17 +140,10 @@ export class SnapshotRenderer {
             // crafted trace could include them.
             attrName = '__playwright_' + attr.toLowerCase() + '__';
           }
-          if (upperName === 'OBJECT' && attr.toLowerCase() === 'data') {
-            // Neutralize <object data> - it can load arbitrary HTML in the trace
-            // viewer's origin (e.g. via /sha1/ resources), bypassing script and
-            // iframe sanitization.
+          if (upperName === 'OBJECT' && attr.toLowerCase() === 'data')
             attrName = '__playwright_data__';
-          }
-          if (upperName === 'EMBED' && attr.toLowerCase() === 'src') {
-            // Neutralize <embed src> for the same reason as <object data>.
-            // The URL rewrite on line 158 does not catch relative URLs.
+          if (upperName === 'EMBED' && attr.toLowerCase() === 'src')
             attrName = '__playwright_src__';
-          }
           if (isImg && attr === kCurrentSrcAttribute) {
             // Render currentSrc for images, so that trace viewer does not accidentally
             // resolve srcset to a different source.

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -140,6 +140,17 @@ export class SnapshotRenderer {
             // crafted trace could include them.
             attrName = '__playwright_' + attr.toLowerCase() + '__';
           }
+          if (upperName === 'OBJECT' && attr.toLowerCase() === 'data') {
+            // Neutralize <object data> - it can load arbitrary HTML in the trace
+            // viewer's origin (e.g. via /sha1/ resources), bypassing script and
+            // iframe sanitization.
+            attrName = '__playwright_data__';
+          }
+          if (upperName === 'EMBED' && attr.toLowerCase() === 'src') {
+            // Neutralize <embed src> for the same reason as <object data>.
+            // The URL rewrite on line 158 does not catch relative URLs.
+            attrName = '__playwright_src__';
+          }
           if (isImg && attr === kCurrentSrcAttribute) {
             // Render currentSrc for images, so that trace viewer does not accidentally
             // resolve srcset to a different source.

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -84,6 +84,24 @@ test('snapshot renderer neutralizes iframe sandbox', () => {
   expect(html).toContain('__playwright_sandbox__');
 });
 
+test('snapshot renderer neutralizes object data attribute', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['OBJECT', { 'data': '/sha1/malicious', 'type': 'text/html' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain(' data=');
+  expect(html).toContain('__playwright_data__');
+});
+
+test('snapshot renderer neutralizes embed src attribute', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['EMBED', { 'src': '/sha1/malicious', 'type': 'text/html' }]]],
+  })], [], 0);
+  const { html } = renderer.render();
+  expect(html).not.toContain(' src=');
+  expect(html).toContain('__playwright_src__');
+});
+
 test('snapshot renderer handles case-insensitive iframe tag names', () => {
   const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
     html: ['HTML', {}, ['BODY', {}, ['iframe', { 'srcdoc': '<script>alert(1)</script>', 'src': 'http://evil.com' }]]],


### PR DESCRIPTION
## Summary

- Neutralize `<object data>` and `<embed src>` in the snapshot renderer. Both can load arbitrary HTML in the trace viewer's origin, bypassing the script and iframe sanitization added in #40655 and #40676.

## Attack scenario

A crafted trace can include a resource containing malicious HTML/JS with content type `text/html`, and a snapshot referencing it via `<object data="/sha1/<sha1>" type="text/html">`. The service worker serves the resource at `/sha1/` with the attacker-controlled content type. The `<object>` tag renders it in a browsing context within the trace viewer's origin, giving the attacker full JS execution. This allows exfiltrating sensitive data from the trace (API keys, cookies, auth tokens from the tested application).

`<embed src>` has the same issue. Although `src` is processed by `rewriteURLForCustomProtocol`, relative URLs (like `/sha1/...`) pass through unchanged because `new URL(relativePath)` throws and the catch block returns the URL as-is.

## Fix

Rename `data` on `<object>` and `src` on `<embed>` to `__playwright_data__` / `__playwright_src__`, following the same pattern used for `<iframe src>` and `<iframe srcdoc>` since [#40676](https://github.com/microsoft/playwright/pull/40676).

## Origin

The iframe `src` neutralization was introduced by Simon Knott (2024-09-04). It was expanded in [#40676](https://github.com/microsoft/playwright/pull/40676) to cover `srcdoc` and `sandbox`, but `<object>` and `<embed>` were not covered.