### PR TITLE
fix(reporter): honor NO_COLOR in list/line/dot reporters

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -104,6 +104,7 @@ List report supports the following configuration options and environment variabl
 | `PLAYWRIGHT_LIST_PRINT_STEPS` | `printSteps` | Whether to print each step on its own line. | `false`
 | `PLAYWRIGHT_FORCE_TTY` | | Whether to produce output suitable for a live terminal. Supports `true`, `1`, `false`, `0`, `[WIDTH]`, and `[WIDTH]x[HEIGHT]`. `[WIDTH]` and `[WIDTH]x[HEIGHT]` specifies the TTY dimensions. | `true` when terminal is in TTY mode, `false` otherwise.
 | `FORCE_COLOR` | | Whether to produce colored output. | `true` when terminal is in TTY mode, `false` otherwise.
+| `NO_COLOR` | | Whether to disable colored output ([no-color.org](https://no-color.org/)). Any non-empty value disables colors. | unset
 
 
 ### Line reporter
@@ -142,6 +143,7 @@ Line report supports the following configuration options and environment variabl
 |---|---|---|---|
 | `PLAYWRIGHT_FORCE_TTY` | | Whether to produce output suitable for a live terminal. Supports `true`, `1`, `false`, `0`, `[WIDTH]`, and `[WIDTH]x[HEIGHT]`. `[WIDTH]` and `[WIDTH]x[HEIGHT]` specifies the TTY dimensions. | `true` when terminal is in TTY mode, `false` otherwise.
 | `FORCE_COLOR` | | Whether to produce colored output. | `true` when terminal is in TTY mode, `false` otherwise.
+| `NO_COLOR` | | Whether to disable colored output ([no-color.org](https://no-color.org/)). Any non-empty value disables colors. | unset
 
 
 ### Dot reporter
@@ -184,6 +186,7 @@ Dot report supports the following configuration options and environment variable
 |---|---|---|---|
 | `PLAYWRIGHT_FORCE_TTY` | | Whether to produce output suitable for a live terminal. Supports `true`, `1`, `false`, `0`, `[WIDTH]`, and `[WIDTH]x[HEIGHT]`. `[WIDTH]` and `[WIDTH]x[HEIGHT]` specifies the TTY dimensions. | `true` when terminal is in TTY mode, `false` otherwise.
 | `FORCE_COLOR` | | Whether to produce colored output. | `true` when terminal is in TTY mode, `false` otherwise.
+| `NO_COLOR` | | Whether to disable colored output ([no-color.org](https://no-color.org/)). Any non-empty value disables colors. | unset
 
 ### HTML reporter
 

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -122,7 +122,8 @@ export const terminalScreen: TerminalScreen = (() => {
 
   let useColors = isTTY;
   if (process.env.DEBUG_COLORS === '0' || process.env.DEBUG_COLORS === 'false' ||
-      process.env.FORCE_COLOR === '0' || process.env.FORCE_COLOR === 'false')
+      process.env.FORCE_COLOR === '0' || process.env.FORCE_COLOR === 'false' ||
+      (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== ''))
     useColors = false;
   else if (process.env.DEBUG_COLORS || process.env.FORCE_COLOR)
     useColors = true;

--- a/tests/playwright-test/reporter-list.spec.ts
+++ b/tests/playwright-test/reporter-list.spec.ts
@@ -568,6 +568,21 @@ test('strips ansi from test stdout when FORCE_COLOR=0', async ({ runInlineTest }
   expect(result.rawOutput).toContain('GREENDOTEND');
 });
 
+test('strips ansi from test stdout when NO_COLOR is set', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passes', async ({}) => {
+        console.log('\\u001b[31mRED\\u001b[39mWHITE');
+        process.stderr.write('GREEN\\u001b[32mDOT\\u001b[39mEND\\n');
+      });
+    `,
+  }, { reporter: 'list' }, { NO_COLOR: '1', FORCE_COLOR: '', PLAYWRIGHT_FORCE_TTY: '80' });
+  expect(result.exitCode).toBe(0);
+  expect(result.rawOutput).toContain('REDWHITE');
+  expect(result.rawOutput).toContain('GREENDOTEND');
+});
+
 function simpleAnsiRenderer(text, ttyWidth) {
   let lineNumber = 0;
   let columnNumber = 0;


### PR DESCRIPTION
### Context

Per the [NO_COLOR convention](https://no-color.org/), any non-empty `NO_COLOR` value should disable ANSI color output. Playwright's bundled chalk honors that internally, but code in `packages/playwright/src/reporters/base.ts` that consults `useColors` doesn't — so e.g. the `StripAnsiStream` wrapper introduced in [#40688](https://github.com/microsoft/playwright/pull/40688) only kicks in when `FORCE_COLOR=0` is also set.

### What

`NO_COLOR` added to the existing `useColors` disabling branch in `terminalScreen`. Any non-empty `NO_COLOR` now disables colors, matching chalk's behavior and the no-color.org spec.

`isTTY` is left unchanged — no-color.org makes no claims about terminal shape, only about colors. (An earlier revision of this PR also gated `isTTY` on `NO_COLOR`; reverted per review feedback.)

### Tests

One case added in `reporter-list.spec.ts` mirroring the existing `FORCE_COLOR=0` test: asserts `NO_COLOR=1` strips ANSI from test stdout / stderr.

### Docs

`docs/src/test-reporters-js.md` — list/line/dot reporter tables now include a dedicated `NO_COLOR` row pointing at no-color.org.

### Refs

- Refs [#40688](https://github.com/microsoft/playwright/pull/40688) — same precedent (env-driven color suppression).

---

Fixes #40904