### PR TITLE
feat(registry): install-deps via dnf on Fedora and RHEL family

### DIFF
--- a/.github/workflows/tests_fedora.yml
+++ b/.github/workflows/tests_fedora.yml
@@ -67,8 +67,8 @@ jobs:
       run: |
         docker exec --workdir /root/playwright fedora-tests bash -c '
           set -euo pipefail
-          node packages/playwright-core/cli.js install chromium firefox webkit ffmpeg
-          node packages/playwright-core/cli.js install-deps chromium firefox webkit
+          node packages/playwright-core/cli.js install
+          node packages/playwright-core/cli.js install-deps
         '
     - name: Run @smoke tests inside Fedora
       run: |

--- a/.github/workflows/tests_fedora.yml
+++ b/.github/workflows/tests_fedora.yml
@@ -1,0 +1,86 @@
+name: tests Fedora
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - 'packages/playwright-core/browsers.json'
+      - '.github/workflows/tests_fedora.yml'
+  pull_request:
+    branches:
+      - main
+      - release-*
+    paths:
+      - 'packages/playwright-core/browsers.json'
+      - '.github/workflows/tests_fedora.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test_fedora:
+    name: Fedora ${{ matrix.fedora_tag }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_tag: [latest]
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    - run: npm ci
+    - run: npm run build
+    - name: Launch Fedora container
+      run: |
+        docker run \
+          --rm \
+          --name fedora-tests \
+          --platform linux/amd64 \
+          --workdir /root \
+          --env CI \
+          --env FORCE_COLOR \
+          -d \
+          -t \
+          fedora:${{ matrix.fedora_tag }} /bin/bash
+    - name: Copy repository into container
+      run: |
+        docker cp . fedora-tests:/root/playwright
+    - name: Install Node.js and Xvfb in container
+      run: |
+        docker exec fedora-tests bash -c '
+          set -euo pipefail
+          dnf install -y --setopt=install_weak_deps=False nodejs npm xorg-x11-server-Xvfb glibc
+          node --version
+          npm --version
+        '
+    - name: Install browsers and system dependencies via install-deps
+      run: |
+        docker exec --workdir /root/playwright fedora-tests bash -c '
+          set -euo pipefail
+          node packages/playwright-core/cli.js install chromium firefox webkit ffmpeg
+          node packages/playwright-core/cli.js install-deps chromium firefox webkit
+        '
+    - name: Run @smoke tests inside Fedora
+      run: |
+        docker exec --workdir /root/playwright fedora-tests \
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" \
+          npm run test -- --grep "@smoke"
+    - name: Copy test results from container
+      if: ${{ always() }}
+      run: docker cp fedora-tests:/root/playwright/test-results ./test-results || true
+    - name: Upload test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: fedora-${{ matrix.fedora_tag }}-test-results
+        path: ./test-results

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -21,6 +21,7 @@ import path from 'path';
 
 import { wrapInASCIIBox } from '@utils/ascii';
 import { hostPlatform, isOfficiallySupportedPlatform } from '@utils/hostPlatform';
+import { isDnfBasedDistroSync } from '@utils/linuxUtils';
 import { spawnAsync } from '@utils/spawnAsync';
 import { getPlaywrightVersion } from '../userAgent';
 import { deps } from './nativeDeps';
@@ -210,12 +211,11 @@ export async function validateDependenciesWindows(sdkLanguage: string, windowsEx
   }
 }
 
-export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDirectories: string[], dlOpenLibraries: string[]) {
-  const directoryPaths = linuxLddDirectories;
+async function findMissingLinuxLibraries(linuxLddDirectories: string[], dlOpenLibraries: string[]): Promise<Set<string>> {
   const lddPaths: string[] = [];
-  for (const directoryPath of directoryPaths)
+  for (const directoryPath of linuxLddDirectories)
     lddPaths.push(...(await executablesOrSharedLibraries(directoryPath)));
-  const missingDepsPerFile = await Promise.all(lddPaths.map(lddPath => missingFileDependencies(lddPath, directoryPaths)));
+  const missingDepsPerFile = await Promise.all(lddPaths.map(lddPath => missingFileDependencies(lddPath, linuxLddDirectories)));
   const missingDeps: Set<string> = new Set();
   for (const deps of missingDepsPerFile) {
     for (const dep of deps)
@@ -223,6 +223,36 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
   }
   for (const dep of (await missingDLOPENLibraries(dlOpenLibraries)))
     missingDeps.add(dep);
+  return missingDeps;
+}
+
+async function resolveLibrariesWithDnf(libraries: string[]): Promise<{ libToPackage: Map<string, string>, unresolved: string[] }> {
+  const libToPackage = new Map<string, string>();
+  const unresolved: string[] = [];
+  // `dnf repoquery --whatprovides <soname>` returns one line per package
+  // providing that library. Run per-library in parallel so we know the mapping.
+  await Promise.all(libraries.map(async lib => {
+    const { stdout, code, error } = await spawnAsync('dnf', ['-q', 'repoquery', '--queryformat', '%{name}\n', '--whatprovides', lib], {});
+    if (error || code !== 0) {
+      unresolved.push(lib);
+      return;
+    }
+    const candidates = stdout.split('\n').map(s => s.trim()).filter(Boolean)
+        .filter(name => !name.endsWith('-devel') && !name.endsWith('-debuginfo') && !name.endsWith('-debugsource'));
+    if (!candidates.length) {
+      unresolved.push(lib);
+      return;
+    }
+    // Prefer the alphabetically first/shortest match — avoids picking the
+    // i686 variant on x86_64 hosts and longer subpackage names.
+    candidates.sort((a, b) => a.length - b.length || a.localeCompare(b));
+    libToPackage.set(lib, candidates[0]);
+  }));
+  return { libToPackage, unresolved };
+}
+
+export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDirectories: string[], dlOpenLibraries: string[]) {
+  const missingDeps = await findMissingLinuxLibraries(linuxLddDirectories, dlOpenLibraries);
   if (!missingDeps.size)
     return;
   const allMissingDeps = new Set(missingDeps);
@@ -284,6 +314,34 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
       ``,
       `<3 Playwright Team`,
     ]);
