### PR TITLE
test: roll stable-test-runner to 1.60.0-beta-1778518825000

### DIFF
--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.60.0-beta-1778191499000"
+        "@playwright/test": "^1.60.0-beta-1778518825000"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-eJM7mWJvEfdJFLD9Hm+NZFeOliipw1mMLCtSX2HPeQoLw/jp58sxPQH2ldpchRTn0UMgDcuI0XKI24+8nLC1zA==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-MpCYnanAeJYD95hZtlYm0bBHxX5QY1LqKaDdf9EzOMqFvdV41sPokcTQL07UE3TCoEx2rSftKOuD5m/FaQcQkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-beta-1778191499000"
+        "playwright": "1.60.0-beta-1778518825000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-I4ZT4SFIrNdZAXmfDg8K67ya9uAs2ELqXfG0MA8ZcojDXyI6pWqIj2nnF/KqloGM++2ACvOa5MlII4Xa0c92/g==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-wKyEeqeNjxYfPk+LQt1/rWgPe0XhUw+ymnHa9w8ruW2N1pnzhPD9ioTQeFLld05dZ+mLqu69ZumiymAq9dl03Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-beta-1778191499000"
+        "playwright-core": "1.60.0-beta-1778518825000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-beta-1778191499000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778191499000.tgz",
-      "integrity": "sha512-rN9NcOjAXvVf1qexgevYfRK8h4YhVRtu72tRcfcoU7aisGPSRIeoeGxozFYMjNPFWsJJEVsr3kkBYXuwKRPt7g==",
+      "version": "1.60.0-beta-1778518825000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-beta-1778518825000.tgz",
+      "integrity": "sha512-X/PCxX6TTHCB0T0HEkuW5QI0w8J8dIdfwPOWSO2MbWDcILPMsXdWup37/yBG/KtS1i4SwrzPJw/Jl07+b2Y2/Q==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "^1.60.0-beta-1778191499000"
+    "@playwright/test": "^1.60.0-beta-1778518825000"
   }
 }


### PR DESCRIPTION
## Summary
- Roll stable-test-runner from `1.60.0-beta-1778191499000` to `1.60.0-beta-1778518825000` (covers the recent v1.60 cherry-picks).

Part of https://github.com/microsoft/playwright-internal/issues/288.