### PR TITLE
fix(dashboard): treat EEXIST as singleton-already-running

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -266,7 +266,7 @@ async function acquireSingleton(options: DashboardOptions): Promise<AcquireResul
     const server = net.createServer();
     server.listen(socketPath, () => resolve({ role: 'winner', server }));
     server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code !== 'EADDRINUSE')
+      if (err.code !== 'EADDRINUSE' && err.code !== 'EEXIST')
         return reject(err);
       let ackBuffer = '';
       const client = net.connect(socketPath, () => {


### PR DESCRIPTION
Carved out from #40779.

`acquireSingleton` only treats `EADDRINUSE` as "another daemon owns the socket". On macOS, when two `cli show` invocations race into `server.listen()` close enough together, the loser can instead see `EEXIST` (the socket path exists on disk but isn't bound yet). The daemon then exits with `Dashboard daemon exited before signaling READY`.

Hard to reproduce by itself, but inserting `await new Promise(r => setTimeout(r, 250))` right before `server.listen()` makes it reproduce pretty reliably on my machine.
