### PR TITLE
feat(expect): support expect.soft.poll chain

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -234,16 +234,24 @@ await expect.poll(async () => {
 }).toBe(200);
 ```
 
-You can combine `expect.configure({ soft: true })` with expect.poll to perform soft assertions in polling logic.
+You can combine `expect.soft` with `expect.poll` to perform soft assertions in polling logic. This allows the test to continue even if the assertion inside poll fails.
+
+```js
+await expect.soft.poll(async () => {
+  const response = await page.request.get('https://api.example.com');
+  return response.status();
+}).toBe(200);
+```
+
+`expect.configure({ soft: true })` also chains with `expect.poll` and is useful when you want to reuse a configured instance.
 
 ```js
 const softExpect = expect.configure({ soft: true });
 await softExpect.poll(async () => {
   const response = await page.request.get('https://api.example.com');
   return response.status();
-}, {}).toBe(200);
+}).toBe(200);
 ```
-This allows the test to continue even if the assertion inside poll fails.
 
 ## expect.toPass
 

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -267,9 +267,11 @@ function createExpect(info: ExpectMetaInfo): Expect<{}> {
     return createExpect(newInfo);
   };
 
-  expectFn.soft = (actual: unknown, messageOrOptions?: ExpectMessage) => {
-    return createMatchers(actual, { ... info, isSoft: true }, messageOrOptions);
-  };
+  Object.defineProperty(expectFn, 'soft', {
+    configurable: true,
+    enumerable: true,
+    get: () => info.isSoft ? expectFn : createExpect({ ...info, isSoft: true }),
+  });
 
   expectFn.poll = (actual: unknown, messageOrOptions?: ExpectMessage & { timeout?: number, intervals?: number[] }) => {
     const poll = isString(messageOrOptions) ? {} : messageOrOptions || {};

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8535,7 +8535,7 @@ type PollMatchers<R, T, ExtendedMatchers> = {
 
 export type Expect<ExtendedMatchers = {}> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
-  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
+  soft: Expect<ExtendedMatchers>;
   poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => PollMatchers<Promise<void>, T, ExtendedMatchers>;
   extend<MoreMatchers extends Record<string, (this: ExpectMatcherState, receiver: any, ...args: any[]) => MatcherReturnType | Promise<MatcherReturnType>>>(matchers: MoreMatchers): Expect<ExtendedMatchers & MoreMatchers>;
   configure: (configuration: {

--- a/tests/playwright-test/expect-configure.spec.ts
+++ b/tests/playwright-test/expect-configure.spec.ts
@@ -152,3 +152,34 @@ test('should configure soft after poll', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(0);
 });
+
+test('should support expect.soft.poll', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should fail softly', async () => {
+        let probes = 0;
+        const startTime = Date.now();
+        await expect.soft.poll(() => ++probes, { timeout: 1000, intervals: [0, 10000] }).toBe(3);
+        expect(probes).toBe(2);
+        expect(Date.now() - startTime).toBeLessThan(5000);
+        console.log('%% reached-end');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.outputLines).toEqual(['reached-end']);
+});
+
+test('should support expect.soft.poll in passing test', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should pass', async () => {
+        let probes = 0;
+        await expect.soft.poll(() => ++probes).toBe(3);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -481,7 +481,7 @@ type PollMatchers<R, T, ExtendedMatchers> = {
 
 export type Expect<ExtendedMatchers = {}> = {
   <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }): MakeMatchers<void, T, ExtendedMatchers>;
-  soft: <T = unknown>(actual: T, messageOrOptions?: string | { message?: string }) => MakeMatchers<void, T, ExtendedMatchers>;
+  soft: Expect<ExtendedMatchers>;
   poll: <T = unknown>(actual: () => T | Promise<T>, messageOrOptions?: string | { message?: string, timeout?: number, intervals?: number[] }) => PollMatchers<Promise<void>, T, ExtendedMatchers>;
   extend<MoreMatchers extends Record<string, (this: ExpectMatcherState, receiver: any, ...args: any[]) => MatcherReturnType | Promise<MatcherReturnType>>>(matchers: MoreMatchers): Expect<ExtendedMatchers & MoreMatchers>;
   configure: (configuration: {


### PR DESCRIPTION
## Summary
- `expect.soft.poll(...)` now works as a shorthand for `expect.configure({ soft: true }).poll(...)`. `expect.soft` is now a fully chainable `Expect` instance, so `.poll`, `.configure`, `.extend`, etc. all work after `.soft`.

Fixes https://github.com/microsoft/playwright/issues/20773