### PR TITLE
chore(docs): use * for object type alias markers

### DIFF
--- a/docs/src/api/class-apiresponse.md
+++ b/docs/src/api/class-apiresponse.md
@@ -58,8 +58,8 @@ An object with all the response HTTP headers associated with this response.
 ## method: APIResponse.headersArray
 * since: v1.16
 - returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
+  * alias: HttpHeader
+  * alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -304,7 +304,8 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
 ## async method: Browser.bind
 * since: v1.59
 - returns: <[Object]>
-  - alias: BindResult
+  * alias: BindResult
+  * alias-csharp: BrowserBindResult
   - `endpoint` <[string]>
 
 Binds the browser to a named pipe or web socket, making it available for other clients to connect to.

--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -367,7 +367,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
 ### param: BrowserContext.addCookies.cookies
 * since: v1.8
 - `cookies` <[Array]<[Object]>>
-  - alias-java: Cookie
+  * alias-java: Cookie
   - `name` <[string]>
   - `value` <[string]>
   - `url` ?<[string]> Either `url` or both `domain` and `path` are required. Optional.
@@ -607,8 +607,8 @@ The default browser context cannot be closed.
 ## async method: BrowserContext.cookies
 * since: v1.8
 - returns: <[Array]<[Object]>>
-  - alias-csharp: BrowserContextCookiesResult
-  - alias-java: Cookie
+  * alias: Cookie
+  * alias-csharp: BrowserContextCookiesResult
   - `name` <[string]>
   - `value` <[string]>
   - `domain` <[string]>
@@ -769,7 +769,7 @@ Name of the function on the window object.
 ### param: BrowserContext.exposeBinding.callback
 * since: v1.8
 - `callback` <[function]>
-  - alias-java: BindingCallback
+  * alias: BindingCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -961,7 +961,7 @@ Name of the function on the window object.
 ### param: BrowserContext.exposeFunction.callback
 * since: v1.8
 - `callback` <[function]>
-  - alias-java: FunctionCallback
+  * alias: FunctionCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -1498,7 +1498,7 @@ its geolocation.
 ### param: BrowserContext.setGeolocation.geolocation
 * since: v1.8
 - `geolocation` <[null]|[Object]>
-  - alias-java: Geolocation
+  * alias: Geolocation
   - `latitude` <[float]> Latitude between -90 and 90.
   - `longitude` <[float]> Longitude between -180 and 180.
   - `accuracy` ?<[float]> Non-negative accuracy value. Defaults to `0`.

--- a/docs/src/api/class-debugger.md
+++ b/docs/src/api/class-debugger.md
@@ -12,9 +12,9 @@ Emitted when the debugger pauses or resumes.
 ## method: Debugger.pausedDetails
 * since: v1.59
 - returns: <[null]|[Object]>
-  - alias: DebuggerPausedDetails
+  * alias: DebuggerPausedDetails
   - `location` <[Object]>
-    - alias-java: Location
+    * alias: Location
     - `file` <[string]>
     - `line` ?<[int]>
     - `column` ?<[int]>
@@ -49,7 +49,7 @@ Resumes script execution and pauses when an action originates from the given sou
 ### param: Debugger.runTo.location
 * since: v1.59
 - `location` <[Object]>
-  - alias-java: Location
+  * alias: Location
   - `file` <[string]>
   - `line` ?<[int]>
   - `column` ?<[int]>

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -109,8 +109,8 @@ await locator.ClickAsync();
 ## async method: ElementHandle.boundingBox
 * since: v1.8
 - returns: <[null]|[Object]>
-  - alias-csharp: ElementHandleBoundingBoxResult
-  - alias-java: BoundingBox
+  * alias: BoundingBox
+  * alias-csharp: ElementHandleBoundingBoxResult
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-formdata.md
+++ b/docs/src/api/class-formdata.md
@@ -115,7 +115,7 @@ Field name.
 ### param: FormData.append.value
 * since: v1.44
 - `value` <[string]|[boolean]|[int]|[path]|[Object]>
-  - alias: FilePayload
+  * alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -126,7 +126,7 @@ Field value.
 * since: v1.44
 * langs: csharp
 - `value` <[string]|[boolean]|[int]|[Object]>
-  - alias-csharp: FilePayload
+  * alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -216,7 +216,7 @@ Field name.
 ### param: FormData.set.value
 * since: v1.18
 - `value` <[string]|[boolean]|[int]|[path]|[Object]>
