### PR TITLE
devops(webview): enable manual + path-scoped triggers for webview workflow

### DIFF
--- a/.github/workflows/tests_webview_simulator.yml
+++ b/.github/workflows/tests_webview_simulator.yml
@@ -1,7 +1,12 @@
 name: "tests WebView (iOS Simulator)"
 
 on:
-  # pull_request trigger disabled to avoid CI churn during wk_wv iteration - restore before merge
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tests/webview/**'
+      - 'packages/playwright-core/src/server/webkit/webview/**'
+      - '.github/workflows/tests_webview_simulator.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` so the webview iOS Simulator workflow can be run manually
- Re-enable `pull_request` trigger but scope it to webview-related paths to avoid CI churn