### PR TITLE
fix(trace-viewer): highlight network/console timeframe on timeline on hover

### DIFF
--- a/packages/trace-viewer/src/ui/consoleTab.tsx
+++ b/packages/trace-viewer/src/ui/consoleTab.tsx
@@ -148,7 +148,7 @@ export const ConsoleTab: React.FunctionComponent<{
   boundaries: Boundaries,
   consoleModel: ConsoleTabModel,
   selectedTime?: Boundaries | undefined,
-  onEntryHovered?: (ordinal: number | undefined) => void,
+  onEntryHovered?: (time: Boundaries | undefined) => void,
   onAccepted?: (entry: ConsoleEntry) => void,
 }> = ({ consoleModel, boundaries, onEntryHovered, onAccepted }) => {
   if (!consoleModel.entries.length)
@@ -158,7 +158,7 @@ export const ConsoleTab: React.FunctionComponent<{
     <ConsoleListView
       name='console'
       onAccepted={onAccepted}
-      onHighlighted={entry => onEntryHovered?.(entry ? consoleModel.entries.indexOf(entry) : undefined)}
+      onHighlighted={entry => onEntryHovered?.(entry ? { minimum: entry.timestamp, maximum: entry.timestamp } : undefined)}
       items={consoleModel.entries}
       isError={entry => entry.isError}
       isWarning={entry => entry.isWarning}

--- a/packages/trace-viewer/src/ui/networkTab.tsx
+++ b/packages/trace-viewer/src/ui/networkTab.tsx
@@ -68,7 +68,7 @@ export function useNetworkTabModel(model: TraceModel | undefined, selectedTime: 
 export const NetworkTab: React.FunctionComponent<{
   boundaries: Boundaries,
   networkModel: NetworkTabModel,
-  onResourceHovered?: (key: string | undefined) => void,
+  onResourceHovered?: (time: Boundaries | undefined) => void,
   sdkLanguage: Language,
 }> = ({ boundaries, networkModel, onResourceHovered, sdkLanguage }) => {
   const [sorting, setSorting] = React.useState<Sorting | undefined>(undefined);
@@ -102,7 +102,7 @@ export const NetworkTab: React.FunctionComponent<{
     items={renderedEntries}
     selectedItem={visibleSelectedEntry}
     onSelected={item => setSelectedResourceKey(item.resource.id)}
-    onHighlighted={item => onResourceHovered?.(item?.resource.id)}
+    onHighlighted={item => onResourceHovered?.(item ? resourceTimeRange(item.resource) : undefined)}
     columns={visibleColumns(!!visibleSelectedEntry, renderedEntries)}
     columnTitle={columnTitle}
     columnWidths={columnWidths}
@@ -296,6 +296,12 @@ const renderEntry = (resource: ResourceEntry, boundaries: Boundaries, contextIdG
     contextId: contextIdGenerator.contextId(resource),
   };
 };
+
+function resourceTimeRange(resource: ResourceEntry): Boundaries | undefined {
+  if (!resource._monotonicTime)
+    return undefined;
+  return { minimum: resource._monotonicTime, maximum: resource._monotonicTime + resource.time };
+}
 
 function formatRouteStatus(request: ResourceEntry): string {
   if (request._wasAborted)

--- a/packages/trace-viewer/src/ui/timeline.css
+++ b/packages/trace-viewer/src/ui/timeline.css
@@ -59,6 +59,16 @@
   left: 0;
 }
 
+.timeline-highlight {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+  background-color: #1a85ff33;
+  border-left: 2px solid var(--vscode-charts-blue);
+  border-right: 2px solid var(--vscode-charts-blue);
+}
+
 .timeline-window {
   display: flex;
   position: absolute;

--- a/packages/trace-viewer/src/ui/timeline.tsx
+++ b/packages/trace-viewer/src/ui/timeline.tsx
@@ -32,9 +32,10 @@ export const Timeline: React.FunctionComponent<{
   onSelected: (action: ActionTraceEventInContext) => void,
   selectedTime: Boundaries | undefined,
   setSelectedTime: (time: Boundaries | undefined) => void,
+  highlightedTime?: Boundaries,
   sdkLanguage: Language,
   scrubber?: React.ReactNode,
-}> = ({ model, boundaries, onSelected, selectedTime, setSelectedTime, sdkLanguage, scrubber }) => {
+}> = ({ model, boundaries, onSelected, selectedTime, setSelectedTime, highlightedTime, sdkLanguage, scrubber }) => {
   const [measure, ref] = useMeasure<HTMLDivElement>();
   const [dragWindow, setDragWindow] = React.useState<{ startX: number, endX: number, pivot?: number, type: 'resize' | 'move' } | undefined>();
   const [previewPoint, setPreviewPoint] = React.useState<FilmStripPreviewPoint | undefined>();
@@ -54,6 +55,14 @@ export const Timeline: React.FunctionComponent<{
   }, [selectedTime, boundaries, dragWindow, measure]);
 
   const actions = React.useMemo(() => model?.filteredActions(actionsFilter), [model, actionsFilter]);
+
+  const highlight = React.useMemo(() => {
+    if (!highlightedTime)
+      return undefined;
+    const left = timeToPosition(measure.width, boundaries, highlightedTime.minimum);
+    const right = timeToPosition(measure.width, boundaries, highlightedTime.maximum);
+    return { left, width: Math.max(2, right - left) };
+  }, [highlightedTime, boundaries, measure]);
 
   const onMouseDown = React.useCallback((event: React.MouseEvent) => {
     setPreviewPoint(undefined);
@@ -179,6 +188,7 @@ export const Timeline: React.FunctionComponent<{
       }</div>
       <FilmStrip boundaries={boundaries} previewPoint={previewPoint} />
       {scrubber}
+      {highlight && <div className='timeline-highlight' style={{ left: highlight.left, width: highlight.width }}></div>}
       {selectedTime && <div className='timeline-window'>
         <div className='timeline-window-curtain left' style={{ width: curtainLeft }}></div>
         <div className='timeline-window-resizer' style={{ left: -5 }}></div>

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -95,6 +95,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
   // Transient state
   const [highlightedElement, setHighlightedElement] = React.useState<HighlightedElement>({ lastEdited: 'none' });
   const [isInspecting, setIsInspectingState] = React.useState(false);
+  const [highlightedTime, setHighlightedTime] = React.useState<Boundaries | undefined>(undefined);
 
   const setSelectedAction = React.useCallback((action: ActionTraceEventInContext | undefined) => {
     setSelectedCallId(action?.callId);
@@ -264,6 +265,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
       consoleModel={consoleModel}
       boundaries={boundaries}
       selectedTime={selectedTime}
+      onEntryHovered={setHighlightedTime}
       onAccepted={m => setSelectedTime({ minimum: m.timestamp, maximum: m.timestamp })}
     />
   };
@@ -271,7 +273,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
     id: 'network',
     title: 'Network',
     count: networkModel.resources.length,
-    render: () => <NetworkTab boundaries={boundaries} networkModel={networkModel} sdkLanguage={model?.sdkLanguage ?? 'javascript'} />
+    render: () => <NetworkTab boundaries={boundaries} networkModel={networkModel} onResourceHovered={setHighlightedTime} sdkLanguage={model?.sdkLanguage ?? 'javascript'} />
   };
   const attachmentsTab: TabbedPaneTabModel = {
     id: 'attachments',
@@ -367,6 +369,7 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
       sdkLanguage={sdkLanguage}
       selectedTime={selectedTime}
       setSelectedTime={setSelectedTime}
+      highlightedTime={highlightedTime}
       scrubber={<PlaybackScrubber playback={playback} />}
     />}
     <SplitView

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -365,6 +365,15 @@ test('should render console', async ({ showTraceViewer, browserName }) => {
   await expect(listViews.filter({ hasText: 'Cheers!' })).toHaveClass('list-view-entry');
 });
 
+test('should highlight console message on timeline on hover', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer(traceFile);
+  await traceViewer.showConsoleTab();
+  const highlight = traceViewer.page.locator('.timeline-highlight');
+  await expect(highlight).toBeHidden();
+  await traceViewer.consoleLines.filter({ hasText: 'Info' }).hover();
+  await expect(highlight).toBeVisible();
+});
+
 test('should open console errors on click', async ({ showTraceViewer }) => {
   const traceViewer = await showTraceViewer(traceFile);
   await expect(traceViewer.actionIconsText('Evaluate')).toHaveText(['2', '1']);
@@ -466,6 +475,16 @@ test('should have network requests', async ({ showTraceViewer }) => {
   await expect(traceViewer.networkRequests).toContainText([/404GET404text\/plain/]);
   await expect(traceViewer.networkRequests).toContainText([/script.jsGET200application\/javascript/]);
   await expect(traceViewer.networkRequests.filter({ hasText: '404GET404text' })).toHaveCSS('background-color', 'rgb(242, 222, 222)');
+});
+
+test('should highlight network request on timeline on hover', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer(traceFile);
+  await traceViewer.selectAction('Navigate');
+  await traceViewer.showNetworkTab();
+  const highlight = traceViewer.page.locator('.timeline-highlight');
+  await expect(highlight).toBeHidden();
+  await traceViewer.networkRequests.filter({ hasText: 'frame.html' }).hover();
+  await expect(highlight).toBeVisible();
 });
 
 test('should filter network requests by resource type', async ({ page, runAndTrace, server }) => {


### PR DESCRIPTION
## Summary
- Restore the timeline highlight dropped during the timeline redesign (#39634).
- Hovering a network request or console message now highlights its time range on the timeline, via an explicit `highlightedTime` range passed to the `Timeline`.

## Screenshot

<img width="1282" height="145" alt="Screenshot 2026-05-22 at 10 22 32 AM" src="https://github.com/user-attachments/assets/84aea8b8-f83b-4d17-86f8-b3642207e7f2" />


Fixes https://github.com/microsoft/playwright/issues/40949