### PR TITLE
fix(test): time out waiting for worker process to become ready

### DIFF
--- a/packages/playwright/src/runner/processHost.ts
+++ b/packages/playwright/src/runner/processHost.ts
@@ -118,11 +118,19 @@ export class ProcessHost extends EventEmitter {
     if (options.onStdErr)
       this.process.stderr?.on('data', options.onStdErr);
 
-    const error = await new Promise<ProcessExitData | undefined>(resolve => {
+    const readyTimeout = +(process.env.PWTEST_WORKER_READY_TIMEOUT || 60 * 1000);
+    const result = await raceAgainstDeadline(() => new Promise<ProcessExitData | undefined>(resolve => {
       this.process!.once('exit', (code, signal) => resolve({ unexpectedly: true, code, signal }));
       this.once('ready', () => resolve(undefined));
-    });
+    }), monotonicTime() + readyTimeout);
 
+    if (result.timedOut) {
+      this.emit('processError', { message: `Error: ${this._processName} process did not become ready within ${readyTimeout}ms. Set PWTEST_WORKER_READY_TIMEOUT to increase the timeout.` });
+      this._forceKill();
+      return { unexpectedly: true, code: null, signal: null };
+    }
+
+    const error = result.result;
     if (error)
       return error;
 


### PR DESCRIPTION
## Summary

`ProcessHost.startRunner` awaits a `ready` event from the freshly forked worker with no upper bound. If the worker never reaches the message channel — e.g. a preload crash, a sandboxed container that filters the IPC fd, or any other startup hang — the parent waits forever and the test run hangs with no diagnostic output.

Wrap the wait in `raceAgainstDeadline` (60s, overridable via `PWTEST_WORKER_READY_TIMEOUT`). On timeout, force-kill the child, emit a `processError` that points at the env var, and surface the failure as a normal worker exit so the run terminates with a clear, actionable error instead of hanging silently.

Behavior on the happy path is unchanged — workers normally reach `ready` in milliseconds, far under the 60s default.

Verified locally: a normal run passes; setting `PWTEST_WORKER_READY_TIMEOUT=1` produces the expected timeout error and the runner exits cleanly.