### PR TITLE
test(bidi): remove fail expectation for Firefox/Bidi

### DIFF
--- a/tests/library/browsercontext-locale.spec.ts
+++ b/tests/library/browsercontext-locale.spec.ts
@@ -165,8 +165,8 @@ it('should not change default locale in another context', async ({ browser }) =>
   }
 });
 
-it('should propagate locale to workers', async ({ browser, browserName, server }) => {
-  it.fail(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/38919');
+it('should propagate locale to workers', async ({ browser, browserName, isBidi, server }) => {
+  it.fail(browserName === 'firefox' && !isBidi, 'https://github.com/microsoft/playwright/issues/38919');
   const context = await browser.newContext({ locale: 'ru-RU' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
This test now passes with Firefox/Bidi since https://bugzilla.mozilla.org/show_bug.cgi?id=2015655 has been fixed.
(See also #38919)