### PR TITLE
fix(firefox): keep synthetic mouse pointers page-local

### DIFF
--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -482,6 +482,9 @@ export class PageHandler {
 
   async ['Page.dispatchMouseEvent']({type, x, y, button, clickCount, modifiers, buttons}) {
     const win = this._pageTarget._window;
+    // Keep synthetic pointer state page-local so parallel hovers in different tabs
+    // do not send pointerleave to each other when Firefox switches active tabs.
+    const pointerId = this._pageTarget._linkedBrowser.browsingContext.browserId;
     const sendEvents = async (types) => {
       // 1. Scroll element to the desired location first; the coordinates are relative to the element.
       this._pageTarget._linkedBrowser.scrollRectIntoViewIfNeeded(x, y, 0, 0);
@@ -498,7 +501,7 @@ export class PageHandler {
           x + boundingBox.left,
           y + boundingBox.top,
           {
-            identifier: win.windowUtils.DEFAULT_MOUSE_POINTER_ID,
+            identifier: pointerId,
             button,
             buttons,
             clickCount,
@@ -537,7 +540,7 @@ export class PageHandler {
           0 /* x */,
           0 /* y */,
           {
-            identifier: win.windowUtils.DEFAULT_MOUSE_POINTER_ID,
+            identifier: pointerId,
             button,
             clickCount,
             modifiers,

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -70,7 +70,6 @@ it('should be able to click across browser contexts', async function({ browser }
 });
 
 it('should be able to hover across browser contexts in parallel', async function({ browser, browserName, isBidi }) {
-  it.fixme(browserName === 'firefox' && !isBidi);
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40562' });
 
   const html = `


### PR DESCRIPTION
Fixes #40562.

## Summary
- make Firefox Juggler use a stable page-local pointer id for synthetic mouse events
- enable the existing parallel hover regression test for Firefox

## Root cause
Firefox Juggler currently dispatches all synthetic mouse events with `DEFAULT_MOUSE_POINTER_ID`. When multiple pages are hovered in parallel, Firefox has to activate different tabs to dispatch each event. Because every page shares the same synthetic pointer id, those tab switches can produce pointer leave transitions in other pages and clear their hover state.

Using the target browser id as the synthetic pointer id keeps pointer state local to the page target while preserving stable pointer identity within the same page.

## Validation
- `node --check browser_patches/firefox/juggler/protocol/PageHandler.js`

Runtime validation needs a Firefox build that includes this `browser_patches/firefox` change. The locally downloaded prebuilt browser does not include local browser patch changes, so the enabled regression test should be validated by the patched Firefox build in CI/browser-roll flow.
