### PR TITLE
Add `-Dexec.classpathScope=test` to `mvn exec:java -Dexec.mainClass=com.microsoft.playwright.CLI`

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -18,7 +18,7 @@ npx playwright install
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash python
@@ -36,7 +36,7 @@ npx playwright install webkit
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install webkit"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install webkit"
 ```
 
 ```bash python
@@ -54,7 +54,7 @@ npx playwright install --help
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --help"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --help"
 ```
 
 ```bash python
@@ -87,7 +87,7 @@ npx playwright install-deps
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps"
 ```
 
 ```bash python
@@ -105,7 +105,7 @@ npx playwright install-deps chromium
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps chromium"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps chromium"
 ```
 
 ```bash python
@@ -123,7 +123,7 @@ npx playwright install --with-deps chromium
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps chromium"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps chromium"
 ```
 
 ```bash python
@@ -351,7 +351,7 @@ npx playwright install --with-deps --only-shell
 
 ```bash java
 # only running tests headlessly
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps --only-shell"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps --only-shell"
 ```
 
 ```bash python
@@ -428,7 +428,7 @@ npx playwright install --with-deps --no-shell
 
 ```bash java
 # only running tests headlessly
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps --no-shell"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps --no-shell"
 ```
 
 ```bash python
@@ -543,7 +543,7 @@ pwsh bin/Debug/netX/playwright.ps1 install msedge
 ```
 
 ```batch lang=java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install msedge"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install msedge"
 ```
 
 :::warning
@@ -630,17 +630,17 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-HTTPS_PROXY=https://192.0.2.1 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+HTTPS_PROXY=https://192.0.2.1 mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set HTTPS_PROXY=https://192.0.2.1
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:HTTPS_PROXY="https://192.0.2.1"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -705,17 +705,17 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000 mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT="120000"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -739,7 +739,7 @@ sudo HTTPS_PROXY=https://192.0.2.1 npx playwright install-deps
 ```
 
 ```bash java
-sudo HTTPS_PROXY=https://192.0.2.1 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install-deps"
+sudo HTTPS_PROXY=https://192.0.2.1 mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps"
 ```
 
 ```bash python
@@ -790,17 +790,17 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1 mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:PLAYWRIGHT_DOWNLOAD_HOST="http://192.0.2.1"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -856,19 +856,19 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=http://203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1 mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=http://203.0.113.3 PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1 mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST=http://203.0.113.3
 set PLAYWRIGHT_DOWNLOAD_HOST=http://192.0.2.1
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:PLAYWRIGHT_FIREFOX_DOWNLOAD_HOST="http://203.0.113.3"
 $Env:PLAYWRIGHT_DOWNLOAD_HOST="http://192.0.2.1"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -923,17 +923,17 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-PLAYWRIGHT_NODEJS_PATH="/usr/local/bin/node" mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+PLAYWRIGHT_NODEJS_PATH="/usr/local/bin/node" mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set PLAYWRIGHT_NODEJS_PATH=C:\Program Files\nodejs\node.exe
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:PLAYWRIGHT_NODEJS_PATH="C:\Program Files\nodejs\node.exe"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -1001,17 +1001,17 @@ playwright install
 ```
 
 ```bash tab=bash-bash lang=java
-PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+PLAYWRIGHT_BROWSERS_PATH=$HOME/pw-browsers mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```batch tab=bash-batch lang=java
 set PLAYWRIGHT_BROWSERS_PATH=%USERPROFILE%\pw-browsers
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```powershell tab=bash-powershell lang=java
 $Env:PLAYWRIGHT_BROWSERS_PATH="$Env:USERPROFILE\pw-browsers"
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install"
 ```
 
 ```bash tab=bash-bash lang=csharp
@@ -1157,7 +1157,7 @@ npx playwright install --list
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --list"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --list"
 ```
 
 ```bash python
@@ -1177,7 +1177,7 @@ npx playwright uninstall
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="uninstall"
 ```
 
 ```bash python
@@ -1195,7 +1195,7 @@ npx playwright uninstall --all
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall --all"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="uninstall --all"
 ```
 
 ```bash python

--- a/docs/src/ci-intro.md
+++ b/docs/src/ci-intro.md
@@ -132,9 +132,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
     - name: Build & Install
-      run: mvn -B install -D skipTests --no-transfer-progress
+      run: mvn -B install -DskipTests --no-transfer-progress
     - name: Ensure browsers are installed
-      run: mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
+      run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
     - name: Run tests
       run: mvn test
 ```

