### PR TITLE
feat(mcp): add --output-max-size for output dir eviction

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -42,12 +42,14 @@ export class BrowserBackend implements ServerBackend {
   }
 
   async initialize(clientInfo: ClientInfo): Promise<void> {
-    this._sessionLog = this._config.saveSession ? await SessionLog.create(this._config, clientInfo.cwd) : undefined;
     this._context = new Context(this.browserContext, {
       config: this._config,
-      sessionLog: this._sessionLog,
       cwd: clientInfo.cwd,
     });
+    if (this._config.saveSession) {
+      this._sessionLog = await SessionLog.create(this._context, clientInfo.cwd);
+      this._context.sessionLog = this._sessionLog;
+    }
   }
 
   async dispose() {

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -407,7 +407,6 @@ export function outputDir(options: ContextOptions): string {
 async function outputFile(options: ContextOptions, fileName: string, flags: { origin: 'code' | 'llm' }): Promise<string> {
   const resolvedFile = path.resolve(outputDir(options), fileName);
   await checkFile(options, resolvedFile, flags);
-  debug('pw:mcp:file')(resolvedFile);
   return resolvedFile;
 }
 

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -212,7 +211,7 @@ export class Context {
   async outputFile(template: FilenameTemplate, options: { origin: 'code' | 'llm', evictable?: boolean }): Promise<OutputFile> {
     const baseName = template.suggestedFilename || `${template.prefix}-${(template.date ?? new Date()).toISOString().replace(/[:.]/g, '-')}${template.ext ? '.' + template.ext : ''}`;
     const absolutePath = await outputFile(this.options, baseName, options);
-    return this.outputDir.resolve(absolutePath, { evictable: options.evictable });
+    return await this.outputDir.resolve(absolutePath, { evictable: options.evictable });
   }
 
   async startVideoRecording(fileName: string, params: VideoParams) {
@@ -408,7 +407,6 @@ export function outputDir(options: ContextOptions): string {
 async function outputFile(options: ContextOptions, fileName: string, flags: { origin: 'code' | 'llm' }): Promise<string> {
   const resolvedFile = path.resolve(outputDir(options), fileName);
   await checkFile(options, resolvedFile, flags);
-  await fs.promises.mkdir(path.dirname(resolvedFile), { recursive: true });
   debug('pw:mcp:file')(resolvedFile);
   return resolvedFile;
 }

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -26,11 +26,13 @@ import { isPathInside, isSystemDirectory, isWritable } from '@utils/fileUtils';
 import { playwright } from '../../inprocess';
 
 import { Tab } from './tab';
+import { OutputDir } from './outputDir';
 
 import type * as playwrightTypes from '../../..';
 import type { SessionLog } from './sessionLog';
 import type { Disposable } from '@isomorphic/disposable';
 import type { ToolCapability } from './tool';
+import type { OutputFile } from './outputDir';
 
 const testDebug = debug('pw:mcp:test');
 
@@ -45,6 +47,7 @@ export type ContextConfig = {
     blockedOrigins?: string[];
   };
   outputDir?: string;
+  outputMaxSize?: number;
   outputMode?: 'file' | 'stdout';
   saveSession?: boolean;
   saveTrace?: boolean;
@@ -67,7 +70,6 @@ export type ContextConfig = {
 
 type ContextOptions = {
   config: ContextConfig;
-  sessionLog?: SessionLog;
   cwd: string;
 };
 
@@ -92,8 +94,9 @@ type VideoParams = { size?: { width: number; height: number } };
 
 export class Context {
   readonly config: ContextConfig;
-  readonly sessionLog: SessionLog | undefined;
+  sessionLog: SessionLog | undefined;
   readonly options: ContextOptions;
+  readonly outputDir: OutputDir;
   private _rawBrowserContext: playwrightTypes.BrowserContext;
   private _browserContextPromise: Promise<playwrightTypes.BrowserContext> | undefined;
   private _tabs: Tab[] = [];
@@ -117,8 +120,8 @@ export class Context {
 
   constructor(browserContext: playwrightTypes.BrowserContext, options: ContextOptions) {
     this.config = options.config;
-    this.sessionLog = options.sessionLog;
     this.options = options;
+    this.outputDir = new OutputDir(outputDir(options), options.config.outputMaxSize);
     this._rawBrowserContext = browserContext;
     testDebug('create context');
     process.on('unhandledRejection', this._onUnhandledRejection);
@@ -206,9 +209,10 @@ export class Context {
     return await workspaceFile(this.options, fileName, perCallWorkspaceDir);
   }
 
-  async outputFile(template: FilenameTemplate, options: { origin: 'code' | 'llm' }): Promise<string> {
+  async outputFile(template: FilenameTemplate, options: { origin: 'code' | 'llm', evictable?: boolean }): Promise<OutputFile> {
     const baseName = template.suggestedFilename || `${template.prefix}-${(template.date ?? new Date()).toISOString().replace(/[:.]/g, '-')}${template.ext ? '.' + template.ext : ''}`;
-    return await outputFile(this.options, baseName, options);
+    const absolutePath = await outputFile(this.options, baseName, options);
+    return this.outputDir.resolve(absolutePath, { evictable: options.evictable });
   }
 
   async startVideoRecording(fileName: string, params: VideoParams) {
@@ -401,7 +405,7 @@ export function outputDir(options: ContextOptions): string {
   return path.join(options.cwd, baseName);
 }
 
-export async function outputFile(options: ContextOptions, fileName: string, flags: { origin: 'code' | 'llm' }): Promise<string> {
+async function outputFile(options: ContextOptions, fileName: string, flags: { origin: 'code' | 'llm' }): Promise<string> {
   const resolvedFile = path.resolve(outputDir(options), fileName);
   await checkFile(options, resolvedFile, flags);
   await fs.promises.mkdir(path.dirname(resolvedFile), { recursive: true });

--- a/packages/playwright-core/src/tools/backend/logFile.ts
+++ b/packages/playwright-core/src/tools/backend/logFile.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import path from 'path';
 
 import debug from 'debug';
 import type { Context } from './context';
+import type { OutputFile } from './outputDir';
 
 export type LogChunk = {
   type: string;
@@ -34,7 +34,7 @@ export class LogFile {
   private _filePrefix: string;
   private _title: string;
 
-  private _file: string | undefined;
+  private _file: OutputFile | undefined;
   private _stopped: boolean = false;
 
   private _line: number = 0;
@@ -76,7 +76,7 @@ export class LogFile {
       return undefined;
     const chunk: LogChunk = {
       type: this._title.toLowerCase(),
-      file: this._file,
+      file: this._file.path,
       fromLine: this._lastLine + 1,
       toLine: this._line,
       entryCount: this._entries - this._lastEntries,
@@ -89,10 +89,10 @@ export class LogFile {
   private async _write(wallTime: number, text: string) {
     if (this._stopped)
       return;
-    this._file ??= await this._context.outputFile({ prefix: this._filePrefix, ext: 'log', date: new Date(this._startTime) }, { origin: 'code' });
+    this._file ??= await this._context.outputFile({ prefix: this._filePrefix, ext: 'log', date: new Date(this._startTime) }, { origin: 'code', evictable: false });
     const relativeTime = Math.round(wallTime - this._startTime);
     const logLine = `[${String(relativeTime).padStart(8, ' ')}ms] ${text}\n`;
-    await fs.promises.appendFile(this._file, logLine);
+    await this._file.append(logLine);
 
     const lineCount = logLine.split('\n').length - 1;
     this._line += lineCount;

--- a/packages/playwright-core/src/tools/backend/network.ts
+++ b/packages/playwright-core/src/tools/backend/network.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
-
 import * as z from 'zod';
 
 import { getExtensionForMimeType, isTextualMimeType } from '@isomorphic/mimeType';
@@ -257,7 +255,7 @@ async function saveResponseBody(request: playwright.Request, response: ToolRespo
     return undefined;
   const ext = getExtensionForMimeType(httpResponse.headers()['content-type']);
   const resolved = await response.resolveClientFile({ prefix: 'response', ext, suggestedFilename }, 'Response body');
-  await fs.promises.writeFile(resolved.fileName, body);
+  await resolved.file.write(body);
   return resolved.relativeName;
 }
 

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -60,7 +60,7 @@ export class OutputDir {
     if (total <= budget)
       return;
     for (const file of this._files.values()) {
-      if (file === keep || !file.evictable)
+      if (file === keep || !file.evictable || file.size === 0)
         continue;
       total -= file.size;
       fileDebug('evict %s (%d bytes)', file.path, file.size);

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -22,6 +22,10 @@ import { isPathInside } from '@utils/index';
 
 const fileDebug = debug('pw:mcp:file');
 
+// Not safe against concurrent writes to the same path or against another
+// writer's file being evicted mid-flight. Current callers serialize their
+// writes (SessionLog queues, LogFile is single-writer, screenshots/downloads
+// use unique paths), so this is acceptable for now.
 export class OutputDir {
   readonly path: string;
   readonly maxSize: number;

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -122,7 +122,7 @@ export class OutputFile {
 
   _unlink(): void {
     this._dir._files.delete(this.path);
-    void fs.promises.unlink(this.path).catch(() => {});
+    void fs.promises.unlink(this.path).catch(error => fileDebug('unlink failed %s: %s', this.path, error));
   }
 
   // Re-insert at the tail so this file becomes the "newest" for LRU/FIFO eviction.

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -41,6 +41,7 @@ export class OutputDir {
     if (!file) {
       file = new OutputFile(this, absolute, opts?.evictable ?? isPathInside(this.path, absolute));
       this._files.set(absolute, file);
+      fileDebug('resolve %s', absolute);
     }
     await fs.promises.mkdir(path.dirname(absolute), { recursive: true });
     return file;
@@ -58,6 +59,7 @@ export class OutputDir {
       if (file === keep || !file.evictable)
         continue;
       total -= file.size;
+      fileDebug('evict %s (%d bytes)', file.path, file.size);
       file._unlink();
       if (total <= budget)
         return;
@@ -83,7 +85,7 @@ export class OutputFile {
     if (nextSize > this.size)
       this._dir._evict(this._dir.maxSize - nextSize + this.size, this);
     await fs.promises.writeFile(this.path, data);
-    fileDebug(this.path);
+    fileDebug('write %s (%d bytes)', this.path, nextSize);
     this.size = nextSize;
     this._touch();
   }
@@ -92,7 +94,7 @@ export class OutputFile {
     const delta = Buffer.byteLength(data);
     this._dir._evict(this._dir.maxSize - delta, this);
     await fs.promises.appendFile(this.path, data);
-    fileDebug(this.path);
+    fileDebug('append %s (+%d bytes, total %d)', this.path, delta, this.size + delta);
     this.size += delta;
     this._touch();
   }

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -35,13 +35,14 @@ export class OutputDir {
       throw new Error(`outputMaxSize must be non-negative, got ${this.maxSize}`);
   }
 
-  resolve(p: string, opts?: { evictable?: boolean }): OutputFile {
+  async resolve(p: string, opts?: { evictable?: boolean }): Promise<OutputFile> {
     const absolute = path.resolve(this.path, p);
     let file = this._files.get(absolute);
     if (!file) {
       file = new OutputFile(this, absolute, opts?.evictable ?? isPathInside(this.path, absolute));
       this._files.set(absolute, file);
     }
+    await fs.promises.mkdir(path.dirname(absolute), { recursive: true });
     return file;
   }
 
@@ -81,7 +82,6 @@ export class OutputFile {
     const nextSize = Buffer.byteLength(data);
     if (nextSize > this.size)
       this._dir._evict(this._dir.maxSize - nextSize + this.size, this);
-    await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
     await fs.promises.writeFile(this.path, data);
     fileDebug(this.path);
     this.size = nextSize;
@@ -91,7 +91,6 @@ export class OutputFile {
   async append(data: Buffer | string): Promise<void> {
     const delta = Buffer.byteLength(data);
     this._dir._evict(this._dir.maxSize - delta, this);
-    await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
     await fs.promises.appendFile(this.path, data);
     fileDebug(this.path);
     this.size += delta;

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import debug from 'debug';
+
+const fileDebug = debug('pw:mcp:file');
+
+type Entry = {
+  path: string;
+  size: number;
+  addedAt: number;
+  evictable: boolean;
+};
+
+export class OutputDir {
+  readonly path: string;
+  private readonly _maxSize: number | undefined;
+  private readonly _files = new Map<string, OutputFile>();
+  private readonly _entries = new Map<string, Entry>();
+  private _totalSize = 0;
+  private _seq = 0;
+
+  constructor(absolutePath: string, maxSize: number | undefined) {
+    this.path = absolutePath;
+    this._maxSize = maxSize && maxSize > 0 ? maxSize : undefined;
+  }
+
+  resolve(pathInOrAbsolute: string, opts?: { evictable?: boolean }): OutputFile {
+    const absolute = path.isAbsolute(pathInOrAbsolute)
+      ? path.resolve(pathInOrAbsolute)
+      : path.resolve(this.path, pathInOrAbsolute);
+    const existing = this._files.get(absolute);
+    if (existing)
+      return existing;
+    const evictable = opts?.evictable ?? true;
+    const file = new OutputFile(this, absolute, evictable);
+    this._files.set(absolute, file);
+    return file;
+  }
+
+  get hasCap(): boolean {
+    return this._maxSize !== undefined;
+  }
+
+  // Frees evictable entries until `additionalBytes` (the net increase to
+  // totalSize implied by an upcoming upsert/append) fits within the cap.
+  // `excludePath` is the file about to be written and must not be evicted.
+  _evictForBytes(additionalBytes: number, excludePath: string | undefined): void {
+    if (this._maxSize === undefined)
+      return;
+    while (this._totalSize + additionalBytes > this._maxSize) {
+      const oldest = this._oldestEvictable(excludePath);
+      if (!oldest)
+        return;
+      this._removeEntry(oldest);
+      void fs.promises.unlink(oldest.path).catch(() => {});
+    }
+  }
+
+  private _oldestEvictable(excludePath: string | undefined): Entry | undefined {
+    let oldest: Entry | undefined;
+    for (const entry of this._entries.values()) {
+      if (!entry.evictable)
+        continue;
+      if (excludePath && entry.path === excludePath)
+        continue;
+      if (!oldest || entry.addedAt < oldest.addedAt)
+        oldest = entry;
+    }
+    return oldest;
+  }
+
+  private _removeEntry(entry: Entry) {
+    if (this._entries.delete(entry.path))
+      this._totalSize -= entry.size;
+  }
+
+  _upsert(absPath: string, size: number, evictable: boolean): void {
+    if (this._maxSize === undefined)
+      return;
+    const existing = this._entries.get(absPath);
+    if (existing) {
+      this._totalSize -= existing.size;
+      existing.size = size;
+      existing.addedAt = ++this._seq;
+      this._totalSize += size;
+      return;
+    }
+    this._entries.set(absPath, {
+      path: absPath,
+      size,
+      addedAt: ++this._seq,
+      evictable,
+    });
+    this._totalSize += size;
+  }
+
+  _addToEntry(absPath: string, delta: number, evictable: boolean): void {
+    if (this._maxSize === undefined)
+      return;
+    const existing = this._entries.get(absPath);
+    if (existing) {
+      existing.size += delta;
+      this._totalSize += delta;
+      return;
+    }
+    this._entries.set(absPath, {
+      path: absPath,
+      size: delta,
+      addedAt: ++this._seq,
+      evictable,
+    });
+    this._totalSize += delta;
+  }
+
+  _entrySize(absPath: string): number | undefined {
+    return this._entries.get(absPath)?.size;
+  }
+
+  // For tests/diagnostics.
+  totalTrackedSize(): number {
+    return this._totalSize;
+  }
+}
+
+export class OutputFile {
+  readonly path: string;
+  readonly evictable: boolean;
+  private readonly _dir: OutputDir;
+
+  constructor(dir: OutputDir, absolutePath: string, evictable: boolean) {
+    this._dir = dir;
+    this.path = absolutePath;
+    this.evictable = evictable;
+  }
+
+  async write(data: Buffer | string): Promise<void> {
+    const size = Buffer.byteLength(data);
+    const additional = size - (this._dir._entrySize(this.path) ?? 0);
+    this._dir._evictForBytes(additional, this.path);
+    await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
+    await fs.promises.writeFile(this.path, data);
+    fileDebug(this.path);
+    this._dir._upsert(this.path, size, this.evictable);
+  }
+
+  async append(data: Buffer | string): Promise<void> {
+    const delta = Buffer.byteLength(data);
+    this._dir._evictForBytes(delta, this.path);
+    await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
+    await fs.promises.appendFile(this.path, data);
+    fileDebug(this.path);
+    this._dir._addToEntry(this.path, delta, this.evictable);
+  }
+
+  async trackSize(size?: number): Promise<void> {
+    if (!this._dir.hasCap)
+      return;
+    let resolvedSize = size;
+    if (resolvedSize === undefined) {
+      try {
+        const stat = await fs.promises.stat(this.path);
+        resolvedSize = stat.size;
+      } catch {
+        resolvedSize = 0;
+      }
+    }
+    const additional = resolvedSize - (this._dir._entrySize(this.path) ?? 0);
+    this._dir._evictForBytes(additional, this.path);
+    this._dir._upsert(this.path, resolvedSize, this.evictable);
+  }
+}

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -18,130 +18,57 @@ import fs from 'fs';
 import path from 'path';
 
 import debug from 'debug';
+import { isPathInside } from '@utils/index';
 
 const fileDebug = debug('pw:mcp:file');
 
-type Entry = {
-  path: string;
-  size: number;
-  addedAt: number;
-  evictable: boolean;
-};
-
 export class OutputDir {
   readonly path: string;
-  private readonly _maxSize: number | undefined;
-  private readonly _files = new Map<string, OutputFile>();
-  private readonly _entries = new Map<string, Entry>();
-  private _totalSize = 0;
-  private _seq = 0;
+  readonly maxSize: number;
+  // Insertion order encodes age: oldest first, newest last.
+  readonly _files = new Map<string, OutputFile>();
 
-  constructor(absolutePath: string, maxSize: number | undefined) {
-    this.path = absolutePath;
-    this._maxSize = maxSize && maxSize > 0 ? maxSize : undefined;
+  constructor(path: string, maxSize: number | undefined) {
+    this.path = path;
+    this.maxSize = maxSize ?? 0;
+    if (this.maxSize < 0)
+      throw new Error(`outputMaxSize must be non-negative, got ${this.maxSize}`);
   }
 
-  resolve(pathInOrAbsolute: string, opts?: { evictable?: boolean }): OutputFile {
-    const absolute = path.isAbsolute(pathInOrAbsolute)
-      ? path.resolve(pathInOrAbsolute)
-      : path.resolve(this.path, pathInOrAbsolute);
-    const existing = this._files.get(absolute);
-    if (existing)
-      return existing;
-    const evictable = opts?.evictable ?? true;
-    const file = new OutputFile(this, absolute, evictable);
-    this._files.set(absolute, file);
+  resolve(p: string, opts?: { evictable?: boolean }): OutputFile {
+    const absolute = path.resolve(this.path, p);
+    let file = this._files.get(absolute);
+    if (!file) {
+      file = new OutputFile(this, absolute, opts?.evictable ?? isPathInside(this.path, absolute));
+      this._files.set(absolute, file);
+    }
     return file;
   }
 
-  get hasCap(): boolean {
-    return this._maxSize !== undefined;
-  }
-
-  // Frees evictable entries until `additionalBytes` (the net increase to
-  // totalSize implied by an upcoming upsert/append) fits within the cap.
-  // `excludePath` is the file about to be written and must not be evicted.
-  _evictForBytes(additionalBytes: number, excludePath: string | undefined): void {
-    if (this._maxSize === undefined)
+  _evict(budget: number, keep: OutputFile): void {
+    if (this.maxSize === 0)
       return;
-    while (this._totalSize + additionalBytes > this._maxSize) {
-      const oldest = this._oldestEvictable(excludePath);
-      if (!oldest)
+    let total = 0;
+    for (const file of this._files.values())
+      total += file.size;
+    if (total <= budget)
+      return;
+    for (const file of this._files.values()) {
+      if (file === keep || !file.evictable)
+        continue;
+      total -= file.size;
+      file._unlink();
+      if (total <= budget)
         return;
-      this._removeEntry(oldest);
-      void fs.promises.unlink(oldest.path).catch(() => {});
     }
   }
 
-  private _oldestEvictable(excludePath: string | undefined): Entry | undefined {
-    let oldest: Entry | undefined;
-    for (const entry of this._entries.values()) {
-      if (!entry.evictable)
-        continue;
-      if (excludePath && entry.path === excludePath)
-        continue;
-      if (!oldest || entry.addedAt < oldest.addedAt)
-        oldest = entry;
-    }
-    return oldest;
-  }
-
-  private _removeEntry(entry: Entry) {
-    if (this._entries.delete(entry.path))
-      this._totalSize -= entry.size;
-  }
-
-  _upsert(absPath: string, size: number, evictable: boolean): void {
-    if (this._maxSize === undefined)
-      return;
-    const existing = this._entries.get(absPath);
-    if (existing) {
-      this._totalSize -= existing.size;
-      existing.size = size;
-      existing.addedAt = ++this._seq;
-      this._totalSize += size;
-      return;
-    }
-    this._entries.set(absPath, {
-      path: absPath,
-      size,
-      addedAt: ++this._seq,
-      evictable,
-    });
-    this._totalSize += size;
-  }
-
-  _addToEntry(absPath: string, delta: number, evictable: boolean): void {
-    if (this._maxSize === undefined)
-      return;
-    const existing = this._entries.get(absPath);
-    if (existing) {
-      existing.size += delta;
-      this._totalSize += delta;
-      return;
-    }
-    this._entries.set(absPath, {
-      path: absPath,
-      size: delta,
-      addedAt: ++this._seq,
-      evictable,
-    });
-    this._totalSize += delta;
-  }
-
-  _entrySize(absPath: string): number | undefined {
-    return this._entries.get(absPath)?.size;
-  }
-
-  // For tests/diagnostics.
-  totalTrackedSize(): number {
-    return this._totalSize;
-  }
 }
 
 export class OutputFile {
   readonly path: string;
   readonly evictable: boolean;
+  size = 0;
   private readonly _dir: OutputDir;
 
   constructor(dir: OutputDir, absolutePath: string, evictable: boolean) {
@@ -151,38 +78,51 @@ export class OutputFile {
   }
 
   async write(data: Buffer | string): Promise<void> {
-    const size = Buffer.byteLength(data);
-    const additional = size - (this._dir._entrySize(this.path) ?? 0);
-    this._dir._evictForBytes(additional, this.path);
+    const nextSize = Buffer.byteLength(data);
+    if (nextSize > this.size)
+      this._dir._evict(this._dir.maxSize - nextSize + this.size, this);
     await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
     await fs.promises.writeFile(this.path, data);
     fileDebug(this.path);
-    this._dir._upsert(this.path, size, this.evictable);
+    this.size = nextSize;
+    this._touch();
   }
 
   async append(data: Buffer | string): Promise<void> {
     const delta = Buffer.byteLength(data);
-    this._dir._evictForBytes(delta, this.path);
+    this._dir._evict(this._dir.maxSize - delta, this);
     await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
     await fs.promises.appendFile(this.path, data);
     fileDebug(this.path);
-    this._dir._addToEntry(this.path, delta, this.evictable);
+    this.size += delta;
+    this._touch();
   }
 
   async trackSize(size?: number): Promise<void> {
-    if (!this._dir.hasCap)
+    if (this._dir.maxSize === 0)
       return;
-    let resolvedSize = size;
-    if (resolvedSize === undefined) {
+    let nextSize = size;
+    if (nextSize === undefined) {
       try {
-        const stat = await fs.promises.stat(this.path);
-        resolvedSize = stat.size;
+        nextSize = (await fs.promises.stat(this.path)).size;
       } catch {
-        resolvedSize = 0;
+        nextSize = 0;
       }
     }
-    const additional = resolvedSize - (this._dir._entrySize(this.path) ?? 0);
-    this._dir._evictForBytes(additional, this.path);
-    this._dir._upsert(this.path, resolvedSize, this.evictable);
+    if (nextSize > this.size)
+      this._dir._evict(this._dir.maxSize - nextSize + this.size, this);
+    this.size = nextSize;
+    this._touch();
+  }
+
+  _unlink(): void {
+    this._dir._files.delete(this.path);
+    void fs.promises.unlink(this.path).catch(() => {});
+  }
+
+  // Re-insert at the tail so this file becomes the "newest" for LRU/FIFO eviction.
+  private _touch(): void {
+    this._dir._files.delete(this.path);
+    this._dir._files.set(this.path, this);
   }
 }

--- a/packages/playwright-core/src/tools/backend/outputDir.ts
+++ b/packages/playwright-core/src/tools/backend/outputDir.ts
@@ -122,7 +122,7 @@ export class OutputFile {
 
   _unlink(): void {
     this._dir._files.delete(this.path);
-    void fs.promises.unlink(this.path).catch(error => fileDebug('unlink failed %s: %s', this.path, error));
+    void fs.promises.rm(this.path, { recursive: true, force: true }).catch(error => fileDebug('unlink failed %s: %s', this.path, error));
   }
 
   // Re-insert at the tail so this file becomes the "newest" for LRU/FIFO eviction.

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -25,11 +25,12 @@ import type * as playwright from '../../..';
 import type { TabHeader } from './tab';
 import type { CallToolResult, ImageContent, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import type { Context, FilenameTemplate } from './context';
+import type { OutputFile } from './outputDir';
 
 export const requestDebug = debug('pw:mcp:request');
 
 type ResolvedFile = {
-  fileName: string;
+  file: OutputFile;
   relativeName: string;
   printableLink: string;
 };
@@ -78,15 +79,15 @@ export class Response {
     return rel;
   }
 
-  async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
-    let fileName: string;
+  async resolveClientFile(template: FilenameTemplate, title: string, opts?: { evictable?: boolean }): Promise<ResolvedFile> {
+    let file: OutputFile;
     if (template.suggestedFilename)
-      fileName = await this.resolveClientFilename(template.suggestedFilename);
+      file = this._context.outputDir.resolve(await this.resolveClientFilename(template.suggestedFilename), { evictable: false });
     else
-      fileName = await this._context.outputFile(template, { origin: 'llm' });
-    const relativeName = this._computeRelativeTo(fileName);
+      file = await this._context.outputFile(template, { origin: 'llm', evictable: opts?.evictable });
+    const relativeName = this._computeRelativeTo(file.path);
     const printableLink = `- [${title}](${relativeName})`;
-    return { fileName, relativeName, printableLink };
+    return { relativeName, printableLink, file };
   }
 
   async resolveClientFilename(filename: string): Promise<string> {
@@ -108,9 +109,11 @@ export class Response {
 
   private async _writeFile(resolvedFile: ResolvedFile, data: Buffer | string | null) {
     if (typeof data === 'string')
-      await fs.promises.writeFile(resolvedFile.fileName, this._redactSecrets(data), 'utf-8');
+      await resolvedFile.file.write(this._redactSecrets(data));
     else if (data)
-      await fs.promises.writeFile(resolvedFile.fileName, data);
+      await resolvedFile.file.write(data);
+    else
+      await resolvedFile.file.trackSize();
   }
 
   async addFileResult(resolvedFile: ResolvedFile, data: Buffer | string | null) {

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -18,7 +18,6 @@ import fs from 'fs';
 import path from 'path';
 
 import debug from 'debug';
-import { isPathInside } from '@utils/fileUtils';
 import { renderModalStates } from './tab';
 import { scaleImageToFitMessage } from './screenshot';
 
@@ -84,12 +83,7 @@ export class Response {
     let file: OutputFile;
     if (template.suggestedFilename) {
       const resolvedPath = await this.resolveClientFilename(template.suggestedFilename);
-      // If a client-provided filename lands inside the outputDir, treat it like
-      // any auto-generated artifact and allow eviction; files saved to the
-      // user's workspace are pinned so we never delete their data.
-      const insideOutputDir = isPathInside(this._context.outputDir.path, resolvedPath);
-      const evictable = insideOutputDir ? (opts?.evictable ?? true) : false;
-      file = this._context.outputDir.resolve(resolvedPath, { evictable });
+      file = this._context.outputDir.resolve(resolvedPath, { evictable: opts?.evictable });
     } else {
       file = await this._context.outputFile(template, { origin: 'llm', evictable: opts?.evictable });
     }

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -79,13 +79,13 @@ export class Response {
     return rel;
   }
 
-  async resolveClientFile(template: FilenameTemplate, title: string, opts?: { evictable?: boolean }): Promise<ResolvedFile> {
+  async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
     let file: OutputFile;
     if (template.suggestedFilename) {
       const resolvedPath = await this.resolveClientFilename(template.suggestedFilename);
-      file = await this._context.outputDir.resolve(resolvedPath, { evictable: opts?.evictable });
+      file = await this._context.outputDir.resolve(resolvedPath);
     } else {
-      file = await this._context.outputFile(template, { origin: 'llm', evictable: opts?.evictable });
+      file = await this._context.outputFile(template, { origin: 'llm' });
     }
     const relativeName = this._computeRelativeTo(file.path);
     const printableLink = `- [${title}](${relativeName})`;

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import debug from 'debug';
+import { isPathInside } from '@utils/fileUtils';
 import { renderModalStates } from './tab';
 import { scaleImageToFitMessage } from './screenshot';
 
@@ -81,10 +82,17 @@ export class Response {
 
   async resolveClientFile(template: FilenameTemplate, title: string, opts?: { evictable?: boolean }): Promise<ResolvedFile> {
     let file: OutputFile;
-    if (template.suggestedFilename)
-      file = this._context.outputDir.resolve(await this.resolveClientFilename(template.suggestedFilename), { evictable: false });
-    else
+    if (template.suggestedFilename) {
+      const resolvedPath = await this.resolveClientFilename(template.suggestedFilename);
+      // If a client-provided filename lands inside the outputDir, treat it like
+      // any auto-generated artifact and allow eviction; files saved to the
+      // user's workspace are pinned so we never delete their data.
+      const insideOutputDir = isPathInside(this._context.outputDir.path, resolvedPath);
+      const evictable = insideOutputDir ? (opts?.evictable ?? true) : false;
+      file = this._context.outputDir.resolve(resolvedPath, { evictable });
+    } else {
       file = await this._context.outputFile(template, { origin: 'llm', evictable: opts?.evictable });
+    }
     const relativeName = this._computeRelativeTo(file.path);
     const printableLink = `- [${title}](${relativeName})`;
     return { relativeName, printableLink, file };

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -83,7 +83,7 @@ export class Response {
     let file: OutputFile;
     if (template.suggestedFilename) {
       const resolvedPath = await this.resolveClientFilename(template.suggestedFilename);
-      file = this._context.outputDir.resolve(resolvedPath, { evictable: opts?.evictable });
+      file = await this._context.outputDir.resolve(resolvedPath, { evictable: opts?.evictable });
     } else {
       file = await this._context.outputFile(template, { origin: 'llm', evictable: opts?.evictable });
     }

--- a/packages/playwright-core/src/tools/backend/sessionLog.ts
+++ b/packages/playwright-core/src/tools/backend/sessionLog.ts
@@ -14,32 +14,32 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import path from 'path';
 
-import { outputFile  } from './context';
 import { parseResponse } from './response';
 
-import type { ContextConfig } from './context';
+import type { Context } from './context';
+import type { OutputFile } from './outputDir';
 
 export class SessionLog {
-  private _folder: string;
-  private _file: string;
+  private _file: OutputFile;
   private _cwd: string;
   private _sessionFileQueue = Promise.resolve();
 
-  constructor(sessionFolder: string, cwd: string) {
-    this._folder = sessionFolder;
-    this._file = path.join(this._folder, 'session.md');
+  private constructor(file: OutputFile, cwd: string) {
+    this._file = file;
     this._cwd = cwd;
   }
 
-  static async create(config: ContextConfig, cwd: string): Promise<SessionLog> {
-    const sessionFolder = await outputFile({ config, cwd }, `session-${Date.now()}`, { origin: 'code' });
-    await fs.promises.mkdir(sessionFolder, { recursive: true });
+  static async create(context: Context, cwd: string): Promise<SessionLog> {
+    const file = await context.outputFile({
+      prefix: '',
+      ext: '',
+      suggestedFilename: path.join(`session-${Date.now()}`, 'session.md'),
+    }, { origin: 'code', evictable: false });
     // eslint-disable-next-line no-console
-    console.error(`Session: ${sessionFolder}`);
-    return new SessionLog(sessionFolder, cwd);
+    console.error(`Session: ${path.dirname(file.path)}`);
+    return new SessionLog(file, cwd);
   }
 
   logResponse(toolName: string, toolArgs: Record<string, any>, responseObject: any) {
@@ -60,6 +60,6 @@ export class SessionLog {
     }
 
     lines.push('');
-    this._sessionFileQueue = this._sessionFileQueue.then(() => fs.promises.appendFile(this._file, lines.join('\n')));
+    this._sessionFileQueue = this._sessionFileQueue.then(() => this._file.append(lines.join('\n')));
   }
 }

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -203,15 +203,16 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   private async _downloadStarted(download: playwright.Download) {
     // Do not trust web names.
-    const outputFile = await this.context.outputFile({ suggestedFilename: sanitizeForFilePath(download.suggestedFilename()), prefix: 'download', ext: 'bin' }, { origin: 'code' });
+    const file = await this.context.outputFile({ suggestedFilename: sanitizeForFilePath(download.suggestedFilename()), prefix: 'download', ext: 'bin' }, { origin: 'code' });
     const entry = {
       download,
       finished: false,
-      outputFile,
+      outputFile: file.path,
     };
     this._downloads.push(entry);
     this._addLogEntry({ type: 'download-start', wallTime: Date.now(), download: entry });
-    await download.saveAs(entry.outputFile);
+    await download.saveAs(file.path);
+    await file.trackSize();
     entry.finished = true;
     this._addLogEntry({ type: 'download-finish', wallTime: Date.now(), download: entry });
   }

--- a/packages/playwright-core/src/tools/backend/tracing.ts
+++ b/packages/playwright-core/src/tools/backend/tracing.ts
@@ -31,7 +31,8 @@ const tracingStart = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    const tracesDir = await context.outputFile({ prefix: '', suggestedFilename: `traces`, ext: '' }, { origin: 'code' });
+    // We don't own writing so we cannot track file size for this.
+    const { path: tracesDir } = await context.outputFile({ prefix: '', suggestedFilename: `traces`, ext: '' }, { origin: 'code', evictable: false });
     const name = 'trace-' + Date.now();
     await browserContext.tracing.start({
       name,

--- a/packages/playwright-core/src/tools/backend/tracing.ts
+++ b/packages/playwright-core/src/tools/backend/tracing.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import * as z from 'zod';
 import { defineTool } from './tool';
 
+import type { OutputFile } from './outputDir';
+
+type TraceLegend = { tracesDir: OutputFile, name: string };
 
 const tracingStart = defineTool({
   capability: 'devtools',
@@ -31,8 +37,7 @@ const tracingStart = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    // We don't own writing so we cannot track file size for this.
-    const { path: tracesDir } = await context.outputFile({ prefix: '', suggestedFilename: `traces`, ext: '' }, { origin: 'code', evictable: false });
+    const tracesDir = await context.outputFile({ prefix: '', suggestedFilename: `traces`, ext: '' }, { origin: 'code' });
     const name = 'trace-' + Date.now();
     await browserContext.tracing.start({
       name,
@@ -41,11 +46,11 @@ const tracingStart = defineTool({
       live: true,
     });
     response.addTextResult(`Trace recording started`);
-    response.addFileLink('Action log', `${tracesDir}/${name}.trace`);
-    response.addFileLink('Network log', `${tracesDir}/${name}.network`);
-    response.addFileLink('Resources', `${tracesDir}/resources`);
+    response.addFileLink('Action log', `${tracesDir.path}/${name}.trace`);
+    response.addFileLink('Network log', `${tracesDir.path}/${name}.network`);
+    response.addFileLink('Resources', `${tracesDir.path}/resources`);
     // eslint-disable-next-line no-restricted-syntax
-    (browserContext.tracing as any)[traceLegendSymbol] = { tracesDir, name };
+    (browserContext.tracing as any)[traceLegendSymbol] = { tracesDir, name } satisfies TraceLegend;
   },
 });
 
@@ -64,16 +69,19 @@ const tracingStop = defineTool({
     const browserContext = await context.ensureBrowserContext();
     await browserContext.tracing.stop();
     // eslint-disable-next-line no-restricted-syntax
-    const traceLegend = (browserContext.tracing as any)[traceLegendSymbol];
+    const traceLegend: TraceLegend | undefined = (browserContext.tracing as any)[traceLegendSymbol];
     if (!traceLegend)
       throw new Error('Tracing is not started');
     // eslint-disable-next-line no-restricted-syntax
     delete (browserContext.tracing as any)[traceLegendSymbol];
 
+    const tracesDir = traceLegend.tracesDir;
+    await tracesDir.trackSize(await directorySize(tracesDir.path));
+
     response.addTextResult(`Trace recording stopped.`);
-    response.addFileLink('Trace', `${traceLegend.tracesDir}/${traceLegend.name}.trace`);
-    response.addFileLink('Network log', `${traceLegend.tracesDir}/${traceLegend.name}.network`);
-    response.addFileLink('Resources', `${traceLegend.tracesDir}/resources`);
+    response.addFileLink('Trace', `${tracesDir.path}/${traceLegend.name}.trace`);
+    response.addFileLink('Network log', `${tracesDir.path}/${traceLegend.name}.network`);
+    response.addFileLink('Resources', `${tracesDir.path}/resources`);
   },
 });
 
@@ -83,3 +91,20 @@ export default [
 ];
 
 const traceLegendSymbol = Symbol('tracesDir');
+
+async function directorySize(dir: string): Promise<number> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true, recursive: true });
+  } catch {
+    return 0;
+  }
+  const sizes = await Promise.all(entries.filter(e => e.isFile()).map(async e => {
+    try {
+      return (await fs.promises.stat(path.join(e.parentPath, e.name))).size;
+    } catch {
+      return 0;
+    }
+  }));
+  return sizes.reduce((a, b) => a + b, 0);
+}

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -36,7 +36,7 @@ const videoStart = defineTool({
 
   handle: async (context, params, response) => {
     const resolvedFile = await response.resolveClientFile({ prefix: 'video', ext: 'webm', suggestedFilename: params.filename }, 'Video');
-    await context.startVideoRecording(resolvedFile.fileName, { size: params.size });
+    await context.startVideoRecording(resolvedFile.file.path, { size: params.size });
     response.addTextResult('Video recording started.');
   },
 });

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -159,6 +159,11 @@ export type Config = {
    */
   outputDir?: string;
 
+  /**
+   * Threshold for evicting old output files, in bytes.
+   */
+  outputMaxSize?: number;
+
   console?: {
     /**
      * The level of console messages to return. Each level includes the messages of more severe levels. Defaults to "info".

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -60,6 +60,7 @@ export type CLIOptions = {
   imageResponses?: 'allow' | 'omit';
   sandbox?: boolean;
   outputDir?: string;
+  outputMaxSize?: number;
   port?: number;
   proxyBypass?: string;
   proxyServer?: string;
@@ -356,6 +357,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
     sharedBrowserContext: cliOptions.sharedBrowserContext,
     snapshot: cliOptions.snapshotMode ? { mode: cliOptions.snapshotMode } : undefined,
     outputDir: cliOptions.outputDir,
+    outputMaxSize: cliOptions.outputMaxSize,
     imageResponses: cliOptions.imageResponses,
     testIdAttribute: cliOptions.testIdAttribute,
     timeouts: {
@@ -401,6 +403,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
     options.imageResponses = enumParser<'allow' | 'omit'>('--image-responses', ['allow', 'omit'], e.PLAYWRIGHT_MCP_IMAGE_RESPONSES);
   options.sandbox = envToBoolean(e.PLAYWRIGHT_MCP_SANDBOX);
   options.outputDir = envToString(e.PLAYWRIGHT_MCP_OUTPUT_DIR);
+  options.outputMaxSize = numberParser(e.PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE);
   options.port = numberParser(e.PLAYWRIGHT_MCP_PORT);
   options.proxyBypass = envToString(e.PLAYWRIGHT_MCP_PROXY_BYPASS);
   options.proxyServer = envToString(e.PLAYWRIGHT_MCP_PROXY_SERVER);

--- a/packages/playwright-core/src/tools/mcp/configIni.ts
+++ b/packages/playwright-core/src/tools/mcp/configIni.ts
@@ -161,6 +161,7 @@ const longhandTypes: Record<string, LonghandType> = {
   'saveVideo': 'size',
   'sharedBrowserContext': 'boolean',
   'outputDir': 'string',
+  'outputMaxSize': 'number',
   'imageResponses': 'string',
   'allowUnrestrictedFileAccess': 'boolean',
   'codegen': 'string',

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -59,6 +59,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".', enumParser.bind(null, '--image-responses', ['allow', 'omit']))
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
+      .option('--output-max-size <bytes>', 'Threshold for evicting old output files, in bytes.', numberParser)
       .option('--output-mode <mode>', 'whether to save snapshots, console messages, network logs to a file or to the standard output. Can be "file" or "stdout". Default is "stdout".', enumParser.bind(null, '--output-mode', ['file', 'stdout']))
       .option('--port <port>', 'port to listen on for SSE transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -59,6 +59,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".', enumParser.bind(null, '--image-responses', ['allow', 'omit']))
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
+      // TODO: accept human-readable sizes like "10MB" / "1GiB" in addition to raw bytes.
       .option('--output-max-size <bytes>', 'Threshold for evicting old output files, in bytes.', numberParser)
       .option('--output-mode <mode>', 'whether to save snapshots, console messages, network logs to a file or to the standard output. Can be "file" or "stdout". Default is "stdout".', enumParser.bind(null, '--output-mode', ['file', 'stdout']))
       .option('--port <port>', 'port to listen on for SSE transport.')

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -59,7 +59,6 @@ export function decorateMCPCommand(command: Command) {
       .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow" or "omit", Defaults to "allow".', enumParser.bind(null, '--image-responses', ['allow', 'omit']))
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
-      // TODO: accept human-readable sizes like "10MB" / "1GiB" in addition to raw bytes.
       .option('--output-max-size <bytes>', 'Threshold for evicting old output files, in bytes.', numberParser)
       .option('--output-mode <mode>', 'whether to save snapshots, console messages, network logs to a file or to the standard output. Can be "file" or "stdout". Default is "stdout".', enumParser.bind(null, '--output-mode', ['file', 'stdout']))
       .option('--port <port>', 'port to listen on for SSE transport.')

--- a/tests/mcp/output-max-size.spec.ts
+++ b/tests/mcp/output-max-size.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { test, expect } from './fixtures';
+
+async function takeScreenshot(client: any) {
+  return await client.callTool({
+    name: 'browser_take_screenshot',
+  });
+}
+
+function listFiles(dir: string, ext: string) {
+  if (!fs.existsSync(dir))
+    return [];
+  return fs.readdirSync(dir).filter(f => f.endsWith(ext));
+}
+
+function totalBytes(dir: string, ext: string) {
+  return listFiles(dir, ext).reduce((acc, f) => acc + fs.statSync(path.join(dir, f)).size, 0);
+}
+
+test('evicts oldest evictable files before write exceeds cap', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: {
+      outputDir,
+      // Pick a low cap so even one extra screenshot triggers eviction.
+      outputMaxSize: 10_000,
+    },
+  });
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  const beforeCount = listFiles(outputDir, '.png').length;
+  // Take more screenshots than would fit in the cap.
+  for (let i = 0; i < 8; i++) {
+    await takeScreenshot(client);
+    // Ensure subsequent files have distinct timestamps in their names.
+    await new Promise(r => setTimeout(r, 5));
+  }
+  const after = listFiles(outputDir, '.png');
+  // Fewer than 8 should remain.
+  expect(after.length).toBeLessThan(8);
+  expect(after.length).toBeGreaterThan(beforeCount);
+  // Total size must not exceed cap.
+  expect(totalBytes(outputDir, '.png')).toBeLessThanOrEqual(10_000);
+});
+
+test('oversize single file evicts everything and still writes', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: {
+      outputDir,
+      // Tiny cap, smaller than a single screenshot.
+      outputMaxSize: 100,
+    },
+  });
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  await takeScreenshot(client);
+  await new Promise(r => setTimeout(r, 5));
+  await takeScreenshot(client);
+
+  // Older file should be removed; newest is written even though it exceeds the cap.
+  expect(listFiles(outputDir, '.png')).toHaveLength(1);
+});
+
+test('session.md is pinned and survives eviction', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: {
+      outputDir,
+      saveSession: true,
+      outputMaxSize: 50_000,
+    },
+  });
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  // Fill the cap with evictable assets.
+  for (let i = 0; i < 6; i++) {
+    await takeScreenshot(client);
+    await new Promise(r => setTimeout(r, 5));
+  }
+
+  const entries = fs.readdirSync(outputDir);
+  const sessionFolder = entries.find(e => e.startsWith('session-'));
+  expect(sessionFolder).toBeTruthy();
+  const sessionFile = path.join(outputDir, sessionFolder!, 'session.md');
+  expect(fs.existsSync(sessionFile)).toBe(true);
+});
+
+test('no cap means no eviction', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+  });
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  for (let i = 0; i < 3; i++) {
+    await takeScreenshot(client);
+    await new Promise(r => setTimeout(r, 5));
+  }
+
+  expect(listFiles(outputDir, '.png')).toHaveLength(3);
+});
+
+test('honors PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE env var', async ({ startClient, server }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  const { client } = await startClient({
+    config: { outputDir },
+    env: { PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE: '100' },
+  });
+
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  await takeScreenshot(client);
+  await new Promise(r => setTimeout(r, 5));
+  await takeScreenshot(client);
+
+  expect(listFiles(outputDir, '.png')).toHaveLength(1);
+});

--- a/tests/mcp/output-max-size.spec.ts
+++ b/tests/mcp/output-max-size.spec.ts
@@ -19,47 +19,27 @@ import path from 'path';
 
 import { test, expect } from './fixtures';
 
-async function takeScreenshot(client: any) {
-  return await client.callTool({
-    name: 'browser_take_screenshot',
-  });
-}
-
-function listFiles(dir: string, ext: string) {
-  if (!fs.existsSync(dir))
-    return [];
-  return fs.readdirSync(dir).filter(f => f.endsWith(ext));
-}
-
-function totalBytes(dir: string, ext: string) {
-  return listFiles(dir, ext).reduce((acc, f) => acc + fs.statSync(path.join(dir, f)).size, 0);
-}
-
-test('evicts oldest evictable files before write exceeds cap', async ({ startClient, server }, testInfo) => {
+test('evicts oldest evictable files before write exceeds cap, pinned session.md survives', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({
     config: {
       outputDir,
-      // Pick a low cap so even one extra screenshot triggers eviction.
+      saveSession: true,
       outputMaxSize: 10_000,
     },
   });
 
   await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
 
-  const beforeCount = listFiles(outputDir, '.png').length;
-  // Take more screenshots than would fit in the cap.
-  for (let i = 0; i < 8; i++) {
-    await takeScreenshot(client);
-    // Ensure subsequent files have distinct timestamps in their names.
-    await new Promise(r => setTimeout(r, 5));
-  }
-  const after = listFiles(outputDir, '.png');
-  // Fewer than 8 should remain.
-  expect(after.length).toBeLessThan(8);
-  expect(after.length).toBeGreaterThan(beforeCount);
-  // Total size must not exceed cap.
-  expect(totalBytes(outputDir, '.png')).toBeLessThanOrEqual(10_000);
+  for (let i = 0; i < 8; i++)
+    await client.callTool({ name: 'browser_take_screenshot' });
+  const pngs = fs.readdirSync(outputDir).filter(f => f.endsWith('.png'));
+  expect(pngs.length).toBeLessThan(8);
+  expect(pngs.reduce((acc, f) => acc + fs.statSync(path.join(outputDir, f)).size, 0)).toBeLessThanOrEqual(10_000);
+
+  const sessionFolder = fs.readdirSync(outputDir).find(e => e.startsWith('session-'));
+  expect(sessionFolder).toBeTruthy();
+  expect(fs.existsSync(path.join(outputDir, sessionFolder!, 'session.md'))).toBe(true);
 });
 
 test('oversize single file evicts everything and still writes', async ({ startClient, server }, testInfo) => {
@@ -67,74 +47,14 @@ test('oversize single file evicts everything and still writes', async ({ startCl
   const { client } = await startClient({
     config: {
       outputDir,
-      // Tiny cap, smaller than a single screenshot.
       outputMaxSize: 100,
     },
   });
 
   await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
 
-  await takeScreenshot(client);
-  await new Promise(r => setTimeout(r, 5));
-  await takeScreenshot(client);
+  await client.callTool({ name: 'browser_take_screenshot' });
+  await client.callTool({ name: 'browser_take_screenshot' });
 
-  // Older file should be removed; newest is written even though it exceeds the cap.
-  expect(listFiles(outputDir, '.png')).toHaveLength(1);
-});
-
-test('session.md is pinned and survives eviction', async ({ startClient, server }, testInfo) => {
-  const outputDir = testInfo.outputPath('output');
-  const { client } = await startClient({
-    config: {
-      outputDir,
-      saveSession: true,
-      outputMaxSize: 50_000,
-    },
-  });
-
-  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
-
-  // Fill the cap with evictable assets.
-  for (let i = 0; i < 6; i++) {
-    await takeScreenshot(client);
-    await new Promise(r => setTimeout(r, 5));
-  }
-
-  const entries = fs.readdirSync(outputDir);
-  const sessionFolder = entries.find(e => e.startsWith('session-'));
-  expect(sessionFolder).toBeTruthy();
-  const sessionFile = path.join(outputDir, sessionFolder!, 'session.md');
-  expect(fs.existsSync(sessionFile)).toBe(true);
-});
-
-test('no cap means no eviction', async ({ startClient, server }, testInfo) => {
-  const outputDir = testInfo.outputPath('output');
-  const { client } = await startClient({
-    config: { outputDir },
-  });
-
-  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
-
-  for (let i = 0; i < 3; i++) {
-    await takeScreenshot(client);
-    await new Promise(r => setTimeout(r, 5));
-  }
-
-  expect(listFiles(outputDir, '.png')).toHaveLength(3);
-});
-
-test('honors PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE env var', async ({ startClient, server }, testInfo) => {
-  const outputDir = testInfo.outputPath('output');
-  const { client } = await startClient({
-    config: { outputDir },
-    env: { PLAYWRIGHT_MCP_OUTPUT_MAX_SIZE: '100' },
-  });
-
-  await client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
-
-  await takeScreenshot(client);
-  await new Promise(r => setTimeout(r, 5));
-  await takeScreenshot(client);
-
-  expect(listFiles(outputDir, '.png')).toHaveLength(1);
+  expect(fs.readdirSync(outputDir)).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- New `--output-max-size <bytes>` option (CLI / config / env) for the MCP output directory.
- Before each tracked write, OutputDir evicts the oldest evictable artifacts until the new write fits.
- Session log and user-supplied workspace files are pinned (never evicted).