### PR TITLE
fix(recorder): use light color-scheme for highlight overlay

### DIFF
--- a/packages/injected/src/highlight.css
+++ b/packages/injected/src/highlight.css
@@ -18,6 +18,7 @@
   font-size: 13px;
   font-family: system-ui, "Ubuntu", "Droid Sans", sans-serif;
   color: #333;
+  color-scheme: light;
 }
 
 svg {


### PR DESCRIPTION
## Summary
- Pin the codegen overlay's shadow DOM to `color-scheme: light` so the assert-text textarea's UA-default background stops inheriting `dark` from the host page, where it produced unreadable dark `#333` text on a dark background.

Fixes https://github.com/microsoft/playwright/issues/40857