### PR TITLE
test(mcp): disable chromium sandbox on Windows to probe launch flake

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -213,6 +213,8 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   if (browser.browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
     if (process.platform === 'linux')
       browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
+    else if (process.platform === 'win32')
+      browser.launchOptions.chromiumSandbox = false;
     else
       browser.launchOptions.chromiumSandbox = true;
   }

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -109,13 +109,16 @@ test.describe('browserName and channel', () => {
 test.describe('sandbox', () => {
   test('chromium sandbox enabled for chrome channel', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chrome' }, emptyEnv);
-    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+    if (process.platform === 'win32')
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+    else
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
   test('chromium sandbox for chrome-for-testing channel', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chromium' }, emptyEnv);
     expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
-    if (process.platform === 'linux')
+    if (process.platform === 'linux' || process.platform === 'win32')
       expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
     else
       expect(config.browser.launchOptions.chromiumSandbox).toBe(true);


### PR DESCRIPTION
Experimental probe — do not merge.

On Windows, defaults `chromiumSandbox = false` for all Chromium channels in MCP config (Linux/macOS unchanged) to test whether Windows sandbox-init contention is the cause of the residual `tests/mcp/cli-fixtures` flake (dashboard, annotate, cli-*) under parallel workers.

If Windows MCP shards turn green here vs main, sandbox is implicated and a narrower fix follows.