### PR TITLE
feat(mcp): highlight click targets during actions

### DIFF
--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -21,6 +21,7 @@ import { defineTabTool } from './tool';
 import type * as playwright from '../../..';
 
 const elementTargetDescription = 'Exact target element reference from the page snapshot, or a unique element selector';
+const actionHighlightStyle = 'outline: 2px solid #1a73e8; background-color: rgba(26, 115, 232, 0.10)';
 
 export const optionalElementSchema = z.object({
   element: z.string().optional().describe('Human-readable element description used to obtain permission to interact with the element'),
@@ -88,10 +89,12 @@ const click = defineTabTool({
       response.addCode(`await page.${resolved}.click(${optionsArg});`);
 
     await tab.waitForCompletion(async () => {
-      if (params.doubleClick)
-        await locator.dblclick(options);
-      else
-        await locator.click(options);
+      await withActionHighlight(locator, async () => {
+        if (params.doubleClick)
+          await locator.dblclick(options);
+        else
+          await locator.click(options);
+      });
     });
   },
 });
@@ -234,3 +237,12 @@ export default [
   check,
   uncheck,
 ];
+
+async function withActionHighlight(locator: playwright.Locator, action: () => Promise<void>) {
+  await locator.highlight({ style: actionHighlightStyle }).catch(() => {});
+  try {
+    await action();
+  } finally {
+    await locator.hideHighlight().catch(() => {});
+  }
+}

--- a/tests/mcp/click.spec.ts
+++ b/tests/mcp/click.spec.ts
@@ -23,6 +23,7 @@ test('browser_click', async ({ client, server }) => {
     <script>
       const button = document.querySelector('button');
       button.addEventListener('click', () => {
+        window.highlightedDuringClick = !!document.querySelector('x-pw-glass')?.shadowRoot?.querySelector('x-pw-highlight');
         button.focus(); // without manual focus, webkit focuses body
       });
     </script>
@@ -42,6 +43,15 @@ test('browser_click', async ({ client, server }) => {
   })).toHaveResponse({
     code: `await page.getByRole('button', { name: 'Submit' }).click();`,
     snapshot: expect.stringContaining(`button "Submit" [active] [ref=e2]`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: '() => ({ highlightedDuringClick: window.highlightedDuringClick, remainingHighlights: document.querySelector("x-pw-glass")?.shadowRoot?.querySelectorAll("x-pw-highlight").length ?? 0 })',
+    },
+  })).toHaveResponse({
+    result: JSON.stringify({ highlightedDuringClick: true, remainingHighlights: 0 }, null, 2),
   });
 });
 


### PR DESCRIPTION
## Summary
- show the existing Playwright highlight overlay around MCP browser_click targets while the click action runs
- clean up the transient overlay after the action completes
- add MCP click coverage that verifies the highlight exists during the click and is removed afterward

References microsoft/playwright-mcp#492

## Testing
- npm run build
- npm run ctest-mcp -- tests/mcp/click.spec.ts
- npx eslint packages/playwright-core/src/tools/backend/snapshot.ts tests/mcp/click.spec.ts