### PR TITLE
docs: add junit breaking change to 1.59 release notes

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -377,6 +377,7 @@ await using page = await context.newPage();
 
 - Removed macOS 14 support for WebKit. We recommend upgrading your macOS version, or keeping an older Playwright version.
 - Removed `@playwright/experimental-ct-svelte` package.
+- `junit` test reporter now differentiates between types of errors, so some of the previous `<failure>`s are now reported as `<error>`s.
 
 ### Browser Versions
 


### PR DESCRIPTION
Closes #40943.