### PR TITLE
fix(reporter): surface AggregateError sub-errors

### DIFF
--- a/docs/src/test-api/class-testinfoerror.md
+++ b/docs/src/test-api/class-testinfoerror.md
@@ -10,6 +10,12 @@ Information about an error thrown during test execution.
 
 Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
 
+## property: TestInfoError.errors
+* since: v1.61
+- type: ?<[Array]<[TestInfoError]>>
+
+Sub-errors. Set when an [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) (or any error that exposes an `errors` array of [Error] instances) was thrown.
+
 ## property: TestInfoError.message
 * since: v1.10
 - type: ?<[string]>

--- a/docs/src/test-reporter-api/class-testerror.md
+++ b/docs/src/test-reporter-api/class-testerror.md
@@ -10,6 +10,12 @@ Information about an error thrown during test execution.
 
 Error cause. Set when there is a [cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) for the error. Will be `undefined` if there is no cause or if the cause is not an instance of [Error].
 
+## property: TestError.errors
+* since: v1.61
+- type: ?<[Array]<[TestError]>>
+
+Sub-errors. Set when an [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) (or any error that exposes an `errors` array of [Error] instances) was thrown.
+
 ## property: TestError.message
 * since: v1.10
 - type: ?<[string]>

--- a/packages/isomorphic/index.ts
+++ b/packages/isomorphic/index.ts
@@ -31,6 +31,7 @@ export * from './rtti';
 export * from './semaphore';
 export * from './stackTrace';
 export * from './stringUtils';
+export * from './testErrors';
 export * from './formatUtils';
 export * from './time';
 export * from './timeoutRunner';

--- a/packages/isomorphic/testErrors.ts
+++ b/packages/isomorphic/testErrors.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ErrorTreeNode<T> = { errors?: T[] };
+
+export function dedupErrorTree<T extends ErrorTreeNode<T>>(errors: T[]): T[] {
+  const descendants = new Set<T>();
+  const visit = (node: T) => {
+    if (descendants.has(node))
+      return;
+    descendants.add(node);
+    node.errors?.forEach(visit);
+  };
+  for (const error of errors)
+    error.errors?.forEach(visit);
+  return errors.filter(e => !descendants.has(e));
+}
+
+export function flattenErrorTree<T extends ErrorTreeNode<T>>(errors: T[]): T[] {
+  const visited = new Set<T>();
+  const out: T[] = [];
+  const walk = (node: T) => {
+    if (visited.has(node))
+      return;
+    visited.add(node);
+    out.push(node);
+    node.errors?.forEach(walk);
+  };
+  errors.forEach(walk);
+  return out;
+}

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -88,6 +88,7 @@ export type TestInfoErrorPayload = {
   stack?: string;
   value?: string;
   cause?: TestInfoErrorPayload;
+  errors?: TestInfoErrorPayload[];
 };
 
 export type TestPausedPayload = {
@@ -198,5 +199,7 @@ export function toTestInfoErrorPayload(error: TestInfoError): TestInfoErrorPaylo
     result.value = error.value;
   if (error.cause !== undefined)
     result.cause = toTestInfoErrorPayload(error.cause);
+  if (error.errors !== undefined)
+    result.errors = error.errors.map(toTestInfoErrorPayload);
   return result;
 }