--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -24,7 +24,7 @@ configurations for common CI providers.
    playwright install --with-deps
    ```
    ```bash java
-   mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
+   mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
    ```
    ```bash csharp
    dotnet build
@@ -155,9 +155,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
     - name: Build & Install
-      run: mvn -B install -D skipTests --no-transfer-progress
+      run: mvn -B install -DskipTests --no-transfer-progress
     - name: Ensure browsers are installed
-      run: mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
+      run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
     - name: Run tests
       run: mvn test
 ```
@@ -271,7 +271,7 @@ jobs:
           distribution: 'temurin'
           java-version: '25'
       - name: Build & Install
-        run: mvn -B install -D skipTests --no-transfer-progress
+        run: mvn -B install -DskipTests --no-transfer-progress
       - name: Run tests
         run: mvn test
 ```
@@ -373,9 +373,9 @@ jobs:
         distribution: 'temurin'
         java-version: '25'
     - name: Build & Install
-      run: mvn -B install -D skipTests --no-transfer-progress
+      run: mvn -B install -DskipTests --no-transfer-progress
     - name: Install Playwright
-      run: mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
+      run: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
     - name: Run tests
       run: mvn test
       env:
@@ -524,9 +524,9 @@ steps:
     versionSpec: '25'
     jdkArchitectureOption: 'x64'
     jdkSourceOption: AzureStorage
-- script: mvn -B install -D skipTests --no-transfer-progress
+- script: mvn -B install -DskipTests --no-transfer-progress
   displayName: 'Build and install'
-- script: mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps"
+- script: mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --with-deps"
   displayName: 'Install Playwright browsers'
 - script: mvn test
   displayName: 'Run tests'
@@ -725,7 +725,7 @@ steps:
     jdkArchitectureOption: 'x64'
     jdkSourceOption: AzureStorage
 
-- script: mvn -B install -D skipTests --no-transfer-progress
+- script: mvn -B install -DskipTests --no-transfer-progress
   displayName: 'Build and install'
 - script: mvn test
   displayName: 'Run tests'
