### PR TITLE
devops: bots for Node 26

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -137,6 +137,16 @@ jobs:
             shardIndex: 2
             shardTotal: 2
             shardWeights: '58:42'
+          - os: ubuntu-latest
+            node-version: 26
+            shardIndex: 1
+            shardTotal: 2
+            shardWeights: '58:42'
+          - os: ubuntu-latest
+            node-version: 26
+            shardIndex: 2
+            shardTotal: 2
+            shardWeights: '58:42'
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
@@ -221,6 +231,7 @@ jobs:
     - uses: ./.github/actions/run-test
       with:
         command: npm run itest
+        node-version: 22
         bot-name: "package-installations-${{ matrix.os }}"
         shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
         flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -96,9 +96,9 @@ jobs:
         - os: ubuntu-latest
           node_version: 20
         - os: ubuntu-latest
-          node_version: 22
-        - os: ubuntu-latest
           node_version: 24
+        - os: ubuntu-latest
+          node_version: 26
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Disables all warnings in the Node.js process before using `module.register()` in Node.js 26. Unfortunately, finer-grained methods all failed, probably because the warning is triggered asynchronously from somewhere inside node.

References #40868.