### PR TITLE
Remove unnecessary tabIndex from gantt chart SVG rect elements for improved accessibility 

### DIFF
--- a/packages/html-reporter/src/gantt.tsx
+++ b/packages/html-reporter/src/gantt.tsx
@@ -157,7 +157,6 @@ export const GanttChart = ({
                 height={barHeight}
                 fill={color}
                 rx='2'
-                tabIndex={0}
               >
                 <title>{entry.tooltip}</title>
               </rect>


### PR DESCRIPTION
This PR removes the tabIndex={0} attribute from gantt chart bar elements that lack corresponding keyboard event handlers, fixing an accessibility anti-pattern that violates WCAG 2.1 guidelines.

Problem
The gantt chart in the HTML reporter renders SVG elements with tabIndex={0}, making them appear focusable and interactive to keyboard and screen reader users. However, these elements have no keyboard event handlers, creating a confusing and broken user experience:

Keyboard users tab onto gantt bars but can't interact with them
Screen readers announce bars as focusable when they're not interactive
Users waste keyboard navigation effort.

Solution
Remove tabIndex={0} from gantt bar elements since they are purely visual timeline indicators with no interactive purpose. The <title> element already provides tooltip accessibility.

Changes Made
File: packages/html-reporter/src/gantt.tsx

Change: Removed tabIndex={0} from SVG rect element (line 157).

fixes https://github.com/microsoft/playwright/issues/41027

@pavelfeldman kindly consider this tiny minor change