@@ -838,7 +838,7 @@ pipeline {
    stages {
       stage('e2e-tests') {
          steps {
-            sh 'mvn -B install -D skipTests --no-transfer-progress'
+            sh 'mvn -B install -DskipTests --no-transfer-progress'
             sh 'mvn test'
          }
       }

--- a/docs/src/codegen-intro.md
+++ b/docs/src/codegen-intro.md
@@ -21,7 +21,7 @@ npx playwright codegen demo.playwright.dev/todomvc
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen demo.playwright.dev/todomvc"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen demo.playwright.dev/todomvc"
 ```
 
 ```bash python

--- a/docs/src/codegen.md
+++ b/docs/src/codegen.md
@@ -78,7 +78,7 @@ npx playwright codegen demo.playwright.dev/todomvc
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen demo.playwright.dev/todomvc"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen demo.playwright.dev/todomvc"
 ```
 
 ```bash python
@@ -168,7 +168,7 @@ npx playwright codegen --viewport-size="800,600" playwright.dev
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --viewport-size='800,600' playwright.dev"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --viewport-size='800,600' playwright.dev"
 ```
 
 ```bash python
@@ -208,7 +208,7 @@ npx playwright codegen --device="iPhone 13" playwright.dev
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='codegen --device="iPhone 13" playwright.dev'
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='codegen --device="iPhone 13" playwright.dev'
 ```
 
 ```bash python
@@ -248,7 +248,7 @@ npx playwright codegen --color-scheme=dark playwright.dev
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --color-scheme=dark playwright.dev"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --color-scheme=dark playwright.dev"
 ```
 
 ```bash python
@@ -291,7 +291,7 @@ npx playwright codegen --timezone="Europe/Rome" --geolocation="41.890221,12.4923
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" bing.com/maps'
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" bing.com/maps'
 ```
 
 ```bash python
@@ -332,7 +332,7 @@ npx playwright codegen github.com/microsoft/playwright --save-storage=auth.json
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen github.com/microsoft/playwright  --save-storage=auth.json"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen github.com/microsoft/playwright  --save-storage=auth.json"
 ```
 
 ```bash python
@@ -382,7 +382,7 @@ npx playwright codegen --load-storage=auth.json github.com/microsoft/playwright
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --load-storage=auth.json github.com/microsoft/playwright"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --load-storage=auth.json github.com/microsoft/playwright"
 ```
 
 ```bash python
@@ -427,7 +427,7 @@ npx playwright codegen --user-data-dir=/path/to/your/browser/data/ github.com/mi
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --user-data-dir=/path/to/your/browser/data/ github.com/microsoft/playwright"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --user-data-dir=/path/to/your/browser/data/ github.com/microsoft/playwright"
 ```
 
 ```bash python

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -85,7 +85,7 @@ public class App {
 With the App.java and pom.xml above, compile and execute your new program as follows:
 
 ```bash
-mvn compile exec:java -D exec.mainClass="org.example.App"
+mvn compile exec:java -Dexec.mainClass="org.example.App"
 ```
 
 Running it downloads the Playwright package and installs browser binaries for Chromium, Firefox and WebKit. To modify this behavior see [installation parameters](./browsers.md#install-browsers).
@@ -121,7 +121,7 @@ playwright.firefox().launch(new BrowserType.LaunchOptions().setHeadless(false).s
 ## Running the Example script
 
 ```bash
-mvn compile exec:java -D exec.mainClass="org.example.App"
+mvn compile exec:java -Dexec.mainClass="org.example.App"
 ```
 
 By default browsers launched with Playwright run headless, meaning no browser UI will open up when running the script. To change that you can pass `new BrowserType.LaunchOptions().setHeadless(false)` when launching the browser.

--- a/docs/src/mock.md
+++ b/docs/src/mock.md
@@ -431,7 +431,7 @@ npx playwright open --save-har=example.har --save-har-glob="**/api/**" https://e
 
 ```bash java
 # Save API requests from example.com as "example.har" archive.
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="open --save-har=example.har --save-har-glob='**/api/**' https://example.com"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="open --save-har=example.har --save-har-glob='**/api/**' https://example.com"
 ```
 
 ```bash python

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -304,10 +304,10 @@ This version was also tested against the following stable channels:
 
 - New option `--user-data-dir` in multiple commands. You can specify the same user data dir to reuse browsing state, like authentication, between sessions.
   ```bash
-  mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --user-data-dir=./user-data"
+  mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --user-data-dir=./user-data"
   ```
 
-- `mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args=open` command does not open the test recorder anymore. Use `mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args=codegen` instead.
+- `mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args=open` command does not open the test recorder anymore. Use `mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args=codegen` instead.
 
 ### Browser Versions
 
@@ -331,7 +331,7 @@ This version was also tested against the following stable channels:
   Locator button = page.getByTestId("btn-sub").describe("Subscribe button");
   button.click();
   ```
-- `mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --list"` will now list all installed browsers, versions and locations.
+- `mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install --list"` will now list all installed browsers, versions and locations.
 
 ### Browser Versions
 
@@ -1111,8 +1111,8 @@ This version was also tested against the following stable channels:
 
 * New `uninstall` CLI command to uninstall browser binaries:
   ```bash
-  $ mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall" # remove browsers installed by this installation
-  $ mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="uninstall --all" # remove all ever-install Playwright browsers
+  $ mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="uninstall" # remove browsers installed by this installation
+  $ mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="uninstall --all" # remove all ever-install Playwright browsers
   ```
 
 ### Browser Versions
@@ -1503,7 +1503,7 @@ Now you can record network traffic into a HAR file and re-use this traffic in yo
 To record network into HAR file:
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="open --save-har=example.har --save-har-glob='**/api/**' https://example.com"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="open --save-har=example.har --save-har-glob='**/api/**' https://example.com"
 ```
 
 Alternatively, you can record HAR programmatically:
@@ -1815,7 +1815,7 @@ Playwright Trace Viewer is now **available online** at https://trace.playwright.
 - Playwright now supports **Ubuntu 20.04 ARM64**. You can now run Playwright tests inside Docker on Apple M1 and on Raspberry Pi.
 - You can now use Playwright to install stable version of Edge on Linux:
     ```bash
-    mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install msedge"
+    mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install msedge"
     ```
 
 
@@ -1842,7 +1842,7 @@ Read more about [`method: Locator.waitFor`].
 
 ### 🎭 Playwright Trace Viewer
 
-- run trace viewer with `mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="show-trace"` and drop trace files to the trace viewer PWA
+- run trace viewer with `mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace"` and drop trace files to the trace viewer PWA
 - better visual attribution of action targets
 
 Read more about [Trace Viewer](./trace-viewer).
@@ -2020,7 +2020,7 @@ Traces are examined later with the Playwright CLI:
 
 
 ```sh
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="show-trace trace.zip"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace trace.zip"
 ```
 
 That will open the following GUI:
@@ -2131,7 +2131,7 @@ This version of Playwright was also tested against the following stable channels
 - [Selecting elements based on layout](./other-locators.md#css-matching-elements-based-on-layout) with `:left-of()`, `:right-of()`, `:above()` and `:below()`.
 - Playwright now includes command line interface, former playwright-cli.
   ```bash java
-  mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="--help"
+  mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="--help"
   ```
 - [`method: Page.selectOption`] now waits for the options to be present.
 - New methods to [assert element state](./actionability#assertions) like [`method: Page.isEditable`].

--- a/docs/src/trace-viewer-intro-java-python.md
+++ b/docs/src/trace-viewer-intro-java-python.md
@@ -91,7 +91,7 @@ This will record the trace and place it into the file named `trace.zip`.
 You can open the saved trace using the Playwright CLI or in your browser on [`trace.playwright.dev`](https://trace.playwright.dev). Make sure to add the full path to where your trace's zip file is located. Once opened you can click on each action or use the timeline to see the state of the page before and after each action. You can also inspect the log, source and network during each step of the test. The trace viewer creates a DOM snapshot so you can fully interact with it, open devtools etc.
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="show-trace trace.zip"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace trace.zip"
 ```
 
 ```bash python

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -26,7 +26,7 @@ npx playwright show-trace path/to/trace.zip
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="show-trace trace.zip"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace trace.zip"
 ```
 
 ```bash python
@@ -54,7 +54,7 @@ npx playwright show-trace https://example.com/trace.zip
 ```
 
 ```bash java
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="show-trace https://example.com/trace.zip"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="show-trace https://example.com/trace.zip"
 ```
 
 ```bash python


### PR DESCRIPTION
For whatever reason https://playwright.dev/java/docs/intro proposes adding Playwright to compile scope. I guess that could make sense for a module which solely consists of Playwright tests, but I think a more typical setup would specify

```xml
<scope>test</scope>
```

In that environment, running `exec:java` commands as shown fails:

```
…
java.lang.ClassNotFoundException: com.microsoft.playwright.CLI
    at org.codehaus.mojo.exec.URLClassLoaderBuilder$ExecJavaClassLoader.loadClass (URLClassLoaderBuilder.java:211)
…
```

https://www.mojohaus.org/exec-maven-plugin/java-mojo.html#classpathScope is normally what you want (and this should work even for a project which _does_ have Playwright at `compile` scope).

I have also taken the liberty of conjoining the `key=value` with the `-D` in Maven options, which is more typical (when not using `--define`) although either format is accepted.

(originally https://github.com/microsoft/playwright.dev/pull/2034)