### PR TITLE
fix(html-reporter): render compound ANSI SGR codes

### DIFF
--- a/packages/web/src/ansi2html.ts
+++ b/packages/web/src/ansi2html.ts
@@ -27,82 +27,84 @@ export function ansi2html(text: string, defaultColors: { bg: string, fg: string 
   while ((match = regex.exec(text)) !== null) {
     const [, , codeStr, , text] = match;
     if (codeStr) {
-      const code = +codeStr;
-      switch (code) {
-        case 0: style = {}; break;
-        case 1: style['font-weight'] = 'bold'; break;
-        case 2: style['opacity'] = '0.8'; break;
-        case 3: style['font-style'] = 'italic'; break;
-        case 4: style['text-decoration'] = 'underline'; break;
-        case 7:
-          reverse = true;
-          break;
-        case 8: style.display = 'none'; break;
-        case 9: style['text-decoration'] = 'line-through'; break;
-        case 22:
-          delete style['font-weight'];
-          delete style['font-style'];
-          delete style['opacity'];
-          delete style['text-decoration'];
-          break;
-        case 23:
-          delete style['font-weight'];
-          delete style['font-style'];
-          delete style['opacity'];
-          break;
-        case 24:
-          delete style['text-decoration'];
-          break;
-        case 27:
-          reverse = false;
-          break;
-        case 30:
-        case 31:
-        case 32:
-        case 33:
-        case 34:
-        case 35:
-        case 36:
-        case 37:
-          fg = ansiColors[code - 30];
-          break;
-        case 39:
-          fg = defaultColors?.fg;
-          break;
-        case 40:
-        case 41:
-        case 42:
-        case 43:
-        case 44:
-        case 45:
-        case 46:
-        case 47:
-          bg = ansiColors[code - 40];
-          break;
-        case 49:
-          bg = defaultColors?.bg;
-          break;
-        case 53: style['text-decoration'] = 'overline'; break;
-        case 90:
-        case 91:
-        case 92:
-        case 93:
-        case 94:
-        case 95:
-        case 96:
-        case 97:
-          fg = brightAnsiColors[code - 90];
-          break;
-        case 100:
-        case 101:
-        case 102:
-        case 103:
-        case 104:
-        case 105:
-        case 106:
-        case 107:
-          bg = brightAnsiColors[code - 100];
-          break;
+      for (const segment of codeStr.split(';')) {
+        const code = +segment;
+        switch (code) {
+          case 0: style = {}; break;
+          case 1: style['font-weight'] = 'bold'; break;
+          case 2: style['opacity'] = '0.8'; break;
+          case 3: style['font-style'] = 'italic'; break;
+          case 4: style['text-decoration'] = 'underline'; break;
+          case 7:
+            reverse = true;
+            break;
+          case 8: style.display = 'none'; break;
+          case 9: style['text-decoration'] = 'line-through'; break;
+          case 22:
+            delete style['font-weight'];
+            delete style['font-style'];
+            delete style['opacity'];
+            delete style['text-decoration'];
+            break;
+          case 23:
+            delete style['font-weight'];
+            delete style['font-style'];
+            delete style['opacity'];
+            break;
+          case 24:
+            delete style['text-decoration'];
+            break;
+          case 27:
+            reverse = false;
+            break;
+          case 30:
+          case 31:
+          case 32:
+          case 33:
+          case 34:
+          case 35:
+          case 36:
+          case 37:
+            fg = ansiColors[code - 30];
+            break;
+          case 39:
+            fg = defaultColors?.fg;
+            break;
+          case 40:
+          case 41:
+          case 42:
+          case 43:
+          case 44:
+          case 45:
+          case 46:
+          case 47:
+            bg = ansiColors[code - 40];
+            break;
+          case 49:
+            bg = defaultColors?.bg;
+            break;
+          case 53: style['text-decoration'] = 'overline'; break;
+          case 90:
+          case 91:
+          case 92:
+          case 93:
+          case 94:
+          case 95:
+          case 96:
+          case 97:
+            fg = brightAnsiColors[code - 90];
+            break;
+          case 100:
+          case 101:
+          case 102:
+          case 103:
+          case 104:
+          case 105:
+          case 106:
+          case 107:
+            bg = brightAnsiColors[code - 100];
+            break;
+        }
       }
     } else if (text) {
       const styleCopy = { ...style };

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -570,6 +570,28 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('.test-error-view span:has-text("true")').first()).toHaveCSS('color', 'rgb(205, 49, 49)');
     });
 
+    test('should render compound ANSI SGR codes', {
+      annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40826' },
+    }, async ({ runInlineTest, page, showReport }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('fails', async () => {
+            throw new Error('\\x1b[1;31mBOLD RED\\x1b[0m \\x1b[0;32mRESET GREEN\\x1b[0m');
+          });
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(1);
+      expect(result.failed).toBe(1);
+
+      await showReport();
+      await page.getByRole('link', { name: 'fails' }).click();
+      const boldRed = page.locator('.test-error-view span:has-text("BOLD RED")').first();
+      await expect(boldRed).toHaveCSS('color', 'rgb(205, 49, 49)');
+      await expect(boldRed).toHaveCSS('font-weight', '700');
+      await expect(page.locator('.test-error-view span:has-text("RESET GREEN")').first()).toHaveCSS('color', 'rgb(0, 188, 0)');
+    });
+
     test('should show trace source', async ({ runInlineTest, page, showReport }) => {
       const result = await runInlineTest({
         'playwright.config.js': `


### PR DESCRIPTION
## Summary
- Split compound ANSI SGR sequences like `\x1b[1;31m` on `;` before parsing each segment — previously `+"1;31"` returned `NaN`, so the entire sequence was dropped and styling was lost in the HTML reporter, trace viewer, and other `ansi2html` consumers.

Fixes https://github.com/microsoft/playwright/issues/40826