### PR TITLE
fix(recorder): skip click on file inputs and use hoveredModel

### DIFF
--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -615,13 +615,7 @@ class RecordActionTool implements RecorderTool {
   }
 
   private _shouldIgnoreMouseEvent(event: MouseEvent): boolean {
-    const target = this._recorder.deepEventTarget(event);
-    const nodeName = target.nodeName;
-    if (nodeName === 'SELECT' || nodeName === 'OPTION')
-      return true;
-    if (nodeName === 'INPUT' && ['color', 'date', 'datetime-local', 'file', 'month', 'range', 'time', 'week'].includes((target as HTMLInputElement).type))
-      return true;
-    return false;
+    return shouldIgnoreMouseEvent(this._recorder.deepEventTarget(event));
   }
 
   private _actionInProgress(event: Event): boolean {
@@ -892,13 +886,7 @@ class JsonRecordActionTool implements RecorderTool {
   }
 
   private _shouldIgnoreMouseEvent(event: MouseEvent): boolean {
-    const target = this._recorder.deepEventTarget(event);
-    const nodeName = target.nodeName;
-    if (nodeName === 'SELECT' || nodeName === 'OPTION')
-      return true;
-    if (nodeName === 'INPUT' && ['color', 'date', 'datetime-local', 'file', 'month', 'range', 'time', 'week'].includes((target as HTMLInputElement).type))
-      return true;
-    return false;
+    return shouldIgnoreMouseEvent(this._recorder.deepEventTarget(event));
   }
 
   private _shouldGenerateKeyPressFor(event: KeyboardEvent): boolean {
@@ -1885,6 +1873,18 @@ function isRangeInput(node: Node | null): node is HTMLInputElement {
     return false;
   const inputElement = node as HTMLInputElement;
   return inputElement.type.toLowerCase() === 'range';
+}
+
+// Non-text input types that open native pickers.
+const kNativePickerInputTypes = new Set(['color', 'date', 'datetime-local', 'file', 'month', 'range', 'time', 'week']);
+
+function shouldIgnoreMouseEvent(target: Node): boolean {
+  const nodeName = target.nodeName;
+  if (nodeName === 'SELECT' || nodeName === 'OPTION')
+    return true;
+  if (nodeName === 'INPUT' && kNativePickerInputTypes.has((target as HTMLInputElement).type))
+    return true;
+  return false;
 }
 
 function addEventListener(target: EventTarget, eventName: string, listener: EventListener, useCapture?: boolean): () => void {

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -619,7 +619,7 @@ class RecordActionTool implements RecorderTool {
     const nodeName = target.nodeName;
     if (nodeName === 'SELECT' || nodeName === 'OPTION')
       return true;
-    if (nodeName === 'INPUT' && ['date', 'range', 'file'].includes((target as HTMLInputElement).type))
+    if (nodeName === 'INPUT' && ['color', 'date', 'datetime-local', 'file', 'month', 'range', 'time', 'week'].includes((target as HTMLInputElement).type))
       return true;
     return false;
   }
@@ -896,7 +896,7 @@ class JsonRecordActionTool implements RecorderTool {
     const nodeName = target.nodeName;
     if (nodeName === 'SELECT' || nodeName === 'OPTION')
       return true;
-    if (nodeName === 'INPUT' && ['date', 'range', 'file'].includes((target as HTMLInputElement).type))
+    if (nodeName === 'INPUT' && ['color', 'date', 'datetime-local', 'file', 'month', 'range', 'time', 'week'].includes((target as HTMLInputElement).type))
       return true;
     return false;
   }

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -414,7 +414,8 @@ class RecordActionTool implements RecorderTool {
     if (target.nodeName === 'INPUT' && (target as HTMLInputElement).type.toLowerCase() === 'file') {
       this._recordAction({
         name: 'setInputFiles',
-        selector: this._activeModel!.selector,
+        // webkit doesn't focus file inputs on click, so activeModel is unreliable here.
+        selector: this._hoveredModel!.selector,
         signals: [],
         files: [...((target as HTMLInputElement).files || [])].map(file => file.name),
       });
@@ -618,7 +619,7 @@ class RecordActionTool implements RecorderTool {
     const nodeName = target.nodeName;
     if (nodeName === 'SELECT' || nodeName === 'OPTION')
       return true;
-    if (nodeName === 'INPUT' && ['date', 'range'].includes((target as HTMLInputElement).type))
+    if (nodeName === 'INPUT' && ['date', 'range', 'file'].includes((target as HTMLInputElement).type))
       return true;
     return false;
   }
@@ -895,7 +896,7 @@ class JsonRecordActionTool implements RecorderTool {
     const nodeName = target.nodeName;
     if (nodeName === 'SELECT' || nodeName === 'OPTION')
       return true;
-    if (nodeName === 'INPUT' && ['date', 'range'].includes((target as HTMLInputElement).type))
+    if (nodeName === 'INPUT' && ['date', 'range', 'file'].includes((target as HTMLInputElement).type))
       return true;
     return false;
   }

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -97,12 +97,6 @@ export function shouldMergeAction(action: actions.ActionInContext, lastAction: a
       return isSameAction(action, lastAction);
     case 'click':
       return isSameAction(action, lastAction) && isSameSelector(action, lastAction) && isShortlyAfter(action, lastAction) && action.action.clickCount > (lastAction.action as actions.ClickAction).clickCount;
-    case 'setInputFiles':
-      // Drop the click that opens the file picker — setInputFiles already does it,
-      // and on replay the leftover click() opens an extra picker that never closes.
-      // No time check: picking a file from the OS dialog can take many seconds and
-      // no other recorder actions can run while the dialog is open.
-      return lastAction.action.name === 'click' && isSameSelector(action, lastAction);
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Fixes recurring `cli-codegen-2.spec.ts:105 "should upload a single file"` failure on every webkit-headless CI run (windows-latest, macos-15, macos-26) since #40861 landed.
- Adds `'file'` to the recorder's ignored mouse-event input types alongside `'date'` and `'range'`, so the click that opens the file picker is never recorded. Replaces the post-hoc click+setInputFiles merge from #40861, which relied on selectors matching — a property that doesn't hold on WebKit headless.
- Uses `_hoveredModel` instead of `_activeModel` for setInputFiles, mirroring range inputs. WebKit doesn't focus file inputs on click, so `_activeModel` is unreliable.

Refs https://github.com/microsoft/playwright/issues/40854