### PR TITLE
feat: Allow configuring last-run output file location

### DIFF
--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -91,6 +91,11 @@ To run only the tests that failed in the last test run, first run your tests and
 npx playwright test --last-failed
 ```
 
+Playwright stores the list of failed tests from the previous run in `<outputDir>/.last-run.json` (see [`property: TestConfig.outputDir`](./test-configuration.md)). To read and write that file at a different path, pass `--last-run-file=<path>`, or set the `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable. Use `--last-failed` together with `--last-run-file` to re-run only failures recorded in that file.
+
+```bash
+npx playwright test --last-failed --last-run-file=.cache/last-run-shard-1.json
+```
 
 ### Run tests in VS Code
 

--- a/docs/src/running-tests-js.md
+++ b/docs/src/running-tests-js.md
@@ -91,10 +91,10 @@ To run only the tests that failed in the last test run, first run your tests and
 npx playwright test --last-failed
 ```
 
-Playwright stores the list of failed tests from the previous run in `<outputDir>/.last-run.json` (see [`property: TestConfig.outputDir`](./test-configuration.md)). To read and write that file at a different path, pass `--last-run-file=<path>`, or set the `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable. Use `--last-failed` together with `--last-run-file` to re-run only failures recorded in that file.
+Playwright stores the list of failed tests from the previous run in `<outputDir>/.last-run.json` (see [`property: TestConfig.outputDir`](./test-configuration.md)). To use a different file path, pass `--last-failed-file=<path>` or set `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE`.
 
 ```bash
-npx playwright test --last-failed --last-run-file=.cache/last-run-shard-1.json
+npx playwright test --last-failed --last-failed-file=.cache/last-run-shard-1.json
 ```
 
 ### Run tests in VS Code

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -91,6 +91,7 @@ npx playwright test --ui
 | `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
 | `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
 | `--last-failed` | Only re-run the failures. |
