### PR TITLE
chore(trace): track snapshot targets via generation counter

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -93,7 +93,6 @@ export class InjectedScript {
   readonly isUnderTest: boolean;
   private _sdkLanguage: Language;
   private _testIdAttributeNameForStrictErrorAndConsoleCodegen: string = 'data-testid';
-  private _markedElements?: { callId: string, elements: Set<Element> };
   readonly window: Window & typeof globalThis;
   readonly document: Document;
   readonly consoleApi: ConsoleAPI;
@@ -1379,34 +1378,21 @@ export class InjectedScript {
     }
   }
 
-  markTargetElements(markedElements: Set<Element>, callId: string) {
-    if (this._markedElements?.callId !== callId)
-      this._markedElements = undefined;
-    const previous = this._markedElements?.elements || new Set();
-
-    const unmarkEvent = new CustomEvent('__playwright_unmark_target__', {
+  markTargetElements(markedElements: Set<Element>) {
+    const resetEvent = new CustomEvent('__playwright_reset_targets__', {
       bubbles: true,
       cancelable: true,
-      detail: callId,
       composed: true,
     });
-    for (const element of previous) {
-      if (!markedElements.has(element))
-        element.dispatchEvent(unmarkEvent);
-    }
+    this.document.dispatchEvent(resetEvent);
 
     const markEvent = new CustomEvent('__playwright_mark_target__', {
       bubbles: true,
       cancelable: true,
-      detail: callId,
       composed: true,
     });
-    for (const element of markedElements) {
-      if (!previous.has(element))
-        element.dispatchEvent(markEvent);
-    }
-
-    this._markedElements = { callId, elements: markedElements };
+    for (const element of markedElements)
+      element.dispatchEvent(markEvent);
   }
 
   private _setupGlobalListenersRemovalDetection() {

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -362,13 +362,22 @@ function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefine
         element.removeAttribute('__playwright_dialog_open_');
       }
 
+      // Highlight targets marked by the current snapshotter, which sets `__playwright_target__`
+      // to an empty string on the active target elements. For traces produced by older versions,
+      // also match by callId/snapshotName, which used to be stored as the attribute value.
+      const highlightTarget = (target: Element) => {
+        const style = (target as HTMLElement).style;
+        style.outline = '2px solid #006ab1';
+        style.backgroundColor = '#6fa8dc7f';
+        targetElements.push(target);
+      };
+      for (const target of root.querySelectorAll(`[__playwright_target__=""]`))
+        highlightTarget(target);
       for (const targetId of targetIds) {
-        for (const target of root.querySelectorAll(`[__playwright_target__="${targetId}"]`)) {
-          const style = (target as HTMLElement).style;
-          style.outline = '2px solid #006ab1';
-          style.backgroundColor = '#6fa8dc7f';
-          targetElements.push(target);
-        }
+        if (!targetId)
+          continue;
+        for (const target of root.querySelectorAll(`[__playwright_target__="${targetId}"]`))
+          highlightTarget(target);
       }
 
       for (const iframe of root.querySelectorAll('iframe, frame')) {

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -519,12 +519,10 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   private async _markAsTargetElement(progress: Progress) {
-    if (!progress.metadata.id)
-      return;
-    await progress.race(this.evaluateInUtility(([injected, node, callId]) => {
+    await progress.race(this.evaluateInUtility(([injected, node]) => {
       if (node.nodeType === 1 /* Node.ELEMENT_NODE */)
-        injected.markTargetElements(new Set([node as Node as Element]), callId);
-    }, progress.metadata.id));
+        injected.markTargetElements(new Set([node as Node as Element]));
+    }, {}));
   }
 
   async hover(progress: Progress, options: types.PointerActionOptions & types.PointerActionWaitOptions): Promise<void> {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1172,10 +1172,9 @@ export class Frame extends SdkObject<FrameEventMap> {
           throw new dom.NonRecoverableDOMError('Element(s) not found');
         return continuePolling;
       }
-      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, callId }) => {
+      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info }) => {
         const elements = injected.querySelectorAll(info.parsed, document);
-        if (callId)
-          injected.markTargetElements(new Set(elements), callId);
+        injected.markTargetElements(new Set(elements));
         const element = elements[0] as Element | undefined;
         let log = '';
         if (elements.length > 1) {
@@ -1187,7 +1186,7 @@ export class Frame extends SdkObject<FrameEventMap> {
         }
         injected.checkDeprecatedSelectorUsage(info.parsed, elements);
         return { log, success: !!element, element };
-      }, { info: resolved.info, callId: progress.metadata.id }));
+      }, { info: resolved.info }));
       const { log, success } = await progress.race(result.evaluate(r => ({ log: r.log, success: r.success })));
       if (log)
         progress.log(log);
