### PR TITLE
feat(ui-mode): add "Stop on first failure" toggle

### DIFF
--- a/packages/playwright/src/isomorphic/testServerInterface.ts
+++ b/packages/playwright/src/isomorphic/testServerInterface.ts
@@ -86,6 +86,7 @@ export interface TestServerInterface {
     testIds?: string[];
     headed?: boolean;
     workers?: number | string;
+    maxFailures?: number;
     updateSnapshots?: 'all' | 'changed' | 'missing' | 'none';
     updateSourceMethod?: 'overwrite' | 'patch' | '3way';
     reporters?: string[],

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -69,6 +69,7 @@ export type RunTestsParams = {
   testIds?: string[];
   headed?: boolean;
   workers?: number | string;
+  maxFailures?: number;
   updateSnapshots?: 'all' | 'changed' | 'missing' | 'none';
   updateSourceMethod?: 'overwrite' | 'patch' | '3way';
   reporters?: string[],
@@ -309,6 +310,7 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
       ...(params.updateSnapshots ? { updateSnapshots: params.updateSnapshots } : {}),
       ...(params.updateSourceMethod ? { updateSourceMethod: params.updateSourceMethod } : {}),
       ...(params.workers ? { workers: params.workers } : {}),
+      ...(params.maxFailures ? { maxFailures: params.maxFailures } : {}),
     };
 
     const config = await this._loadConfigOrReportError(new InternalReporter([userReporter]), overrides);

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -267,12 +267,6 @@ export const UIModeView: React.FC<{}> = ({
       setProgress(undefined);
   }, [testModel, isRunningTest]);
 
-  // Stop on first failure.
-  React.useEffect(() => {
-    if (isRunningTest && stopOnFailure && progress?.failed)
-      testServerConnection?.stopTestsNoReply({});
-  }, [isRunningTest, stopOnFailure, progress?.failed, testServerConnection]);
-
   // Test tree is built from the model and filters.
   const { testTree } = React.useMemo(() => {
     if (!testModel)
@@ -327,6 +321,7 @@ export const UIModeView: React.FC<{}> = ({
         updateSnapshots,
         reporters: queryParams.reporters,
         workers: singleWorker ? 1 : undefined,
+        maxFailures: stopOnFailure ? 1 : undefined,
         trace: 'on',
       });
       // Clear pending tests in case of interrupt.
@@ -337,7 +332,7 @@ export const UIModeView: React.FC<{}> = ({
       setTestModel({ ...testModel });
       setRunningState(oldState => oldState ? ({ ...oldState, completed: true }) : undefined);
     });
-  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots, singleWorker]);
+  }, [projectFilters, isRunningTest, testModel, testServerConnection, updateSnapshots, singleWorker, stopOnFailure]);
 
   const runVisibleTests = React.useCallback(() => runTests('bounce-if-busy', testTree.collectTestIds(testTree.rootItem)), [runTests, testTree]);
 

--- a/packages/trace-viewer/src/ui/uiModeView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeView.tsx
@@ -130,6 +130,7 @@ export const UIModeView: React.FC<{}> = ({
   const [singleWorker, setSingleWorker] = useSetting<boolean>('single-worker', false);
   const [updateSnapshots, setUpdateSnapshots] = useSetting<reporterTypes.FullConfig['updateSnapshots']>('updateSnapshots', 'missing');
   const [onlyChanged, setOnlyChanged] = useSetting<boolean>('only-changed', false);
+  const [stopOnFailure, setStopOnFailure] = useSetting<boolean>('stop-on-failure', false);
   const [mergeFiles] = useSetting('mergeFiles', false);
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -265,6 +266,12 @@ export const UIModeView: React.FC<{}> = ({
     else if (!testModel)
       setProgress(undefined);
   }, [testModel, isRunningTest]);
+
+  // Stop on first failure.
+  React.useEffect(() => {
+    if (isRunningTest && stopOnFailure && progress?.failed)
+      testServerConnection?.stopTestsNoReply({});
+  }, [isRunningTest, stopOnFailure, progress?.failed, testServerConnection]);
 
   // Test tree is built from the model and filters.
   const { testTree } = React.useMemo(() => {
@@ -547,6 +554,7 @@ export const UIModeView: React.FC<{}> = ({
         </Toolbar>
         {testingOptionsVisible && <SettingsView settings={[
           { type: 'check', value: singleWorker, set: setSingleWorker, name: 'Single worker' },
+          { type: 'check', value: stopOnFailure, set: setStopOnFailure, name: 'Stop on first failure' },
           { type: 'select', options: [
             { label: 'All', value: 'all' },
             { label: 'Changed', value: 'changed' },

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -103,6 +103,25 @@ test('should show running progress', async ({ runUITest }) => {
   await expect(page.getByTestId('status-line')).toBeHidden();
 });
 
+test('should stop on first failure', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test 1', async () => {});
+      test('test 2', async () => { expect(1).toBe(2); });
+      test('test 3', async () => {});
+      test('test 4', async () => {});
+    `,
+  });
+
+  await page.getByText('Testing Options').click();
+  await page.getByLabel('Stop on first failure').check();
+
+  await page.getByTitle('Run all').click();
+  // After test 2 fails, the run is stopped. Test 4 does not start.
+  await expect(page.getByTestId('status-line')).toHaveText('3/4 (75%) — 1 passed, 1 failed, 1 skipped');
+});
+
 test('should run on hover', async ({ runUITest }) => {
   const { page } = await runUITest({
     'a.test.ts': `

--- a/tests/playwright-test/ui-mode-test-run.spec.ts
+++ b/tests/playwright-test/ui-mode-test-run.spec.ts
@@ -118,8 +118,8 @@ test('should stop on first failure', async ({ runUITest }) => {
   await page.getByLabel('Stop on first failure').check();
 
   await page.getByTitle('Run all').click();
-  // After test 2 fails, the run is stopped. Test 4 does not start.
-  await expect(page.getByTestId('status-line')).toHaveText('3/4 (75%) — 1 passed, 1 failed, 1 skipped');
+  // After test 2 fails, the runner stops dispatching: tests 3 and 4 never start.
+  await expect(page.getByTestId('status-line')).toHaveText('2/4 (50%) — 1 passed, 1 failed');
 });
 
 test('should run on hover', async ({ runUITest }) => {


### PR DESCRIPTION
## Summary
- Adds a Testing Options checkbox in UI Mode that halts the run as soon as a test fails (equivalent to `-x` on the CLI)
- The existing auto-select-failing-test logic then surfaces the failure in the sidebar and detail panel without an extra click

Fixes https://github.com/microsoft/playwright/issues/40820