### PR TITLE
fix(screenshotter): race cleanup against progress to honor timeout

### DIFF
--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -218,7 +218,7 @@ export class Screenshotter {
         const viewportRect = options.clip ? trimClipToSize(options.clip, viewportSize) : { x: 0, y: 0, ...viewportSize };
         return await this._screenshot(progress, format, undefined, viewportRect, true, options);
       } finally {
-        await this._restorePageAfterScreenshot();
+        await progress.race(this._restorePageAfterScreenshot()).catch(() => {});
       }
     });
   }
@@ -245,7 +245,7 @@ export class Screenshotter {
         documentRect.y += scrollOffset.y;
         return await this._screenshot(progress, format, helper.enclosingIntRect(documentRect), undefined, fitsViewport, options);
       } finally {
-        await this._restorePageAfterScreenshot();
+        await progress.race(this._restorePageAfterScreenshot()).catch(() => {});
       }
     });
   }

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -211,6 +211,16 @@ browserTest.describe('page screenshot', () => {
     expect(pixel(0, 999).r).toBeLessThan(128);
     expect(pixel(0, 999).b).toBeGreaterThan(128);
   });
+
+  browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page }) => {
+    browserTest.setTimeout(5000);
+    await page.evaluate(() => {
+      setTimeout(() => {
+        while (true) {}
+      }, 10);
+    });
+    await expect(page.screenshot({ fullPage: true, timeout: 200 })).rejects.toThrow(/page.screenshot: Timeout 200ms exceeded/);
+  });
 });
 
 browserTest.describe('element screenshot', () => {


### PR DESCRIPTION
Cleanup in `screenshotPage` / `screenshotElement` `finally` blocks was not raced against `progress`. When the renderer's event loop is blocked, `nonStallingEvaluateInExistingContext` only races against navigation / open dialogs — not arbitrary timeouts — so cleanup would hang indefinitely and swallow the timeout error.

Fixes https://github.com/microsoft/playwright/issues/36702