### PR TITLE
fix(webview): dispatch key events in their own tasks

### DIFF
--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -110,11 +110,22 @@ function dispatchKeyEvent(node: EventTarget, type: string, init: KeyboardEventIn
 export class WebViewInput {
   private _window: Window & typeof globalThis;
   private _document: Document;
+  private _setTimeout: Window['setTimeout'];
   private _hoverTarget: Element | null = null;
 
   constructor(window: Window & typeof globalThis, document: Document) {
     this._window = window;
     this._document = document;
+    // Captured before page scripts run (bootstrap), so a page that later
+    // overrides setTimeout cannot break the per-event task scheduling below.
+    this._setTimeout = window.setTimeout.bind(window);
+  }
+
+  // Real input events are each delivered in their own event-loop task; dispatch
+  // a sequence the same way so handlers that schedule work between events behave
+  // as they would on a real device.
+  private _nextTask(): Promise<void> {
+    return new Promise(resolve => this._setTimeout(resolve));
   }
 
   // Descend through open shadow roots so synthetic events land on the actual
@@ -155,7 +166,7 @@ export class WebViewInput {
     }
   }
 
-  keydown(params: KeyEventParams) {
+  keydown(params: KeyEventParams): void | Promise<void> {
     const target = this._deepActiveElement() || this._document.body;
     if (!target)
       return;
@@ -175,17 +186,26 @@ export class WebViewInput {
       metaKey: params.metaKey,
     };
     const notPrevented = dispatchKeyEvent(target, 'keydown', init, params.keyCode, params.key);
+    // Non-text keys produce only keydown — nothing more to deliver.
     if (params.text === undefined)
       return;
-    const charCode = params.text.charCodeAt(0);
+    return this._typeCharacter(target, init, notPrevented, params.text);
+  }
+
+  // keypress and textInput follow keydown, each in its own task — real WebKit
+  // delivers every key event in a separate event-loop task.
+  private async _typeCharacter(target: EventTarget, init: KeyboardEventInit, keydownNotPrevented: boolean, text: string) {
+    await this._nextTask();
+    const charCode = text.charCodeAt(0);
     const charNotPrevented = markAndDispatch(target, new KeyboardEvent('keypress', { ...init, charCode, keyCode: charCode, which: charCode }));
-    if (!notPrevented || !charNotPrevented)
+    if (!keydownNotPrevented || !charNotPrevented)
       return;
+    await this._nextTask();
     // Real WebKit fires a `textInput` (TextEvent) whose default action performs
     // the insertion (and the subsequent beforeinput/input). Replicate it; the
     // event's default does the insertion, so we do not insert manually. Enter's
     // text is '\r' but the inserted/textInput data is a newline.
-    this._dispatchTextInput(target, params.text === '\r' ? '\n' : params.text);
+    this._dispatchTextInput(target, text === '\r' ? '\n' : text);
   }
 
   private _dispatchTextInput(target: EventTarget, text: string) {

--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -186,17 +186,18 @@ export class WebViewInput {
       metaKey: params.metaKey,
     };
     const notPrevented = dispatchKeyEvent(target, 'keydown', init, params.keyCode, params.key);
-    // Non-text keys produce only keydown — nothing more to deliver.
-    if (params.text === undefined)
+    // Non-text keys produce only keydown; a cancelled keydown also suppresses the
+    // keypress and the default text insertion.
+    if (params.text === undefined || !notPrevented)
       return;
-    return this._typeCharacter(target, init, notPrevented, params.text);
+    return this._typeCharacter(target, init, params.text);
   }
 
-  private async _typeCharacter(target: EventTarget, init: KeyboardEventInit, keydownNotPrevented: boolean, text: string) {
+  private async _typeCharacter(target: EventTarget, init: KeyboardEventInit, text: string) {
     await this._nextTask();
     const charCode = text.charCodeAt(0);
     const charNotPrevented = markAndDispatch(target, new KeyboardEvent('keypress', { ...init, charCode, keyCode: charCode, which: charCode }));
-    if (!keydownNotPrevented || !charNotPrevented)
+    if (!charNotPrevented)
       return;
     await this._nextTask();
     // Real WebKit fires a `textInput` (TextEvent) whose default action performs

--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -110,22 +110,22 @@ function dispatchKeyEvent(node: EventTarget, type: string, init: KeyboardEventIn
 export class WebViewInput {
   private _window: Window & typeof globalThis;
   private _document: Document;
-  private _setTimeout: Window['setTimeout'];
   private _hoverTarget: Element | null = null;
 
   constructor(window: Window & typeof globalThis, document: Document) {
     this._window = window;
     this._document = document;
-    // Captured before page scripts run (bootstrap), so a page that later
-    // overrides setTimeout cannot break the per-event task scheduling below.
-    this._setTimeout = window.setTimeout.bind(window);
   }
 
   // Real input events are each delivered in their own event-loop task; dispatch
   // a sequence the same way so handlers that schedule work between events behave
-  // as they would on a real device.
+  // as they would on a real device. Timers come from the globals snapshot (taken
+  // at bootstrap), so a page overriding setTimeout cannot break scheduling.
   private _nextTask(): Promise<void> {
-    return new Promise(resolve => this._setTimeout(resolve));
+    const builtins = (this._window as any).__pwSnapshotGlobals || this._window;
+    // setImmediate avoids setTimeout's clamping, but WebKit does not implement it.
+    const schedule = builtins.setImmediate || builtins.setTimeout;
+    return new Promise(resolve => schedule.call(this._window, resolve));
   }
 
   // Descend through open shadow roots so synthetic events land on the actual
@@ -192,8 +192,6 @@ export class WebViewInput {
     return this._typeCharacter(target, init, notPrevented, params.text);
   }
 
-  // keypress and textInput follow keydown, each in its own task — real WebKit
-  // delivers every key event in a separate event-loop task.
   private async _typeCharacter(target: EventTarget, init: KeyboardEventInit, keydownNotPrevented: boolean, text: string) {
     await this._nextTask();
     const charCode = text.charCodeAt(0);

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -377,8 +377,14 @@ const snapshottedFunctionBuiltins = [
 // Non-callable globals (objects) — Prototype.js historically replaced JSON.
 const snapshottedObjectBuiltins = ['JSON', 'Math'];
 
+// Timer builtins are routinely overridden by frameworks and fake-timer shims; the
+// snapshot lets injected code schedule real tasks regardless. They are only added
+// to the snapshot object below, not to the main-world `const` block, so they never
+// shadow timers inside the injected bundle. (setImmediate is absent in most engines.)
+const snapshottedTimerBuiltins = ['setTimeout', 'setImmediate'];
+
 export const saveGlobalsSnapshotSource = `window.__pwSnapshotGlobals = {
-${[...snapshottedFunctionBuiltins, ...snapshottedObjectBuiltins].map(n => `  ${n}: window.${n}`).join(',\n')}
+${[...snapshottedFunctionBuiltins, ...snapshottedObjectBuiltins, ...snapshottedTimerBuiltins].map(n => `  ${n}: window.${n}`).join(',\n')}
 };`;
 
 export const mainWorldGlobalsSnapshotSource = `

--- a/packages/playwright-core/src/server/webkit/webview/wvInput.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvInput.ts
@@ -140,5 +140,13 @@ async function callWebViewInput(progress: Progress, session: WVSession | undefin
   if (!session)
     throw new Error('Page is not initialized');
   const expression = `window.__pwWebViewInput.${method}(${JSON.stringify(arg)})`;
-  await progress.race(session.send('Runtime.evaluate', { expression, returnByValue: true } as any));
+  // Some dispatchers are async — they spread events across event-loop tasks the
+  // way a real device does. Await the returned promise so the action only
+  // resolves once every event has been delivered. Stock WebKit's Runtime.evaluate
+  // has no awaitPromise option, so use the separate Runtime.awaitPromise command.
+  const { result } = await progress.race(session.send('Runtime.evaluate', { expression, returnByValue: false } as any)) as { result: { objectId?: string } };
+  if (result?.objectId) {
+    await progress.race(session.send('Runtime.awaitPromise', { promiseObjectId: result.objectId, returnByValue: true } as any));
+    await progress.race(session.sendMayFail('Runtime.releaseObject', { objectId: result.objectId }));
+  }
 }

--- a/packages/playwright-core/src/server/webkit/webview/wvInput.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvInput.ts
@@ -144,9 +144,13 @@ async function callWebViewInput(progress: Progress, session: WVSession | undefin
   // way a real device does. Await the returned promise so the action only
   // resolves once every event has been delivered. Stock WebKit's Runtime.evaluate
   // has no awaitPromise option, so use the separate Runtime.awaitPromise command.
-  const { result } = await progress.race(session.send('Runtime.evaluate', { expression, returnByValue: false } as any)) as { result: { objectId?: string } };
-  if (result?.objectId) {
-    await progress.race(session.send('Runtime.awaitPromise', { promiseObjectId: result.objectId, returnByValue: true } as any));
-    await progress.race(session.sendMayFail('Runtime.releaseObject', { objectId: result.objectId }));
+  const { result } = await progress.race(session.send('Runtime.evaluate', { expression, returnByValue: false }));
+  // `result` is absent if evaluation failed (e.g. the frame navigated away).
+  // Only promises carry an objectId here — every __pwWebViewInput method returns
+  // void or a Promise — so this both awaits async dispatch and avoids leaking a
+  // handle for the synchronous (void) case.
+  if (result?.className === 'Promise' && result.objectId) {
+    await progress.race(session.send('Runtime.awaitPromise', { promiseObjectId: result.objectId, returnByValue: true }));
+    session.sendMayFail('Runtime.releaseObject', { objectId: result.objectId });
   }
 }

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -98,6 +98,23 @@ it('should emit keydown, keypress, textInput and input when typing a character',
   expect(await events.jsonValue()).toEqual(['keydown', 'keypress', 'textInput', 'input', 'keyup']);
 });
 
+it('should dispatch key events in separate tasks', async ({ page, browserName }) => {
+  it.skip(browserName === 'firefox', 'Firefox dispatches keydown and keypress in the same task');
+  await page.setContent(`<input>`);
+  const log = await page.evaluateHandle(() => {
+    const log: string[] = [];
+    const input = document.querySelector('input');
+    for (const type of ['keydown', 'keypress'])
+      input.addEventListener(type, () => { log.push(type); queueMicrotask(() => log.push('microtask-' + type)); });
+    input.focus();
+    return log;
+  });
+  await page.keyboard.press('a');
+  // A microtask scheduled in the keydown handler must run before keypress,
+  // proving each event is delivered in its own task rather than synchronously.
+  expect(await log.jsonValue()).toEqual(['keydown', 'microtask-keydown', 'keypress', 'microtask-keypress']);
+});
+
 it('should report shiftKey', async ({ page, server, browserName, platform }) => {
   it.fail(browserName === 'firefox' && platform === 'darwin');
 


### PR DESCRIPTION
## Summary

Dispatch the synthesized keyboard events in their own event-loop tasks, matching real WebKit.

Real WebKit delivers `keydown`, `keypress` and `textInput` each in a separate task (a microtask checkpoint runs between them), so page handlers that schedule promises/microtasks between events behave correctly. The WebView dispatcher fired them synchronously in one task. This spreads the `keydown → keypress → textInput` sequence across tasks and awaits the result via `Runtime.awaitPromise` (stock WebKit's `Runtime.evaluate` has no `awaitPromise` option). Timers are taken from the existing globals snapshot (`saveGlobalsSnapshotSource`, now extended with `setTimeout`/`setImmediate`) so a page overriding them can't break scheduling.

Also: a cancelled `keydown` now suppresses `keypress`/insertion (checked at the call site), matching the platform.

Adds a cross-browser test asserting a microtask scheduled in the `keydown` handler runs before `keypress`.

Mouse dispatch is intentionally left synchronous: task-separating it shifts when hover-triggered interstitials appear relative to Playwright's hit-target interception, which destabilizes `addLocatorHandler`.
