### PR TITLE
fix(injected): replace control characters in element preview with U+FFFD

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -1739,7 +1739,7 @@ export class InjectedScript {
 }
 
 function oneLine(s: string): string {
-  return s.replace(/\n/g, '↵').replace(/\t/g, '⇆');
+  return s.replace(/\n/g, '↵').replace(/\t/g, '⇆').replace(/[\x00-\x1f\x7f-\x9f]/g, '�');
 }
 
 function createAttributeMatcher(part: AttributeSelectorPart): (s: string) => boolean {

--- a/tests/page/page-strict.spec.ts
+++ b/tests/page/page-strict.spec.ts
@@ -119,3 +119,12 @@ it('should escape tag names', async ({ page }) => {
   expect(error.message).toContain(`getByText('special test description').first()`);
   expect(error.message).toContain(`locator('q\\\\:template').filter({ hasText: 'special test description' })`);
 });
+
+it('should strip ANSI/control characters from element preview in strict mode error', async ({ page }) => {
+  await page.setContent(`<span data-x="a\x1b[31mRED\x1b[0m">one</span><span>two</span>`);
+  const error = await page.textContent('span', { strict: true }).catch(e => e);
+  expect(error.message).toContain('strict mode violation');
+  expect(error.message).toContain('data-x="a�[31mRED�[0m"');
+  const previewLine = error.message.split('\n').find((l: string) => l.includes('data-x='))!;
+  expect(previewLine).not.toContain('\x1b');
+});


### PR DESCRIPTION
## Summary
- `oneLine()` already substitutes `\n` and `\t` with visible glyphs to keep the locator-resolved-to preview on a single line. Extend the same treatment to the rest of the C0/C1/DEL control range so DOM-derived attribute values render legibly in error messages and trace logs.