### PR TITLE
chore(page): split protocol close into close and runBeforeUnload

### DIFF
--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -244,6 +244,7 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['Response.sizes', { internal: true, }],
   ['Page.addInitScript', { title: 'Add init script', group: 'configuration', }],
   ['Page.close', { title: 'Close page', pause: true, }],
+  ['Page.runBeforeUnload', { title: 'Run beforeunload', pause: true, }],
   ['Page.clearConsoleMessages', { title: 'Clear console messages', }],
   ['Page.consoleMessages', { title: 'Get console messages', group: 'getter', }],
   ['Page.emulateMedia', { title: 'Emulate media', snapshot: true, pause: true, }],

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -647,8 +647,10 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     try {
       if (this._ownedContext)
         await this._ownedContext.close();
+      else if (options.runBeforeUnload)
+        await this._channel.runBeforeUnload();
       else
-        await this._channel.close(options);
+        await this._channel.close({ reason: options.reason });
     } catch (e) {
       if (isTargetClosedError(e) && !options.runBeforeUnload)
         return;

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -2281,10 +2281,11 @@ scheme.PageAddInitScriptResult = tObject({
   disposable: tChannel(['Disposable']),
 });
 scheme.PageCloseParams = tObject({
-  runBeforeUnload: tOptional(tBoolean),
   reason: tOptional(tString),
 });
 scheme.PageCloseResult = tOptional(tObject({}));
+scheme.PageRunBeforeUnloadParams = tOptional(tObject({}));
+scheme.PageRunBeforeUnloadResult = tOptional(tObject({}));
 scheme.PageClearConsoleMessagesParams = tOptional(tObject({}));
 scheme.PageClearConsoleMessagesResult = tOptional(tObject({}));
 scheme.PageConsoleMessagesParams = tObject({

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -250,9 +250,12 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
   }
 
   async close(params: channels.PageCloseParams, progress: Progress): Promise<void> {
-    if (!params.runBeforeUnload)
-      progress.metadata.potentiallyClosesScope = true;
+    progress.metadata.potentiallyClosesScope = true;
     await this._page.close(progress, params);
+  }
+
+  async runBeforeUnload(params: channels.PageRunBeforeUnloadParams, progress: Progress): Promise<void> {
+    await this._page.runBeforeUnload(progress);
   }
 
   async updateSubscription(params: channels.PageUpdateSubscriptionParams, progress: Progress): Promise<void> {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -804,31 +804,36 @@ export class Page extends SdkObject<PageEventMap> {
     return await this.screenshotter.screenshotPage(progress, options);
   }
 
-  async close(progress: Progress, options: { runBeforeUnload?: boolean, reason?: string } = {}) {
+  async close(progress: Progress, options: { reason?: string } = {}) {
     await progress.race(this._close(options));
   }
 
-  private async _close(options: { runBeforeUnload?: boolean, reason?: string } = {}) {
+  private async _close(options: { reason?: string } = {}) {
     if (this._closedState === 'closed')
       return;
 
     if (options.reason)
       this._closeReason = options.reason;
-    const runBeforeUnload = !!options.runBeforeUnload;
 
-    if (!runBeforeUnload)
-      await this.screencast.handlePageOrContextClose();
+    await this.screencast.handlePageOrContextClose();
 
     if (this._closedState !== 'closing') {
-      // If runBeforeUnload is true, we don't know if we will close, so don't modify the state
-      if (!runBeforeUnload)
-        this._closedState = 'closing';
+      this._closedState = 'closing';
       // This might throw if the browser context containing the page closes
       // while we are trying to close the page.
-      await this.delegate.closePage(runBeforeUnload).catch(e => debugLogger.log('error', e));
+      await this.delegate.closePage(false).catch(e => debugLogger.log('error', e));
     }
-    if (!runBeforeUnload)
-      await this.closedPromise;
+    await this.closedPromise;
+  }
+
+  async runBeforeUnload(progress: Progress) {
+    await progress.race(this._runBeforeUnload());
+  }
+
+  private async _runBeforeUnload() {
+    // This might throw if the browser context containing the page closes
+    // while we are trying to close the page.
+    await this.delegate.closePage(true).catch(e => debugLogger.log('error', e));
   }
 
   isClosed(): boolean {

--- a/packages/protocol/spec/page.yml
+++ b/packages/protocol/spec/page.yml
@@ -39,8 +39,12 @@ Page:
     close:
       title: Close page
       parameters:
-        runBeforeUnload: boolean?
         reason: string?
+      flags:
+        pause: true
+
+    runBeforeUnload:
+      title: Run beforeunload
       flags:
         pause: true
 

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -3981,6 +3981,7 @@ export interface PageChannel extends PageEventTarget, Channel {
   _type_Page: boolean;
   addInitScript(params: PageAddInitScriptParams, progress?: Progress): Promise<PageAddInitScriptResult>;
   close(params: PageCloseParams, progress?: Progress): Promise<PageCloseResult>;
+  runBeforeUnload(params?: PageRunBeforeUnloadParams, progress?: Progress): Promise<PageRunBeforeUnloadResult>;
   clearConsoleMessages(params?: PageClearConsoleMessagesParams, progress?: Progress): Promise<PageClearConsoleMessagesResult>;
   consoleMessages(params: PageConsoleMessagesParams, progress?: Progress): Promise<PageConsoleMessagesResult>;
   emulateMedia(params: PageEmulateMediaParams, progress?: Progress): Promise<PageEmulateMediaResult>;
@@ -4088,14 +4089,15 @@ export type PageAddInitScriptResult = {
   disposable: DisposableChannel,
 };
 export type PageCloseParams = {
-  runBeforeUnload?: boolean,
   reason?: string,
 };
 export type PageCloseOptions = {
-  runBeforeUnload?: boolean,
   reason?: string,
 };
 export type PageCloseResult = void;
+export type PageRunBeforeUnloadParams = {};
+export type PageRunBeforeUnloadOptions = {};
+export type PageRunBeforeUnloadResult = void;
 export type PageClearConsoleMessagesParams = {};
 export type PageClearConsoleMessagesOptions = {};
 export type PageClearConsoleMessagesResult = void;


### PR DESCRIPTION
## Summary
- Split the `Page.close` protocol command into `close` and `runBeforeUnload`; the server-side `Page` and the dispatcher get matching split methods.
- The public client `page.close({ runBeforeUnload })` API is unchanged — it routes to the appropriate channel command based on the flag.