### PR TITLE
fix(dashboard): retry pending reveal on TabsChanged

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -61,7 +61,10 @@ export class DashboardConnection implements Transport {
       this._pushSessions();
       void this._tryRevealPending();
     });
-    this._provider.on(SessionProviderEvent.TabsChanged, () => this._pushTabs());
+    this._provider.on(SessionProviderEvent.TabsChanged, () => {
+      this._pushTabs();
+      void this._tryRevealPending();
+    });
     this._provider.on(SessionProviderEvent.ContextClosed, context => {
       if (this._attachedPage?.page.context() === context) {
         this._attachedPage.dispose();


### PR DESCRIPTION
We weren't retrying `_tryRevealPending` when a new page was added. So if the event progression in dashboard is `Session created -> reveal --page -> Page created`, we swallowed the reveal.

This is hopefully the root cause for the recent flakiness in `tests/mcp/annotate.spec.ts` and `tests/mcp/dashboard.spec.ts:54` on Windows MCP CI runs. Not for the kind that manifests as `browser did not come up`, but for the kind that shows `expected "Dashboard: annotate", didnt appear`
