### PR TITLE
docs(cli): clarify --profile flag is the user data directory

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -47,7 +47,7 @@ const open = declareCommand({
     config: z.string().optional().describe('Path to the configuration file, defaults to .playwright/cli.config.json'),
     headed: z.boolean().optional().describe('Run browser in headed mode'),
     persistent: z.boolean().optional().describe('Use persistent browser profile'),
-    profile: z.string().optional().describe('Path to a persistent user data directory.'),
+    profile: z.string().optional().describe('Path to the browser user data directory (parent of Default/Profile N folders); always uses the Default profile.'),
   }),
   toolName: '',
   toolParams: () => ({}),

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -37,7 +37,7 @@ export function decorateProgram(program: Command) {
       .option('--extension', 'run with the extension')
       .option('--browser <name>', 'browser to use (chromium, chrome, firefox, webkit)')
       .option('--persistent', 'use a persistent browser context')
-      .option('--profile <path>', 'path to the user data dir')
+      .option('--profile <path>', 'path to the browser user data directory (parent of Default/Profile N folders); always uses the Default profile')
       .option('--config <path>', 'path to the config file; by default uses .playwright/cli.config.json in the project directory and ~/.playwright/cli.config.json as global config')
       .option('--cdp <url>', 'connect to an existing browser via CDP endpoint URL')
       .option('--endpoint <endpoint>', 'attach to a running Playwright browser endpoint')


### PR DESCRIPTION
## Summary
- `--profile` is the Chrome User Data Directory (parent of `Default`/`Profile N`), not a specific profile folder; the prior help text invited users to point it at a `Default` folder, which then nested as `Default/Default`.

Fixes https://github.com/microsoft/playwright-cli/issues/256