+  } else if (isDnfBasedDistroSync()) {
+    // Fedora and the RHEL family — ask dnf which packages provide the missing libraries.
+    const { libToPackage, unresolved } = await resolveLibrariesWithDnf([...allMissingDeps]);
+    const dnfPackages = Array.from(new Set(libToPackage.values())).sort();
+    if (dnfPackages.length) {
+      errorLines.push(...[
+        `Please install them with the following command:`,
+        ``,
+        `    ${maybeSudo}${buildPlaywrightCLICommand(sdkLanguage, 'install-deps')}`,
+        ``,
+        `Alternatively, use dnf:`,
+        `    ${maybeSudo}dnf install ${dnfPackages.join(' \\\n        ')}`,
+        ``,
+      ]);
+      if (unresolved.length) {
+        errorLines.push(...[
+          `Could not find a dnf package for the following libraries (install manually):`,
+          ...unresolved.map(dep => '    ' + dep),
+          ``,
+        ]);
+      }
+      errorLines.push(`<3 Playwright Team`);
+    } else {
+      errorLines.push(...[
+        `Missing libraries:`,
+        ...[...allMissingDeps].map(dep => '    ' + dep),
+      ]);
+    }
   } else {
     // Unhappy path: we either run on unknown distribution, or we failed to resolve all missing
     // libraries to package names.
@@ -295,6 +353,74 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
   }
 
   throw new Error('\n' + wrapInASCIIBox(errorLines.join('\n'), 1));
