### PR TITLE
fix(chromium): resolve iframe worker response headers

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -489,7 +489,7 @@ export class CRNetworkManager {
   }
 
   _onLoadingFinished(sessionInfo: SessionInfo, event: Protocol.Network.loadingFinishedPayload) {
-    this._responseExtraInfoTracker.loadingFinished(event);
+    this._responseExtraInfoTracker.loadingFinished(event, !!sessionInfo.workerFrame);
 
     const request = this._requestIdToRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
@@ -511,7 +511,7 @@ export class CRNetworkManager {
   }
 
   _onLoadingFailed(sessionInfo: SessionInfo, event: Protocol.Network.loadingFailedPayload) {
-    this._responseExtraInfoTracker.loadingFailed(event);
+    this._responseExtraInfoTracker.loadingFailed(event, !!sessionInfo.workerFrame);
 
     let request = this._requestIdToRequest.get(event.requestId);
 
@@ -778,20 +778,20 @@ class ResponseExtraInfoTracker {
     this._patchHeaders(info, info.responses.length - 1);
   }
 
-  loadingFinished(event: Protocol.Network.loadingFinishedPayload) {
+  loadingFinished(event: Protocol.Network.loadingFinishedPayload, finishedOnWorkerTarget: boolean) {
     const info = this._requests.get(event.requestId);
     if (!info)
       return;
     info.loadingFinished = event;
-    this._checkFinished(info);
+    this._checkFinished(info, finishedOnWorkerTarget);
   }
 
-  loadingFailed(event: Protocol.Network.loadingFailedPayload) {
+  loadingFailed(event: Protocol.Network.loadingFailedPayload, finishedOnWorkerTarget: boolean) {
     const info = this._requests.get(event.requestId);
     if (!info)
       return;
     info.loadingFailed = event;
-    this._checkFinished(info);
+    this._checkFinished(info, finishedOnWorkerTarget);
   }
 
   _getOrCreateEntry(requestId: string): RequestInfo {
@@ -823,12 +823,23 @@ class ResponseExtraInfoTracker {
     }
   }
 
-  private _checkFinished(info: RequestInfo) {
+  private _checkFinished(info: RequestInfo, finishedOnWorkerTarget?: boolean) {
     if (!info.loadingFinished && !info.loadingFailed)
       return;
 
     if (info.responses.length <= info.responseReceivedExtraInfo.length) {
       // We have extra info for each response.
+      this._stopTracking(info.requestId);
+      return;
+    }
+
+    if (finishedOnWorkerTarget) {
+      for (let i = info.responseReceivedExtraInfo.length; i < info.responses.length; ++i) {
+        const response = info.responses[i];
+        response.request().setRawRequestHeaders(null);
+        response.setResponseHeadersSize(null);
+        response.setRawResponseHeaders(null);
+      }
       this._stopTracking(info.requestId);
       return;
     }

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -260,6 +260,35 @@ it('should report worker script as network request', {
   expect(text).toContain(`console.log('hello from the worker');`);
 });
 
+it('should resolve allHeaders for worker script inside iframe', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39948' },
+}, async ({ page, server, browserName }) => {
+  it.skip(browserName !== 'chromium', 'Chromium-specific regression');
+
+  server.setRoute('/iframe-worker.html', (req, res) => {
+    res.setHeader('Content-Type', 'text/html');
+    res.end(`<script>new Worker('/iframe-worker.js')</script>`);
+  });
+  server.setRoute('/iframe-worker.js', (req, res) => {
+    res.setHeader('Content-Type', 'text/javascript');
+    res.setHeader('x-worker-script', 'loaded');
+    res.end(`console.log('hello from iframe worker');`);
+  });
+
+  await page.goto(server.EMPTY_PAGE);
+  const [request] = await Promise.all([
+    page.waitForEvent('request', r => r.url().endsWith('/iframe-worker.js')),
+    page.waitForEvent('requestfinished', r => r.url().endsWith('/iframe-worker.js')),
+    attachFrame(page, 'frame1', server.PREFIX + '/iframe-worker.html'),
+  ]);
+  const response = await request.response();
+  const headers = await Promise.race([
+    response.allHeaders(),
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Timed out waiting for worker script response headers')), 3000)),
+  ]);
+  expect(headers['x-worker-script']).toBe('loaded');
+});
+
 it('should report worker script as network request after redirect', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35678' },
 }, async ({ page, server, browserName }) => {


### PR DESCRIPTION
Fixes #39948.

## Summary
- resolve Chromium worker-target response headers when the matching extra-info event never arrives
- add a regression test for `response.allHeaders()` on a worker script created inside an iframe

## Root cause
For a worker script loaded from an iframe, Chromium can mark the response as expecting extra info while the matching `Network.responseReceivedExtraInfo` event is not delivered for the worker target lifecycle. Playwright then leaves the raw response header promise unresolved, so `response.allHeaders()` hangs after the request has already finished.

## Validation
- `PLAYWRIGHT_HTML_OPEN=never bun run test tests/page/workers.spec.ts -g "allHeaders for worker script inside iframe" --project=chromium-page --workers=1 --reporter=line`
- `PLAYWRIGHT_HTML_OPEN=never bun run test tests/page/workers.spec.ts -g "worker script as network request|allHeaders for worker script inside iframe" --project=chromium-page --workers=1 --reporter=line`
- `bun run eslint packages/playwright-core/src/server/chromium/crNetworkManager.ts tests/page/workers.spec.ts`

