### PR TITLE
fix(test-runner): match file paths containing spaces on Windows

### DIFF
--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -16,7 +16,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import url from 'url';
 import util from 'util';
 
 import debug from 'debug';
@@ -114,12 +113,12 @@ export function createFileMatcher(patterns: string | RegExp | (string | RegExp)[
         return true;
     }
     // Windows might still receive unix style paths from Cygwin or Git Bash.
-    // Check against the file url as well.
+    // Check against the forward-slash form as well.
     if (path.sep === '\\') {
-      const fileURL = url.pathToFileURL(filePath).href;
+      const unixPath = filePath.split(path.sep).join('/');
       for (const re of reList) {
         re.lastIndex = 0;
-        if (re.test(fileURL))
+        if (re.test(unixPath))
           return true;
       }
     }

--- a/tests/playwright-test/command-line-filter.spec.ts
+++ b/tests/playwright-test/command-line-filter.spec.ts
@@ -174,8 +174,7 @@ test('should focus a single nested test spec', async ({ runInlineTest }) => {
   expect(result.report.suites[1].suites[0].suites[0].specs[0].title).toEqual('pass2');
 });
 
-test('should accept absolute file path containing a space', async ({ runInlineTest }, testInfo) => {
-  const absolutePath = path.join(testInfo.outputPath(), 'dir with space', 'a.spec.ts').split(path.sep).join('/');
+test('should accept unix file path containing a space', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'dir with space/a.spec.ts': `
       import { test, expect } from '@playwright/test';
@@ -185,7 +184,7 @@ test('should accept absolute file path containing a space', async ({ runInlineTe
       import { test, expect } from '@playwright/test';
       test('not picked', () => { expect(1).toBe(2); });
     `,
-  }, undefined, undefined, { additionalArgs: [absolutePath] });
+  }, undefined, undefined, { additionalArgs: ['dir with space/a.spec.ts'] });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
   expect(result.report.suites).toHaveLength(1);

--- a/tests/playwright-test/command-line-filter.spec.ts
+++ b/tests/playwright-test/command-line-filter.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import path from 'path';
+
 import { test, expect } from './playwright-test-fixtures';
 
 test('should filter by file name', async ({ runInlineTest }) => {
@@ -170,6 +172,24 @@ test('should focus a single nested test spec', async ({ runInlineTest }) => {
   expect(result.skipped).toBe(0);
   expect(result.report.suites[0].specs[0].title).toEqual('pass3');
   expect(result.report.suites[1].suites[0].suites[0].specs[0].title).toEqual('pass2');
+});
+
+test('should accept absolute file path containing a space', async ({ runInlineTest }, testInfo) => {
+  const absolutePath = path.join(testInfo.outputPath(), 'dir with space', 'a.spec.ts').split(path.sep).join('/');
+  const result = await runInlineTest({
+    'dir with space/a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passes', () => { expect(1).toBe(1); });
+    `,
+    'dir with space/b.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('not picked', () => { expect(1).toBe(2); });
+    `,
+  }, undefined, undefined, { additionalArgs: [absolutePath] });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.report.suites).toHaveLength(1);
+  expect(result.report.suites[0].specs[0].title).toBe('passes');
 });
 
 test('should focus a single test suite', async ({ runInlineTest }) => {

--- a/tests/playwright-test/command-line-filter.spec.ts
+++ b/tests/playwright-test/command-line-filter.spec.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import path from 'path';
-
 import { test, expect } from './playwright-test-fixtures';
 
 test('should filter by file name', async ({ runInlineTest }) => {


### PR DESCRIPTION
## Summary
- On Windows, `createFileMatcher` falls back to a forward-slash form to handle unix-style paths from Cygwin / Git Bash. It used `url.pathToFileURL()`, which percent-encodes spaces, so an absolute CLI arg like `C:/test dir/example.spec.mjs` never matched the collected file `C:\test dir\example.spec.mjs` (file URL contains `test%20dir`).
- Replace the URL conversion with a plain separator normalization (`filePath.split(path.sep).join('/')`) so spaces (and other URL-reserved characters) are preserved.

Fixes https://github.com/microsoft/playwright/issues/40767