-  - alias: FilePayload
+  * alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
@@ -227,7 +227,7 @@ Field value.
 * since: v1.18
 * langs: csharp
 - `value` <[string]|[boolean]|[int]|[Object]>
-  - alias-csharp: FilePayload
+  * alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -251,8 +251,8 @@ Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) 
 ## async method: Locator.boundingBox
 * since: v1.14
 - returns: <[null]|[Object]>
-  - alias-csharp: LocatorBoundingBoxResult
-  - alias-java: BoundingBox
+  * alias: BoundingBox
+  * alias-csharp: LocatorBoundingBoxResult
   - `x` <[float]> the x coordinate of the element in pixels.
   - `y` <[float]> the y coordinate of the element in pixels.
   - `width` <[float]> the width of the element in pixels.

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -1829,7 +1829,7 @@ Name of the function on the window object.
 ### param: Page.exposeBinding.callback
 * since: v1.8
 - `callback` <[function]>
-  - alias-java: BindingCallback
+  * alias: BindingCallback
 
 Callback function that will be called in the Playwright's context.
 
@@ -2023,7 +2023,7 @@ Name of the function on the window object
 ### param: Page.exposeFunction.callback
 * since: v1.8
 - `callback` <[function]>
-  - alias-java: FunctionCallback
+  * alias: FunctionCallback
 
 Callback function which will be called in Playwright's context.
 
@@ -3006,7 +3006,7 @@ Paper margins, defaults to none.
 * since: v1.8
 * langs: csharp, java
 - `margin` <[Object]>
-  - alias-java: Margin
+  * alias-java: Margin
   - `top` ?<[string]> Top margin, accepts values labeled with units. Defaults to `0`.
   - `right` ?<[string]> Right margin, accepts values labeled with units. Defaults to `0`.
   - `bottom` ?<[string]> Bottom margin, accepts values labeled with units. Defaults to `0`.
@@ -4471,8 +4471,8 @@ Video object associated with this page. Can be used to access the video file whe
 ## method: Page.viewportSize
 * since: v1.8
 - returns: <[null]|[Object]>
-  - alias-csharp: PageViewportSizeResult
-  - alias-java: ViewportSize
+  * alias: ViewportSize
+  * alias-csharp: PageViewportSizeResult
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 

--- a/docs/src/api/class-request.md
+++ b/docs/src/api/class-request.md
@@ -114,8 +114,8 @@ You can use [`method: Request.allHeaders`] for complete list of headers that inc
 ## async method: Request.headersArray
 * since: v1.15
 - returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
+  * alias: HttpHeader
+  * alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -313,8 +313,8 @@ Requests originated in a Service Worker do not have a [`method: Request.frame`] 
 ## async method: Request.sizes
 * since: v1.15
 - returns: <[Object]>
-  - alias-csharp: RequestSizesResult
-  - alias-java: Sizes
+  * alias-csharp: RequestSizesResult
+  * alias-java: Sizes
   - `requestBodySize` <[int]> Size of the request body (POST data payload) in bytes. Set to 0 if there was no body.
   - `requestHeadersSize` <[int]> Total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body.
   - `responseBodySize` <[int]> Size of the received response body (encoded) in bytes.
@@ -325,8 +325,8 @@ Returns resource size information for given request.
 ## method: Request.timing
 * since: v1.8
 - returns: <[Object]>
-  - alias-csharp: RequestTimingResult
-  - alias-java: Timing
+  * alias-csharp: RequestTimingResult
+  * alias-java: Timing
   - `startTime` <[float]> Request start time in milliseconds elapsed since January 1, 1970 00:00:00 UTC
   - `domainLookupStart` <[float]> Time immediately before the browser starts the domain name lookup for the
     resource. The value is given in milliseconds relative to `startTime`, -1 if not available.

--- a/docs/src/api/class-response.md
+++ b/docs/src/api/class-response.md
@@ -49,8 +49,8 @@ You can use [`method: Response.allHeaders`] for complete list of headers that in
 ## async method: Response.headersArray
 * since: v1.15
 - returns: <[Array]<[Object]>>
-  - alias-csharp: Header
-  - alias-java: HttpHeader
+  * alias: HttpHeader
+  * alias-csharp: Header
   - `name` <[string]> Name of the header.
   - `value` <[string]> Value of the header.
 