+| `--last-run-file <file>` | Path of the last-run JSON file used with `--last-failed`. |
 | `--list` | Collect all the tests and report them, but do not run. |
 | `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
 | `--no-deps` | Do not run project dependencies. |

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -91,7 +91,7 @@ npx playwright test --ui
 | `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
 | `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |
 | `--last-failed` | Only re-run the failures. |
-| `--last-run-file <file>` | Path of the last-run JSON file used with `--last-failed`. |
+| `--last-failed-file <file>` | Override the default last-run JSON path for `--last-failed` (default: `<outputDir>/.last-run.json`). Same as `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable. |
 | `--list` | Collect all the tests and report them, but do not run. |
 | `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
 | `--no-deps` | Do not run project dependencies. |

--- a/packages/playwright/src/cli/testActions.ts
+++ b/packages/playwright/src/cli/testActions.ts
@@ -39,7 +39,7 @@ export async function runTests(args: string[], opts: { [key: string]: any }) {
     projectFilter: opts.project || undefined,
     passWithNoTests: !!opts.passWithNoTests,
     lastFailed: !!opts.lastFailed,
-    lastRunFile: opts.lastRunFile,
+    lastFailedFile: opts.lastFailedFile,
     testList: opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined,
     testListInvert: opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined,
     shardWeights: resolveShardWeightsOption(),

--- a/packages/playwright/src/cli/testActions.ts
+++ b/packages/playwright/src/cli/testActions.ts
@@ -39,6 +39,7 @@ export async function runTests(args: string[], opts: { [key: string]: any }) {
     projectFilter: opts.project || undefined,
     passWithNoTests: !!opts.passWithNoTests,
     lastFailed: !!opts.lastFailed,
+    lastRunFile: opts.lastRunFile,
     testList: opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined,
     testListInvert: opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined,
     shardWeights: resolveShardWeightsOption(),

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -192,6 +192,7 @@ const testOptions: [string, { description: string, choices?: string[], preset?: 
   ['--headed', { description: `Run tests in headed browsers (default: headless)` }],
   ['--ignore-snapshots', { description: `Ignore screenshot and snapshot expectations` }],
   ['--last-failed', { description: `Only re-run the failures` }],
+  ['--last-run-file <file>', { description: `Path of the last-run JSON file used by --last-failed (also configurable via PLAYWRIGHT_LAST_RUN_OUTPUT_FILE).` }],
   ['--list', { description: `Collect all the tests and report them, but do not run` }],
   ['--max-failures <N>', { description: `Stop after the first N failures` }],
   ['--no-deps', { description: `Do not run project dependencies` }],

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -192,7 +192,7 @@ const testOptions: [string, { description: string, choices?: string[], preset?: 
   ['--headed', { description: `Run tests in headed browsers (default: headless)` }],
   ['--ignore-snapshots', { description: `Ignore screenshot and snapshot expectations` }],
   ['--last-failed', { description: `Only re-run the failures` }],
-  ['--last-run-file <file>', { description: `Path of the last-run JSON file used by --last-failed (also configurable via PLAYWRIGHT_LAST_RUN_OUTPUT_FILE).` }],
+  ['--last-failed-file <file>', { description: `Override the default path for the last-run JSON file used with --last-failed (default: <outputDir>/.last-run.json). Same as PLAYWRIGHT_LAST_RUN_OUTPUT_FILE environment variable.` }],
   ['--list', { description: `Collect all the tests and report them, but do not run` }],
   ['--max-failures <N>', { description: `Stop after the first N failures` }],
   ['--no-deps', { description: `Do not run project dependencies` }],

--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -33,9 +33,14 @@ export class LastRunReporter implements ReporterV2 {
 
   constructor(filteredProjects: commonConfig.FullProjectInternal[], listMode?: boolean) {
     this._listMode = !!listMode;
-    const [project] = filteredProjects;
-    if (project)
-      this._lastRunFile = path.join(project.project.outputDir, '.last-run.json');
+    const lastRunFromEnv = process.env.PLAYWRIGHT_LAST_RUN_OUTPUT_FILE;
+    if (lastRunFromEnv) {
+      this._lastRunFile = path.resolve(process.cwd(), lastRunFromEnv);
+    } else {
+      const [project] = filteredProjects;
+      if (project)
+        this._lastRunFile = path.join(project.project.outputDir, '.last-run.json');
+    }
   }
 
   async filterLastFailed(): Promise<string[]> {

--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -31,11 +31,11 @@ export class LastRunReporter implements ReporterV2 {
   private _suite: Suite | undefined;
   private _listMode: boolean;
 
-  constructor(filteredProjects: commonConfig.FullProjectInternal[], listMode?: boolean) {
+  constructor(filteredProjects: commonConfig.FullProjectInternal[], listMode?: boolean, lastRunFileOverride?: string) {
     this._listMode = !!listMode;
-    const lastRunFromEnv = process.env.PLAYWRIGHT_LAST_RUN_OUTPUT_FILE;
-    if (lastRunFromEnv) {
-      this._lastRunFile = path.resolve(process.cwd(), lastRunFromEnv);
+    const override = lastRunFileOverride ?? process.env.PLAYWRIGHT_LAST_RUN_OUTPUT_FILE;
+    if (override) {
+      this._lastRunFile = path.resolve(process.cwd(), override);
     } else {
       const [project] = filteredProjects;
       if (project)

--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -31,9 +31,9 @@ export class LastRunReporter implements ReporterV2 {
   private _suite: Suite | undefined;
   private _listMode: boolean;
 
-  constructor(filteredProjects: commonConfig.FullProjectInternal[], listMode?: boolean, lastRunFileOverride?: string) {
+  constructor(filteredProjects: commonConfig.FullProjectInternal[], listMode?: boolean, lastFailedFileOverride?: string) {
     this._listMode = !!listMode;
-    const override = lastRunFileOverride ?? process.env.PLAYWRIGHT_LAST_RUN_OUTPUT_FILE;
+    const override = lastFailedFileOverride ?? process.env.PLAYWRIGHT_LAST_RUN_OUTPUT_FILE;
     if (override) {
       this._lastRunFile = path.resolve(process.cwd(), override);
     } else {

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -64,7 +64,7 @@ export type TestRunOptions = {
   listMode?: boolean;
   passWithNoTests?: boolean;
   lastFailed?: boolean;
-  lastRunFile?: string;
+  lastFailedFile?: string;
   testList?: string;
   testListInvert?: string;
   lastFailedTestIds?: string[];

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -64,6 +64,7 @@ export type TestRunOptions = {
   listMode?: boolean;
   passWithNoTests?: boolean;
   lastFailed?: boolean;
+  lastRunFile?: string;
   testList?: string;
   testListInvert?: string;
   lastFailedTestIds?: string[];

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -444,7 +444,7 @@ export async function runAllTestsWithConfig(config: FullConfigInternal, options:
 
   const filteredProjects = filterProjects(config.projects, options.projectFilter);
   const reporters = await createReporters(config, options.listMode ? 'list' : 'test', undefined, options);
-  const lastRun = new LastRunReporter(filteredProjects, options.listMode);
+  const lastRun = new LastRunReporter(filteredProjects, options.listMode, options.lastRunFile);
   if (options.lastFailed) {
     const lastFailedTestIds = await lastRun.filterLastFailed();
     if (lastFailedTestIds.length)

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -444,7 +444,7 @@ export async function runAllTestsWithConfig(config: FullConfigInternal, options:
 
   const filteredProjects = filterProjects(config.projects, options.projectFilter);
   const reporters = await createReporters(config, options.listMode ? 'list' : 'test', undefined, options);
-  const lastRun = new LastRunReporter(filteredProjects, options.listMode, options.lastRunFile);
+  const lastRun = new LastRunReporter(filteredProjects, options.listMode, options.lastFailedFile);
   if (options.lastFailed) {
     const lastFailedTestIds = await lastRun.filterLastFailed();
     if (lastFailedTestIds.length)

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -879,36 +879,10 @@ test('should run last failed tests in a shard', async ({ runInlineTest }) => {
   expect(result2.output).toContain('b.spec.js:4:11 › fail-b');
 });
 
-test('should respect PLAYWRIGHT_LAST_RUN_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
-  const customRel = '.cache/custom-last-run.json';
+test('should run last failed tests in a shard with PLAYWRIGHT_LAST_RUN_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
+  const customRel = '.cache/shard-2-last-run.json';
   const customAbs = path.join(testInfo.outputPath(), customRel);
   const defaultLastRun = path.join(testInfo.outputPath(), 'test-results', '.last-run.json');
-  const env = { PLAYWRIGHT_LAST_RUN_OUTPUT_FILE: customRel };
-  const workspace = {
-    'a.spec.js': `
-      import { test, expect } from '@playwright/test';
-      test('pass', async () => {});
-      test('fail', async () => {
-        expect(1).toBe(2);
-      });
-    `
-  };
-  const result1 = await runInlineTest(workspace, {}, env);
-  expect(result1.exitCode).toBe(1);
-  expect(result1.passed).toBe(1);
-  expect(result1.failed).toBe(1);
-  expect(fs.existsSync(customAbs)).toBe(true);
-  expect(fs.existsSync(defaultLastRun)).toBe(false);
-
-  const result2 = await runInlineTest(workspace, {}, env, { additionalArgs: ['--last-failed'] });
-  expect(result2.exitCode).toBe(1);
-  expect(result2.passed).toBe(0);
-  expect(result2.failed).toBe(1);
-});
-
-test('should support per-shard last-run files via env var', async ({ runInlineTest }, testInfo) => {
-  const customRel = 'shard-2-last-run.json';
-  const customAbs = path.join(testInfo.outputPath(), customRel);
   const env = { PLAYWRIGHT_LAST_RUN_OUTPUT_FILE: customRel };
   const workspace = {
     'a.spec.js': `
