### PR TITLE
fix(server): close WriteStreams on createTempFiles failure

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -230,15 +230,25 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     const tempDirWithRootName = params.rootDirName ? path.join(tmpDir, path.basename(params.rootDirName)) : tmpDir;
     await progress.race(fs.promises.mkdir(tempDirWithRootName, { recursive: true }));
     this._context._tempDirs.push(tmpDir);
-    return {
-      rootDir: params.rootDirName ? new WritableStreamDispatcher(this, tempDirWithRootName) : undefined,
-      writableStreams: await Promise.all(params.items.map(async item => {
+
+    const streams: fs.WriteStream[] = [];
+    try {
+      const writableStreams = await Promise.all(params.items.map(async item => {
         const itemPath = throwingResolveWithinRoot(tempDirWithRootName, item.name);
         await progress.race(fs.promises.mkdir(path.dirname(itemPath), { recursive: true }));
         const file = fs.createWriteStream(itemPath);
+        streams.push(file);
         return new WritableStreamDispatcher(this, file, item.lastModifiedMs);
-      }))
-    };
+      }));
+      return {
+        rootDir: params.rootDirName ? new WritableStreamDispatcher(this, tempDirWithRootName) : undefined,
+        writableStreams,
+      };
+    } catch (e) {
+      for (const stream of streams)
+        stream.destroy();
+      throw e;
+    }
   }
 
   async exposeBinding(params: channels.BrowserContextExposeBindingParams, progress: Progress): Promise<channels.BrowserContextExposeBindingResult> {


### PR DESCRIPTION
## Summary
- Wrap `Promise.all` in try-catch to clean up WriteStreams if any file creation fails
- On error, destroy all WriteStreams created before the failure point
- Prevents fd leaks when `mkdir` or `createWriteStream` fails mid-way through creating multiple temp files

Introduced in #31165 (2022-03-18). Related: #40754 (path validation), #40764 (WritableStreamDispatcher._onDispose).