### PR TITLE
Preserve AggregateError nested errors in reporter output

### DIFF
--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -36,17 +36,22 @@ import type { TestCase } from './common/test';
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core/package.json'));
 
-export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace> } {
+export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace>, errors?: ReturnType<typeof filterStackTrace>[] } {
   const name = e.name ? e.name + ': ' : '';
   const cause = e.cause instanceof Error ? filterStackTrace(e.cause) : undefined;
+  const errors = e instanceof AggregateError
+    ? e.errors.filter(error => error instanceof Error).map(error => filterStackTrace(error))
+    : undefined;
+
   if (process.env.PWDEBUGIMPL)
-    return { message: name + e.message, stack: e.stack || '', cause };
+    return { message: name + e.message, stack: e.stack || '', cause, errors };
 
   const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || []));
   return {
     message: name + e.message,
     stack: `${name}${e.message}${stackLines.map(line => '\n' + line).join('')}`,
     cause,
+    errors,
   };
 }
 

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -165,6 +165,27 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.output).toContain('afterAll executed successfully');
     });
 
+    test('should print AggregateError nested errors', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'a.spec.ts': `
+          import { test, expect } from '@playwright/test';
+    
+          test('foobar', async () => {
+            throw new AggregateError([
+              new Error('inner-message-1'),
+              new Error('inner-message-2'),
+            ], 'aggregate-message');
+          });
+        `
+      });
+    
+      expect(result.exitCode).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.output).toContain('AggregateError: aggregate-message');
+      expect(result.output).toContain('inner-message-1');
+      expect(result.output).toContain('inner-message-2');
+    });
+
     test('should print codeframe from a helper', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'helper.ts': `


### PR DESCRIPTION
Summary
Preserve `AggregateError.errors[]` entries when filtering and serializing stack traces for reporter output.
Previously, `filterStackTrace()` recursively preserved `error.cause`, but omitted nested errors contained in `AggregateError.errors[]`.

Changes
* Added recursive serialization support for `AggregateError.errors[]`
* Preserved nested aggregate sub-errors in reporter output
* Added regression coverage in `reporter-base.spec.ts`

Testing
* `npm run build`
* `npm run ttest -- tests/playwright-test/reporter-base.spec.ts`
