### PR TITLE
fix: fallback Ubuntu 26.04 to Ubuntu 24.04 browser builds

### DIFF
--- a/packages/utils/hostPlatform.ts
+++ b/packages/utils/hostPlatform.ts
@@ -93,7 +93,7 @@ function calculatePlatform(): { hostPlatform: HostPlatform, isOfficiallySupporte
         return { hostPlatform: ('ubuntu22.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: isUbuntu && version === '22.04' };
       if (major < 26)
         return { hostPlatform: ('ubuntu24.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: isUbuntu && version === '24.04' };
-      return { hostPlatform: ('ubuntu' + distroInfo.version + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
+       return { hostPlatform: ('ubuntu24.04' + archSuffix) as HostPlatform, isOfficiallySupportedPlatform: false };
     }
     // Linux Mint is ubuntu-based but does not have the same versions
     if (distroInfo?.id === 'linuxmint') {


### PR DESCRIPTION
Fixes #40117.

Ubuntu 26.04 currently resolves to `ubuntu26.04-x64`, but the browser download registry only defines Ubuntu entries up to `ubuntu24.04-*`. As a result, installing Chromium fails with:

```text
ERROR: Playwright does not support chromium on ubuntu26.04-x64

This change makes Ubuntu 26.04 and newer fall back to the existing Ubuntu 24.04 browser builds, while keeping isOfficiallySupportedPlatform: false until dedicated Ubuntu 26.04 support is added.