### PR TITLE
fix(client-certificates): pass through non-matching origins

### DIFF
--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -180,14 +180,19 @@ class SocksProxyConnection {
     const browserALPNProtocols = parseALPNFromClientHello(clientHello) || ['http/1.1'];
     debugLogger.log('client-certificates', `Browser->Proxy ${this.host}:${this.port} offers ALPN ${browserALPNProtocols}`);
 
+    const secureContext = this.socksProxy.secureContextMap.get(normalizeOrigin(`https://${this.host}:${this.port}`));
+    // Without a matching client certificate the proxy is a transparent pass-through, so let the
+    // browser validate the server cert instead of failing here on e.g. self-signed certs.
+    const rejectUnauthorized = !!secureContext && !this.socksProxy.ignoreHTTPSErrors;
+
     const serverDecrypted = tls.connect({
       socket: this._serverEncrypted,
       host: this.host,
       port: this.port,
-      rejectUnauthorized: !this.socksProxy.ignoreHTTPSErrors,
+      rejectUnauthorized,
       ALPNProtocols: browserALPNProtocols,
       servername: !net.isIP(this.host) ? this.host : undefined,
-      secureContext: this.socksProxy.secureContextMap.get(new URL(`https://${this.host}:${this.port}`).origin),
+      secureContext,
     }, async () => {
       const browserDecrypted = await this._upgradeToTLSIfNeeded(browserEncrypted, serverDecrypted.alpnProtocol);
       debugLogger.log('client-certificates', `Proxy->Server ${this.host}:${this.port} chooses ALPN ${browserDecrypted.alpnProtocol}`);

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -326,6 +326,23 @@ test.describe('browser', () => {
     await page.close();
   });
 
+  test('should pass through to non-matching origin with self-signed cert', async ({ browser, asset, httpsServer }) => {
+    httpsServer.setRoute('/hello.html', (req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><body><div data-testid="message">hello</div></body></html>');
+    });
+    const page = await browser.newPage({
+      clientCertificates: [{
+        origin: 'https://not-matching.com',
+        certPath: asset('client-certificates/client/trusted/cert.pem'),
+        keyPath: asset('client-certificates/client/trusted/key.pem'),
+      }],
+    });
+    await page.goto(httpsServer.PREFIX + '/hello.html');
+    await expect(page.getByTestId('message')).toHaveText('hello');
+    await page.close();
+  });
+
   test('should fail with no client certificates', async ({ browser, startCCServer, asset, browserName, isMac }) => {
     const serverURL = await startCCServer({ useFakeLocalhost: browserName === 'webkit' && isMac });
     const page = await browser.newPage({
@@ -745,14 +762,15 @@ test.describe('browser', () => {
   });
 
   test('should have ignoreHTTPSErrors=false by default', async ({ browser, httpsServer, asset, browserName, platform }) => {
+    const targetURL = browserName === 'webkit' && platform === 'darwin' ? httpsServer.EMPTY_PAGE.replace('localhost', 'local.playwright') : httpsServer.EMPTY_PAGE;
     const page = await browser.newPage({
       clientCertificates: [{
-        origin: 'https://just-there-that-the-client-certificates-proxy-server-is-getting-launched.com',
+        origin: new URL(targetURL).origin,
         certPath: asset('client-certificates/client/trusted/cert.pem'),
         keyPath: asset('client-certificates/client/trusted/key.pem'),
       }],
     });
-    await page.goto(browserName === 'webkit' && platform === 'darwin' ? httpsServer.EMPTY_PAGE.replace('localhost', 'local.playwright') : httpsServer.EMPTY_PAGE);
+    await page.goto(targetURL);
     await expect(page.getByText('Playwright client-certificate error: self-signed certificate')).toBeVisible();
     await page.close();
   });
@@ -814,7 +832,7 @@ test.describe('browser', () => {
     const serverURL = await startCCServer({ http2: true });
     const page = await browser.newPage({
       clientCertificates: [{
-        origin: 'https://just-there-that-the-client-certificates-proxy-server-is-getting-launched.com',
+        origin: new URL(serverURL).origin,
         certPath: asset('client-certificates/client/trusted/cert.pem'),
         keyPath: asset('client-certificates/client/trusted/key.pem'),
       }],


### PR DESCRIPTION
## Summary
- When `clientCertificates` is configured, the SOCKS proxy MITM'd all HTTPS connections and validated the server cert with `rejectUnauthorized: true` even for origins without a matching client cert. Servers with self-signed certs (e.g. internal hosts) failed before navigation could proceed — Chromium's `--ignore-certificate-errors` doesn't affect the Node-side proxy.
- Skip server cert validation when no client cert is configured for the origin; defer validation to the browser instead.

Fixes https://github.com/microsoft/playwright/issues/40787