### PR TITLE
fix(chromium): resolve allHeaders for worker script in iframe

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -827,13 +827,18 @@ class ResponseExtraInfoTracker {
     if (!info.loadingFinished && !info.loadingFailed)
       return;
 
-    if (info.responses.length <= info.responseReceivedExtraInfo.length) {
-      // We have extra info for each response.
-      this._stopTracking(info.requestId);
-      return;
+    if (info.responses.length > info.responseReceivedExtraInfo.length) {
+      // Use provisional headers for responses that never received extra info,
+      // e.g. worker scripts in iframes where CDP does not deliver the event.
+      for (let i = info.responseReceivedExtraInfo.length; i < info.responses.length; i++) {
+        if (!info.responses[i])
+          continue;
+        info.responses[i].request().setRawRequestHeaders(null);
+        info.responses[i].setResponseHeadersSize(null);
+        info.responses[i].setRawResponseHeaders(null);
+      }
     }
-
-    // We are not done yet.
+    this._stopTracking(info.requestId);
   }
 
   private _stopTracking(requestId: string) {

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -260,6 +260,19 @@ it('should report worker script as network request', {
   expect(text).toContain(`console.log('hello from the worker');`);
 });
 
+it('should resolve allHeaders for worker script in iframe', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39948' },
+}, async function({ page, server }) {
+  await page.goto(server.EMPTY_PAGE);
+  const [request] = await Promise.all([
+    page.waitForEvent('requestfinished', r => r.url().includes('worker.js')),
+    attachFrame(page, 'frame1', server.PREFIX + '/worker/worker.html'),
+  ]);
+  const response = await request.response();
+  const headers = await response!.allHeaders();
+  expect(headers['content-type']).toBeTruthy();
+});
+
 it('should report worker script as network request after redirect', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35678' },
 }, async ({ page, server, browserName }) => {


### PR DESCRIPTION
## Summary

- Fall back to provisional headers in `ResponseExtraInfoTracker._checkFinished` when loading completes with unmatched responses

## The problem

When a Web Worker is loaded inside an iframe, `response.allHeaders()` hangs indefinitely. The `_rawResponseHeadersPromise` in `network.ts` never resolves because `ResponseExtraInfoTracker._checkFinished` waits for a `responseReceivedExtraInfo` CDP event that Chromium never delivers in this scenario.

The call chain that hangs:
1. `response.allHeaders()` calls `rawResponseHeaders()` (network.ts:551)
2. Which awaits `_rawResponseHeadersPromise` (a `ManualPromise`)
3. Which resolves only when `setRawResponseHeaders()` is called
4. `_checkFinished` sees `info.responses.length > info.responseReceivedExtraInfo.length` and returns with `// We are not done yet`, never resolving the promise

For worker scripts in iframes, CDP splits lifecycle events across sessions (parent vs worker). The `responseReceivedExtraInfo` event may never arrive after `loadingFinished`, leaving the promise pending forever.

## The fix

When loading completes (`loadingFinished`/`loadingFailed`) with more responses than extra info events, fall back to provisional headers instead of waiting. This is the same approach Firefox and WebKit use (they always resolve with provisional headers), and the same pattern already used for cached responses at line 769-772 of the same file.

## Prior art

- [#40209](https://github.com/microsoft/playwright/pull/40209): Previous attempt at this fix, closed as too broad (spread across 2 files, added 3 new methods). This PR keeps the change to 1 method.
- [#8526](https://github.com/microsoft/playwright/pull/8526): PR that introduced `_checkFinished` (2021-08-30, pavelfeldman). The `// We are not done yet` fallthrough assumed CDP would always deliver extra info before loading completes.
- [puppeteer#8239](https://github.com/puppeteer/puppeteer/pull/8239): Puppeteer fixed a similar `responseReceivedExtraInfo` ordering issue where extra info events were not properly correlated with responses.

Fixes https://github.com/microsoft/playwright/issues/39948