### PR TITLE
fix(server): clearCookies({name}) should not transiently delete other cookies

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -309,8 +309,11 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
   }
 
   async clearCookies(options: {name?: string | RegExp, domain?: string | RegExp, path?: string | RegExp}): Promise<void> {
-    const currentCookies = await this._cookies();
-    await this.doClearCookies();
+    const hasFilter = options.name !== undefined || options.domain !== undefined || options.path !== undefined;
+    if (!hasFilter) {
+      await this.doClearCookies();
+      return;
+    }
 
     const matches = (cookie: channels.NetworkCookie, prop: 'name' | 'domain' | 'path', value: string | RegExp | undefined) => {
       if (!value)
@@ -322,13 +325,23 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       return cookie[prop] === value;
     };
 
-    const cookiesToReadd = currentCookies.filter(cookie => {
-      return !matches(cookie, 'name', options.name)
-        || !matches(cookie, 'domain', options.domain)
-        || !matches(cookie, 'path', options.path);
+    const currentCookies = await this._cookies();
+    const cookiesToExpire = currentCookies.filter(cookie => {
+      return matches(cookie, 'name', options.name)
+        && matches(cookie, 'domain', options.domain)
+        && matches(cookie, 'path', options.path);
     });
 
-    await this.addCookies(cookiesToReadd);
+    if (!cookiesToExpire.length)
+      return;
+
+    await this.addCookies(cookiesToExpire.map(cookie => ({
+      name: cookie.name,
+      value: '',
+      domain: cookie.domain,
+      path: cookie.path,
+      expires: 0,
+    })));
   }
 
   setHTTPCredentials(progress: Progress, httpCredentials?: types.Credentials): Promise<void> {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -336,10 +336,8 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       return;
 
     await this.addCookies(cookiesToExpire.map(cookie => ({
-      name: cookie.name,
+      ...cookie,
       value: '',
-      domain: cookie.domain,
-      path: cookie.path,
       expires: 0,
     })));
   }

--- a/tests/library/browsercontext-clearcookies.spec.ts
+++ b/tests/library/browsercontext-clearcookies.spec.ts
@@ -199,7 +199,9 @@ it('should not transiently delete non-matching cookies when filtering', {
   expect(await page.evaluate('document.cookie')).toBe('keep_me=1');
 });
 
-it('should remove partitioned cookies by name', async ({ browser, httpsServer, browserName }) => {
+it('should remove partitioned cookies by name', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40953' },
+}, async ({ browser, httpsServer, browserName }) => {
   it.skip(browserName !== 'chromium', 'Partitioned cookies (CHIPS) are Chromium-specific');
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   await context.addCookies([

--- a/tests/library/browsercontext-clearcookies.spec.ts
+++ b/tests/library/browsercontext-clearcookies.spec.ts
@@ -215,6 +215,17 @@ it.describe('clearCookies with filter preserves cookie identity', () => {
     expect(await context.cookies()).toEqual([expect.objectContaining({ name: 'keep_me' })]);
   });
 
+  it('should remove __Host- prefixed cookies by name', async ({ context, httpsServer }) => {
+    await context.addCookies([
+      { name: '__Host-delete_me', value: '1', url: httpsServer.PREFIX, secure: true, sameSite: 'None' },
+      { name: 'keep_me', value: '2', url: httpsServer.PREFIX, secure: true, sameSite: 'None' },
+    ]);
+    expect((await context.cookies()).map(c => c.name).sort()).toEqual(['__Host-delete_me', 'keep_me']);
+
+    await context.clearCookies({ name: '__Host-delete_me' });
+    expect(await context.cookies()).toEqual([expect.objectContaining({ name: 'keep_me' })]);
+  });
+
   it('should remove partitioned cookies by name', async ({ context, httpsServer, browserName }) => {
     it.skip(browserName !== 'chromium', 'Partitioned cookies (CHIPS) are Chromium-specific');
     await context.addCookies([

--- a/tests/library/browsercontext-clearcookies.spec.ts
+++ b/tests/library/browsercontext-clearcookies.spec.ts
@@ -164,3 +164,45 @@ it('should remove cookies by name and domain', async ({ context, page, server })
   await page.goto(server.CROSS_PROCESS_PREFIX);
   expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
 });
+
+it('should not transiently delete non-matching cookies when filtering', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40953' },
+}, async ({ context, page, server, browserName }) => {
+  it.skip(browserName !== 'chromium', 'cookieStore API is only available in Chromium');
+
+  await context.addCookies([{
+    name: 'keep_me',
+    value: '1',
+    domain: new URL(server.PREFIX).hostname,
+    path: '/',
+  },
+  {
+    name: 'delete_me',
+    value: '2',
+    domain: new URL(server.PREFIX).hostname,
+    path: '/',
+  }
+  ]);
+  await page.goto(server.PREFIX);
+
+  await page.evaluate(() => {
+    (window as any).__cookieEvents = [];
+    (window as any).cookieStore.addEventListener('change', (event: any) => {
+      for (const changed of event.changed)
+        (window as any).__cookieEvents.push({ kind: 'changed', name: changed.name });
+      for (const deleted of event.deleted)
+        (window as any).__cookieEvents.push({ kind: 'deleted', name: deleted.name });
+    });
+  });
+
+  await context.clearCookies({ name: 'delete_me' });
+
+  // Flush microtasks so any change events fired during clearCookies are observed.
+  await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 50)));
+
+  const events: { kind: string, name: string }[] = await page.evaluate(() => (window as any).__cookieEvents);
+
+  // The kept cookie must never appear in a deletion event.
+  expect(events.filter(e => e.kind === 'deleted' && e.name === 'keep_me')).toEqual([]);
+  expect(await page.evaluate('document.cookie')).toBe('keep_me=1');
+});

--- a/tests/library/browsercontext-clearcookies.spec.ts
+++ b/tests/library/browsercontext-clearcookies.spec.ts
@@ -167,9 +167,7 @@ it('should remove cookies by name and domain', async ({ context, page, server })
 
 it('should not transiently delete non-matching cookies when filtering', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40953' },
-}, async ({ context, page, server, browserName }) => {
-  it.skip(browserName !== 'chromium', 'cookieStore API is only available in Chromium');
-
+}, async ({ context, page, server }) => {
   await context.addCookies([{
     name: 'keep_me',
     value: '1',
@@ -185,24 +183,58 @@ it('should not transiently delete non-matching cookies when filtering', {
   ]);
   await page.goto(server.PREFIX);
 
-  await page.evaluate(() => {
-    (window as any).__cookieEvents = [];
-    (window as any).cookieStore.addEventListener('change', (event: any) => {
+  const eventsHandle = await page.evaluateHandle(() => {
+    const events: { kind: string, name: string }[] = [];
+    cookieStore.addEventListener('change', event => {
       for (const changed of event.changed)
-        (window as any).__cookieEvents.push({ kind: 'changed', name: changed.name });
+        events.push({ kind: 'changed', name: changed.name });
       for (const deleted of event.deleted)
-        (window as any).__cookieEvents.push({ kind: 'deleted', name: deleted.name });
+        events.push({ kind: 'deleted', name: deleted.name });
     });
+    return events;
   });
 
   await context.clearCookies({ name: 'delete_me' });
+  await expect.poll(() => eventsHandle.jsonValue()).toContainEqual({ kind: 'deleted', name: 'delete_me' });
 
-  // Flush microtasks so any change events fired during clearCookies are observed.
-  await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 50)));
-
-  const events: { kind: string, name: string }[] = await page.evaluate(() => (window as any).__cookieEvents);
-
-  // The kept cookie must never appear in a deletion event.
-  expect(events.filter(e => e.kind === 'deleted' && e.name === 'keep_me')).toEqual([]);
+  expect(await eventsHandle.jsonValue()).not.toContainEqual({ kind: 'deleted', name: 'keep_me' });
   expect(await page.evaluate('document.cookie')).toBe('keep_me=1');
+});
+
+it.describe('clearCookies with filter preserves cookie identity', () => {
+  it.use({ ignoreHTTPSErrors: true });
+
+  it('should remove __Secure- prefixed cookies by name', async ({ context, httpsServer }) => {
+    await context.addCookies([
+      { name: '__Secure-delete_me', value: '1', domain: httpsServer.HOSTNAME, path: '/', secure: true, sameSite: 'None' },
+      { name: 'keep_me', value: '2', domain: httpsServer.HOSTNAME, path: '/', secure: true, sameSite: 'None' },
+    ]);
+    expect((await context.cookies()).map(c => c.name).sort()).toEqual(['__Secure-delete_me', 'keep_me']);
+
+    await context.clearCookies({ name: '__Secure-delete_me' });
+    expect(await context.cookies()).toEqual([expect.objectContaining({ name: 'keep_me' })]);
+  });
+
+  it('should remove partitioned cookies by name', async ({ context, httpsServer, browserName }) => {
+    it.skip(browserName !== 'chromium', 'Partitioned cookies (CHIPS) are Chromium-specific');
+    await context.addCookies([
+      {
+        name: 'delete_me',
+        value: '1',
+        domain: httpsServer.HOSTNAME,
+        path: '/',
+        secure: true,
+        sameSite: 'None',
+        partitionKey: `https://${httpsServer.HOSTNAME}`,
+      },
+    ]);
+    const before = await context.cookies();
+    expect(before).toEqual([expect.objectContaining({
+      name: 'delete_me',
+      partitionKey: `https://${httpsServer.HOSTNAME}`,
+    })]);
+
+    await context.clearCookies({ name: 'delete_me' });
+    expect(await context.cookies()).toHaveLength(0);
+  });
 });

--- a/tests/library/browsercontext-clearcookies.spec.ts
+++ b/tests/library/browsercontext-clearcookies.spec.ts
@@ -184,68 +184,53 @@ it('should not transiently delete non-matching cookies when filtering', {
   await page.goto(server.PREFIX);
 
   const eventsHandle = await page.evaluateHandle(() => {
-    const events: { kind: string, name: string }[] = [];
+    const events: string[] = [];
     cookieStore.addEventListener('change', event => {
       for (const changed of event.changed)
-        events.push({ kind: 'changed', name: changed.name });
+        events.push(`changed ${changed.name}`);
       for (const deleted of event.deleted)
-        events.push({ kind: 'deleted', name: deleted.name });
+        events.push(`deleted ${deleted.name}`);
     });
     return events;
   });
 
   await context.clearCookies({ name: 'delete_me' });
-  await expect.poll(() => eventsHandle.jsonValue()).toContainEqual({ kind: 'deleted', name: 'delete_me' });
-
-  expect(await eventsHandle.jsonValue()).not.toContainEqual({ kind: 'deleted', name: 'keep_me' });
+  await expect.poll(() => eventsHandle.jsonValue()).toEqual(['deleted delete_me']);
   expect(await page.evaluate('document.cookie')).toBe('keep_me=1');
 });
 
-it.describe('clearCookies with filter preserves cookie identity', () => {
-  it.use({ ignoreHTTPSErrors: true });
-
-  it('should remove __Secure- prefixed cookies by name', async ({ context, httpsServer }) => {
-    await context.addCookies([
-      { name: '__Secure-delete_me', value: '1', domain: httpsServer.HOSTNAME, path: '/', secure: true, sameSite: 'None' },
-      { name: 'keep_me', value: '2', domain: httpsServer.HOSTNAME, path: '/', secure: true, sameSite: 'None' },
-    ]);
-    expect((await context.cookies()).map(c => c.name).sort()).toEqual(['__Secure-delete_me', 'keep_me']);
-
-    await context.clearCookies({ name: '__Secure-delete_me' });
-    expect(await context.cookies()).toEqual([expect.objectContaining({ name: 'keep_me' })]);
-  });
-
-  it('should remove __Host- prefixed cookies by name', async ({ context, httpsServer }) => {
-    await context.addCookies([
-      { name: '__Host-delete_me', value: '1', url: httpsServer.PREFIX, secure: true, sameSite: 'None' },
-      { name: 'keep_me', value: '2', url: httpsServer.PREFIX, secure: true, sameSite: 'None' },
-    ]);
-    expect((await context.cookies()).map(c => c.name).sort()).toEqual(['__Host-delete_me', 'keep_me']);
-
-    await context.clearCookies({ name: '__Host-delete_me' });
-    expect(await context.cookies()).toEqual([expect.objectContaining({ name: 'keep_me' })]);
-  });
-
-  it('should remove partitioned cookies by name', async ({ context, httpsServer, browserName }) => {
-    it.skip(browserName !== 'chromium', 'Partitioned cookies (CHIPS) are Chromium-specific');
-    await context.addCookies([
-      {
-        name: 'delete_me',
-        value: '1',
-        domain: httpsServer.HOSTNAME,
-        path: '/',
-        secure: true,
-        sameSite: 'None',
-        partitionKey: `https://${httpsServer.HOSTNAME}`,
-      },
-    ]);
-    const before = await context.cookies();
-    expect(before).toEqual([expect.objectContaining({
+it('should remove partitioned cookies by name', async ({ browser, httpsServer, browserName }) => {
+  it.skip(browserName !== 'chromium', 'Partitioned cookies (CHIPS) are Chromium-specific');
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  await context.addCookies([
+    {
       name: 'delete_me',
+      value: '1',
+      domain: httpsServer.HOSTNAME,
+      path: '/',
+      secure: true,
+      sameSite: 'None',
       partitionKey: `https://${httpsServer.HOSTNAME}`,
-    })]);
+    },
+    {
+      name: 'keep_me',
+      value: '2',
+      domain: httpsServer.HOSTNAME,
+      path: '/',
+      secure: true,
+      sameSite: 'None',
+      partitionKey: `https://${httpsServer.HOSTNAME}`,
+    },
+  ]);
+  const before = await context.cookies();
+  expect(before).toEqual([
+    expect.objectContaining({ name: 'delete_me', partitionKey: `https://${httpsServer.HOSTNAME}` }),
+    expect.objectContaining({ name: 'keep_me', partitionKey: `https://${httpsServer.HOSTNAME}` }),
+  ]);
 
-    await context.clearCookies({ name: 'delete_me' });
-    expect(await context.cookies()).toHaveLength(0);
-  });
+  await context.clearCookies({ name: 'delete_me' });
+  expect(await context.cookies()).toEqual([
+    expect.objectContaining({ name: 'keep_me', partitionKey: `https://${httpsServer.HOSTNAME}` }),
+  ]);
+  await context.close();
 });


### PR DESCRIPTION
Fixes #40953.

`BrowserContext.clearCookies(options)` currently wipes every cookie via `doClearCookies()` and then re-adds the ones that did not match the filter. Pages that subscribe to the `cookieStore.change` API observe a transient deletion of the kept cookies during the gap between the wipe and the readd, which is enough to trip route-guards, `useSyncExternalStore`-style auth state machines, and similar listeners. With `cookieStore` now Baseline 2025, this race window is observable from user code.

When a filter (`name`, `domain`, or `path`) is set, this PR expires only the matching cookies in place by calling `addCookies` with `expires: 0`; the no-filter path still delegates to `doClearCookies()` as before, so no per-browser code is touched.

Credit to @jasikpark for the full root-cause analysis and the proposed fix shape in the issue.

Added a Chromium-only test in `tests/library/browsercontext-clearcookies.spec.ts` that adds two cookies, subscribes to `cookieStore.change` via the page, then calls `clearCookies({ name: 'delete_me' })` and asserts the kept cookie never appears in a deletion event.