### PR TITLE
fix(recorder): skip click action on <input type=file>

### DIFF
--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -262,16 +262,7 @@ class RecordActionTool implements RecorderTool {
       return;
     }
 
-    const target = this._recorder.deepEventTarget(event);
-    if (target.nodeName === 'INPUT' && (target as HTMLInputElement).type.toLowerCase() === 'file') {
-      // Clicking the file input opens the file picker; a setInputFiles action will be
-      // recorded from the resulting change event. Recording the click here would also
-      // emit click() in the output, which opens an extra picker on replay that never closes.
-      this._cancelPendingClickAction();
-      return;
-    }
-
-    const checkbox = asCheckbox(target);
+    const checkbox = asCheckbox(this._recorder.deepEventTarget(event));
     if (checkbox && event.detail === 1) {
       // Interestingly, inputElement.checked is reversed inside this event handler.
       this._performAction({

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -262,7 +262,16 @@ class RecordActionTool implements RecorderTool {
       return;
     }
 
-    const checkbox = asCheckbox(this._recorder.deepEventTarget(event));
+    const target = this._recorder.deepEventTarget(event);
+    if (target.nodeName === 'INPUT' && (target as HTMLInputElement).type.toLowerCase() === 'file') {
+      // Clicking the file input opens the file picker; a setInputFiles action will be
+      // recorded from the resulting change event. Recording the click here would also
+      // emit click() in the output, which opens an extra picker on replay that never closes.
+      this._cancelPendingClickAction();
+      return;
+    }
+
+    const checkbox = asCheckbox(target);
     if (checkbox && event.detail === 1) {
       // Interestingly, inputElement.checked is reversed inside this event handler.
       this._performAction({

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -97,6 +97,10 @@ export function shouldMergeAction(action: actions.ActionInContext, lastAction: a
       return isSameAction(action, lastAction);
     case 'click':
       return isSameAction(action, lastAction) && isSameSelector(action, lastAction) && isShortlyAfter(action, lastAction) && action.action.clickCount > (lastAction.action as actions.ClickAction).clickCount;
+    case 'setInputFiles':
+      // Drop the click that opens the file picker — setInputFiles already does it,
+      // and on replay the leftover click() opens an extra picker that never closes.
+      return lastAction.action.name === 'click' && isSameSelector(action, lastAction) && isShortlyAfter(action, lastAction);
   }
   return false;
 }

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -100,7 +100,9 @@ export function shouldMergeAction(action: actions.ActionInContext, lastAction: a
     case 'setInputFiles':
       // Drop the click that opens the file picker — setInputFiles already does it,
       // and on replay the leftover click() opens an extra picker that never closes.
-      return lastAction.action.name === 'click' && isSameSelector(action, lastAction) && isShortlyAfter(action, lastAction);
+      // No time check: picking a file from the OS dialog can take many seconds and
+      // no other recorder actions can run while the dialog is open.
+      return lastAction.action.name === 'click' && isSameSelector(action, lastAction);
   }
   return false;
 }

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -110,14 +110,18 @@ await page.CloseAsync();`);
     </form>
   `);
 
-    await page.focus('input[type=file]');
-    await page.setInputFiles('input[type=file]', asset('file-to-upload.txt'));
-    await page.click('input[type=file]');
+    await recorder.hoverOverElement('input[type=file]');
+    const [chooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      recorder.trustedClick(),
+    ]);
+    await chooser.setFiles(asset('file-to-upload.txt'));
 
     const sources = await recorder.waitForOutput('JavaScript', 'setInputFiles');
 
     expect(sources.get('JavaScript')!.text).toContain(`
   await page.getByRole('button', { name: 'Choose File' }).setInputFiles('file-to-upload.txt');`);
+    expect(sources.get('JavaScript')!.text).not.toContain(`click()`);
 
     expect(sources.get('Java')!.text).toContain(`
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Choose File")).setInputFiles(Paths.get("file-to-upload.txt"));`);

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -115,6 +115,9 @@ await page.CloseAsync();`);
       page.waitForEvent('filechooser'),
       recorder.trustedClick(),
     ]);
+    // Simulate the time a real user takes to pick a file from the OS dialog
+    // so the merge logic cannot rely on a short delay between click and setInputFiles.
+    await new Promise(f => setTimeout(f, 1000));
     await chooser.setFiles(asset('file-to-upload.txt'));
 
     const sources = await recorder.waitForOutput('JavaScript', 'setInputFiles');


### PR DESCRIPTION
## Summary
- Codegen no longer emits a redundant `click()` before `setInputFiles()` for `<input type="file">`. The click was generating an extra OS picker on replay that `setInputFiles()` doesn't close.

Fixes https://github.com/microsoft/playwright/issues/40854