### PR TITLE
fix(test): import EventEmitter from 'events', not 'stream'

### DIFF
--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -16,7 +16,7 @@
 
 import path from 'path';
 import readline from 'readline';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 
 import { remote } from 'playwright-core/lib/coreBundle';
 import colors from 'colors/safe';


### PR DESCRIPTION
## Summary

`EventEmitter` is the documented named export of `node:events`. It is not part of the documented public surface of `node:stream` — Node's CJS interop happens to expose it transitively (because `stream`'s prototype chain reaches `EventEmitter`), but strict ESM analyzers reject the import statically as 'export not found'.

Switching `packages/playwright/src/runner/watchMode.ts` to import from `'events'` keeps behavior identical on Node and lets strict-analysis runtimes load the test runner without choking on this import.