### PR TITLE
test: skip 'should play audio' on webkit macOS 15

### DIFF
--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -92,8 +92,9 @@ it('should play webm video @smoke', async ({ page, asset, browserName, platform,
   await page.$eval('video', v => v.pause());
 });
 
-it('should play audio @smoke', async ({ page, server, browserName, platform }) => {
+it('should play audio @smoke', async ({ page, server, browserName, platform, macVersion }) => {
   it.fixme(browserName === 'webkit' && platform === 'win32', 'https://github.com/microsoft/playwright/issues/10892');
+  it.fixme(browserName === 'webkit' && platform === 'darwin' && macVersion === 15, 'audio output is unreliable on hosted macOS 15 runners');
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<audio src="${server.PREFIX}/example.mp3"></audio>`);
   await page.$eval('audio', e => e.play());


### PR DESCRIPTION
## Summary
- `currentTime` advances ~0.3ms in 3s on macos-15-large webkit (e.g. https://github.com/microsoft/playwright/actions/runs/26048282720/job/76578085031?pr=40896) — `play()` resolves but CoreAudio never advances samples. Previous timeout bumps (#40200) and threshold drops (#11878) didn't help because it's a "playback never started" failure, not slowness.
- macOS 26 webkit runners pass reliably, so the fixme is scoped to `macVersion === 15`.