### PR TITLE
test: unflake console timestamp tests on Windows

### DIFF
--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -229,14 +229,12 @@ it('do not update console count on unhandled rejections', async ({ page }) => {
 it('should have timestamp', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
-  // vs sub-millisecond browser timestamps.
-  const before = Date.now() - 1000;
+  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
   const [message] = await Promise.all([
     page.waitForEvent('console'),
     page.evaluate(() => console.log('timestamp test')),
   ]);
-  const after = Date.now() + 1000;
+  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
   expect(message.timestamp()).toBeGreaterThanOrEqual(before);
   expect(message.timestamp()).toBeLessThanOrEqual(after);
 });
@@ -257,12 +255,10 @@ it('should have increasing timestamps', async ({ page }) => {
 it('should have timestamp in consoleMessages', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
-  // vs sub-millisecond browser timestamps.
-  const before = Date.now() - 1000;
+  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
   await page.evaluate(() => console.log('stored message'));
-  const after = Date.now() + 1000;
   const messages = await page.consoleMessages();
+  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
   expect(messages.length).toBeGreaterThanOrEqual(1);
   const last = messages[messages.length - 1];
   expect(last.text()).toBe('stored message');

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -229,12 +229,14 @@ it('do not update console count on unhandled rejections', async ({ page }) => {
 it('should have timestamp', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
+  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
+  // vs sub-millisecond browser timestamps.
+  const before = Date.now() - 100;
   const [message] = await Promise.all([
     page.waitForEvent('console'),
     page.evaluate(() => console.log('timestamp test')),
   ]);
-  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
+  const after = Date.now() + 100;
   expect(message.timestamp()).toBeGreaterThanOrEqual(before);
   expect(message.timestamp()).toBeLessThanOrEqual(after);
 });
@@ -255,10 +257,12 @@ it('should have increasing timestamps', async ({ page }) => {
 it('should have timestamp in consoleMessages', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
+  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
+  // vs sub-millisecond browser timestamps.
+  const before = Date.now() - 100;
   await page.evaluate(() => console.log('stored message'));
+  const after = Date.now() + 100;
   const messages = await page.consoleMessages();
-  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
   expect(messages.length).toBeGreaterThanOrEqual(1);
   const last = messages[messages.length - 1];
   expect(last.text()).toBe('stored message');

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -229,12 +229,14 @@ it('do not update console count on unhandled rejections', async ({ page }) => {
 it('should have timestamp', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
+  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
+  // vs sub-millisecond browser timestamps.
+  const before = Date.now() - 1000;
   const [message] = await Promise.all([
     page.waitForEvent('console'),
     page.evaluate(() => console.log('timestamp test')),
   ]);
-  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
+  const after = Date.now() + 1000;
   expect(message.timestamp()).toBeGreaterThanOrEqual(before);
   expect(message.timestamp()).toBeLessThanOrEqual(after);
 });
@@ -255,9 +257,11 @@ it('should have increasing timestamps', async ({ page }) => {
 it('should have timestamp in consoleMessages', async ({ page, isAndroid }) => {
   it.skip(isAndroid, 'there is a time difference between android emulator and host machine');
 
-  const before = Date.now() - 1;  // Account for the rounding of fractional timestamps.
+  // Generous slack to absorb host wall-clock resolution (e.g. ~15.6ms on Windows)
+  // vs sub-millisecond browser timestamps.
+  const before = Date.now() - 1000;
   await page.evaluate(() => console.log('stored message'));
-  const after = Date.now() + 1;  // Account for the rounding of fractional timestamps.
+  const after = Date.now() + 1000;
   const messages = await page.consoleMessages();
   expect(messages.length).toBeGreaterThanOrEqual(1);
   const last = messages[messages.length - 1];


### PR DESCRIPTION
## Summary
- Widen the `Date.now()` slack around `ConsoleMessage.timestamp()` assertions from ±1ms to ±1000ms.
- Windows' wall-clock has ~15.6ms resolution while WebKit emits sub-millisecond timestamps, so the prior ±1ms window was occasionally exceeded on the WebKit Windows bots (e.g. https://github.com/microsoft/playwright-browsers/actions/runs/25698829477/job/75462779984?pr=2238).