### PR TITLE
test: fix flaky 'should filter actions by text'

### DIFF
--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -197,6 +197,7 @@ test('should filter actions by text', async ({ showTraceViewer }) => {
   const filterInput = traceViewer.page.getByRole('searchbox', { name: 'Filter actions' });
   await expect(filterInput).toBeVisible();
 
+  await expect(traceViewer.actionTitles.filter({ hasText: 'Close page' })).toBeVisible();
   const fullCount = await traceViewer.actionTitles.count();
   await filterInput.fill('Click');
   await expect(traceViewer.actionTitles.filter({ hasText: 'Click' }).first()).toBeVisible();


### PR DESCRIPTION
## Summary
- The test reads `fullCount = actionTitles.count()` right after the trace viewer loads, but actions render asynchronously. On slow runners (macOS 26, webkit/win) `fullCount` was sometimes `0`, making the subsequent `toBeLessThan(fullCount)` impossible (`Expected: < 0, Received: 1`).
- Wait for the last recorded action (`Close page`) to be visible before counting.