+}
+
+export type LinuxBrowserToInstall = {
+  name: string,
+  browserDirectory: string,
+  linuxLddDirectories: string[],
+  dlOpenLibraries: string[],
+};
+
+export async function installDependenciesFedora(sdkLanguage: string, browsers: LinuxBrowserToInstall[], dryRun: boolean) {
+  const browsersWithMissingBinaries = browsers.filter(b => !fs.existsSync(b.browserDirectory));
+  if (browsersWithMissingBinaries.length) {
+    const installCommand = buildPlaywrightCLICommand(sdkLanguage, 'install');
+    throw new Error('\n' + wrapInASCIIBox([
+      `Cannot detect system dependencies for ${browsersWithMissingBinaries.map(b => b.name).join(', ')}: browser binaries are not installed.`,
+      ``,
+      `On Fedora and the RHEL family, Playwright resolves dependencies by inspecting`,
+      `installed browser binaries. Please install browsers first:`,
+      ``,
+      `    ${installCommand}`,
+      ``,
+      `Then re-run "install-deps".`,
+      ``,
+      `<3 Playwright Team`,
+    ].join('\n'), 1));
+  }
+  const missingLibraries = new Set<string>();
+  for (const b of browsers) {
+    for (const lib of await findMissingLinuxLibraries(b.linuxLddDirectories, b.dlOpenLibraries))
+      missingLibraries.add(lib);
+  }
+  if (!missingLibraries.size) {
+    console.log('All system dependencies are installed.'); // eslint-disable-line no-console
+    return;
+  }
+  const { libToPackage, unresolved } = await resolveLibrariesWithDnf([...missingLibraries]);
+  const packages = Array.from(new Set(libToPackage.values())).sort();
+  if (dryRun) {
+    if (packages.length) {
+      // eslint-disable-next-line no-console
+      console.log(`Missing system dependencies (${packages.length}):\n${packages.map(p => `  ${p}`).join('\n')}`);
+    }
+    if (unresolved.length) {
+      // eslint-disable-next-line no-console
+      console.warn(`Could not resolve dnf packages for libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
+    }
+    if (packages.length || unresolved.length)
+      process.exitCode = 1;
+    return;
+  }
+  if (!packages.length)
+    throw new Error(`Could not resolve dnf packages for missing libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
+  console.log(`Installing dependencies...`); // eslint-disable-line no-console
+  const commands: string[] = [
+    ['dnf', 'install', '-y', ...packages].join(' '),
+  ];
+  const { command, args, elevatedPermissions } = await transformCommandsForRoot(commands);
+  if (elevatedPermissions)
+    console.log('Switching to root user to install dependencies...'); // eslint-disable-line no-console
+  const child = childProcess.spawn(command, args, { stdio: 'inherit' });
+  await new Promise<void>((resolve, reject) => {
+    child.on('exit', (code: number) => code === 0 ? resolve() : reject(new Error(`Installation process exited with code: ${code}`)));
+    child.on('error', reject);
+  });
+  if (unresolved.length) {
+    // eslint-disable-next-line no-console
+    console.warn(`Note: could not resolve dnf packages for libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
+  }
 }
 
 function isSharedLib(basename: string) {

--- a/packages/playwright-core/src/server/registry/dependencies.ts
+++ b/packages/playwright-core/src/server/registry/dependencies.ts
@@ -108,12 +108,14 @@ export async function installDependenciesLinux(targets: Set<DependencyGroup>, dr
     await reportMissingDependenciesLinux(uniqueLibraries);
     return;
   }
+  await runPackageInstall([
+    'apt-get update',
+    ['apt-get', 'install', '-y', '--no-install-recommends', ...uniqueLibraries].join(' '),
+  ]);
+}
+
+async function runPackageInstall(commands: string[]) {
   console.log(`Installing dependencies...`);  // eslint-disable-line no-console
-  const commands: string[] = [];
-  commands.push('apt-get update');
-  commands.push(['apt-get', 'install', '-y', '--no-install-recommends',
-    ...uniqueLibraries,
-  ].join(' '));
   const { command, args, elevatedPermissions } = await transformCommandsForRoot(commands);
   if (elevatedPermissions)
     console.log('Switching to root user to install dependencies...'); // eslint-disable-line no-console
@@ -229,22 +231,22 @@ async function findMissingLinuxLibraries(linuxLddDirectories: string[], dlOpenLi
 async function resolveLibrariesWithDnf(libraries: string[]): Promise<{ libToPackage: Map<string, string>, unresolved: string[] }> {
   const libToPackage = new Map<string, string>();
   const unresolved: string[] = [];
-  // `dnf repoquery --whatprovides <soname>` returns one line per package
-  // providing that library. Run per-library in parallel so we know the mapping.
   await Promise.all(libraries.map(async lib => {
     const { stdout, code, error } = await spawnAsync('dnf', ['-q', 'repoquery', '--queryformat', '%{name}\n', '--whatprovides', lib], {});
     if (error || code !== 0) {
       unresolved.push(lib);
       return;
     }
+    // -devel/-debuginfo/-debugsource subpackages ship the same SONAMEs in their
+    // file lists but are not runtime install targets.
     const candidates = stdout.split('\n').map(s => s.trim()).filter(Boolean)
         .filter(name => !name.endsWith('-devel') && !name.endsWith('-debuginfo') && !name.endsWith('-debugsource'));
     if (!candidates.length) {
       unresolved.push(lib);
       return;
     }
-    // Prefer the alphabetically first/shortest match — avoids picking the
-    // i686 variant on x86_64 hosts and longer subpackage names.
+    // Prefer the shortest match: avoids picking the i686 variant on x86_64 hosts
+    // (e.g. `glibc` over `glibc-langpack-en`) and longer subpackage names.
     candidates.sort((a, b) => a.length - b.length || a.localeCompare(b));
     libToPackage.set(lib, candidates[0]);
   }));
@@ -315,7 +317,6 @@ export async function validateDependenciesLinux(sdkLanguage: string, linuxLddDir
       `<3 Playwright Team`,
     ]);
   } else if (isDnfBasedDistroSync()) {
-    // Fedora and the RHEL family — ask dnf which packages provide the missing libraries.
     const { libToPackage, unresolved } = await resolveLibrariesWithDnf([...allMissingDeps]);
     const dnfPackages = Array.from(new Set(libToPackage.values())).sort();
     if (dnfPackages.length) {
@@ -362,26 +363,27 @@ export type LinuxBrowserToInstall = {
   dlOpenLibraries: string[],
 };
 
-export async function installDependenciesFedora(sdkLanguage: string, browsers: LinuxBrowserToInstall[], dryRun: boolean) {
+export async function installDependenciesDnf(sdkLanguage: string, browsers: LinuxBrowserToInstall[], dryRun: boolean) {
   const browsersWithMissingBinaries = browsers.filter(b => !fs.existsSync(b.browserDirectory));
   if (browsersWithMissingBinaries.length) {
-    const installCommand = buildPlaywrightCLICommand(sdkLanguage, 'install');
     throw new Error('\n' + wrapInASCIIBox([
       `Cannot detect system dependencies for ${browsersWithMissingBinaries.map(b => b.name).join(', ')}: browser binaries are not installed.`,
       ``,
       `On Fedora and the RHEL family, Playwright resolves dependencies by inspecting`,
       `installed browser binaries. Please install browsers first:`,
       ``,
-      `    ${installCommand}`,
+      `    ${buildPlaywrightCLICommand(sdkLanguage, 'install')}`,
       ``,
       `Then re-run "install-deps".`,
       ``,
       `<3 Playwright Team`,
     ].join('\n'), 1));
   }
+
+  const perBrowser = await Promise.all(browsers.map(b => findMissingLinuxLibraries(b.linuxLddDirectories, b.dlOpenLibraries)));
   const missingLibraries = new Set<string>();
-  for (const b of browsers) {
-    for (const lib of await findMissingLinuxLibraries(b.linuxLddDirectories, b.dlOpenLibraries))
+  for (const libs of perBrowser) {
+    for (const lib of libs)
       missingLibraries.add(lib);
   }
   if (!missingLibraries.size) {
@@ -391,36 +393,29 @@ export async function installDependenciesFedora(sdkLanguage: string, browsers: L
   const { libToPackage, unresolved } = await resolveLibrariesWithDnf([...missingLibraries]);
   const packages = Array.from(new Set(libToPackage.values())).sort();
   if (dryRun) {
-    if (packages.length) {
-      // eslint-disable-next-line no-console
-      console.log(`Missing system dependencies (${packages.length}):\n${packages.map(p => `  ${p}`).join('\n')}`);
-    }
-    if (unresolved.length) {
-      // eslint-disable-next-line no-console
-      console.warn(`Could not resolve dnf packages for libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
-    }
-    if (packages.length || unresolved.length)
-      process.exitCode = 1;
+    reportDnfResolution(packages, unresolved);
     return;
   }
   if (!packages.length)
     throw new Error(`Could not resolve dnf packages for missing libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
-  console.log(`Installing dependencies...`); // eslint-disable-line no-console
-  const commands: string[] = [
-    ['dnf', 'install', '-y', ...packages].join(' '),
-  ];
-  const { command, args, elevatedPermissions } = await transformCommandsForRoot(commands);
-  if (elevatedPermissions)
-    console.log('Switching to root user to install dependencies...'); // eslint-disable-line no-console
-  const child = childProcess.spawn(command, args, { stdio: 'inherit' });
-  await new Promise<void>((resolve, reject) => {
-    child.on('exit', (code: number) => code === 0 ? resolve() : reject(new Error(`Installation process exited with code: ${code}`)));
-    child.on('error', reject);
-  });
+  await runPackageInstall([['dnf', 'install', '-y', ...packages].join(' ')]);
   if (unresolved.length) {
     // eslint-disable-next-line no-console
     console.warn(`Note: could not resolve dnf packages for libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
   }
+}
+
+function reportDnfResolution(packages: string[], unresolved: string[]) {
+  if (packages.length) {
+    // eslint-disable-next-line no-console
+    console.log(`Missing system dependencies (${packages.length}):\n${packages.map(p => `  ${p}`).join('\n')}`);
+  }
+  if (unresolved.length) {
+    // eslint-disable-next-line no-console
+    console.warn(`Could not resolve dnf packages for libraries:\n${unresolved.map(l => `  ${l}`).join('\n')}`);
+  }
+  if (packages.length || unresolved.length)
+    process.exitCode = 1;
 }
 
 function isSharedLib(basename: string) {

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -28,10 +28,11 @@ import { spawnAsync } from '@utils/spawnAsync';
 import { canAccessFile, existsAsync, removeFolders } from '@utils/fileUtils';
 import { calculateSha1 } from '@utils/crypto';
 import { getAsBooleanFromENV, getFromENV, getPackageManagerExecCommand } from '@utils/env';
+import { isDnfBasedDistroSync } from '@utils/linuxUtils';
 import { lock } from '@utils/third_party/lockfile';
 import { fetchData } from '../utils';
 import { getEmbedderName } from '../userAgent';
-import { installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
+import { installDependenciesFedora, installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
 import { dockerVersion, readDockerVersionSync, transformCommandsForRoot } from './dependencies';
 import { downloadBrowserWithProgressBar, logPolitely } from './browserFetcher';
 import { packageRoot, binPath } from '../../package';
@@ -595,6 +596,7 @@ interface ExecutableImpl extends Executable {
   _install?: (force: boolean) => Promise<void>;
   _dependencyGroup?: DependencyGroup;
   _isHermeticInstallation?: boolean;
+  _linuxValidation?: { lddDirectories: string[], dlOpenLibraries: string[] };
 }
 
 export class Registry {
@@ -660,7 +662,8 @@ export class Registry {
       executablePath: () => chromiumExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumExecutable, chromium.installByDefault, sdkLanguage),
       installType: chromium.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromium.dir, ['chrome-linux'], [], ['chrome-win']),
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromium.dir, ['chrome-linux', 'chrome-linux64'], [], ['chrome-win']),
+      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(chromium),
       title: chromium.title,
       revision: chromium.revision,
@@ -679,7 +682,8 @@ export class Registry {
       executablePath: () => chromiumHeadlessShellExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumHeadlessShellExecutable, chromiumHeadlessShell.installByDefault, sdkLanguage),
       installType: chromiumHeadlessShell.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumHeadlessShell.dir, ['chrome-linux'], [], ['chrome-win']),
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumHeadlessShell.dir, ['chrome-linux', 'chrome-headless-shell-linux64'], [], ['chrome-win']),
+      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(chromiumHeadlessShell),
       title: chromiumHeadlessShell.title,
       revision: chromiumHeadlessShell.revision,
@@ -698,7 +702,8 @@ export class Registry {
       executablePath: () => chromiumTipOfTreeHeadlessShellExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumTipOfTreeHeadlessShellExecutable, chromiumTipOfTreeHeadlessShell.installByDefault, sdkLanguage),
       installType: chromiumTipOfTreeHeadlessShell.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTreeHeadlessShell.dir, ['chrome-linux'], [], ['chrome-win']),
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTreeHeadlessShell.dir, ['chrome-linux', 'chrome-headless-shell-linux64'], [], ['chrome-win']),
+      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(chromiumTipOfTreeHeadlessShell),
       title: chromiumTipOfTreeHeadlessShell.title,
       revision: chromiumTipOfTreeHeadlessShell.revision,
@@ -717,7 +722,8 @@ export class Registry {
       executablePath: () => chromiumTipOfTreeExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium-tip-of-tree', chromiumTipOfTreeExecutable, chromiumTipOfTree.installByDefault, sdkLanguage),
       installType: chromiumTipOfTree.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTree.dir, ['chrome-linux'], [], ['chrome-win']),
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTree.dir, ['chrome-linux', 'chrome-linux64'], [], ['chrome-win']),
+      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(chromiumTipOfTree),
       title: chromiumTipOfTree.title,
       revision: chromiumTipOfTree.revision,
