### PR TITLE
fix(cli): do not pass PLAYWRIGHT_CLI_SESSION as daemon --endpoint

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -105,7 +105,7 @@ export class TextOutput implements Output {
   }
 
   errorAttachConflict(): never {
-    console.error(`Error: cannot use target name with --cdp, --endpoint, or --extension`);
+    console.error(`Error: only one of [name], --cdp, --endpoint, or --extension can be specified`);
     return process.exit(1);
   }
 
@@ -288,7 +288,7 @@ export class JsonOutput implements Output {
   }
 
   errorAttachConflict(): never {
-    this._emit({ isError: true, error: `cannot use target name with --cdp, --endpoint, or --extension` });
+    this._emit({ isError: true, error: `only one of [name], --cdp, --endpoint, or --extension can be specified` });
     return process.exit(1);
   }
 

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -156,7 +156,8 @@ export async function program(options?: { embedderVersion?: string}) {
     }
     case 'attach': {
       const attachTarget = args._[1] as string | undefined;
-      if (attachTarget && (args.cdp || args.endpoint || args.extension))
+      const targetCount = (attachTarget ? 1 : 0) + (args.cdp ? 1 : 0) + (args.endpoint ? 1 : 0) + (args.extension ? 1 : 0);
+      if (targetCount > 1)
         output.errorAttachConflict();
       if (attachTarget)
         args.endpoint = attachTarget;

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -125,8 +125,6 @@ export class Session {
     ];
     if (cliArgs.headed)
       args.push('--headed');
-    if (cliArgs.extension)
-      args.push('--extension');
     if (cliArgs.browser)
       args.push(`--browser=${cliArgs.browser}`);
     if (cliArgs.persistent)
@@ -135,9 +133,11 @@ export class Session {
       args.push(`--profile=${cliArgs.profile}`);
     if (cliArgs.config)
       args.push(`--config=${cliArgs.config}`);
-    if (cliArgs.cdp)
+    if (cliArgs.extension)
+      args.push('--extension');
+    else if (cliArgs.cdp)
       args.push(`--cdp=${cliArgs.cdp}`);
-    if (cliArgs.endpoint)
+    else if (cliArgs.endpoint)
       args.push(`--endpoint=${cliArgs.endpoint}`);
 
     const child = spawn(process.execPath, args, {

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -139,8 +139,6 @@ export class Session {
       args.push(`--cdp=${cliArgs.cdp}`);
     if (cliArgs.endpoint)
       args.push(`--endpoint=${cliArgs.endpoint}`);
-    else if (mode === 'attach' && process.env.PLAYWRIGHT_CLI_SESSION)
-      args.push(`--endpoint=${process.env.PLAYWRIGHT_CLI_SESSION}`);
 
     const child = spawn(process.execPath, args, {
       detached: true,

--- a/tests/mcp/cli-cdp.spec.ts
+++ b/tests/mcp/cli-cdp.spec.ts
@@ -57,6 +57,12 @@ test('attach via cdp URL keeps the default session', async ({ cdpServer, cli, se
   expect(listOutput).toContain('(attached)');
 });
 
+test('attach via cdp URL honors PLAYWRIGHT_CLI_SESSION as session name', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-cli/issues/414' } }, async ({ cdpServer, cli }) => {
+  await cdpServer.start();
+  const { exitCode } = await cli('attach', `--cdp=${cdpServer.endpoint}`, { env: { PLAYWRIGHT_CLI_SESSION: 'myname' } });
+  expect(exitCode).toBe(0);
+});
+
 test('detach tears down an attached session', async ({ cdpServer, cli }) => {
   await cdpServer.start();
 

--- a/tests/mcp/cli-cdp.spec.ts
+++ b/tests/mcp/cli-cdp.spec.ts
@@ -63,6 +63,12 @@ test('attach via cdp URL honors PLAYWRIGHT_CLI_SESSION as session name', { annot
   expect(exitCode).toBe(0);
 });
 
+test('attach rejects combining --cdp, --endpoint, or --extension', async ({ cli }) => {
+  const { error, exitCode } = await cli('attach', '--cdp=chrome-dev', '--endpoint=/tmp/foo');
+  expect(exitCode).toBe(1);
+  expect(error).toContain('only one of [name], --cdp, --endpoint, or --extension can be specified');
+});
+
 test('detach tears down an attached session', async ({ cdpServer, cli }) => {
   await cdpServer.start();
 


### PR DESCRIPTION
## Summary
- `PLAYWRIGHT_CLI_SESSION` was being passed to the daemon as `--endpoint=<value>` in `attach` mode, in addition to its correct use as the session name. The daemon then tried to connect to a socket at the literal session-name path.
- Removed the vestigial fallback in `startDaemon`. `resolveSessionName` already consumes the env var with its documented meaning.

Fixes https://github.com/microsoft/playwright-cli/issues/414
