### PR TITLE
docs: fix Firefox patch comment typos

### DIFF
--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -317,7 +317,7 @@ export class PageHandler {
     const rect = new DOMRect(clip.x, clip.y, clip.width, clip.height);
 
     const browsingContext = this._pageTarget.linkedBrowser().browsingContext;
-    // `win.devicePixelRatio` returns a non-overriden value to priveleged code.
+    // `win.devicePixelRatio` returns a non-overridden value to privileged code.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1761032
     // See https://phabricator.services.mozilla.com/D141323
     const devicePixelRatio = browsingContext.overrideDPPX || this._pageTarget._window.devicePixelRatio;


### PR DESCRIPTION
## Summary

Fixes two spelling typos in a comment in the Firefox page handler patch.

## Files changed

- `browser_patches/firefox/juggler/protocol/PageHandler.js`: `non-overriden` -> `non-overridden`, `priveleged` -> `privileged`

## Before / after

Before, the comment describing the `devicePixelRatio` behavior contained two misspellings. After, the comment text is corrected with no behavior change.

## Verification

- Inspected the diff to confirm this is a comment-only change.
- Ran `rg "overriden|priveleged" browser_patches/firefox/juggler/protocol/PageHandler.js` and confirmed no matches.

## Competing PR check

Checked for existing PRs with:

- `gh pr list --repo microsoft/playwright --search "priveleged PageHandler" --state all --limit 10`
- `gh pr list --repo microsoft/playwright --search "overriden devicePixelRatio" --state all --limit 10`

No matching PRs were returned.