@@ -1516,7 +1515,6 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   private async _expectInternal(progress: Progress, selector: string | undefined, options: FrameExpectParams, lastIntermediateResult: { received?: ExpectReceived, isSet: boolean, errorMessage?: string }, noAbort: boolean) {
     const progressLog = (text: string) => progress.log(text);
-    const callId = progress.metadata.id;
     // The first expect check, a.k.a. one-shot, always finishes - even when progress is aborted.
     if (noAbort)
       progress = nullProgress;
@@ -1527,10 +1525,9 @@ export class Frame extends SdkObject<FrameEventMap> {
     const context = await progress.race(frame.context(world));
     const injected = await progress.race(context.injectedScript());
 
-    const { log, matches, received, missingReceived } = await progress.race(injected.evaluate(async (injected, { info, options, callId }) => {
+    const { log, matches, received, missingReceived } = await progress.race(injected.evaluate(async (injected, { info, options }) => {
       const elements = info ? injected.querySelectorAll(info.parsed, document) : [];
-      if (callId)
-        injected.markTargetElements(new Set(elements), callId);
+      injected.markTargetElements(new Set(elements));
       const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
       let log = '';
       if (isArray)
@@ -1542,7 +1539,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       if (info)
         injected.checkDeprecatedSelectorUsage(info.parsed, elements);
       return { log, ...await injected.expect(elements[0], options, elements) };
-    }, { info, options, callId }));
+    }, { info, options }));
 
     if (log)
       progressLog(log);
@@ -1692,16 +1689,15 @@ export class Frame extends SdkObject<FrameEventMap> {
       const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, options, scope));
       if (!resolved)
         return continuePolling;
-      const { log, success, value } = await progress.race(resolved.injected.evaluate((injected, { info, callbackText, taskData, callId, root }) => {
+      const { log, success, value } = await progress.race(resolved.injected.evaluate((injected, { info, callbackText, taskData, root }) => {
         const callback = injected.eval(callbackText) as ElementCallback<T, R>;
         const element = injected.querySelector(info.parsed, root || document, info.strict);
         if (!element)
           return { success: false };
         const log = `  locator resolved to ${injected.previewNode(element)}`;
-        if (callId)
-          injected.markTargetElements(new Set([element]), callId);
+        injected.markTargetElements(new Set([element]));
         return { log, success: true, value: callback(injected, element, taskData as T) };
-      }, { info: resolved.info, callbackText, taskData, callId: progress.metadata.id, root: resolved.frame === this ? scope : undefined }));
+      }, { info: resolved.info, callbackText, taskData, root: resolved.frame === this ? scope : undefined }));
       if (log)
         progress.log(log);
       if (!success)

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -102,11 +102,12 @@ export class Snapshotter {
     eventsHelper.removeEventListeners(this._eventListeners);
   }
 
-  private async _captureFrameSnapshot(frame: Frame): Promise<SnapshotData | void> {
+  private async _captureFrameSnapshot(frame: Frame, resetTargets: boolean): Promise<SnapshotData | void> {
     // Prepare expression synchronously.
-    const needsReset = !!(frame as any)[kNeedsResetSymbol];
+    const needsHistoryReset = !!(frame as any)[kNeedsResetSymbol];
     (frame as any)[kNeedsResetSymbol] = false;
-    const expression = `window["${this._snapshotStreamer}"].captureSnapshot(${needsReset ? 'true' : 'false'})`;
+    const reset = needsHistoryReset ? 'history' : (resetTargets ? 'targets' : undefined);
+    const expression = `window["${this._snapshotStreamer}"].captureSnapshot(${JSON.stringify(reset)})`;
     try {
       return await frame.nonStallingRawEvaluateInExistingMainContext(expression);
     } catch (e) {
@@ -118,10 +119,10 @@ export class Snapshotter {
     }
   }
 
-  async captureSnapshot(page: Page, callId: string, snapshotName: string): Promise<void> {
+  async captureSnapshot(page: Page, callId: string, snapshotName: string, resetTargets: boolean): Promise<void> {
     // In each frame, in a non-stalling manner, capture the snapshots.
     const snapshots = page.frames().map(async frame => {
-      const data = await this._captureFrameSnapshot(frame);
+      const data = await this._captureFrameSnapshot(frame, resetTargets);
       // Something went wrong -> bail out, our snapshots are best-efforty.
       if (!data || !this._started)
         return;

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -90,6 +90,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     private _readingStyleSheet = false;  // To avoid invalidating due to our own reads.
     private _fakeBase: HTMLBaseElement;
     private _observer: MutationObserver;
+    private _targetGeneration = 0;
 
     constructor() {
       const invalidateCSSGroupingRule = (rule: CSSGroupingRule) => {
@@ -148,17 +149,13 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
 
     private _refreshListeners() {
       (document as any).addEventListener('__playwright_mark_target__', (event: CustomEvent) => {
-        if (!event.detail)
+        const target = event.composedPath()[0] as Element;
+        if (target?.nodeType !== Node.ELEMENT_NODE)
           return;
-        const callId = event.detail as string;
-        (event.composedPath()[0] as any).__playwright_target__ = callId;
+        (target as any).__playwright_target__ = this._targetGeneration;
       });
-      (document as any).addEventListener('__playwright_unmark_target__', (event: CustomEvent) => {
-        if (!event.detail)
-          return;
-        const callId = event.detail as string;
-        if ((event.composedPath()[0] as any).__playwright_target__ === callId)
-          delete (event.composedPath()[0] as any).__playwright_target__;
+      (document as any).addEventListener('__playwright_reset_targets__', () => {
+        ++this._targetGeneration;
       });
     }
 
@@ -255,7 +252,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       (iframeElement as any)[kSnapshotFrameId] = frameId;
     }
 
-    reset() {
+    resetHistory() {
       this._staleStyleSheets.clear();
 
       const visitNode = (node: Node | ShadowRoot) => {
@@ -339,11 +336,13 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       }
     }
 
-    captureSnapshot(needsReset: boolean): SnapshotData | undefined {
+    captureSnapshot(reset?: 'history' | 'targets'): SnapshotData | undefined {
       const timestamp = performance.now();
       const snapshotNumber = ++this._lastSnapshotNumber;
-      if (needsReset)
-        this.reset();
+      if (reset === 'history')
+        this.resetHistory();
+      if (reset)
+        ++this._targetGeneration;
       let nodeCounter = 0;
       let shadowDomNesting = 0;
       let headNesting = 0;
@@ -506,10 +505,9 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
             visitChild(element.shadowRoot);
             --shadowDomNesting;
           }
-          if ('__playwright_target__' in element) {
+          if ((element as any).__playwright_target__ === this._targetGeneration) {
             expectValue(kTargetAttribute);
-            expectValue(element['__playwright_target__']);
-            attrs[kTargetAttribute] = element['__playwright_target__'] as string;
+            attrs[kTargetAttribute] = '';
           }
         }
 

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -458,10 +458,10 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     return { artifact };
   }
 
-  private async _captureSnapshot(snapshotName: string | undefined, sdkObject: SdkObject, metadata: CallMetadata): Promise<void> {
+  private async _captureSnapshot(snapshotName: string | undefined, sdkObject: SdkObject, metadata: CallMetadata, resetTargets: boolean): Promise<void> {
     if (!snapshotName || !sdkObject.attribution.page)
       return;
-    await this._snapshotter?.captureSnapshot(sdkObject.attribution.page, metadata.id, snapshotName).catch(() => {});
+    await this._snapshotter?.captureSnapshot(sdkObject.attribution.page, metadata.id, snapshotName, resetTargets).catch(() => {});
   }
 
   private _shouldCaptureSnapshot(sdkObject: SdkObject, metadata: CallMetadata, phase: 'before' | 'after' | 'input') {
@@ -489,7 +489,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       event.beforeSnapshot = `before@${metadata.id}`;
     this._state?.callIds.add(metadata.id);
     this._appendTraceEvent(event);
-    return this._captureSnapshot(event.beforeSnapshot, sdkObject, metadata);
+    return this._captureSnapshot(event.beforeSnapshot, sdkObject, metadata, true);
   }
 
   onBeforeInputAction(sdkObject: SdkObject, metadata: CallMetadata) {
@@ -503,7 +503,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     if (this._shouldCaptureSnapshot(sdkObject, metadata, 'input'))
       event.inputSnapshot = `input@${metadata.id}`;
     this._appendTraceEvent(event);
-    return this._captureSnapshot(event.inputSnapshot, sdkObject, metadata);
+    return this._captureSnapshot(event.inputSnapshot, sdkObject, metadata, false);
   }
 
   onCallLog(sdkObject: SdkObject, metadata: CallMetadata, logName: string, message: string) {
@@ -530,7 +530,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     if (this._shouldCaptureSnapshot(sdkObject, metadata, 'after'))
       event.afterSnapshot = `after@${metadata.id}`;
     this._appendTraceEvent(event);
-    return this._captureSnapshot(event.afterSnapshot, sdkObject, metadata);
+    return this._captureSnapshot(event.afterSnapshot, sdkObject, metadata, false);
   }
 
   onEntryStarted(entry: har.Entry) {


### PR DESCRIPTION
## Summary
- Replace per-element Set tracking in snapshotterInjected with a generation counter; stale marks are ignored at serialization, no element refs retained.
- `captureSnapshot` now takes `reset?: 'history' | 'targets'`; `'targets'` is opted in by tracing for the before-action snapshot via a new `resetTargets` argument. Renames `Streamer.reset` → `resetHistory`.
- `InjectedScript.markTargetElements` no longer takes a `callId` — always reset+mark; callers always invoke it.
- `snapshotRenderer` highlights `__playwright_target__=""` and keeps the legacy `callId`/`snapshotName` match for older traces.