### PR TITLE
fix(mcp): prevent orphan chrome via PPID polling + force-kill on hard exit

### DIFF
--- a/packages/playwright-core/src/tools/mcp/watchdog.ts
+++ b/packages/playwright-core/src/tools/mcp/watchdog.ts
@@ -14,24 +14,73 @@
  * limitations under the License.
  */
 
-import { gracefullyCloseAll, gracefullyCloseSet } from '@utils/processLauncher';
+import { gracefullyCloseAll, gracefullyCloseSet, killSet } from '@utils/processLauncher';
 import { testDebug } from './log';
+
+const PPID_POLL_INTERVAL_MS = 2000;
+const HARD_EXIT_TIMEOUT_MS = 15000;
 
 export function setupExitWatchdog() {
   let isExiting = false;
+
+  const forceKillSubprocesses = () => {
+    for (const kill of killSet) {
+      try {
+        kill();
+      } catch {
+        // Best-effort sync kill — nothing we can do if it throws.
+      }
+    }
+  };
+
   const handleExit = async (signal: string) => {
     if (isExiting)
       return;
     isExiting = true;
+    testDebug(`watchdog exit (${signal}); gracefully closing ${gracefullyCloseSet.size} subprocess(es)`);
+    // Hard fallback: if any graceful close hangs past HARD_EXIT_TIMEOUT_MS, force-kill
+    // every spawned subprocess (chrome process groups) before exiting. The previous
+    // implementation only called `process.exit(0)` on timeout, which leaves chrome
+    // re-parented to PID 1 (orphaned). See microsoft/playwright-mcp#1568.
     // eslint-disable-next-line no-restricted-properties
-    setTimeout(() => process.exit(0), 15000);
-    testDebug('gracefully closing ' + gracefullyCloseSet.size);
+    setTimeout(() => {
+      testDebug(`watchdog forced exit; force-killing ${killSet.size} subprocess(es)`);
+      forceKillSubprocesses();
+      // eslint-disable-next-line no-restricted-properties
+      process.exit(0);
+    }, HARD_EXIT_TIMEOUT_MS);
     await gracefullyCloseAll();
     // eslint-disable-next-line no-restricted-properties
     process.exit(0);
   };
 
-  process.stdin.on('close', () => handleExit('close'));
+  process.stdin.on('close', () => handleExit('stdin-close'));
   process.on('SIGINT', () => handleExit('SIGINT'));
   process.on('SIGTERM', () => handleExit('SIGTERM'));
+  process.on('SIGHUP', () => handleExit('SIGHUP'));
+
+  // IPC channel close — when the MCP host spawns us with `stdio: 'ipc'` and disconnects,
+  // this fires even if the stdin pipe is held alive by an intermediary (e.g. `npm exec`).
+  if (process.connected)
+    process.on('disconnect', () => handleExit('disconnect'));
+
+  // PPID polling — when the parent process dies via SIGKILL, is reaped by the OS, or sits
+  // behind an `npm exec` intermediary so stdin close doesn't propagate, no signal arrives
+  // and stdin may stay open. The kernel re-parents us to PID 1 in that case. Poll cheaply
+  // every PPID_POLL_INTERVAL_MS; on any change of parent (or PPID dropping to 1), treat as
+  // parent-death and exit. Covers the stdio-via-npm-exec orphan pattern documented in
+  // microsoft/playwright-mcp#1512 and the chrome orphan pattern in #1568.
+  const initialPpid = process.ppid;
+  const ppidTimer = setInterval(() => {
+    if (process.ppid !== initialPpid || process.ppid === 1) {
+      clearInterval(ppidTimer);
+      handleExit(`parent-died (ppid ${initialPpid} -> ${process.ppid})`);
+    }
+  }, PPID_POLL_INTERVAL_MS);
+  ppidTimer.unref();
+
+  // Last-resort synchronous kill on Node's `exit` event. Async work isn't allowed here,
+  // but `killSet` callbacks are synchronous SIGKILLs against subprocess groups — the
+  // exact thing needed to guarantee chrome doesn't outlive us in the orphan corner cases.
+  process.on('exit', forceKillSubprocesses);
 }


### PR DESCRIPTION
## Problem

The MCP exit watchdog (`packages/playwright-core/src/tools/mcp/watchdog.ts`) has three holes that combine to leak chrome process trees as orphans owned by PID 1, accumulating over time:

1. **No PPID polling** — when the MCP host dies via SIGKILL or sits behind an `npm exec` intermediary, no signal arrives at the MCP server and `process.stdin.on('close')` doesn't propagate through the intermediary. The watchdog never triggers; chrome lives forever.
2. **15s hard-exit doesn't kill subprocesses** — the existing `setTimeout(() => process.exit(0), 15e3)` fires `process.exit(0)` directly without first invoking `killSet`. If `gracefullyCloseAll()` hangs (CDP unresponsive, slow renderer teardown), the process exits cleanly but leaves every chrome alive.
3. **No `process.on('exit')` last-resort kill** — Node's synchronous exit hook is the final chance to fire SIGKILL at subprocess groups before the process actually goes away.

This is documented in detail by other users:
- microsoft/playwright-mcp#1568 — chrome orphans on stdio close, often consuming many cores via SwiftShader after parent dies.
- microsoft/playwright-mcp#1512 — sister bug (orphan MCP server processes via `npm exec`).

Both were closed as no-repro, but the bug is real and easy to hit on standard stdio MCP setups. Multi-hour sessions reliably leave behind `mcp-chrome-*` user-data-dirs and multi-renderer chrome trees owned by init.

## Reproduction

Standard stdio MCP config (e.g. `.claude/mcp.json`):
```json
{ "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] } }
```
1. Start a client session, call `browser_navigate` (spawns chrome under `~/.cache/ms-playwright/mcp-chrome-*`).
2. Force-end the client process (`kill -9 <pid>`, IDE reload, anything that bypasses graceful shutdown).
3. `pgrep -a -f 'ms-playwright/mcp-chrome'` — chrome master + renderers still alive, re-parented to PID 1.

## Fix

Five additive cleanup paths in `watchdog.ts`. No behavior change for the happy path; same module surface area; ~50 LOC, no new deps.

| Path | Catches |
|---|---|
| **PPID polling** (every 2s; exit on `process.ppid` change or drop to 1) | npm-exec intermediary + SIGKILL'd parent |
| **IPC `disconnect`** handler | Hosts using `stdio: 'ipc'` |
| **SIGHUP** handler | Terminal hangup |
| **Hard-exit timeout** now invokes `killSet` before `process.exit(0)` | Slow / hung graceful close |
| **`process.on('exit')`** sync killer | Final fallback for any uncaught path |

The PPID poll interval is unref'd so it doesn't keep the event loop alive on its own.

## Notes

- All cleanup mechanisms (`killSet`, `killProcessAndCleanup` with `process.kill(-pid, 'SIGKILL')`) already exist in `packages/utils/processLauncher.ts` — this patch wires them to the missing exit paths.
- Tests would need an integration harness that SIGKILLs the MCP server process and asserts `pgrep -f 'mcp-chrome'` is empty after N seconds. Happy to add in a follow-up if a reviewer points me at the right harness (couldn't find an existing one specifically for the MCP server shutdown path).

Closes microsoft/playwright-mcp#1568.
Related: microsoft/playwright-mcp#1512.