@@ -121,8 +121,8 @@ Returns the matching [Request] object.
 ## async method: Response.securityDetails
 * since: v1.13
 - returns: <[null]|[Object]>
-  - alias-csharp: ResponseSecurityDetailsResult
-  - alias-java: SecurityDetails
+  * alias: SecurityDetails
+  * alias-csharp: ResponseSecurityDetailsResult
   - `issuer` ?<[string]> Common Name component of the Issuer field.
     from the certificate. This should only be used for informational purposes. Optional.
   - `protocol` ?<[string]> The specific TLS protocol used. (e.g. `TLS 1.3`). Optional.
@@ -138,8 +138,8 @@ Returns SSL and other security information.
 ## async method: Response.serverAddr
 * since: v1.13
 - returns: <[null]|[Object]>
-  - alias-csharp: ResponseServerAddrResult
-  - alias-java: ServerAddr
+  * alias-csharp: ResponseServerAddrResult
+  * alias-java: ServerAddr
   - `ipAddress` <[string]> IPv4 or IPV6 address of the server.
   - `port` <[int]>
 

--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -34,7 +34,7 @@ await page.screencast.stop();
 ### option: Screencast.start.onFrame
 * since: v1.59
 - `onFrame` <[function]\([Object]\): [Promise]>
-  - alias: ScreencastFrame
+  * alias: ScreencastFrame
   - `data` <[Buffer]> JPEG-encoded frame data.
   - `viewportWidth` <[int]> Width of the page viewport at the time the frame was captured.
   - `viewportHeight` <[int]> Height of the page viewport at the time the frame was captured.
@@ -57,7 +57,7 @@ The quality of the image, between 0-100.
 * since: v1.59
 * langs: js
 - `size` ?<[Object]>
-  - alias-csharp: ScreencastSize
+  * alias-csharp: ScreencastSize
   - `width` <[int]> Max frame width in pixels.
   - `height` <[int]> Max frame height in pixels.
 

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -444,7 +444,7 @@ Group name shown in the trace viewer.
 ### option: Tracing.group.location
 * since: v1.49
 - `location` ?<[Object]>
-  - alias-java: Location
+  * alias: Location
   - `file` <[string]>
   - `line` ?<[int]>
   - `column` ?<[int]>

--- a/docs/src/api/class-weberror.md
+++ b/docs/src/api/class-weberror.md
@@ -69,7 +69,7 @@ Unhandled error that was thrown.
 ## method: WebError.location
 * since: v1.60
 - returns: <[Object]>
-  - alias: WebErrorLocation
+  * alias: WebErrorLocation
   - `url` <[string]> URL of the resource.
   - `line` <[int]> 0-based line number in the resource.
   - `column` <[int]> 0-based column number in the resource.

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -97,7 +97,7 @@ A selector to search for an element to drop onto. If there are multiple elements
 
 ## input-position
 - `position` <[Object]>
