### PR TITLE
docs: include 's' in Locators hyperlink on locators.md

### DIFF
--- a/docs/src/locators.md
+++ b/docs/src/locators.md
@@ -5,7 +5,7 @@ title: "Locators"
 
 ## Introduction
 
-[Locator]s are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent
+[Locators][Locator] are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent
 a way to find element(s) on the page at any moment.
 
 ### Quick Guide


### PR DESCRIPTION
## Summary of Changes

Fixed the hyperlink wording in `docs/src/locators.md` where `[Locator]s` rendered the word "Locators" with only "Locator" linked and the trailing "s" outside the link. Changed to `[Locators][Locator]` which now links the entire word.

## Root Cause / What Was Fixed

The markdown reference-style link `[Locator]s` placed the 's' outside the link brackets, making it visually out of place:
- **Before**: `[Locator]s` → renders as [Locator](link)s
- **After**: `[Locators][Locator]` → renders as [Locators](link)

## Testing Done

- Verified the markdown syntax is valid (reference link `[Locators][Locator]` correctly resolves to the `[Locator]` definition)
- Single-line change, no impact on other content

## Related Issue

Closes microsoft/playwright-python#3077
