### PR TITLE
chore(browserType): merge connectOverCDP and connectOverCDPTransport

### DIFF
--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -115,7 +115,6 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['BrowserType.launch', { title: 'Launch browser', }],
   ['BrowserType.launchPersistentContext', { title: 'Launch persistent context', }],
   ['BrowserType.connectOverCDP', { title: 'Connect over CDP', }],
-  ['BrowserType.connectOverCDPTransport', { title: 'Connect over CDP transport', }],
   ['BrowserType.connectToWorker', { title: 'Connect to worker', }],
   ['Disposable.dispose', { internal: true, potentiallyClosesScope: true, }],
   ['Electron.launch', { title: 'Launch electron', }],

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -15439,7 +15439,8 @@ export interface BrowserType<Unused = {}> {
    * `ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4`.
    * @param options
    */
-  connectOverCDP(transport: ConnectionTransport): Promise<Browser>;
+  connectOverCDP(transport: ConnectionTransport, options?: ConnectOverCDPOptions): Promise<Browser>;
+
   /**
    * This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
    *

--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -138,39 +138,39 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
 
   async connectOverCDP(options: api.ConnectOverCDPOptions  & { wsEndpoint?: string }): Promise<api.Browser>;
   async connectOverCDP(endpointURL: string, options?: api.ConnectOverCDPOptions): Promise<api.Browser>;
-  async connectOverCDP(transport: api.ConnectionTransport): Promise<api.Browser>;
-  async connectOverCDP(endpointURLOrOptions: (api.ConnectOverCDPOptions & { wsEndpoint?: string })|string|api.ConnectionTransport, options?: api.ConnectOverCDPOptions) {
-    if (typeof endpointURLOrOptions === 'string')
-      return await this._connectOverCDP(endpointURLOrOptions, options);
-    if (isConnectionTransport(endpointURLOrOptions))
-      return await this._connectOverCDPTransport(endpointURLOrOptions);
-    const endpointURL = 'endpointURL' in endpointURLOrOptions ? endpointURLOrOptions.endpointURL : endpointURLOrOptions.wsEndpoint;
-    assert(endpointURL, 'Cannot connect over CDP without wsEndpoint.');
-    return await this._connectOverCDP(endpointURL, endpointURLOrOptions);
-  }
-
-  async _connectOverCDP(endpointURL: string, params: api.ConnectOverCDPOptions = {}): Promise<Browser>  {
-    if (this.name() !== 'chromium' && this.name() !== 'webkit')
+  async connectOverCDP(transport: api.ConnectionTransport, options?: api.ConnectOverCDPOptions): Promise<api.Browser>;
+  async connectOverCDP(overloaded: (api.ConnectOverCDPOptions & { wsEndpoint?: string }) | string | api.ConnectionTransport, options?: api.ConnectOverCDPOptions): Promise<Browser> {
+    let endpointURL: string | undefined;
+    let transport: api.ConnectionTransport | undefined;
+    let params: api.ConnectOverCDPOptions;
+    if (typeof overloaded === 'string') {
+      endpointURL = overloaded;
+      params = options ?? {};
+    } else if (isConnectionTransport(overloaded)) {
+      if (this.name() !== 'chromium' && this.name() !== 'webkit')
+        throw new Error('Connecting over CDP is only supported in Chromium and WebKit.');
+      if (this._connection.isRemote())
+        throw new Error('Passing a ConnectionTransport to connectOverCDP is not supported when connecting remotely.');
+      transport = overloaded;
+      params = options ?? {};
+    } else {
+      endpointURL = 'endpointURL' in overloaded ? (overloaded as any).endpointURL : overloaded.wsEndpoint;
+      assert(endpointURL, 'Cannot connect over CDP without wsEndpoint.');
+      params = overloaded;
+    }
+    if (endpointURL && this.name() !== 'chromium' && this.name() !== 'webkit')
       throw new Error('Connecting over CDP is only supported in Chromium and WebKit.');
-    const headers = params.headers ? headersObjectToArray(params.headers) : undefined;
+
     const result = await this._channel.connectOverCDP({
       endpointURL,
-      headers,
+      transport: transport as any,
+      headers: params.headers ? headersObjectToArray(params.headers) : undefined,
       slowMo: params.slowMo,
       timeout: new TimeoutSettings(this._platform).timeout(params),
       isLocal: params.isLocal,
       noDefaults: params.noDefaults,
       artifactsDir: params.artifactsDir,
     });
-    return await this._browserFromConnectResult(result);
-  }
-
-  async _connectOverCDPTransport(transport: api.ConnectionTransport): Promise<Browser> {
-    if (this.name() !== 'chromium')
-      throw new Error('Connecting over CDP is only supported in Chromium.');
-    if (this._connection.isRemote())
-      throw new Error('Passing a ConnectionTransport to connectOverCDP is not supported when connecting remotely.');
-    const result = await this._channel.connectOverCDPTransport({ transport: transport as any });
     return await this._browserFromConnectResult(result);
   }
 

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1087,22 +1087,16 @@ scheme.BrowserTypeLaunchPersistentContextResult = tObject({
   context: tChannel(['BrowserContext']),
 });
 scheme.BrowserTypeConnectOverCDPParams = tObject({
-  endpointURL: tString,
+  endpointURL: tOptional(tString),
   headers: tOptional(tArray(tType('NameValue'))),
   slowMo: tOptional(tFloat),
   timeout: tFloat,
   isLocal: tOptional(tBoolean),
   noDefaults: tOptional(tBoolean),
   artifactsDir: tOptional(tString),
+  transport: tOptional(tBinary),
 });
 scheme.BrowserTypeConnectOverCDPResult = tObject({
-  browser: tChannel(['Browser']),
-  defaultContext: tOptional(tChannel(['BrowserContext'])),
-});
-scheme.BrowserTypeConnectOverCDPTransportParams = tObject({
-  transport: tBinary,
-});
-scheme.BrowserTypeConnectOverCDPTransportResult = tObject({
   browser: tChannel(['Browser']),
   defaultContext: tOptional(tChannel(['BrowserContext'])),
 });

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -286,11 +286,7 @@ export abstract class BrowserType extends SdkObject {
     }
   }
 
-  async connectOverCDP(progress: Progress, endpointURL: string, options: { slowMo?: number, timeout?: number, headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean, artifactsDir?: string }): Promise<Browser> {
-    throw new Error('CDP connections are only supported by Chromium');
-  }
-
-  async connectOverCDPTransport(progress: Progress, transport: ConnectionTransport): Promise<Browser> {
+  async connectOverCDP(progress: Progress, params: channels.BrowserTypeConnectOverCDPParams): Promise<Browser> {
     throw new Error('CDP connections are only supported by Chromium');
   }
 

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -81,8 +81,10 @@ export class Chromium extends BrowserType {
     return super.launchPersistentContext(progress, userDataDir, options);
   }
 
-  override async connectOverCDP(progress: Progress, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean, artifactsDir?: string }) {
-    return await this._connectOverCDPInternal(progress, endpointURL, options);
+  override async connectOverCDP(progress: Progress, params: channels.BrowserTypeConnectOverCDPParams) {
+    if (params.transport)
+      return this._connectOverCDPImpl(progress, params.transport as any, async () => (params.transport as any).close(), { ...params, isLocal: true });
+    return await this._connectOverCDPInternal(progress, params.endpointURL!, params);
   }
 
   async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: types.LaunchOptions & { headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean, artifactsDir?: string }, onClose?: () => Promise<void>) {
@@ -164,11 +166,6 @@ export class Chromium extends BrowserType {
       await progress.race(doClose().catch(() => {}));
       throw error;
     }
-  }
-
-  override async connectOverCDPTransport(progress: Progress, transport: ConnectionTransport) {
-    const closeAndWait = async () => transport.close();
-    return this._connectOverCDPImpl(progress, transport, closeAndWait, { isLocal: true });
   }
 
   override async connectToWorker(progress: Progress, endpoint: string) {

--- a/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserTypeDispatcher.ts
@@ -57,21 +57,12 @@ export class BrowserTypeDispatcher extends Dispatcher<BrowserType, channels.Brow
     if (this._denyLaunch)
       throw new Error(`Launching more browsers is not allowed.`);
 
-    const browser = await this._object.connectOverCDP(progress, params.endpointURL, params);
+    const browser = await this._object.connectOverCDP(progress, params);
     const browserDispatcher = new BrowserDispatcher(this, browser);
     return {
       browser: browserDispatcher,
       defaultContext: browser._defaultContext ? BrowserContextDispatcher.from(browserDispatcher, browser._defaultContext) : undefined,
     };
-  }
-
-  async connectOverCDPTransport(params: channels.BrowserTypeConnectOverCDPTransportParams, progress: Progress): Promise<channels.BrowserTypeConnectOverCDPTransportResult> {
-    if (this._denyLaunch)
-      throw new Error(`Launching more browsers is not allowed.`);
-
-    const browser = await this._object.connectOverCDPTransport(progress, params.transport as any);
-    const browserDispatcher = new BrowserDispatcher(this, browser);
-    return { browser: browserDispatcher, defaultContext: browser._defaultContext ? BrowserContextDispatcher.from(browserDispatcher, browser._defaultContext) : undefined };
   }
 
   async connectToWorker(params: channels.BrowserTypeConnectToWorkerParams, progress: Progress): Promise<channels.BrowserTypeConnectToWorkerResult> {

--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -30,6 +30,7 @@ import type { SdkObject } from '../instrumentation';
 import type { Progress } from '../progress';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
+import type * as channels from '@protocol/channels';
 
 export class WebKit extends BrowserType {
   constructor(parent: SdkObject) {
@@ -40,8 +41,8 @@ export class WebKit extends BrowserType {
     return WKBrowser.connect(this.attribution.playwright, transport, options);
   }
 
-  override async connectOverCDP(progress: Progress, endpointURL: string, options: { slowMo?: number, headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean }): Promise<Browser> {
-    return connectOverRDP(progress, this, endpointURL, options);
+  override async connectOverCDP(progress: Progress, params: channels.BrowserTypeConnectOverCDPParams): Promise<Browser> {
+    return connectOverRDP(progress, this, params.endpointURL!, params);
   }
 
   override amendEnvironment(env: NodeJS.ProcessEnv, userDataDir: string, isPersistent: boolean, options: types.LaunchOptions): NodeJS.ProcessEnv {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -15439,7 +15439,8 @@ export interface BrowserType<Unused = {}> {
    * `ws://127.0.0.1:9222/devtools/browser/387adf4c-243f-4051-a181-46798f4a46f4`.
    * @param options
    */
-  connectOverCDP(transport: ConnectionTransport): Promise<Browser>;
+  connectOverCDP(transport: ConnectionTransport, options?: ConnectOverCDPOptions): Promise<Browser>;
+
   /**
    * This method attaches Playwright to an existing browser instance created via `BrowserType.launchServer` in Node.js.
    *

--- a/packages/protocol/spec/browserType.yml
+++ b/packages/protocol/spec/browserType.yml
@@ -43,7 +43,7 @@ BrowserType:
     connectOverCDP:
       title: Connect over CDP
       parameters:
-        endpointURL: string
+        endpointURL: string?
         headers:
           type: array?
           items: NameValue
@@ -52,14 +52,7 @@ BrowserType:
         isLocal: boolean?
         noDefaults: boolean?
         artifactsDir: string?
-      returns:
-        browser: Browser
-        defaultContext: BrowserContext?
-
-    connectOverCDPTransport:
-      title: Connect over CDP transport
-      parameters:
-        transport: binary
+        transport: binary?
       returns:
         browser: Browser
         defaultContext: BrowserContext?

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -1822,7 +1822,6 @@ export interface BrowserTypeChannel extends BrowserTypeEventTarget, Channel {
   launch(params: BrowserTypeLaunchParams, progress?: Progress): Promise<BrowserTypeLaunchResult>;
   launchPersistentContext(params: BrowserTypeLaunchPersistentContextParams, progress?: Progress): Promise<BrowserTypeLaunchPersistentContextResult>;
   connectOverCDP(params: BrowserTypeConnectOverCDPParams, progress?: Progress): Promise<BrowserTypeConnectOverCDPResult>;
-  connectOverCDPTransport(params: BrowserTypeConnectOverCDPTransportParams, progress?: Progress): Promise<BrowserTypeConnectOverCDPTransportResult>;
   connectToWorker(params: BrowserTypeConnectToWorkerParams, progress?: Progress): Promise<BrowserTypeConnectToWorkerResult>;
 }
 export type BrowserTypeLaunchParams = {
@@ -2060,32 +2059,25 @@ export type BrowserTypeLaunchPersistentContextResult = {
   context: BrowserContextChannel,
 };
 export type BrowserTypeConnectOverCDPParams = {
-  endpointURL: string,
+  endpointURL?: string,
   headers?: NameValue[],
   slowMo?: number,
   timeout: number,
   isLocal?: boolean,
   noDefaults?: boolean,
   artifactsDir?: string,
+  transport?: Binary,
 };
 export type BrowserTypeConnectOverCDPOptions = {
+  endpointURL?: string,
   headers?: NameValue[],
   slowMo?: number,
   isLocal?: boolean,
   noDefaults?: boolean,
   artifactsDir?: string,
+  transport?: Binary,
 };
 export type BrowserTypeConnectOverCDPResult = {
-  browser: BrowserChannel,
-  defaultContext?: BrowserContextChannel,
-};
-export type BrowserTypeConnectOverCDPTransportParams = {
-  transport: Binary,
-};
-export type BrowserTypeConnectOverCDPTransportOptions = {
-
-};
-export type BrowserTypeConnectOverCDPTransportResult = {
   browser: BrowserChannel,
   defaultContext?: BrowserContextChannel,
 };

--- a/tests/library/browsertype-basic.spec.ts
+++ b/tests/library/browsertype-basic.spec.ts
@@ -32,8 +32,8 @@ test('browserType.name should work', async ({ browserType, browserName }) => {
 });
 
 test('should throw when trying to connect with not-chromium', async ({ browserType, browserName }) => {
-  test.skip(browserName === 'chromium');
+  test.skip(browserName === 'chromium' || browserName === 'webkit');
 
   const error = await browserType.connectOverCDP({ endpointURL: 'ws://foo' }).catch(e => e);
-  expect(error.message).toBe('Connecting over CDP is only supported in Chromium.');
+  expect(error.message).toBe('Connecting over CDP is only supported in Chromium and WebKit.');
 });

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -216,7 +216,8 @@ export interface BrowserType<Unused = {}> {
    * @deprecated
    */
   connectOverCDP(options: ConnectOverCDPOptions & { wsEndpoint?: string }): Promise<Browser>;
-  connectOverCDP(transport: ConnectionTransport): Promise<Browser>;
+  connectOverCDP(transport: ConnectionTransport, options?: ConnectOverCDPOptions): Promise<Browser>;
+
   connect(wsEndpoint: string, options?: ConnectOptions): Promise<Browser>;
   /**
    * wsEndpoint in options is deprecated. Instead use `wsEndpoint`.


### PR DESCRIPTION
## Summary
- Collapse the URL- and transport-based CDP connect paths into a single protocol method.
- Merge the three client overload dispatchers into one.
- Merge the corresponding dispatcher and base-server entrypoints.