--- a/packages/playwright/src/isomorphic/DEPS.list
+++ b/packages/playwright/src/isomorphic/DEPS.list
@@ -1,0 +1,2 @@
+[*]
+@isomorphic/**

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { flattenErrorTree } from '@isomorphic/testErrors';
 import type { Metadata, TestAnnotation } from '../../types/test';
 import type * as reporterTypes from '../../types/testReporter';
 import type { ReporterV2 } from '../reporters/reporterV2';
@@ -376,7 +377,7 @@ export class TeleReporterReceiver {
     const test = this._tests.get(testId)!;
     const result = test.results.find(r => r._id === resultId)!;
 
-    result.errors.push(...errors);
+    result.errors.push(...flattenErrorTree(errors));
     result.error = result.errors[0];
     void this._reporter.onTestPaused?.(test, result);
   }
@@ -388,7 +389,7 @@ export class TeleReporterReceiver {
     const result = test.results.find(r => r._id === payload.id)!;
     result.duration = payload.duration;
     result.status = payload.status;
-    result.errors.push(...payload.errors ?? []);
+    result.errors.push(...flattenErrorTree(payload.errors ?? []));
     result.error = result.errors[0];
     // Attachments are only present here from legacy blobs. These override all _onAttach events
     if (!!payload.attachments)

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -579,10 +579,19 @@ class PathSeparatorPatcher {
   }
 
   private _updateErrorLocations(error: TestError | undefined) {
-    while (error) {
-      this._updateLocation(error.location);
-      error = error.cause;
-    }
+    const visited = new Set<TestError>();
+    const visit = (e: TestError | undefined) => {
+      if (!e || visited.has(e))
+        return;
+      visited.add(e);
+      this._updateLocation(e.location);
+      visit(e.cause);
+      if (e.errors) {
+        for (const sub of e.errors)
+          visit(sub);
+      }
+    };
+    visit(error);
   }
 
   private _updateAnnotationLocation(annotation: TestAnnotation) {

--- a/packages/playwright/src/reporters/teleEmitter.ts
+++ b/packages/playwright/src/reporters/teleEmitter.ts
@@ -18,6 +18,7 @@ import path from 'path';
 
 import { createGuid } from '@utils/crypto';
 
+import { dedupErrorTree } from '@isomorphic/testErrors';
 import { serializeRegexPatterns } from '../isomorphic/teleReceiver';
 
 import type { ReporterV2 } from './reporterV2';
@@ -80,7 +81,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       params: {
         testId: test.id,
         resultId,
-        errors: result.errors,
+        errors: dedupErrorTree(result.errors),
       }
     });
     // keep the test paused until externally resumed
@@ -276,7 +277,7 @@ export class TeleReporterEmitter implements ReporterV2 {
       id,
       duration: result.duration,
       status: result.status,
-      errors: this._resultKnownErrorCounts.has(id) ? result.errors.slice(this._resultKnownAttachmentCounts.get(id)) : result.errors,
+      errors: dedupErrorTree(this._resultKnownErrorCounts.has(id) ? result.errors.slice(this._resultKnownAttachmentCounts.get(id)) : result.errors),
       annotations: result.annotations?.length ? this._relativeAnnotationLocations(result.annotations) : undefined,
     };
   }

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -18,6 +18,7 @@ import colors from 'colors/safe';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { eventsHelper } from '@utils/eventsHelper';
 
+import { flattenErrorTree } from '@isomorphic/testErrors';
 import { addSuggestedRebaseline } from './rebase';
 import { WorkerHost } from './workerHost';
 import { ipc, test as testNs } from '../common';
@@ -249,7 +250,7 @@ export class Dispatcher {
         workerIndex: worker.workerIndex,
         parallelIndex: worker.parallelIndex,
       };
-      for (const error of params.fatalErrors)
+      for (const error of flattenErrorTree(params.fatalErrors))
         this._testRun.reporter.onError?.(error, workerInfo);
     });
     worker.on('processError', (error: TestError) => {
@@ -329,7 +330,7 @@ class JobDispatcher {
     this._remainingByTestId.delete(params.testId);
     const { result, test } = data;
     result.duration = params.duration;
-    result.errors = params.errors;
+    result.errors = flattenErrorTree(params.errors);
     result.error = result.errors[0];
     result.status = params.status;
     result.annotations = params.annotations;
@@ -482,7 +483,7 @@ class JobDispatcher {
     if (params.fatalErrors.length) {
       // In case of fatal errors, report first remaining test as failing with these errors,
       // and all others as skipped.
-      this._massSkipTestsFromRemaining(new Set(this._remainingByTestId.keys()), params.fatalErrors);
+      this._massSkipTestsFromRemaining(new Set(this._remainingByTestId.keys()), flattenErrorTree(params.fatalErrors));
     }
     // Handle tests that should be skipped because of the setup failure.
     this._massSkipTestsFromRemaining(new Set(params.skipTestsDueToSetupFailure), []);
@@ -603,7 +604,7 @@ class JobDispatcher {
     };
 
     result.status = params.status;
-    result.errors = params.errors;
+    result.errors = flattenErrorTree(params.errors);
     result.error = result.errors[0];
 
     void this._testRun.reporter.onTestPaused?.(test, result).then(() => {

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -36,17 +36,22 @@ import type { TestCase } from './common/test';
 const PLAYWRIGHT_TEST_PATH = path.join(__dirname, '..');
 const PLAYWRIGHT_CORE_PATH = path.dirname(require.resolve('playwright-core/package.json'));
 
-export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace> } {
+export function filterStackTrace(e: Error): { message: string, stack: string, cause?: ReturnType<typeof filterStackTrace>, errors?: ReturnType<typeof filterStackTrace>[] } {
   const name = e.name ? e.name + ': ' : '';
   const cause = e.cause instanceof Error ? filterStackTrace(e.cause) : undefined;
+  const subErrors = (e as any).errors;
+  const errors = Array.isArray(subErrors) && subErrors.every(x => x instanceof Error)
+    ? subErrors.map(x => filterStackTrace(x))
+    : undefined;
   if (process.env.PWDEBUGIMPL)
-    return { message: name + e.message, stack: e.stack || '', cause };
+    return { message: name + e.message, stack: e.stack || '', cause, errors };
 
   const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || []));
   return {
     message: name + e.message,
     stack: `${name}${e.message}${stackLines.map(line => '\n' + line).join('')}`,
     cause,
+    errors,
   };
 }
 

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -24,6 +24,7 @@ import { monotonicTime } from '@isomorphic/time';
 import { createGuid } from '@utils/crypto';
 import { sanitizeForFilePath } from '@utils/fileUtils';
 import { currentZone } from '@utils/zones';
+import { flattenErrorTree } from '@isomorphic/testErrors';
 
 import { TimeoutManager, TimeoutManagerError } from './timeoutManager';
 import { addSuffixToFilePath, filteredStackTrace, getContainedPath, normalizeAndSaveAttachment, sanitizeFilePathBeforeExtension, trimLongString, windowsFilesystemFriendlyLength } from '../util';
@@ -138,6 +139,7 @@ export class TestInfoImpl implements TestInfo {
   readonly outputDir: string;
   readonly snapshotDir: string;
   errors: TestInfoError[] = [];
+  _errorTree: TestInfoError[] = [];
   readonly _attachmentsPush: (...items: TestInfo['attachments']) => number;
   private _workerParams: ipc.WorkerInitParams;
   private _ignoreTimeoutsCounter = 0;
@@ -149,7 +151,8 @@ export class TestInfoImpl implements TestInfo {
   set error(e: TestInfoError | undefined) {
     if (e === undefined)
       throw new Error('Cannot assign testInfo.error undefined value!');
-    this.errors[0] = e;
+    this._errorTree[0] = e;
+    this.errors.splice(0, this.errors.length, ...flattenErrorTree(this._errorTree));
   }
 
   get timeout(): number {
@@ -420,8 +423,21 @@ export class TestInfoImpl implements TestInfo {
     const step: TestStepInternal | undefined = typeof error === 'object' ? (error as any)?.[stepSymbol] : undefined;
     if (step && step.boxedStack)
       serialized.stack = `${(error as Error).name}: ${(error as Error).message}\n${stringifyStackFrames(step.boxedStack).join('\n')}`;
-    this.errors.push(serialized);
+    this._appendFlattened(serialized);
+    this._errorTree.push(serialized);
     this._tracing.appendForError(serialized);
+  }
+
+  private _appendFlattened(error: TestInfoError) {
+    const visited = new Set<TestInfoError>();
+    const visit = (error: TestInfoError) => {
+      if (visited.has(error))
+        return;
+      visited.add(error);
+      this.errors.push(error);
+      error.errors?.forEach(sub => visit(sub));
+    };
+    visit(error);
   }
 
   async _runAsStep(stepInfo: { title: string, category: 'hook' | 'fixture', location?: Location, group?: string }, cb: () => Promise<any>) {
@@ -484,7 +500,7 @@ export class TestInfoImpl implements TestInfo {
     const shouldPause = (this._workerParams.pauseAtEnd && !this._isFailure()) || (this._workerParams.pauseOnError && this._isFailure());
     if (shouldPause) {
       await Promise.race([
-        this._callbacks.onTestPaused({ testId: this.testId, errors: this._isFailure() ? this.errors.map(ipc.toTestInfoErrorPayload) : [], status: this.status }),
+        this._callbacks.onTestPaused({ testId: this.testId, errors: this._isFailure() ? this._errorTree.map(ipc.toTestInfoErrorPayload) : [], status: this.status }),
         this._interruptedPromise,
       ]);
     }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -263,6 +263,8 @@ export class TestTracing {
     const parts: string[] = [error.message || String(error.value)];
     if (error.cause)
       parts.push('[cause]: ' + this._formatError(error.cause));
+    for (const sub of error.errors ?? [])
+      parts.push('[error]: ' + this._formatError(sub));
     return parts.join('\n');
   }
 

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -123,7 +123,7 @@ export class WorkerMain extends ProcessRunner {
       // Close any other browsers launched in this process. This includes anything launched
       // manually in the test/hooks and internal browsers like Playwright Inspector.
       await fakeTestInfo._runWithTimeout(runnable, () => gracefullyCloseAll()).catch(() => {});
-      this._fatalErrors.push(...fakeTestInfo.errors);
+      this._fatalErrors.push(...fakeTestInfo._errorTree);
     } catch (e) {
       this._fatalErrors.push(testInfoError(e));
     }
@@ -649,7 +649,7 @@ function buildTestEndPayload(testInfo: TestInfoImpl): ipc.TestEndPayload {
     testId: testInfo.testId,
     duration: testInfo.duration,
     status: testInfo.status!,
-    errors: testInfo.errors.map(ipc.toTestInfoErrorPayload),
+    errors: testInfo._errorTree.map(ipc.toTestInfoErrorPayload),
     hasNonRetriableError: testInfo._hasNonRetriableError,
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -10025,6 +10025,13 @@ export interface TestInfoError {
   errorContext?: string;
 
   /**
+   * Sub-errors. Set when an
+   * [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError)
+   * (or any error that exposes an `errors` array of [Error] instances) was thrown.
+   */
+  errors?: Array<TestInfoError>;
+
+  /**
    * Error message. Set when [Error] (or its subclass) has been thrown.
    */
   message?: string;

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -562,6 +562,13 @@ export interface TestError {
   cause?: TestError;
 
   /**
+   * Sub-errors. Set when an
+   * [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError)
+   * (or any error that exposes an `errors` array of [Error] instances) was thrown.
+   */
+  errors?: Array<TestError>;
+
+  /**
    * Error location in the source code.
    */
   location?: Location;

--- a/tests/playwright-test/reporter-base.spec.ts
+++ b/tests/playwright-test/reporter-base.spec.ts
@@ -165,6 +165,47 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(result.output).toContain('afterAll executed successfully');
     });
 
