### PR TITLE
fix(firefox): supply fallback location in uncaught error handler for Firefox browser

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -222,7 +222,7 @@ export class FFPage implements PageDelegate {
     const error = new Error(message);
     error.stack = params.message + '\n' + params.stack.split('\n').filter(Boolean).map(a => a.replace(/([^@]*)@(.*)/, '    at $1 ($2)')).join('\n');
     error.name = name;
-    this._page.addPageError(error, params.location);
+    this._page.addPageError(error, params.location ?? { url: '', lineNumber: 0, columnNumber: 0 });
   }
 
   _onConsole(payload: Protocol.Runtime.consolePayload) {

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -230,3 +230,17 @@ it('should fire illegal character error', {
   else
     expect(error.message).toContain('illegal character');
 });
+
+it('should keep driver alive after firefox page error', async ({ page, browserName }) => {
+  // Smoke test for the FFPage._onUncaughtError -> addPageError -> dispatcher path.
+  // Older Firefox builds (~v1475) sometimes delivered Page.uncaughtError with an
+  // undefined location, and the unguarded location.url access killed the Node
+  // driver. A subsequent evaluate would then throw a connection error.
+  it.skip(browserName !== 'firefox');
+  const [error] = await Promise.all([
+    page.waitForEvent('pageerror'),
+    page.setContent(`<script>throw new Error('no-location')</script>`),
+  ]);
+  expect(error.message).toContain('no-location');
+  expect(await page.evaluate('1 + 1')).toBe(2);
+});

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -231,7 +231,9 @@ it('should fire illegal character error', {
     expect(error.message).toContain('illegal character');
 });
 
-it('should keep driver alive after firefox page error', async ({ page, browserName }) => {
+it('should keep driver alive after firefox page error', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40978' },
+}, async ({ page, browserName }) => {
   // Smoke test for the FFPage._onUncaughtError -> addPageError -> dispatcher path.
   // Older Firefox builds (~v1475) sometimes delivered Page.uncaughtError with an
   // undefined location, and the unguarded location.url access killed the Node


### PR DESCRIPTION
## Summary
- Add a `{ url: '', lineNumber: 0, columnNumber: 0 }` fallback in `FFPage._onUncaughtError` when Juggler's `Page.uncaughtError` arrives with an undefined `location`.
- Matches the existing fallback pattern in chromium (`stackTraceToLocation`), webkit (`wkPage.ts`), and bidi (`bidiPage.ts`). Firefox was the only handler without one.
- Adds a Firefox-only smoke test asserting the driver process survives an uncaught page error.

Fixes #40978
