### PR TITLE
fix(tools): pass time parameter to page.evaluate in waitForTimeout

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -483,7 +483,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       return;
     }
 
-    await this.page.evaluate(() => new Promise(f => setTimeout(f, 1000))).catch(() => {});
+    await this.page.evaluate(ms => new Promise(f => setTimeout(f, ms)), time).catch(() => {});
   }
 }
 


### PR DESCRIPTION
`waitForTimeout(time)` has two branches:

- **Blocked path** (dialog active): correctly uses the `time` parameter
- **Normal path**: hardcodes `1000`ms, ignoring `time`

Both callers in `utils.ts` pass `500`, so every `waitForCompletion` cycle (click, fill, navigate, and other interactive tools) waits 1000ms instead of the intended 500ms. This adds an unnecessary 500ms to each tool call.

The fix passes the `time` parameter through to `page.evaluate`, making the normal path consistent with the blocked path.

**Before:**
```typescript
await this.page.evaluate(() => new Promise(f => setTimeout(f, 1000))).catch(() => {});
```

**After:**
```typescript
await this.page.evaluate(ms => new Promise(f => setTimeout(f, ms)), time).catch(() => {});
```

This was introduced in #37286 when MCP tools were moved into the monorepo.