### PR TITLE
fix(webkit): use monotonic time for synthetic NSEvent timestamp on macOS

### DIFF
--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -16390,7 +16390,7 @@ index 0000000000000000000000000000000000000000..e6d3a8764ef084790a4ca4e9891b09dd
 +    }
 +    int clickCount = optionalClickCount ? *optionalClickCount : 0;
 +
-+    NSTimeInterval timestamp = [NSDate timeIntervalSinceReferenceDate];
++    NSTimeInterval timestamp = MonotonicTime::now().secondsSinceEpoch().value();
 +    NSWindow *window = m_page.platformWindow();
 +    NSInteger windowNumber = window.windowNumber;
 +


### PR DESCRIPTION
## Summary

- On macOS, `WebPageInspectorInputAgent::platformDispatchMouseEvent` set the synthetic `NSEvent`'s timestamp from `[NSDate timeIntervalSinceReferenceDate]` (seconds since 2001-01-01) instead of the monotonic seconds-since-boot scale that `NSEvent.timestamp` is contractually expected to use.
- The wrong scale propagated through `WebMouseEvent` into DOM `MouseEvent.timeStamp`, producing bogus, low-precision values for synthetic clicks (`page.click()`, `locator.click()`, ...). Real hardware clicks were unaffected.
- Switched to `MonotonicTime::now().secondsSinceEpoch().value()`, matching the convention already used elsewhere in the same patch (keyboard, touch, screencast frames).

Note: `browser_patches/webkit/patches/bootstrap.diff` is regenerated from a separate patch-source checkout, so this change will also need to be ported there to survive the next patch roll.

⚠️ **This PR was produced with the help of an AI coding agent and has not been verified end-to-end against a locally rebuilt WebKit (Xcode wasn't available on the author's machine). It needs a careful human review of both the diagnosis and the fix.**

Fixes https://github.com/microsoft/playwright/issues/40822
