### PR TITLE
fix(mcp): pass browser name for remote endpoint

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -132,8 +132,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
 
   const endpoint = config.browser.remoteEndpoint!;
   const playwrightObject = playwright as Playwright;
-  // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
-  const browser = await connectToBrowser(playwrightObject, { endpoint });
+  const browser = await connectToBrowser(playwrightObject, { endpoint, browserName: config.browser.browserName });
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
   return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
 }

--- a/tests/mcp/storage.spec.ts
+++ b/tests/mcp/storage.spec.ts
@@ -202,6 +202,31 @@ test('--storage-state option works with remote endpoint in config', async ({ sta
   });
 });
 
+test('remote endpoint config connects to run-server with configured browser', async ({ startClient, server, childProcess }) => {
+  const runServer = childProcess({
+    command: ['node', path.join(__dirname, '..', '..', 'packages', 'playwright-core', 'cli.js'), 'run-server'],
+    env: { NODE_OPTIONS: process.env.NODE_OPTIONS },
+  });
+  await runServer.waitForOutput('Listening on ');
+  const wsEndpoint = runServer.output.match(/Listening on (ws:\/\/[^\s]+)/)![1];
+
+  const { client } = await startClient({
+    config: { browser: { browserName: 'chromium', remoteEndpoint: wsEndpoint, isolated: true } },
+  });
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const result = await client.callTool({
+    name: 'browser_snapshot',
+  });
+  expect(result).toHaveResponse({
+    inlineSnapshot: expect.stringContaining('Hello, world!'),
+  });
+});
+
 test('browser_storage_state and browser_set_storage_state roundtrip', async ({ startClient, server, mcpBrowser }, testInfo) => {
   const { client } = await startClient({
     config: { capabilities: ['storage'] },


### PR DESCRIPTION
## Summary
- Pass the configured browser name when MCP connects to a remote Playwright endpoint.
- Add a regression test covering MCP remote endpoint config against `playwright run-server`.

Fixes https://github.com/microsoft/playwright/issues/40814