### PR TITLE
fix(server): destroy stream in WritableStreamDispatcher._onDispose

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/writableStreamDispatcher.ts
@@ -69,4 +69,9 @@ export class WritableStreamDispatcher extends Dispatcher<WritableStreamSdkObject
       return this._object.streamOrDirectory;
     return this._object.streamOrDirectory.path as string;
   }
+
+  override _onDispose() {
+    if (typeof this._object.streamOrDirectory !== 'string')
+      this._object.streamOrDirectory.destroy();
+  }
 }


### PR DESCRIPTION
## Summary
- Add `_onDispose()` to `WritableStreamDispatcher` to destroy the underlying `fs.WriteStream` when the dispatcher is disposed
- Matches the existing pattern in `StreamDispatcher` (#40759)
- Prevents file handle leaks when the client disconnects without calling `close()`

Introduced in #12860 (2022-03-18). The `_onDispose()` method was never added.