### PR TITLE
feat(browserType): throw on remote connectOverCDP(transport)

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -168,6 +168,8 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
   async _connectOverCDPTransport(transport: api.ConnectionTransport): Promise<Browser> {
     if (this.name() !== 'chromium')
       throw new Error('Connecting over CDP is only supported in Chromium.');
+    if (this._connection.isRemote())
+      throw new Error('Passing a ConnectionTransport to connectOverCDP is not supported when connecting remotely.');
     const result = await this._channel.connectOverCDPTransport({ transport: transport as any });
     return await this._browserFromConnectResult(result);
   }


### PR DESCRIPTION
## Summary
- Throw an explicit error in `connectOverCDP(transport)` when the client is connected to a remote server.
- The protocol declares `transport: binary` but the dispatcher uses `as any` on both sides to forward the live JS object — so it only works in-process. Over a wire the validator would coerce the transport to a Buffer and the server would fail downstream.
- Mirrors the `isRemote()` guards in `artifact.ts`, `video.ts`, and `elementHandle.ts`.

Context: introduced in 8f50322 ("feat(browserType): allow passing a ConnectionTransport to connectOverCDP", #40972).