@@ -821,6 +827,7 @@ export class Registry {
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox', firefoxExecutable, firefox.installByDefault, sdkLanguage),
       installType: firefox.installByDefault ? 'download-by-default' : 'download-on-demand',
       _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefox.dir, ['firefox'], [], ['firefox']),
+      _linuxValidation: { lddDirectories: ['firefox'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(firefox),
       title: firefox.title,
       revision: firefox.revision,
@@ -840,6 +847,7 @@ export class Registry {
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox-beta', firefoxBetaExecutable, firefoxBeta.installByDefault, sdkLanguage),
       installType: firefoxBeta.installByDefault ? 'download-by-default' : 'download-on-demand',
       _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefoxBeta.dir, ['firefox'], [], ['firefox']),
+      _linuxValidation: { lddDirectories: ['firefox'], dlOpenLibraries: [] },
       downloadURLs: this._downloadURLs(firefoxBeta),
       title: firefoxBeta.title,
       revision: firefoxBeta.revision,
@@ -869,6 +877,7 @@ export class Registry {
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('webkit', webkitExecutable, webkit.installByDefault, sdkLanguage),
       installType: webkit.installByDefault ? 'download-by-default' : 'download-on-demand',
       _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, webkit.dir, webkitLinuxLddDirectories, ['libGLESv2.so.2', 'libx264.so'], ['']),
+      _linuxValidation: { lddDirectories: webkitLinuxLddDirectories, dlOpenLibraries: ['libGLESv2.so.2', 'libx264.so'] },
       downloadURLs: this._downloadURLs(webkit),
       title: webkit.title,
       revision: webkit.revision,
@@ -1070,8 +1079,20 @@ export class Registry {
     targets.add('tools');
     if (os.platform() === 'win32')
       return await installDependenciesWindows(targets, dryRun);
-    if (os.platform() === 'linux')
+    if (os.platform() === 'linux') {
+      if (isDnfBasedDistroSync()) {
+        const browsers = executables
+            .filter((e: ExecutableImpl) => !!e._linuxValidation && !!e.directory)
+            .map((e: ExecutableImpl) => ({
+              name: e.name,
+              browserDirectory: e.directory!,
+              linuxLddDirectories: e._linuxValidation!.lddDirectories.map(d => path.join(e.directory!, d)),
+              dlOpenLibraries: e._linuxValidation!.dlOpenLibraries,
+            }));
+        return await installDependenciesFedora(process.env.PW_LANG_NAME || 'javascript', browsers, dryRun);
+      }
       return await installDependenciesLinux(targets, dryRun);
+    }
   }
 
   async install(executablesToInstall: Executable[], options?: { force?: boolean }) {

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -32,7 +32,7 @@ import { isDnfBasedDistroSync } from '@utils/linuxUtils';
 import { lock } from '@utils/third_party/lockfile';
 import { fetchData } from '../utils';
 import { getEmbedderName } from '../userAgent';
-import { installDependenciesFedora, installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
+import { installDependenciesDnf, installDependenciesLinux, installDependenciesWindows, validateDependenciesLinux, validateDependenciesWindows } from './dependencies';
 import { dockerVersion, readDockerVersionSync, transformCommandsForRoot } from './dependencies';
 import { downloadBrowserWithProgressBar, logPolitely } from './browserFetcher';
 import { packageRoot, binPath } from '../../package';
@@ -655,6 +655,7 @@ export class Registry {
 
     const chromium = descriptors.find(d => d.name === 'chromium')!;
     const chromiumExecutable = findExecutablePath(chromium.dir, 'chromium');
+    const chromiumLinuxValidation = { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'chromium',
       browserName: 'chromium',
@@ -662,8 +663,8 @@ export class Registry {
       executablePath: () => chromiumExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumExecutable, chromium.installByDefault, sdkLanguage),
       installType: chromium.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromium.dir, ['chrome-linux', 'chrome-linux64'], [], ['chrome-win']),
-      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromium.dir, chromiumLinuxValidation, ['chrome-win']),
+      _linuxValidation: chromiumLinuxValidation,
       downloadURLs: this._downloadURLs(chromium),
       title: chromium.title,
       revision: chromium.revision,
@@ -675,6 +676,7 @@ export class Registry {
 
     const chromiumHeadlessShell = descriptors.find(d => d.name === 'chromium-headless-shell')!;
     const chromiumHeadlessShellExecutable = findExecutablePath(chromiumHeadlessShell.dir, 'chromium-headless-shell');
+    const chromiumHeadlessShellLinuxValidation = { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'chromium-headless-shell',
       browserName: 'chromium',
@@ -682,8 +684,8 @@ export class Registry {
       executablePath: () => chromiumHeadlessShellExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumHeadlessShellExecutable, chromiumHeadlessShell.installByDefault, sdkLanguage),
       installType: chromiumHeadlessShell.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumHeadlessShell.dir, ['chrome-linux', 'chrome-headless-shell-linux64'], [], ['chrome-win']),
-      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumHeadlessShell.dir, chromiumHeadlessShellLinuxValidation, ['chrome-win']),
+      _linuxValidation: chromiumHeadlessShellLinuxValidation,
       downloadURLs: this._downloadURLs(chromiumHeadlessShell),
       title: chromiumHeadlessShell.title,
       revision: chromiumHeadlessShell.revision,
@@ -695,6 +697,7 @@ export class Registry {
 
     const chromiumTipOfTreeHeadlessShell = descriptors.find(d => d.name === 'chromium-tip-of-tree-headless-shell')!;
     const chromiumTipOfTreeHeadlessShellExecutable = findExecutablePath(chromiumTipOfTreeHeadlessShell.dir, 'chromium-tip-of-tree-headless-shell');
+    const chromiumTipOfTreeHeadlessShellLinuxValidation = { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'chromium-tip-of-tree-headless-shell',
       browserName: 'chromium',
@@ -702,8 +705,8 @@ export class Registry {
       executablePath: () => chromiumTipOfTreeHeadlessShellExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumTipOfTreeHeadlessShellExecutable, chromiumTipOfTreeHeadlessShell.installByDefault, sdkLanguage),
       installType: chromiumTipOfTreeHeadlessShell.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTreeHeadlessShell.dir, ['chrome-linux', 'chrome-headless-shell-linux64'], [], ['chrome-win']),
-      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-headless-shell-linux64'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTreeHeadlessShell.dir, chromiumTipOfTreeHeadlessShellLinuxValidation, ['chrome-win']),
+      _linuxValidation: chromiumTipOfTreeHeadlessShellLinuxValidation,
       downloadURLs: this._downloadURLs(chromiumTipOfTreeHeadlessShell),
       title: chromiumTipOfTreeHeadlessShell.title,
       revision: chromiumTipOfTreeHeadlessShell.revision,
@@ -715,6 +718,7 @@ export class Registry {
 
     const chromiumTipOfTree = descriptors.find(d => d.name === 'chromium-tip-of-tree')!;
     const chromiumTipOfTreeExecutable = findExecutablePath(chromiumTipOfTree.dir, 'chromium-tip-of-tree');
+    const chromiumTipOfTreeLinuxValidation = { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'chromium-tip-of-tree',
       browserName: 'chromium',
@@ -722,8 +726,8 @@ export class Registry {
       executablePath: () => chromiumTipOfTreeExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium-tip-of-tree', chromiumTipOfTreeExecutable, chromiumTipOfTree.installByDefault, sdkLanguage),
       installType: chromiumTipOfTree.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTree.dir, ['chrome-linux', 'chrome-linux64'], [], ['chrome-win']),
-      _linuxValidation: { lddDirectories: ['chrome-linux', 'chrome-linux64'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTree.dir, chromiumTipOfTreeLinuxValidation, ['chrome-win']),
+      _linuxValidation: chromiumTipOfTreeLinuxValidation,
       downloadURLs: this._downloadURLs(chromiumTipOfTree),
       title: chromiumTipOfTree.title,
       revision: chromiumTipOfTree.revision,
@@ -819,6 +823,7 @@ export class Registry {
 
     const firefox = descriptors.find(d => d.name === 'firefox')!;
     const firefoxExecutable = findExecutablePath(firefox.dir, 'firefox');
+    const firefoxLinuxValidation = { lddDirectories: ['firefox'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'firefox',
       browserName: 'firefox',
@@ -826,8 +831,8 @@ export class Registry {
       executablePath: () => firefoxExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox', firefoxExecutable, firefox.installByDefault, sdkLanguage),
       installType: firefox.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefox.dir, ['firefox'], [], ['firefox']),
-      _linuxValidation: { lddDirectories: ['firefox'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefox.dir, firefoxLinuxValidation, ['firefox']),
+      _linuxValidation: firefoxLinuxValidation,
       downloadURLs: this._downloadURLs(firefox),
       title: firefox.title,
       revision: firefox.revision,
@@ -839,6 +844,7 @@ export class Registry {
 
     const firefoxBeta = descriptors.find(d => d.name === 'firefox-beta')!;
     const firefoxBetaExecutable = findExecutablePath(firefoxBeta.dir, 'firefox');
+    const firefoxBetaLinuxValidation = { lddDirectories: ['firefox'], dlOpenLibraries: [] };
     this._executables.push({
       name: 'firefox-beta',
       browserName: 'firefox',
@@ -846,8 +852,8 @@ export class Registry {
       executablePath: () => firefoxBetaExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox-beta', firefoxBetaExecutable, firefoxBeta.installByDefault, sdkLanguage),
       installType: firefoxBeta.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefoxBeta.dir, ['firefox'], [], ['firefox']),
-      _linuxValidation: { lddDirectories: ['firefox'], dlOpenLibraries: [] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefoxBeta.dir, firefoxBetaLinuxValidation, ['firefox']),
+      _linuxValidation: firefoxBetaLinuxValidation,
       downloadURLs: this._downloadURLs(firefoxBeta),
       title: firefoxBeta.title,
       revision: firefoxBeta.revision,
@@ -859,16 +865,19 @@ export class Registry {
 
     const webkit = descriptors.find(d => d.name === 'webkit')!;
     const webkitExecutable = findExecutablePath(webkit.dir, 'webkit');
-    const webkitLinuxLddDirectories = [
-      path.join('minibrowser-gtk'),
-      path.join('minibrowser-gtk', 'bin'),
-      path.join('minibrowser-gtk', 'lib'),
-      path.join('minibrowser-gtk', 'sys', 'lib'),
-      path.join('minibrowser-wpe'),
-      path.join('minibrowser-wpe', 'bin'),
-      path.join('minibrowser-wpe', 'lib'),
-      path.join('minibrowser-wpe', 'sys', 'lib'),
-    ];
+    const webkitLinuxValidation = {
+      lddDirectories: [
+        path.join('minibrowser-gtk'),
+        path.join('minibrowser-gtk', 'bin'),
+        path.join('minibrowser-gtk', 'lib'),
+        path.join('minibrowser-gtk', 'sys', 'lib'),
+        path.join('minibrowser-wpe'),
+        path.join('minibrowser-wpe', 'bin'),
+        path.join('minibrowser-wpe', 'lib'),
+        path.join('minibrowser-wpe', 'sys', 'lib'),
+      ],
+      dlOpenLibraries: ['libGLESv2.so.2', 'libx264.so'],
+    };
     this._executables.push({
       name: 'webkit',
       browserName: 'webkit',
@@ -876,8 +885,8 @@ export class Registry {
       executablePath: () => webkitExecutable,
       executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('webkit', webkitExecutable, webkit.installByDefault, sdkLanguage),
       installType: webkit.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, webkit.dir, webkitLinuxLddDirectories, ['libGLESv2.so.2', 'libx264.so'], ['']),
-      _linuxValidation: { lddDirectories: webkitLinuxLddDirectories, dlOpenLibraries: ['libGLESv2.so.2', 'libx264.so'] },
+      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, webkit.dir, webkitLinuxValidation, ['']),
+      _linuxValidation: webkitLinuxValidation,
       downloadURLs: this._downloadURLs(webkit),
       title: webkit.title,
       revision: webkit.revision,
@@ -1062,9 +1071,9 @@ export class Registry {
     return Array.from(new Set(executables as ExecutableImpl[]));
   }
 
-  private async _validateHostRequirements(sdkLanguage: string, browserDirectory: string, linuxLddDirectories: string[], dlOpenLibraries: string[], windowsExeAndDllDirectories: string[]) {
+  private async _validateHostRequirements(sdkLanguage: string, browserDirectory: string, linuxValidation: { lddDirectories: string[], dlOpenLibraries: string[] }, windowsExeAndDllDirectories: string[]) {
     if (os.platform() === 'linux')
-      return await validateDependenciesLinux(sdkLanguage, linuxLddDirectories.map(d => path.join(browserDirectory, d)), dlOpenLibraries);
+      return await validateDependenciesLinux(sdkLanguage, linuxValidation.lddDirectories.map(d => path.join(browserDirectory, d)), linuxValidation.dlOpenLibraries);
     if (os.platform() === 'win32' && os.arch() === 'x64')
       return await validateDependenciesWindows(sdkLanguage, windowsExeAndDllDirectories.map(d => path.join(browserDirectory, d)));
   }
@@ -1089,7 +1098,7 @@ export class Registry {
               linuxLddDirectories: e._linuxValidation!.lddDirectories.map(d => path.join(e.directory!, d)),
               dlOpenLibraries: e._linuxValidation!.dlOpenLibraries,
             }));
-        return await installDependenciesFedora(process.env.PW_LANG_NAME || 'javascript', browsers, dryRun);
+        return await installDependenciesDnf(getEmbedderName().embedderName, browsers, dryRun);
       }
       return await installDependenciesLinux(targets, dryRun);
     }

--- a/packages/utils/linuxUtils.ts
+++ b/packages/utils/linuxUtils.ts
@@ -20,10 +20,11 @@ import fs from 'fs';
 let didFailToReadOSRelease = false;
 let osRelease: {
   id: string,
+  idLike: string[],
   version: string,
 } | undefined;
 
-export function getLinuxDistributionInfoSync(): { id: string, version: string } | undefined {
+export function getLinuxDistributionInfoSync(): { id: string, idLike: string[], version: string } | undefined {
   if (process.platform !== 'linux')
     return undefined;
   if (!osRelease && !didFailToReadOSRelease) {
@@ -34,6 +35,7 @@ export function getLinuxDistributionInfoSync(): { id: string, version: string } 
       const fields = parseOSReleaseText(osReleaseText);
       osRelease = {
         id: fields.get('id') ?? '',
+        idLike: (fields.get('id_like') ?? '').split(/\s+/).filter(Boolean),
         version: fields.get('version_id') ?? '',
       };
     } catch (e) {
@@ -41,6 +43,19 @@ export function getLinuxDistributionInfoSync(): { id: string, version: string } 
     }
   }
   return osRelease;
+}
+
+// Distributions that use dnf as their package manager. Covers Fedora and the
+// RHEL family (RHEL, CentOS Stream, Rocky, Alma, Oracle, Amazon Linux 2023).
+const DNF_DISTRO_IDS = new Set(['fedora', 'rhel', 'centos', 'rocky', 'almalinux', 'ol', 'amzn']);
+
+export function isDnfBasedDistroSync(): boolean {
+  const info = getLinuxDistributionInfoSync();
+  if (!info)
+    return false;
+  if (DNF_DISTRO_IDS.has(info.id))
+    return true;
+  return info.idLike.some(id => DNF_DISTRO_IDS.has(id));
 }
 
 function parseOSReleaseText(osReleaseText: string): Map<string, string> {


### PR DESCRIPTION
## Summary
- Adds a dnf-based code path to `playwright install-deps` for Fedora and the RHEL family (RHEL, CentOS Stream, Rocky, Alma, Oracle, Amazon Linux 2023).
- Resolves missing SONAMEs via `dnf repoquery --whatprovides` against installed browser binaries, then either prints the list (`--dry-run`) or runs `dnf install -y` via the existing root-elevation helper.
- Updates the host-requirements error path to suggest the dnf install command on dnf-based distros.
- Adds a GitHub Action that runs `@smoke` tests inside a stock `fedora:latest` container whenever `packages/playwright-core/browsers.json` changes.

Note: Chromium and Firefox work; WebKit currently fails because it links against Ubuntu's libicu/libjpeg/libx264 SONAMEs that Fedora does not ship — that needs a separate Fedora WebKit build and is out of scope here.

Towards https://github.com/microsoft/playwright/issues/37812
Towards https://github.com/microsoft/playwright-cli/issues/309