### PR TITLE
docs(cli-client/skill): use the real requests command in heal diagnose step

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/references/spec-driven-testing.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/references/spec-driven-testing.md
@@ -261,7 +261,7 @@ The test is paused at the start. Step forward or run to until just before the fa
 ```bash
 playwright-cli snapshot                # did the element change / move / rename?
 playwright-cli console                 # app-side errors?
-playwright-cli network                 # failed request? wrong payload?
+playwright-cli requests                # failed request? wrong payload?
 playwright-cli show --annotate         # ask the user to point somewhere
 ```
 


### PR DESCRIPTION
## Summary

- The spec-driven-testing skill's heal diagnose snippet listed `playwright-cli network`, which is not a real command. The network commands are `requests` (and `request <n>` for details), `route`, `route-list`, and `network-state-set`.
- Switched the line to `playwright-cli requests`, matching the DevTools usage already documented in `SKILL.md`. That is the right command for the inline comment's intent ("failed request? wrong payload?").

Minor docs-only fix, no API or behavior change.