### PR TITLE
feat(aria-snapshot): expose aria-invalid in ARIA snapshots

### DIFF
--- a/docs/src/aria-snapshots.md
+++ b/docs/src/aria-snapshots.md
@@ -564,7 +564,7 @@ Groups capture nested elements, such as `<details>` elements with summary conten
 
 ### Attributes and states
 
-Commonly used ARIA attributes, like `checked`, `disabled`, `expanded`, `level`, `pressed`, and `selected`, represent
+Commonly used ARIA attributes, like `checked`, `disabled`, `expanded`, `invalid`, `level`, `pressed`, and `selected`, represent
 control states.
 
 #### Checkbox with `checked` attribute
@@ -585,4 +585,14 @@ control states.
 
 ```yaml title="aria snapshot"
 - button "Toggle" [pressed=true]
+```
+
+#### Input with `aria-invalid` attribute
+
+```html
+<input type="text" aria-label="Email" aria-invalid="true" value="not-an-email">
+```
+
+```yaml title="aria snapshot"
+- textbox "Email" [invalid]: not-an-email
 ```

--- a/docs/src/aria-snapshots.md
+++ b/docs/src/aria-snapshots.md
@@ -156,7 +156,7 @@ Each accessible element in the tree is represented as a YAML node:
 - **role**: Specifies the ARIA or HTML role of the element (e.g., `heading`, `list`, `listitem`, `button`).
 - **"name"**: Accessible name of the element. Quoted strings indicate exact values, `/patterns/` are used for regular expression.
 - **[attribute=value]**: Attributes and values, in square brackets, represent specific ARIA attributes, such
