### PR TITLE
fix(codegen): never generate getByRole with mismatched name/description exactness

### DIFF
--- a/packages/injected/src/selectorGenerator.ts
+++ b/packages/injected/src/selectorGenerator.ts
@@ -359,7 +359,7 @@ function buildTextCandidates(injectedScript: InjectedScript, element: Element, i
       if (ariaDescription) {
         candidates.push([{ engine: 'internal:role', selector: `${ariaRole}[name=${escapeForAttributeSelector(ariaName, true)}][description=${escapeForAttributeSelector(ariaDescription, true)}]`, score: kRoleWithNameScoreExact + 1 }]);
         for (const alternative of suitableTextAlternatives(ariaName))
-          candidates.push([{ engine: 'internal:role', selector: `${ariaRole}[name=${escapeForAttributeSelector(alternative.text, false)}][description=${escapeForAttributeSelector(ariaDescription, true)}]`, score: kRoleWithNameScore - alternative.scoreBonus + 1 }]);
+          candidates.push([{ engine: 'internal:role', selector: `${ariaRole}[name=${escapeForAttributeSelector(alternative.text, false)}][description=${escapeForAttributeSelector(ariaDescription, false)}]`, score: kRoleWithNameScore - alternative.scoreBonus + 1 }]);
       }
     } else {
       const roleToken = { engine: 'internal:role', selector: `${ariaRole}`, score: kRoleWithoutNameScore };

--- a/packages/isomorphic/locatorGenerators.ts
+++ b/packages/isomorphic/locatorGenerators.ts
@@ -163,9 +163,13 @@ function innerAsLocators(factory: LocatorFactory, parsed: ParsedSelector, isFram
       const options: LocatorOptions = { attrs: [] };
       for (const attr of attrSelector.attributes) {
         if (attr.name === 'name') {
+          if (options.exact !== undefined && options.exact !== attr.caseSensitive)
+            throw new Error(`Conflicting exactness in internal:role selector: ${stringifySelector({ parts: [part] })}`);
           options.exact = attr.caseSensitive;
           options.name = attr.value;
         } else if (attr.name === 'description') {
+          if (options.exact !== undefined && options.exact !== attr.caseSensitive)
+            throw new Error(`Conflicting exactness in internal:role selector: ${stringifySelector({ parts: [part] })}`);
           options.exact = attr.caseSensitive;
           options.description = attr.value;
         } else {

--- a/tests/library/locator-generator.spec.ts
+++ b/tests/library/locator-generator.spec.ts
@@ -253,6 +253,17 @@ it('reverse engineer getByRole', async ({ page }) => {
   });
 });
 
+it('refuses to translate internal:role with conflicting name/description exactness', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41032' }
+}, async () => {
+  const conflicting = 'internal:role=row[name="abc"i][description="d"s]';
+  const conflictingReversed = 'internal:role=row[name="abc"s][description="d"i]';
+  for (const lang of ['javascript', 'python', 'java', 'csharp'] as const) {
+    expect.soft(asLocator(lang, conflicting), lang).toBe(conflicting);
+    expect.soft(asLocator(lang, conflictingReversed), lang).toBe(conflictingReversed);
+  }
+});
+
 it('reverse engineer ignore-case locators', async ({ page }) => {
   expect.soft(generate(page.getByText('hello my\nwo"rld'))).toEqual({
     csharp: 'GetByText("hello my\\nwo\\"rld")',

--- a/tests/library/selector-generator.spec.ts
+++ b/tests/library/selector-generator.spec.ts
@@ -95,8 +95,8 @@ it.describe('selector generator', () => {
       <button aria-description="Upload report">Submit</button>
       <button aria-description="Upload photo">Submit</button>
     `);
-    expect(await generate(page, 'button[aria-description="Upload report"]')).toBe('internal:role=button[name="Submit"i][description="Upload report"s]');
-    expect(await generate(page, 'button[aria-description="Upload photo"]')).toBe('internal:role=button[name="Submit"i][description="Upload photo"s]');
+    expect(await generate(page, 'button[aria-description="Upload report"]')).toBe('internal:role=button[name="Submit"i][description="Upload report"i]');
+    expect(await generate(page, 'button[aria-description="Upload photo"]')).toBe('internal:role=button[name="Submit"i][description="Upload photo"i]');
   });
 
   it('should not use description when name is unique', async ({ page }) => {
@@ -114,8 +114,8 @@ it.describe('selector generator', () => {
       <button aria-describedby="desc1">Submit</button>
       <button aria-describedby="desc2">Submit</button>
     `);
-    expect(await generate(page, 'button[aria-describedby="desc1"]')).toBe('internal:role=button[name="Submit"i][description="Save form data"s]');
-    expect(await generate(page, 'button[aria-describedby="desc2"]')).toBe('internal:role=button[name="Submit"i][description="Save as draft"s]');
+    expect(await generate(page, 'button[aria-describedby="desc1"]')).toBe('internal:role=button[name="Submit"i][description="Save form data"i]');
+    expect(await generate(page, 'button[aria-describedby="desc2"]')).toBe('internal:role=button[name="Submit"i][description="Save as draft"i]');
   });
 
   it('should fall back to nth when name and description are both not unique', async ({ page }) => {
@@ -124,6 +124,28 @@ it.describe('selector generator', () => {
       <button aria-description="Same desc">Submit</button>
     `);
     expect(await generate(page, 'button:first-of-type')).toBe('internal:role=button[name="Submit"i] >> nth=0');
+  });
+
+  it('should use consistent exactness for name and description', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41032' }
+  }, async ({ page }) => {
+    // The public getByRole API has a single `exact` flag that covers both
+    // `name` and `description`, so the producer must not emit a candidate
+    // that mixes substring name with exact description (or vice versa).
+    await page.setContent(`
+      <table>
+        <tr title="table row 1">
+          <td>foo</td><td>bar</td><td>baz</td><td>foo</td><td>bar</td><td>baz</td><td>foo</td><td>bar</td><td>baz</td>
+        </tr>
+        <tr title="table row 2">
+          <td>foo</td><td>bar</td><td>baz</td><td>foo</td><td>bar</td><td>baz</td><td>foo</td><td>bar</td><td>baz</td>
+        </tr>
+      </table>
+    `);
+    const selector = await generate(page, 'tr[title="table row 1"]');
+    // Both name and description must share the same case-sensitivity flag.
+    expect(selector).not.toMatch(/\[name="[^"]*"i\]\[description="[^"]*"s\]/);
+    expect(selector).not.toMatch(/\[name="[^"]*"s\]\[description="[^"]*"i\]/);
   });
 
   it('should use description when role has no name', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Producer: align `description`'s case-sensitivity with `name`'s in the alternative-name loop of `selectorGenerator`, so every emitted `internal:role` candidate is representable in the public `getByRole` API.
- Translator: throw on conflicting per-attr exactness in the `internal:role` branch of `locatorGenerators`. The existing `try/catch` in `asLocator` falls back to the raw selector, so progress logs and error messages stay intact.

Fixes https://github.com/microsoft/playwright/issues/41032
