### PR TITLE
[fix:] Add keyboard navigation support to TabbedPane for WCAG 2.1 compliance

### DIFF
--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -82,6 +82,7 @@ export const TabbedPane: React.FunctionComponent<{
               key={tab.id}
               role='tab'
               aria-selected={selectedTab === tab.id}
+              aria-controls={`${idPrefix}-${tab.id}-panel`}
               tabIndex={selectedTab === tab.id ? 0 : -1}>
               <div className='tabbed-pane-tab-label'>{tab.title}</div>
             </div>
@@ -91,7 +92,7 @@ export const TabbedPane: React.FunctionComponent<{
       {
         tabs.map(tab => {
           if (selectedTab === tab.id)
-            return <div key={tab.id} className='tab-content' role='tabpanel' aria-labelledby={`${idPrefix}-${tab.id}`}>{tab.render()}</div>;
+            return <div key={tab.id} id={`${idPrefix}-${tab.id}-panel`} className='tab-content' role='tabpanel' aria-labelledby={`${idPrefix}-${tab.id}`} tabIndex={0}>{tab.render()}</div>;
         })
       }
     </div>

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -32,17 +32,58 @@ export const TabbedPane: React.FunctionComponent<{
   setSelectedTab: (tab: string) => void
 }> = ({ tabs, selectedTab, setSelectedTab }) => {
   const idPrefix = React.useId();
+  const tabRefs = React.useRef<{ [key: string]: HTMLDivElement | null }>({});
+
+  // Focus the selected tab after selection changes
+  React.useEffect(() => {
+    tabRefs.current[selectedTab]?.focus();
+  }, [selectedTab]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = tabs.findIndex(t => t.id === selectedTab);
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        const nextTab = tabs[(currentIndex + 1) % tabs.length];
+        setSelectedTab(nextTab.id);
+        break;
+
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        const prevTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+        setSelectedTab(prevTab.id);
+        break;
+
+      case 'Home':
+        event.preventDefault();
+        setSelectedTab(tabs[0].id);
+        break;
+
+      case 'End':
+        event.preventDefault();
+        setSelectedTab(tabs[tabs.length - 1].id);
+        break;
+    }
+  };
+
   return <div className='tabbed-pane'>
     <div className='vbox'>
       <div className='hbox' style={{ flex: 'none' }}>
         <div className='tabbed-pane-tab-strip' role='tablist'>{
           tabs.map(tab => (
-            <div className={clsx('tabbed-pane-tab-element', selectedTab === tab.id && 'selected')}
+            <div
+              ref={el => tabRefs.current[tab.id] = el}
+              className={clsx('tabbed-pane-tab-element', selectedTab === tab.id && 'selected')}
               onClick={() => setSelectedTab(tab.id)}
+              onKeyDown={handleKeyDown}
               id={`${idPrefix}-${tab.id}`}
               key={tab.id}
               role='tab'
-              aria-selected={selectedTab === tab.id}>
+              aria-selected={selectedTab === tab.id}
+              tabIndex={selectedTab === tab.id ? 0 : -1}>
               <div className='tabbed-pane-tab-label'>{tab.title}</div>
             </div>
           ))

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -34,11 +34,6 @@ export const TabbedPane: React.FunctionComponent<{
   const idPrefix = React.useId();
   const tabRefs = React.useRef<{ [key: string]: HTMLDivElement | null }>({});
 
-  // Focus the selected tab after selection changes
-  React.useEffect(() => {
-    tabRefs.current[selectedTab]?.focus();
-  }, [selectedTab]);
-
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const currentIndex = tabs.findIndex(t => t.id === selectedTab);
 
@@ -48,6 +43,7 @@ export const TabbedPane: React.FunctionComponent<{
         event.preventDefault();
         const nextTab = tabs[(currentIndex + 1) % tabs.length];
         setSelectedTab(nextTab.id);
+        tabRefs.current[nextTab.id]?.focus();
         break;
 
       case 'ArrowLeft':
@@ -55,16 +51,19 @@ export const TabbedPane: React.FunctionComponent<{
         event.preventDefault();
         const prevTab = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
         setSelectedTab(prevTab.id);
+        tabRefs.current[prevTab.id]?.focus();
         break;
 
       case 'Home':
         event.preventDefault();
         setSelectedTab(tabs[0].id);
+        tabRefs.current[tabs[0].id]?.focus();
         break;
 
       case 'End':
         event.preventDefault();
         setSelectedTab(tabs[tabs.length - 1].id);
+        tabRefs.current[tabs[tabs.length - 1].id]?.focus();
         break;
     }
   };

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1066,6 +1066,53 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       expect(popup.url()).toBe(server.EMPTY_PAGE);
     });
 
+    test('should support keyboard navigation in tabbedPane', async ({ runInlineTest, page, showReport }) => {
+      const result = await runInlineTest({
+        'playwright.config.js': `
+          module.exports = { timeout: 1500, retries: 2 };
+        `,
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('test with retries', async ({}) => {
+            throw new Error('fail');
+          });
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.failed).toBe(1);
+
+      await showReport();
+      await page.getByRole('link', { name: 'test with retries' }).click();
+
+      // Get all tabs for navigation
+      const retryTab1 = page.getByRole('tab', { name: 'Retry #1' });
+      const retryTab2 = page.getByRole('tab', { name: 'Retry #2' });
+      const mainTab = page.getByRole('tab').first();
+      // Focus on main tab
+      await mainTab.focus();
+      await expect(mainTab).toBeFocused();
+      await mainTab.press('ArrowRight');
+      await expect(retryTab1).toBeFocused();
+      await expect(retryTab1).toHaveAttribute('aria-selected', 'true');
+      await retryTab2.focus();
+      await retryTab2.press('ArrowRight');
+      await expect(mainTab).toBeFocused();
+      await expect(mainTab).toHaveAttribute('aria-selected', 'true');
+      await mainTab.press('ArrowLeft');
+      await expect(retryTab2).toBeFocused();
+      await expect(retryTab2).toHaveAttribute('aria-selected', 'true');
+      await retryTab2.press('Home');
+      await expect(mainTab).toBeFocused();
+      await expect(mainTab).toHaveAttribute('aria-selected', 'true');
+      await mainTab.press('End');
+      await expect(retryTab2).toBeFocused();
+      await expect(retryTab2).toHaveAttribute('aria-selected', 'true');
+      // Verify mouse click still works and doesn't affect keyboard navigation
+      await retryTab1.click();
+      await expect(retryTab1).toHaveAttribute('aria-selected', 'true');
+      await retryTab1.press('ArrowRight');
+      await expect(retryTab2).toBeFocused();
+    });
+
     test('should render text attachments as text', async ({ runInlineTest, page, showReport }) => {
       const result = await runInlineTest({
         'a.test.js': `


### PR DESCRIPTION
This PR adds comprehensive keyboard navigation support to the [TabbedPane](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) component in the HTML reporter, enabling keyboard-only and screen reader users to navigate between tabs using standard web accessibility patterns.

Problem :

The [TabbedPane](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) component currently supports only mouse interaction. Keyboard users cannot navigate between tabs, and the component violates WCAG 2.1 Level AA standards for tab components ([https://www.w3.org/WAI/ARIA/apg/patterns/tabs/](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)). This creates a significant accessibility barrier for:

Keyboard-only users
Screen reader users
Users with motor impairments

Solution:

Implemented WCAG 2.1-compliant keyboard navigation by:

Adding explicit tabIndex management - Selected tab gets [tabIndex={0}](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html), others get [tabIndex={-1}](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Implementing keyboard event handler - Supports Arrow keys, Home, End for navigation

Adding focus management - Automatically focuses newly selected tabs using [useRef](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [useEffect](vscode-file://vscode-app/c:/Users/Yugendra/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Maintaining web platform principles - Leverages platform features without overengineering

Changes Made:

File: packages/html-reporter/src/tabbedPane.tsx


Fixes https://github.com/microsoft/playwright/issues/41005