### PR TITLE
fixed the omnibox issue

### DIFF
--- a/packages/dashboard/src/dashboard.tsx
+++ b/packages/dashboard/src/dashboard.tsx
@@ -341,6 +341,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ model }) => {
                         e.target.select();
                       }}
                       aria-disabled={!interactive || undefined}
+                      aria-label={interactive ? 'Search or enter URL' : 'URL input - enable interactive mode to use this field'}
                       readOnly={!interactive}
                     />
                   </div>


### PR DESCRIPTION
Fixes #41022 

This PR adds a dynamic [aria-label](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) attribute to the Dashboard's omnibox (URL input field) to provide clear accessibility context when the input is disabled in non-interactive mode.

Changes Made
File: packages/dashboard/src/dashboard.tsx

Change: Added dynamic [aria-label](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the omnibox input element
```

// Before
<input
  id='omnibox'
  className='omnibox'
  type='text'
  placeholder='Search or enter URL'
  // ... props
  aria-disabled={!interactive || undefined}
  readOnly={!interactive}
/>

// After
<input
  id='omnibox'
  className='omnibox'
  type='text'
  placeholder='Search or enter URL'
  // ... props
  aria-disabled={!interactive || undefined}
  aria-label={interactive ? 'Search or enter URL' : 'URL input - enable interactive mode to use this field'}
  readOnly={!interactive}
/>
```