@@ -931,10 +905,49 @@ test('should support per-shard last-run files via env var', async ({ runInlineTe
   expect(result1.passed).toBe(1);
   expect(result1.failed).toBe(1);
   expect(fs.existsSync(customAbs)).toBe(true);
+  expect(fs.existsSync(defaultLastRun)).toBe(false);
   expect(result1.output).toContain('b.spec.js:3:11 › pass-b');
   expect(result1.output).toContain('b.spec.js:4:11 › fail-b');
 
   const result2 = await runInlineTest(workspace, { shard: '2/2' }, env, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(1);
+  expect(result2.output).not.toContain('b.spec.js:3:11 › pass-b');
+  expect(result2.output).toContain('b.spec.js:4:11 › fail-b');
+});
+
+test('should run last failed tests in a shard with --last-run-file', async ({ runInlineTest }, testInfo) => {
+  const customRel = '.cache/shard-2-cli-last-run.json';
+  const customAbs = path.join(testInfo.outputPath(), customRel);
+  const defaultLastRun = path.join(testInfo.outputPath(), 'test-results', '.last-run.json');
+  const lastRunArgs = ['--last-failed', `--last-run-file=${customRel}`];
+  const workspace = {
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass-a', async () => {});
+      test('fail-a', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+    'b.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass-b', async () => {});
+      test('fail-b', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+  };
+  const result1 = await runInlineTest(workspace, { shard: '2/2' }, {}, { additionalArgs: lastRunArgs });
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(1);
+  expect(result1.failed).toBe(1);
+  expect(fs.existsSync(customAbs)).toBe(true);
+  expect(fs.existsSync(defaultLastRun)).toBe(false);
+  expect(result1.output).toContain('b.spec.js:3:11 › pass-b');
+  expect(result1.output).toContain('b.spec.js:4:11 › fail-b');
+
+  const result2 = await runInlineTest(workspace, { shard: '2/2' }, {}, { additionalArgs: lastRunArgs });
   expect(result2.exitCode).toBe(1);
   expect(result2.passed).toBe(0);
   expect(result2.failed).toBe(1);

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -878,3 +878,66 @@ test('should run last failed tests in a shard', async ({ runInlineTest }) => {
   expect(result2.output).not.toContain('b.spec.js:3:11 › pass-b');
   expect(result2.output).toContain('b.spec.js:4:11 › fail-b');
 });
+
+test('should respect PLAYWRIGHT_LAST_RUN_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
+  const customRel = '.cache/custom-last-run.json';
+  const customAbs = path.join(testInfo.outputPath(), customRel);
+  const defaultLastRun = path.join(testInfo.outputPath(), 'test-results', '.last-run.json');
+  const env = { PLAYWRIGHT_LAST_RUN_OUTPUT_FILE: customRel };
+  const workspace = {
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+      test('fail', async () => {
+        expect(1).toBe(2);
+      });
+    `
+  };
+  const result1 = await runInlineTest(workspace, {}, env);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(1);
+  expect(result1.failed).toBe(1);
+  expect(fs.existsSync(customAbs)).toBe(true);
+  expect(fs.existsSync(defaultLastRun)).toBe(false);
+
+  const result2 = await runInlineTest(workspace, {}, env, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(1);
+});
+
+test('should support per-shard last-run files via env var', async ({ runInlineTest }, testInfo) => {
+  const customRel = 'shard-2-last-run.json';
+  const customAbs = path.join(testInfo.outputPath(), customRel);
+  const env = { PLAYWRIGHT_LAST_RUN_OUTPUT_FILE: customRel };
+  const workspace = {
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass-a', async () => {});
+      test('fail-a', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+    'b.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass-b', async () => {});
+      test('fail-b', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+  };
+  const result1 = await runInlineTest(workspace, { shard: '2/2' }, env);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(1);
+  expect(result1.failed).toBe(1);
+  expect(fs.existsSync(customAbs)).toBe(true);
+  expect(result1.output).toContain('b.spec.js:3:11 › pass-b');
+  expect(result1.output).toContain('b.spec.js:4:11 › fail-b');
+
+  const result2 = await runInlineTest(workspace, { shard: '2/2' }, env, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(1);
+  expect(result2.output).not.toContain('b.spec.js:3:11 › pass-b');
+  expect(result2.output).toContain('b.spec.js:4:11 › fail-b');
+});

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -917,11 +917,11 @@ test('should run last failed tests in a shard with PLAYWRIGHT_LAST_RUN_OUTPUT_FI
   expect(result2.output).toContain('b.spec.js:4:11 › fail-b');
 });
 
-test('should run last failed tests in a shard with --last-run-file', async ({ runInlineTest }, testInfo) => {
+test('should run last failed tests in a shard with --last-failed-file', async ({ runInlineTest }, testInfo) => {
   const customRel = '.cache/shard-2-cli-last-run.json';
   const customAbs = path.join(testInfo.outputPath(), customRel);
   const defaultLastRun = path.join(testInfo.outputPath(), 'test-results', '.last-run.json');
-  const lastRunArgs = ['--last-failed', `--last-run-file=${customRel}`];
+  const lastRunArgs = ['--last-failed', `--last-failed-file=${customRel}`];
   const workspace = {
     'a.spec.js': `
       import { test, expect } from '@playwright/test';


### PR DESCRIPTION
Allow configuration via environment variable like other reporters.

Left undocumented for now as lastRun is an internal reporter, so it didn't fit well adding it to the existing reporters doc.

Fixes #40805