### PR TITLE
fix(mcp): tear down dashboard server on cli show --kill

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -107,7 +107,11 @@ async function startDashboardServer(provider: SessionProvider, options: Dashboar
     return await Promise.race([...connections].map(c => c.emitAnnotate({ signal: cancellation })));
   };
 
-  const close = () => httpServer.stop();
+  const close = async () => {
+    for (const c of connections)
+      c.close?.();
+    await httpServer.stop();
+  };
   return { url: httpServer.urlPrefix('human-readable'), reveal, triggerAnnotate, close };
 }
 
@@ -355,8 +359,8 @@ async function startApp(server: net.Server, options: DashboardOptions) {
           socket.end(e);
         }
       } else if (parsed.kill) {
-        socket.end();
-        gracefullyProcessExitDoNotHang(0);
+        await dashboard.close().catch(() => {});
+        gracefullyProcessExitDoNotHang(0, () => new Promise(r => socket.end(r)));
       } else {
         try {
           await page?.bringToFront();


### PR DESCRIPTION
## Summary
- `cli show --kill` on the dashboard never closed the dashboard's HTTP/WS server, so `DashboardConnection.onclose` → `AttachedPage.dispose` → `page.screencast.stop` never ran. The active screencast was still up when the daemon then tried to graceful-close the bound browser, and on Windows the 30s `gracefullyProcessExitDoNotHang` safety timer consistently won — making `cli show --kill` take ~30s in MCP CI jobs (e.g. https://github.com/microsoft/playwright/actions/runs/26235830215/job/77208610752).
- `DashboardServer.close()` now closes WS connections before stopping the HTTP server (matches the `WSServer.close()` / `CDPRelay.stop()` pattern in the repo).
- The `--kill` branch awaits `dashboard.close()` before scheduling exit, and moves `socket.end()` into `gracefullyProcessExitDoNotHang`'s `onExit` so the cli client only sees the IPC FIN at actual process exit.

Follow-up to https://github.com/microsoft/playwright/pull/40967 (same root-cause investigation; that one disconnects the per-tracker upstream browser connection on dispose).
