### PR TITLE
fix(mcp): disconnect tracked browser on BrowserTracker.dispose

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/registrySessionProvider.ts
+++ b/packages/playwright-core/src/tools/dashboard/registrySessionProvider.ts
@@ -68,6 +68,7 @@ class BrowserTracker {
     for (const listeners of this._contextListeners.values())
       listeners.forEach(d => d.dispose());
     this._contextListeners.clear();
+    void this.browser.close().catch(() => {});
   }
 
   private _wireContext(context: api.BrowserContext) {


### PR DESCRIPTION
## Summary
- `BrowserTracker` opens a remote Playwright connection to each bound daemon browser but never closes it on dispose, leaking the WS (and any client-driven subscriptions on it, e.g. screencast) until the dashboard process exits.
- Adds a fire-and-forget `browser.close()` at the end of `dispose()`.

Suspected contributor to the ~30s `cli show --kill` durations seen in MCP Windows Firefox CI jobs (e.g. https://github.com/microsoft/playwright/actions/runs/26235830215/job/77208610752), where the dashboard's `gracefullyProcessExitDoNotHang` 30s force-exit timer wins because cleanup didn't run.