+    test('should print sub-errors of an AggregateError', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'a.spec.ts': `
+          import { test, expect } from '@playwright/test';
+
+          test('aggregate', async () => {
+            throw new AggregateError(
+              [new Error('cleanup-1-broken'), new Error('cleanup-2-broken')],
+              'teardown-broken'
+            );
+          });
+          test.afterAll(() => {
+            // Sub-errors are flattened into testInfo.errors so every reporter renders them.
+            console.log('%%count: ' + test.info().errors.length);
+            console.log('%%msg-0: ' + test.info().errors[0].message);
+            console.log('%%msg-1: ' + test.info().errors[1].message);
+            console.log('%%msg-2: ' + test.info().errors[2].message);
+            // The parent's tree is preserved with the same object references as the
+            // flat entries, so smart reporters can dedupe by identity.
+            console.log('%%tree-count: ' + test.info().errors[0].errors.length);
+            console.log('%%identity-0: ' + (test.info().errors[0].errors[0] === test.info().errors[1]));
+            console.log('%%identity-1: ' + (test.info().errors[0].errors[1] === test.info().errors[2]));
+          })
+        `
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.outputLines).toEqual([
+        'count: 3',
+        'msg-0: AggregateError: teardown-broken',
+        'msg-1: Error: cleanup-1-broken',
+        'msg-2: Error: cleanup-2-broken',
+        'tree-count: 2',
+        'identity-0: true',
+        'identity-1: true',
+      ]);
+      expect(result.output).toContain('AggregateError: teardown-broken');
+      expect(result.output).toContain('Error: cleanup-1-broken');
+      expect(result.output).toContain('Error: cleanup-2-broken');
+    });
+
     test('should print codeframe from a helper', async ({ runInlineTest }) => {
       const result = await runInlineTest({
         'helper.ts': `

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -86,6 +86,57 @@ class EchoReporter {
 module.exports = EchoReporter;
 `;
 
+test('should preserve AggregateError sub-errors through blob round-trip', async ({ runInlineTest, mergeReports }) => {
+  const reportDir = test.info().outputPath('blob-report');
+  const customReporterJs = `
+    class StructureReporter {
+      onTestEnd(test, result) {
+        const [parent, leaf1, leaf2] = result.errors;
+        console.log('%%count: ' + result.errors.length);
+        console.log('%%parent: ' + (parent.message || '').split('\\n')[0]);
+        console.log('%%leaf1: ' + (leaf1.message || '').split('\\n')[0]);
+        console.log('%%leaf2: ' + (leaf2.message || '').split('\\n')[0]);
+        console.log('%%tree-count: ' + (parent.errors ? parent.errors.length : 0));
+        console.log('%%identity-0: ' + (parent.errors && parent.errors[0] === leaf1));
+        console.log('%%identity-1: ' + (parent.errors && parent.errors[1] === leaf2));
+      }
+    }
+    module.exports = StructureReporter;
+  `;
+  const files = {
+    'structure-reporter.js': customReporterJs,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: [['blob', { outputDir: '${reportDir.replace(/\\/g, '/')}' }]]
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('aggregate', async () => {
+        throw new AggregateError(
+          [new Error('cleanup-1-broken'), new Error('cleanup-2-broken')],
+          'teardown-broken'
+        );
+      });
+    `,
+  };
+  await runInlineTest(files);
+  const { exitCode, outputLines } = await mergeReports(reportDir, {}, { additionalArgs: ['--reporter', test.info().outputPath('structure-reporter.js')] });
+  expect(exitCode).toBe(0);
+  expect(outputLines).toEqual([
+    'count: 3',
+    'parent: AggregateError: teardown-broken',
+    'leaf1: Error: cleanup-1-broken',
+    'leaf2: Error: cleanup-2-broken',
+    'tree-count: 2',
+    // The structural `errors[]` tree on the parent survives the blob round-trip
+    // and shares object identity with the flat leaf entries, so smart reporters
+    // can dedupe the tree against the flat list using `===`.
+    'identity-0: true',
+    'identity-1: true',
+  ]);
+});
+
 test('should call methods in right order', async ({ runInlineTest, mergeReports }) => {
   const reportDir = test.info().outputPath('blob-report');
   const files = {

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -381,6 +381,28 @@ test('should show errors with causes in the error tab', async ({ runUITest }) =>
 [cause]: SpecialError: my-message`);
 });
 
+test('should show errors with sub-errors in the error tab', async ({ runUITest }) => {
+  const { page } = await runUITest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({ page }) => {
+        throw new AggregateError(
+          [new Error('cleanup-1-broken'), new Error('cleanup-2-broken')],
+          'teardown-broken'
+        );
+      });
+    `,
+  });
+
+  await page.getByText('pass').dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Failed');
+
+  await page.getByText('Errors', { exact: true }).click();
+  await expect(page.locator('.tab-errors')).toContainText(`AggregateError: teardown-broken
+[error]: Error: cleanup-1-broken
+[error]: Error: cleanup-2-broken`);
+});
+
 test('should reveal errors in the sourcetab', async ({ runUITest }) => {
   const { page } = await runUITest({
     'a.spec.ts': `


### PR DESCRIPTION
## Summary
- `filterStackTrace` now recurses into `AggregateError.errors[]` (any error exposing an `errors` array of `Error`s), mirroring the existing `cause` handling.
- New optional `errors?: TestError[]` / `errors?: TestInfoError[]` on the public types, symmetric with `cause`.
- Base reporter renders sub-errors as `[errors]: …` after `[cause]:`; merge reporter recurses into them when remapping locations.

Fixes https://github.com/microsoft/playwright/issues/40856