-  - alias-java: Position
+  * alias: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -128,16 +128,16 @@ Defaults to `left`.
 
 ## input-files
 - `files` <[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
-  - alias: FilePayload
+  * alias: FilePayload
   - `name` <[string]> File name
   - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 
 ## drop-payload
 - `payload` <[Object]>
-  - alias: DropPayload
+  * alias: DropPayload
   - `files` ?<[path]|[Array]<[path]>|[Object]|[Array]<[Object]>>
-    - alias: FilePayload
+    * alias: FilePayload
     - `name` <[string]> File name
     - `mimeType` <[string]> File type
     - `buffer` <[Buffer]> File content
@@ -169,7 +169,7 @@ When set, this method only performs the [actionability](../actionability.md) che
 
 ## input-source-position
 - `sourcePosition` <[Object]>
-  - alias-java: Position
+  * alias-java: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -177,7 +177,7 @@ Clicks on the source element at this point relative to the top-left corner of th
 
 ## input-target-position
 - `targetPosition` <[Object]>
-  - alias-java: Position
+  * alias-java: Position
   - `x` <[float]>
   - `y` <[float]>
 
@@ -253,7 +253,7 @@ Dangerous option; use with care. Defaults to `false`.
 
 ## browser-option-proxy
 - `proxy` <[Object]>
-  - alias-java: Proxy
+  * alias: Proxy
   - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example
     `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP
     proxy.
@@ -350,7 +350,7 @@ When using [`method: Page.goto`], [`method: Page.route`], [`method: Page.waitFor
 * langs: js, java
   - alias-java: viewportSize
 - `viewport` <[null]|[Object]>
-  - alias-java: ViewportSize
+  * alias: ViewportSize
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
@@ -384,7 +384,7 @@ It makes the execution of the tests non-deterministic.
   - alias-java: screenSize
   - alias-csharp: screenSize
 - `screen` <[Object]>
-  - alias-java: ScreenSize
+  * alias: ScreenSize
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
@@ -616,7 +616,7 @@ Does not enforce fixed viewport, allows resizing window in the headed mode.
 
 ## context-option-clientCertificates
 - `clientCertificates` <[Array]<[Object]>>
-  - alias-java: ClientCertificate
+  * alias: ClientCertificate
   - `origin` <[string]> Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
   - `certPath` ?<[path]> Path to the file with the certificate in PEM format.
   - `cert` ?<[Buffer]> Direct value of the certificate in PEM format.
@@ -671,7 +671,7 @@ for a list of supported timezone IDs. Defaults to the system timezone.
 
 ## context-option-geolocation
 - `geolocation` <[Object]>
-  - alias-java: Geolocation
+  * alias: Geolocation
   - `latitude` <[float]> Latitude between -90 and 90.
   - `longitude` <[float]> Longitude between -180 and 180.
   - `accuracy` ?<[float]> Non-negative accuracy value. Defaults to `0`.
@@ -699,7 +699,7 @@ Whether to emulate network being offline. Defaults to `false`. Learn more about 
 
 ## context-option-httpcredentials
 - `httpCredentials` <[Object]>
-  - alias-java: HttpCredentials
+  * alias: HttpCredentials
   - `username` <[string]>
   - `password` <[string]>
   - `origin` ?<[string]> Restrain sending http credentials on specific origin (scheme://host:port).
@@ -821,11 +821,9 @@ When set to `minimal`, only record information necessary for routing from HAR. T
   - `size` ?<[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
     scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
     Actual picture of each page will be scaled down if necessary to fit the specified size.
-    - alias-csharp: RecordVideoSize
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
   - `showActions` ?<[Object]> If specified, enables visual annotations on interacted elements during video recording.
-    - alias-csharp: ShowActionsOptions
     - `duration` ?<[float]> How long each annotation is displayed in milliseconds. Defaults to `500`.
     - `position` ?<[AnnotatePosition]<"top-left"|"top"|"top-right"|"bottom-left"|"bottom"|"bottom-right">> Position of the action title overlay. Defaults to `"top-right"`.
     - `fontSize` ?<[int]> Font size of the action title in pixels. Defaults to `24`.
@@ -845,7 +843,7 @@ not recorded. Make sure to call [`method: BrowserContext.close`] for videos to b
 * langs: csharp, java, python
   - alias-python: record_video_size
 - `recordVideoSize` <[Object]>
-  - alias-java: RecordVideoSize
+  * alias-java: RecordVideoSize
   - `width` <[int]> Video frame width.
   - `height` <[int]> Video frame height.
 
@@ -855,7 +853,7 @@ Actual picture of each page will be scaled down if necessary to fit the specifie
 
 ## context-option-proxy
 - `proxy` <[Object]>
-  - alias-java: Proxy
+  * alias: Proxy
   - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example
     `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
   - `bypass` ?<[string]> Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
@@ -903,7 +901,7 @@ Specifies whether to wait for already running handlers and what to do if they th
 ## select-options-values
 * langs: java, js, csharp
 - `values` <[null]|[string]|[ElementHandle]|[Array]<[string]>|[Object]|[Array]<[ElementHandle]>|[Array]<[Object]>>
-  - alias-java: SelectOption
+  * alias-java: SelectOption
   - `value` ?<[string]> Matches by `option.value`. Optional.
   - `label` ?<[string]> Matches by `option.label`. Optional.
   - `index` ?<[int]> Matches by the index. Optional.
@@ -1306,7 +1304,7 @@ When true, takes a screenshot of the full scrollable page, instead of the curren
 
 ## screenshot-option-clip
 - `clip` <[Object]>
-  - alias-java: Clip
+  * alias-java: Clip
   - `x` <[float]> x-coordinate of top-left corner of clip area
   - `y` <[float]> y-coordinate of top-left corner of clip area
   - `width` <[float]> width of clipping area


### PR DESCRIPTION
## Summary
- Switch type-level alias markers from `- alias` to `* alias` so they are visually distinct from sibling property entries under a parameter or return type.