### PR TITLE
chore(mcp): separate attach and page options in config

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -58,7 +58,7 @@ export type ContextConfig = {
     navigation?: number;
     expect?: number;
   };
-  browser?: {
+  page?: {
     initScript?: string[];
     initPage?: string[];
   };
@@ -339,7 +339,7 @@ export class Context {
         },
       });
     }
-    for (const initScript of this.config.browser?.initScript || [])
+    for (const initScript of this.config.page?.initScript || [])
       this._disposables.push(await browserContext.addInitScript({ path: path.resolve(this.options.cwd, initScript) }));
 
     for (const page of browserContext.pages())

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -168,7 +168,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     const requests = await this.page.requests().catch(() => []);
     for (const request of requests.filter(r => r.existingResponse() || r.failure()))
       this._requests.push(request);
-    for (const initPage of this.context.config.browser?.initPage || []) {
+    for (const initPage of this.context.config.page?.initPage || []) {
       try {
         const { default: func } = require(initPage);
         await func({ page: this.page });

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -44,13 +44,13 @@ type BrowserWithInfo = {
 };
 
 export async function createBrowserWithInfo(config: FullConfig, clientInfo: ClientInfo, cliOptions: CLIOptions): Promise<BrowserWithInfo> {
-  if (config.browser.remoteEndpoint)
+  if (config.attach?.remoteEndpoint)
     return await createRemoteBrowser(config);
 
   let browser: playwrightTypes.Browser;
   let canBind = false;
   let ownership: 'attached' | 'own' = 'own';
-  if (config.browser.cdpEndpoint) {
+  if (config.attach?.cdpEndpoint) {
     browser = await createCDPBrowser(config, clientInfo);
     canBind = true;
     ownership = 'attached';
@@ -58,7 +58,7 @@ export async function createBrowserWithInfo(config: FullConfig, clientInfo: Clie
     browser = await createIsolatedBrowser(config, clientInfo);
     canBind = true;
     ownership = 'own';
-  } else if (config.extension) {
+  } else if (config.attach?.extension) {
     const { channel, executablePath } = resolveExtensionOptions(cliOptions);
     browser = await createExtensionBrowser(channel, executablePath, clientInfo.clientName);
     ownership = 'attached';
@@ -106,9 +106,9 @@ async function createIsolatedBrowser(config: FullConfig, clientInfo: ClientInfo)
 async function createCDPBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {
   testDebug('create browser (cdp)');
   const artifactsDir = await computeTracesDir(config, clientInfo);
-  const browser = await playwright.chromium.connectOverCDP(config.browser.cdpEndpoint!, {
-    headers: config.browser.cdpHeaders,
-    timeout: config.browser.cdpTimeout,
+  const browser = await playwright.chromium.connectOverCDP(config.attach!.cdpEndpoint!, {
+    headers: config.attach!.cdpHeaders,
+    timeout: config.attach!.cdpTimeout,
     artifactsDir,
   });
   return browser;
@@ -116,7 +116,8 @@ async function createCDPBrowser(config: FullConfig, clientInfo: ClientInfo): Pro
 
 async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo> {
   testDebug('create browser (remote)');
-  const descriptor = await serverRegistry.find(config.browser.remoteEndpoint!);
+  const endpoint = config.attach!.remoteEndpoint!;
+  const descriptor = await serverRegistry.find(endpoint);
   if (descriptor) {
     const browser = await connectToBrowserAcrossVersions(descriptor);
     return {
@@ -131,8 +132,6 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
       ownership: 'attached'
     };
   }
-
-  const endpoint = config.browser.remoteEndpoint!;
   const playwrightObject = playwright as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
   const browser = await connectToBrowser(playwrightObject, { endpoint });

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -32,7 +32,7 @@ export type ToolCapability =
 
 export type Config = {
   /**
-   * The browser to use.
+   * Options for launching a new browser. Ignored when `attach` selects an existing browser.
    */
   browser?: {
     /**
@@ -65,9 +65,18 @@ export type Config = {
      * This is useful for settings options like `viewport`.
      */
     contextOptions?: playwright.BrowserContextOptions;
+  },
 
+  /**
+   * Attach to an existing browser instead of launching one. When set, the `browser`
+   * section's launch options (other than `browserName`/`launchOptions.channel` used to
+   * identify the target) are ignored. Set at most one of `cdpEndpoint`, `remoteEndpoint`,
+   * or `extension`.
+   */
+  attach?: {
     /**
-     * Chrome DevTools Protocol endpoint to connect to an existing browser instance in case of Chromium family browsers.
+     * Chrome DevTools Protocol endpoint to connect to an existing browser instance in
+     * case of Chromium family browsers.
      */
     cdpEndpoint?: string;
 
@@ -87,6 +96,17 @@ export type Config = {
     remoteEndpoint?: string;
 
     /**
+     * Connect to a running browser instance (Edge/Chrome only).
+     * Requires the "Playwright Extension" to be installed.
+     */
+    extension?: boolean;
+  },
+
+  /**
+   * Per-page setup applied to every page in the session.
+   */
+  page?: {
+    /**
      * Paths to TypeScript files to add as initialization scripts for Playwright page.
      */
     initPage?: string[];
@@ -97,13 +117,6 @@ export type Config = {
      */
     initScript?: string[];
   },
-
-  /**
-   * Connect to a running browser instance (Edge/Chrome only). If specified, `browser`
-   * config is ignored.
-   * Requires the "Playwright Extension" to be installed.
-   */
-  extension?: boolean;
 
   server?: {
     /**

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -32,22 +32,6 @@ async function fileExistsAsync(resolved: string) {
 
 type ViewportSize = { width: number; height: number };
 
-// LegacyConfig accepts the old field locations (browser.cdpEndpoint, top-level
-// extension, etc.) that pre-`attach`/`page` clients still pass at runtime. The
-// public Config type no longer exposes these; `normalizeConfig` strips them and
-// folds them into the canonical `attach` / `page` groups before merging.
-type LegacyConfig = Config & {
-  browser?: NonNullable<Config['browser']> & {
-    cdpEndpoint?: string;
-    cdpHeaders?: Record<string, string>;
-    cdpTimeout?: number;
-    remoteEndpoint?: string;
-    initPage?: string[];
-    initScript?: string[];
-  };
-  extension?: boolean;
-};
-
 export type CLIOptions = {
   allowedHosts?: string[];
   allowedOrigins?: string[];
@@ -126,7 +110,7 @@ export type FullConfig = MergedConfig & {
 };
 
 export async function resolveConfig(config: Config): Promise<FullConfig> {
-  const merged = mergeConfig(defaultConfig, normalizeConfig(config as LegacyConfig));
+  const merged = mergeConfig(defaultConfig, normalizeConfig(config));
   const browser = await validateBrowserConfig(merged.browser);
   await validatePageConfig(merged.page);
   validateAttach(merged.attach);
@@ -299,38 +283,48 @@ async function validatePageConfig(page: NonNullable<Config['page']>) {
   }
 }
 
-// Maps each legacy `browser.*` field to its new home (`attach` or `page`).
-const LEGACY_BROWSER_FIELDS = {
-  cdpEndpoint: 'attach',
-  cdpHeaders: 'attach',
-  cdpTimeout: 'attach',
-  remoteEndpoint: 'attach',
-  initPage: 'page',
-  initScript: 'page',
-} as const;
-
 // Backward-compat: convert old field locations (browser.cdpEndpoint, top-level
-// extension, browser.initPage, etc.) into the new `attach` / `page` groups.
+// `extension`, browser.initPage, etc.) into the new `attach` / `page` groups.
 // New locations win when both are set on the same input.
-function normalizeConfig(input: LegacyConfig): Config {
-  const { extension, browser: legacyBrowser, ...rest } = input;
-  if (!legacyBrowser && !extension)
-    return rest;
-  const browser: Record<string, any> | undefined = legacyBrowser ? { ...legacyBrowser } : undefined;
-  const attach: Record<string, any> = { ...rest.attach };
-  const page: Record<string, any> = { ...rest.page };
-  const targets = { attach, page };
-  if (browser) {
-    for (const [field, target] of Object.entries(LEGACY_BROWSER_FIELDS)) {
-      if (browser[field] === undefined)
-        continue;
-      targets[target][field] ??= browser[field];
-      delete browser[field];
-    }
+function normalizeConfig<T extends Config>(config: T): T {
+  // eslint-disable-next-line no-restricted-syntax -- legacy fields are not on the public Config type
+  const c = config as any;
+  if (!c.browser?.cdpEndpoint && !c.browser?.cdpHeaders && c.browser?.cdpTimeout === undefined
+      && !c.browser?.remoteEndpoint && !c.browser?.initPage && !c.browser?.initScript
+      && c.extension === undefined)
+    return config;
+  const browser = c.browser ? { ...c.browser } : undefined;
+  const attach = { ...c.attach };
+  const page = { ...c.page };
+  if (browser?.cdpEndpoint !== undefined) {
+    attach.cdpEndpoint ??= browser.cdpEndpoint;
+    delete browser.cdpEndpoint;
   }
-  if (extension)
-    attach.extension ??= true;
-  return { ...rest, browser, attach, page } as Config;
+  if (browser?.cdpHeaders !== undefined) {
+    attach.cdpHeaders ??= browser.cdpHeaders;
+    delete browser.cdpHeaders;
+  }
+  if (browser?.cdpTimeout !== undefined) {
+    attach.cdpTimeout ??= browser.cdpTimeout;
+    delete browser.cdpTimeout;
+  }
+  if (browser?.remoteEndpoint !== undefined) {
+    attach.remoteEndpoint ??= browser.remoteEndpoint;
+    delete browser.remoteEndpoint;
+  }
+  if (browser?.initPage !== undefined) {
+    page.initPage ??= browser.initPage;
+    delete browser.initPage;
+  }
+  if (browser?.initScript !== undefined) {
+    page.initScript ??= browser.initScript;
+    delete browser.initScript;
+  }
+  if (c.extension !== undefined)
+    attach.extension ??= c.extension;
+  const result = { ...c, browser, attach, page };
+  delete result.extension;
+  return result;
 }
 
 function resolveBrowserParam(browserOption: string | undefined): { browserName?: 'chromium' | 'firefox' | 'webkit', channel?: string } {
@@ -502,7 +496,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   return configFromCLIOptions(options);
 }
 
-export async function loadConfig(configFile: string | undefined): Promise<LegacyConfig> {
+export async function loadConfig(configFile: string | undefined): Promise<Config> {
   if (!configFile)
     return {};
 

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -32,6 +32,22 @@ async function fileExistsAsync(resolved: string) {
 
 type ViewportSize = { width: number; height: number };
 
+// LegacyConfig accepts the old field locations (browser.cdpEndpoint, top-level
+// extension, etc.) that pre-`attach`/`page` clients still pass at runtime. The
+// public Config type no longer exposes these; `normalizeConfig` strips them and
+// folds them into the canonical `attach` / `page` groups before merging.
+type LegacyConfig = Config & {
+  browser?: NonNullable<Config['browser']> & {
+    cdpEndpoint?: string;
+    cdpHeaders?: Record<string, string>;
+    cdpTimeout?: number;
+    remoteEndpoint?: string;
+    initPage?: string[];
+    initScript?: string[];
+  };
+  extension?: boolean;
+};
+
 export type CLIOptions = {
   allowedHosts?: string[];
   allowedOrigins?: string[];
@@ -81,6 +97,8 @@ const defaultConfig: MergedConfig = {
     launchOptions: {},
     contextOptions: {},
   },
+  attach: {},
+  page: {},
   timeouts: {
     action: 5000,
     navigation: 60000,
@@ -94,20 +112,24 @@ export type MergedConfig = Config & {
   browser: BrowserUserConfig & {
     launchOptions: NonNullable<BrowserUserConfig['launchOptions']>;
     contextOptions: NonNullable<BrowserUserConfig['contextOptions']>;
-  }
+  };
+  attach: NonNullable<Config['attach']>;
+  page: NonNullable<Config['page']>;
 };
 
 export type FullConfig = MergedConfig & {
   browser: MergedConfig['browser'] & {
     browserName: 'chromium' | 'firefox' | 'webkit';
-  },
+  };
   skillMode?: boolean;
   configFile?: string;
 };
 
 export async function resolveConfig(config: Config): Promise<FullConfig> {
-  const merged = mergeConfig(defaultConfig, config);
+  const merged = mergeConfig(defaultConfig, normalizeConfig(config as LegacyConfig));
   const browser = await validateBrowserConfig(merged.browser);
+  await validatePageConfig(merged.page);
+  validateAttach(merged.attach);
   return { ...merged, browser };
 }
 
@@ -119,15 +141,17 @@ export async function resolveCLIConfigForMCP(cliOptions: CLIOptions, env?: NodeJ
   const configDir = configFile ? path.dirname(path.resolve(configFile)) : process.cwd();
 
   let result = defaultConfig;
-  result = mergeConfig(result, resolveConfigPaths(configInFile, configDir));
-  result = mergeConfig(result, resolveConfigPaths(envOverrides, process.cwd()));
-  result = mergeConfig(result, resolveConfigPaths(cliOverrides, process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(configInFile), configDir));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(envOverrides), process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(cliOverrides), process.cwd()));
 
   const browser = await validateBrowserConfig(result.browser);
   if (browser.launchOptions.headless === undefined)
     browser.launchOptions.headless = os.platform() === 'linux' && !process.env.DISPLAY;
 
+  await validatePageConfig(result.page);
   validateOutputDir(result.outputDir);
+  validateAttach(result.attach);
 
   return { ...result, browser, configFile };
 }
@@ -169,22 +193,26 @@ export async function resolveCLIConfigForCLI(daemonProfilesDir: string, sessionN
   const globalConfigDir = globalConfigExists ? path.dirname(globalConfigPath) : process.cwd();
 
   let result = defaultConfig;
-  result = mergeConfig(result, resolveConfigPaths(globalConfigInFile, globalConfigDir));
-  result = mergeConfig(result, resolveConfigPaths(configInFile, configDir));
-  result = mergeConfig(result, resolveConfigPaths(envOverrides, process.cwd()));
-  result = mergeConfig(result, resolveConfigPaths(daemonOverrides, process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(globalConfigInFile), globalConfigDir));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(configInFile), configDir));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(envOverrides), process.cwd()));
+  result = mergeConfig(result, resolveConfigPaths(normalizeConfig(daemonOverrides), process.cwd()));
+
+  validateAttach(result.attach);
+  const isAttaching = attachIsSet(result.attach);
 
   if (result.browser.isolated === undefined)
-    result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !result.browser.remoteEndpoint && !result.browser.cdpEndpoint && !result.extension;
+    result.browser.isolated = !options.profile && !options.persistent && !result.browser.userDataDir && !isAttaching;
 
   if (result.browser.launchOptions.headless === undefined)
     result.browser.launchOptions.headless = true;
 
   const browser = await validateBrowserConfig(result.browser);
+  await validatePageConfig(result.page);
 
   validateOutputDir(result.outputDir);
 
-  if (!result.extension && !browser.isolated && !browser.userDataDir && !browser.remoteEndpoint && !browser.cdpEndpoint) {
+  if (!isAttaching && !browser.isolated && !browser.userDataDir) {
     // No custom value provided, use the daemon data dir.
     const browserToken = browser.launchOptions?.channel ?? browser?.browserName;
     const userDataDir = path.resolve(daemonProfilesDir, `ud-${sessionName}-${browserToken}`);
@@ -220,18 +248,6 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   if (browser.isolated && browser.userDataDir)
     throw new Error('Browser userDataDir is not supported in isolated mode.');
 
-  if (browser.initScript) {
-    for (const script of browser.initScript) {
-      if (!await fileExistsAsync(script))
-        throw new Error(`Init script file does not exist: ${script}`);
-    }
-  }
-  if (browser.initPage) {
-    for (const page of browser.initPage) {
-      if (!await fileExistsAsync(page))
-        throw new Error(`Init page file does not exist: ${page}`);
-    }
-  }
   if (browser.contextOptions.viewport === undefined) {
     if (browser.launchOptions.headless)
       browser.contextOptions.viewport = { width: 1280, height: 720 };
@@ -246,6 +262,75 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   }
 
   return { ...browser, browserName };
+}
+
+type AttachConfig = NonNullable<Config['attach']>;
+
+function attachIsSet(attach: AttachConfig): boolean {
+  return !!(attach.cdpEndpoint || attach.remoteEndpoint || attach.extension);
+}
+
+// `attach.cdpEndpoint`, `attach.remoteEndpoint`, and `attach.extension` select
+// mutually-exclusive attach modes; throw if more than one is set.
+function validateAttach(attach: AttachConfig) {
+  const set: string[] = [];
+  if (attach.cdpEndpoint !== undefined)
+    set.push('cdpEndpoint');
+  if (attach.remoteEndpoint !== undefined)
+    set.push('remoteEndpoint');
+  if (attach.extension)
+    set.push('extension');
+  if (set.length > 1)
+    throw new Error(`attach: set at most one of cdpEndpoint, remoteEndpoint, extension (got: ${set.join(', ')}).`);
+}
+
+async function validatePageConfig(page: NonNullable<Config['page']>) {
+  if (page.initScript) {
+    for (const script of page.initScript) {
+      if (!await fileExistsAsync(script))
+        throw new Error(`Init script file does not exist: ${script}`);
+    }
+  }
+  if (page.initPage) {
+    for (const file of page.initPage) {
+      if (!await fileExistsAsync(file))
+        throw new Error(`Init page file does not exist: ${file}`);
+    }
+  }
+}
+
+// Maps each legacy `browser.*` field to its new home (`attach` or `page`).
+const LEGACY_BROWSER_FIELDS = {
+  cdpEndpoint: 'attach',
+  cdpHeaders: 'attach',
+  cdpTimeout: 'attach',
+  remoteEndpoint: 'attach',
+  initPage: 'page',
+  initScript: 'page',
+} as const;
+
+// Backward-compat: convert old field locations (browser.cdpEndpoint, top-level
+// extension, browser.initPage, etc.) into the new `attach` / `page` groups.
+// New locations win when both are set on the same input.
+function normalizeConfig(input: LegacyConfig): Config {
+  const { extension, browser: legacyBrowser, ...rest } = input;
+  if (!legacyBrowser && !extension)
+    return rest;
+  const browser: Record<string, any> | undefined = legacyBrowser ? { ...legacyBrowser } : undefined;
+  const attach: Record<string, any> = { ...rest.attach };
+  const page: Record<string, any> = { ...rest.page };
+  const targets = { attach, page };
+  if (browser) {
+    for (const [field, target] of Object.entries(LEGACY_BROWSER_FIELDS)) {
+      if (browser[field] === undefined)
+        continue;
+      targets[target][field] ??= browser[field];
+      delete browser[field];
+    }
+  }
+  if (extension)
+    attach.extension ??= true;
+  return { ...rest, browser, attach, page } as Config;
 }
 
 function resolveBrowserParam(browserOption: string | undefined): { browserName?: 'chromium' | 'firefox' | 'webkit', channel?: string } {
@@ -326,14 +411,18 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
       userDataDir: cliOptions.userDataDir,
       launchOptions,
       contextOptions,
+    },
+    attach: {
       cdpEndpoint: cliOptions.cdpEndpoint,
       cdpHeaders: cliOptions.cdpHeader,
       cdpTimeout: cliOptions.cdpTimeout,
+      remoteEndpoint: cliOptions.endpoint,
+      extension: cliOptions.extension,
+    },
+    page: {
       initPage: cliOptions.initPage,
       initScript: cliOptions.initScript,
-      remoteEndpoint: cliOptions.endpoint,
     },
-    extension: cliOptions.extension,
     server: {
       port: cliOptions.port,
       host: cliOptions.host,
@@ -413,7 +502,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   return configFromCLIOptions(options);
 }
 
-export async function loadConfig(configFile: string | undefined): Promise<Config> {
+export async function loadConfig(configFile: string | undefined): Promise<LegacyConfig> {
   if (!configFile)
     return {};
 
@@ -433,10 +522,10 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
 // supplied via CLI flags or PLAYWRIGHT_MCP_INIT_* env vars) so they keep
 // working when the CLI is invoked from a different cwd.
 function resolveConfigPaths(config: Config, baseDir: string): Config {
-  if (config.browser?.initPage)
-    config.browser.initPage = config.browser.initPage.map(p => path.resolve(baseDir, p));
-  if (config.browser?.initScript)
-    config.browser.initScript = config.browser.initScript.map(p => path.resolve(baseDir, p));
+  if (config.page?.initPage)
+    config.page.initPage = config.page.initPage.map(p => path.resolve(baseDir, p));
+  if (config.page?.initScript)
+    config.page.initScript = config.page.initScript.map(p => path.resolve(baseDir, p));
   return config;
 }
 
@@ -469,6 +558,14 @@ function mergeConfig(base: MergedConfig, overrides: Config): MergedConfig {
     ...pickDefined(base),
     ...pickDefined(overrides),
     browser,
+    attach: {
+      ...pickDefined(base.attach),
+      ...pickDefined(overrides.attach),
+    },
+    page: {
+      ...pickDefined(base.page),
+      ...pickDefined(overrides.page),
+    },
     console: {
       ...pickDefined(base.console),
       ...pickDefined(overrides.console),
@@ -489,7 +586,7 @@ function mergeConfig(base: MergedConfig, overrides: Config): MergedConfig {
       ...pickDefined(base.timeouts),
       ...pickDefined(overrides.timeouts),
     },
-  } as FullConfig;
+  } as MergedConfig;
 }
 
 export function semicolonSeparatedList(value: string | undefined): string[] | undefined {

--- a/packages/playwright-core/src/tools/mcp/configIni.ts
+++ b/packages/playwright-core/src/tools/mcp/configIni.ts
@@ -105,11 +105,23 @@ const longhandTypes: Record<string, LonghandType> = {
   'browser.browserName': 'string',
   'browser.isolated': 'boolean',
   'browser.userDataDir': 'string',
+  // Deprecated browser-scoped fields. Read-through for back-compat; new code should
+  // use the matching `attach.*` / `page.*` paths below.
   'browser.cdpEndpoint': 'string',
   'browser.cdpTimeout': 'number',
   'browser.remoteEndpoint': 'string',
   'browser.initPage': 'string[]',
   'browser.initScript': 'string[]',
+
+  // attach
+  'attach.cdpEndpoint': 'string',
+  'attach.cdpTimeout': 'number',
+  'attach.remoteEndpoint': 'string',
+  'attach.extension': 'boolean',
+
+  // page
+  'page.initPage': 'string[]',
+  'page.initScript': 'string[]',
 
   // browser.launchOptions
   'browser.launchOptions.channel': 'string',
@@ -154,6 +166,7 @@ const longhandTypes: Record<string, LonghandType> = {
   'browser.contextOptions.viewport': 'size',
 
   // top-level
+  // Deprecated. Use `attach.extension`.
   'extension': 'boolean',
   'capabilities': 'string[]',
   'saveSession': 'boolean',

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -236,17 +236,31 @@ test.describe('merge order', () => {
     expect(config.browser.browserName).toBe('firefox');
   });
 
-  test('file browser.cdpHeaders preserved when env unset', async ({}, testInfo) => {
+  test('file attach.cdpHeaders preserved when env unset', async ({}, testInfo) => {
     const configFile = testInfo.outputPath('config.json');
     const fileConfig: Config = {
-      browser: {
+      attach: {
         cdpEndpoint: 'ws://example.invalid',
         cdpHeaders: { Authorization: 'Bearer token-from-file' },
       },
     };
     await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
     const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
-    expect(config.browser.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
+    expect(config.attach.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
+  });
+
+  test('legacy browser.cdpHeaders folded into attach for back-compat', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    // Old shape — written verbatim to JSON; resolver normalizes into `attach`.
+    await fs.promises.writeFile(configFile, JSON.stringify({
+      browser: {
+        cdpEndpoint: 'ws://example.invalid',
+        cdpHeaders: { Authorization: 'Bearer token-from-file' },
+      },
+    }));
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.attach.cdpEndpoint).toBe('ws://example.invalid');
+    expect(config.attach.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
   });
 });
 
@@ -519,7 +533,7 @@ test.describe('resolveCLIConfigForCLI - config file discovery', () => {
 test.describe('resolveCLIConfigForCLI - extension', () => {
   test('--extension disables isolated', async ({}, testInfo) => {
     const config = await resolveCLI(testInfo.outputPath('profiles'), 'default', { extension: true }) as any;
-    expect(config.extension).toBe(true);
+    expect(config.attach.extension).toBe(true);
     expect(config.browser.isolated).toBe(false);
   });
 });

--- a/tests/mcp/init-page.spec.ts
+++ b/tests/mcp/init-page.spec.ts
@@ -43,7 +43,7 @@ test('init-page relative path from --config resolves against the config dir', as
   // cwd (or the require() caller), not the config file's directory. We put
   // the config + init page in a sibling subdir of cwd so a cwd-based
   // resolution would miss the file. Same resolution path also covers
-  // browser.initScript.
+  // page.initScript.
   const configDir = test.info().outputPath('cfg');
   const cwd = test.info().outputPath('cwd');
   await fs.promises.mkdir(configDir, { recursive: true });
@@ -57,7 +57,7 @@ test('init-page relative path from --config resolves against the config dir', as
   `);
   const configPath = path.join(configDir, 'config.json');
   await fs.promises.writeFile(configPath, JSON.stringify({
-    browser: { initPage: ['./initPage.ts'] },
+    page: { initPage: ['./initPage.ts'] },
   }));
 
   const { client } = await startClient({

--- a/tests/mcp/storage.spec.ts
+++ b/tests/mcp/storage.spec.ts
@@ -183,7 +183,7 @@ test('--storage-state option works with remote endpoint in config', async ({ sta
   await fs.promises.writeFile(stateFile, JSON.stringify(storageState));
 
   const { client } = await startClient({
-    config: { browser: { remoteEndpoint: wsEndpoint, isolated: true } },
+    config: { browser: { isolated: true }, attach: { remoteEndpoint: wsEndpoint } },
     args: ['--storage-state', stateFile],
   });
 

--- a/tests/mcp/storage.spec.ts
+++ b/tests/mcp/storage.spec.ts
@@ -183,7 +183,7 @@ test('--storage-state option works with remote endpoint in config', async ({ sta
   await fs.promises.writeFile(stateFile, JSON.stringify(storageState));
 
   const { client } = await startClient({
-    config: { browser: { isolated: true }, attach: { remoteEndpoint: wsEndpoint } },
+    config: { attach: { remoteEndpoint: wsEndpoint } },
     args: ['--storage-state', stateFile],
   });
 


### PR DESCRIPTION
## Summary

- Split MCP config so `attach` (cdpEndpoint/cdpHeaders/cdpTimeout/remoteEndpoint/extension) and `page` (initPage/initScript) are top-level fields. `browser` now only carries launch options.
- Old field locations (`browser.cdpEndpoint`, top-level `extension`, `browser.initPage`, etc.) are still accepted at runtime via a normalization step, so existing JSON/INI/JS configs keep working.
- `attach.cdpEndpoint`, `attach.remoteEndpoint`, and `attach.extension` are mutually exclusive; setting more than one throws at resolve time.

Reference https://github.com/microsoft/playwright/issues/40814