-  as `checked`, `disabled`, `expanded`, `level`, `pressed`, or `selected`.
+  as `checked`, `disabled`, `expanded`, `invalid`, `level`, `pressed`, or `selected`.
 
 These values are derived from ARIA attributes or calculated based on HTML semantics. To inspect the accessibility tree
 structure of a page, use the [Chrome DevTools Accessibility Tab](https://developer.chrome.com/docs/devtools/accessibility/reference#tab).
@@ -589,10 +589,21 @@ control states.
 
 #### Input with `aria-invalid` attribute
 
+The `aria-invalid` value is surfaced directly. A value of `true` renders as `[invalid]`, while `grammar`
+and `spelling` render as `[invalid=grammar]` and `[invalid=spelling]`. A `false` value is omitted.
+
 ```html
 <input type="text" aria-label="Email" aria-invalid="true" value="not-an-email">
 ```
 
 ```yaml title="aria snapshot"
 - textbox "Email" [invalid]: not-an-email
+```
+
+```html
+<input type="text" aria-label="Bio" aria-invalid="spelling">
+```
+
+```yaml title="aria snapshot"
+- textbox "Bio" [invalid=spelling]
 ```

--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -270,6 +270,9 @@ function toAriaNode(element: Element, options: InternalOptions): aria.AriaNode |
   if (roleUtils.kAriaExpandedRoles.includes(role))
     result.expanded = roleUtils.getAriaExpanded(element);
 
+  if (roleUtils.kAriaInvalidRoles.includes(role) && roleUtils.getAriaInvalid(element) !== 'false')
+    result.invalid = true;
+
   if (roleUtils.kAriaLevelRoles.includes(role))
     result.level = roleUtils.getAriaLevel(element);
 
@@ -422,6 +425,8 @@ function matchesNode(node: aria.AriaNode | string, template: aria.AriaTemplateNo
   if (template.disabled !== undefined && template.disabled !== node.disabled)
     return false;
   if (template.expanded !== undefined && template.expanded !== node.expanded)
+    return false;
+  if (template.invalid !== undefined && template.invalid !== node.invalid)
     return false;
   if (template.level !== undefined && template.level !== node.level)
     return false;
@@ -614,6 +619,8 @@ export function renderAriaTree(ariaSnapshot: AriaSnapshot, publicOptions: AriaTr
       key += ` [expanded]`;
     if (ariaNode.active && options.renderActive)
       key += ` [active]`;
+    if (ariaNode.invalid)
+      key += ` [invalid]`;
     if (ariaNode.level)
       key += ` [level=${ariaNode.level}]`;
     if (ariaNode.pressed === 'mixed')

--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -270,8 +270,10 @@ function toAriaNode(element: Element, options: InternalOptions): aria.AriaNode |
   if (roleUtils.kAriaExpandedRoles.includes(role))
     result.expanded = roleUtils.getAriaExpanded(element);
 
-  if (roleUtils.kAriaInvalidRoles.includes(role) && roleUtils.getAriaInvalid(element) !== 'false')
-    result.invalid = true;
+  if (roleUtils.kAriaInvalidRoles.includes(role)) {
+    const invalid = roleUtils.getAriaInvalid(element);
+    result.invalid = invalid === 'false' ? false : invalid === 'true' ? true : invalid;
+  }
 
   if (roleUtils.kAriaLevelRoles.includes(role))
     result.level = roleUtils.getAriaLevel(element);
@@ -619,7 +621,9 @@ export function renderAriaTree(ariaSnapshot: AriaSnapshot, publicOptions: AriaTr
       key += ` [expanded]`;
     if (ariaNode.active && options.renderActive)
       key += ` [active]`;
-    if (ariaNode.invalid)
+    if (ariaNode.invalid === 'grammar' || ariaNode.invalid === 'spelling')
+      key += ` [invalid=${ariaNode.invalid}]`;
+    if (ariaNode.invalid === true)
       key += ` [invalid]`;
     if (ariaNode.level)
       key += ` [level=${ariaNode.level}]`;

--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -559,7 +559,26 @@ export function getElementAccessibleDescription(element: Element, includeHidden:
   return accessibleDescription;
 }
 
-function getAriaInvalid(element: Element): 'false' | 'true' | 'grammar' | 'spelling' {
+// Roles where `aria-invalid` is conceptually meaningful per WAI-ARIA 1.2.
+// See https://www.w3.org/TR/wai-aria-1.2/#aria-invalid for the supported list.
+export const kAriaInvalidRoles = [
+  'application',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'gridcell',
+  'listbox',
+  'radiogroup',
+  'rowheader',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'textbox',
+  'tree',
+];
+
+export function getAriaInvalid(element: Element): 'false' | 'true' | 'grammar' | 'spelling' {
   // https://www.w3.org/TR/wai-aria-1.2/#aria-invalid
   // This state is being deprecated as a global state in ARIA 1.2.
   // In future versions it will only be allowed on roles where it is specifically supported.

--- a/packages/isomorphic/ariaSnapshot.ts
+++ b/packages/isomorphic/ariaSnapshot.ts
@@ -30,6 +30,7 @@ export type AriaProps = {
   disabled?: boolean;
   expanded?: boolean;
   active?: boolean;
+  invalid?: boolean;
   level?: number;
   pressed?: boolean | 'mixed';
   selected?: boolean;
@@ -67,7 +68,7 @@ export function hasPointerCursor(ariaNode: AriaNode): boolean {
 }
 
 function ariaPropsEqual(a: AriaProps, b: AriaProps): boolean {
-  return a.active === b.active && a.checked === b.checked && a.disabled === b.disabled && a.expanded === b.expanded && a.selected === b.selected && a.level === b.level && a.pressed === b.pressed;
+  return a.active === b.active && a.checked === b.checked && a.disabled === b.disabled && a.expanded === b.expanded && a.invalid === b.invalid && a.selected === b.selected && a.level === b.level && a.pressed === b.pressed;
 }
 
 // We pass parsed template between worlds using JSON, make it easy.
@@ -494,6 +495,11 @@ export class KeyParser {
     if (key === 'active') {
       this._assert(value === 'true' || value === 'false', 'Value of "active" attribute must be a boolean', errorPos);
       node.active = value === 'true';
+      return;
+    }
+    if (key === 'invalid') {
+      this._assert(value === 'true' || value === 'false', 'Value of "invalid" attribute must be a boolean', errorPos);
+      node.invalid = value === 'true';
       return;
     }
     if (key === 'level') {

--- a/packages/isomorphic/ariaSnapshot.ts
+++ b/packages/isomorphic/ariaSnapshot.ts
@@ -30,7 +30,7 @@ export type AriaProps = {
   disabled?: boolean;
   expanded?: boolean;
   active?: boolean;
-  invalid?: boolean;
+  invalid?: boolean | 'grammar' | 'spelling';
   level?: number;
   pressed?: boolean | 'mixed';
   selected?: boolean;
@@ -498,8 +498,8 @@ export class KeyParser {
       return;
     }
     if (key === 'invalid') {
-      this._assert(value === 'true' || value === 'false', 'Value of "invalid" attribute must be a boolean', errorPos);
-      node.invalid = value === 'true';
+      this._assert(value === 'true' || value === 'false' || value === 'grammar' || value === 'spelling', 'Value of "invalid" attribute must be a boolean, "grammar" or "spelling"', errorPos);
+      node.invalid = value === 'true' ? true : value === 'false' ? false : value;
       return;
     }
     if (key === 'level') {

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -934,3 +934,26 @@ test('treat bad regex as a string', async ({ page }) => {
   expect(stripAnsi(error.message)).toContain('-   - /url: /[a/');
   expect(stripAnsi(error.message)).toContain('+   - /url: /foo');
 });
+
+test('invalid attribute', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34839' } }, async ({ page }) => {
+  await page.setContent(`
+    <input type="text" aria-label="Email" aria-invalid="true" value="not-an-email">
+    <input type="text" aria-label="Name" value="Alice">
+  `);
+
+  await expect(page).toMatchAriaSnapshot(`
+    - textbox "Email" [invalid]: not-an-email
+    - textbox "Name": Alice
+  `);
+
+  await expect(page).toMatchAriaSnapshot(`
+    - textbox "Email" [invalid=true]: not-an-email
+    - textbox "Name" [invalid=false]: Alice
+  `);
+
+  // `aria-invalid="grammar"` and `aria-invalid="spelling"` map to the boolean flag too.
+  await page.setContent(`<input type="text" aria-label="Bio" aria-invalid="spelling">`);
+  await expect(page).toMatchAriaSnapshot(`
+    - textbox "Bio" [invalid]
+  `);
+});

--- a/tests/page/to-match-aria-snapshot.spec.ts
+++ b/tests/page/to-match-aria-snapshot.spec.ts
@@ -951,9 +951,25 @@ test('invalid attribute', { annotation: { type: 'issue', description: 'https://g
     - textbox "Name" [invalid=false]: Alice
   `);
 
-  // `aria-invalid="grammar"` and `aria-invalid="spelling"` map to the boolean flag too.
-  await page.setContent(`<input type="text" aria-label="Bio" aria-invalid="spelling">`);
+  // `aria-invalid="grammar"` and `aria-invalid="spelling"` surface their underlying value.
+  await page.setContent(`
+    <input type="text" aria-label="Bio" aria-invalid="grammar">
+    <input type="text" aria-label="Note" aria-invalid="spelling">
+  `);
   await expect(page).toMatchAriaSnapshot(`
+    - textbox "Bio" [invalid=grammar]
+    - textbox "Note" [invalid=spelling]
+  `);
+
+  // A `grammar` value is distinct from a plain `true` invalid state.
+  const error = await expect(page).toMatchAriaSnapshot(`
     - textbox "Bio" [invalid]
+  `, { timeout: 1 }).catch(e => e);
+  expect(stripAnsi(error.message)).toContain('[invalid=grammar]');
+
+  // Any other non-false value falls back to `true`.
+  await page.setContent(`<input type="text" aria-label="Zip" aria-invalid="garbage">`);
+  await expect(page).toMatchAriaSnapshot(`
+    - textbox "Zip" [invalid]
   `);
 });


### PR DESCRIPTION
## Summary
- Surface `aria-invalid` in ARIA snapshots so form-validation tests can assert on the invalid state. Adds an `invalid` boolean prop next to the existing `checked` / `disabled` / `expanded` / `level` / `pressed` shape, and emits `[invalid]` for elements whose role is in the WAI-ARIA 1.2 list (`textbox`, `combobox`, `checkbox`, `radiogroup`, `spinbutton`, etc.).
- `aria-invalid="true" | "grammar" | "spelling"` all map to the boolean flag for snapshot purposes; the distinct values remain available through the existing `getAriaInvalid` helper for accessibility consumers.

Fixes https://github.com/microsoft/playwright/issues/34839