### PR TITLE
docs(cli-client/skill): fix small typos in skill references

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/references/spec-driven-testing.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/spec-driven-testing.md
@@ -191,7 +191,7 @@ Collect the generated code and write the test file at the path given in the spec
 // seed: tests/seed.spec.ts
 import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
 
-test.describe('Singing in and out', () => {
+test.describe('Signing in and out', () => {
   test('should sign in', async ({ page }) => {
     // 1. Navigate to the application
     // (handled by the seed fixture)

--- a/packages/playwright-core/src/tools/cli-client/skill/references/storage-state.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/storage-state.md
@@ -38,7 +38,7 @@ The saved file contains:
       "value": "abc123",
       "domain": "example.com",
       "path": "/",
-      "expires": 1735689600,
+      "expires": 1893456000,
       "httpOnly": true,
       "secure": true,
       "sameSite": "Lax"
@@ -92,7 +92,7 @@ playwright-cli cookie-set session abc123
 playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
 
 # Cookie with expiration (Unix timestamp)
-playwright-cli cookie-set remember_me token123 --expires=1735689600
+playwright-cli cookie-set remember_me token123 --expires=1893456000
 ```
 
 ### Delete a Cookie

--- a/packages/playwright-core/src/tools/cli-client/skill/references/video-recording.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/video-recording.md
@@ -40,7 +40,7 @@ playwright-cli video-start recordings/checkout-test-run-42.webm
 ### 2. Record entire hero scripts.
 
 When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
-It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+It allows inserting appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
 
 1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
 2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.


### PR DESCRIPTION
Originally opened against [microsoft/playwright-cli#412](https://github.com/microsoft/playwright-cli/pull/412); @dgozman pointed out the source of truth lives here, redoing the PR against this repo.

Small fixes in `packages/playwright-core/src/tools/cli-client/skill/references/`:

- `spec-driven-testing.md` — example test group name was `'Singing in and out'`, changed to `'Signing in and out'`.
- `storage-state.md` — both the `expires` example in the storage-state JSON (line 41) and the `--expires` example for `cookie-set` (line 95) used Unix timestamp `1735689600`, which is Jan 1 2025 — already in the past, making the cookie examples read as expired. Bumped both to `1893456000` (Jan 1 2030).
- `video-recording.md` — "pulling appropriate pauses between the actions" → "inserting appropriate pauses".

No behavior changes — docs only.