### PR TITLE
fix(core): show friendly error for unsupported Node.js versions

### DIFF
--- a/packages/playwright-core/index.js
+++ b/packages/playwright-core/index.js
@@ -13,20 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const minimumMajorNodeVersion = 18;
-const currentNodeVersion = process.versions.node;
-const semver = currentNodeVersion.split('.');
-const [major] = [+semver[0]];
-
-if (major < minimumMajorNodeVersion) {
-  console.error(
-      'You are running Node.js ' +
-      currentNodeVersion +
-      '.\n' +
-      `Playwright requires Node.js ${minimumMajorNodeVersion} or higher. \n` +
-      'Please update your version of Node.js.'
-  );
-  process.exit(1);
-}
-
+require('./lib/bootstrap');
 module.exports = require('./lib/coreBundle').inprocess.playwright;

--- a/packages/playwright-core/src/bootstrap.ts
+++ b/packages/playwright-core/src/bootstrap.ts
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+const minimumMajorNodeVersion = 18;
+const currentNodeVersion = process.versions.node;
+const major = +currentNodeVersion.split('.')[0];
+
+if (major < minimumMajorNodeVersion) {
+  // eslint-disable-next-line no-console
+  console.error(
+      'You are running Node.js ' +
+      currentNodeVersion +
+      '.\n' +
+      `Playwright requires Node.js ${minimumMajorNodeVersion} or higher. \n` +
+      'Please update your version of Node.js.'
+  );
+  // eslint-disable-next-line no-restricted-properties
+  process.exit(1);
+}
+
 if (process.env.PW_INSTRUMENT_MODULES) {
   const Module = require('module');
   const originalLoad = Module._load;


### PR DESCRIPTION
## Summary
- Move the Node.js minimum-version check into `playwright-core/lib/bootstrap` so it runs before `utilsBundle` is loaded.
- On Node <18, the bundled MCP SDK's `class Request extends global.Request` was throwing `Class extends value undefined` at module load, before the existing guard in `playwright-core/index.js` could run (the CLI path doesn't require that file.

Fixes https://github.com/microsoft/playwright/issues/41045
EOF
)