### PR TITLE
fix(ui-mode): include project outputDirs in allowedFileRoots

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -45,7 +45,6 @@ export type TraceViewerServerOptions = {
   port?: number;
   isServer?: boolean;
   transport?: Transport;
-  allowedFileRoots?: string[];
 };
 
 export type TraceViewerRedirectOptions = {
@@ -88,10 +87,9 @@ function validateTraceUrlOrPath(traceFileOrUrl: string | undefined): string | un
   }
 }
 
-export async function startTraceViewerServer(options?: TraceViewerServerOptions): Promise<HttpServer> {
+export async function startTraceViewerServer(options: TraceViewerServerOptions & { allowedFileRoots: () => string[] }): Promise<HttpServer> {
   const server = new HttpServer(libPath('vite', 'traceViewer'));
-  const allowedRoots = (options?.allowedFileRoots ?? [process.cwd()]).map(r => path.resolve(r));
-  const isAllowed = (filePath: string) => allowedRoots.some(root => isPathInside(root, filePath));
+  const isAllowed = (filePath: string) => options.allowedFileRoots().some(root => isPathInside(path.resolve(root), filePath));
 
   const serveTraceDataRoute = (request: http.IncomingMessage, response: http.ServerResponse, relativePath: string): boolean => {
     if (!relativePath.startsWith('/file'))
@@ -154,11 +152,11 @@ export async function startTraceViewerServer(options?: TraceViewerServerOptions)
     });
   }
 
-  const transport = options?.transport || (options?.isServer ? new StdinServer() : undefined);
+  const transport = options.transport || (options.isServer ? new StdinServer() : undefined);
   if (transport)
     server.createWebSocket(() => transport);
 
-  const { host, port } = options || {};
+  const { host, port } = options;
   await server.start({ preferredPort: port, host });
   return server;
 }
@@ -197,7 +195,7 @@ export async function installRootRedirect(server: HttpServer, traceUrl: string |
 
 export async function runTraceViewerApp(traceUrl: string | undefined, browserName: string, options: TraceViewerServerOptions & { headless?: boolean }) {
   traceUrl = validateTraceUrlOrPath(traceUrl);
-  const server = await startTraceViewerServer({ ...options, allowedFileRoots: traceFileRoots(traceUrl, options.allowedFileRoots) });
+  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => traceFileRoots(traceUrl) });
   await installRootRedirect(server, traceUrl, options);
   const page = await openTraceViewerApp(server.urlPrefix('precise'), browserName, options);
   page.on('close', () => gracefullyProcessExitDoNotHang(0));
@@ -206,14 +204,12 @@ export async function runTraceViewerApp(traceUrl: string | undefined, browserNam
 
 export async function runTraceInBrowser(traceUrl: string | undefined, options: TraceViewerServerOptions) {
   traceUrl = validateTraceUrlOrPath(traceUrl);
-  const server = await startTraceViewerServer({ ...options, allowedFileRoots: traceFileRoots(traceUrl, options.allowedFileRoots) });
+  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => traceFileRoots(traceUrl) });
   await installRootRedirect(server, traceUrl, options);
   await openTraceInBrowser(server.urlPrefix('human-readable'));
 }
 
-function traceFileRoots(traceUrl: string | undefined, configured: string[] | undefined): string[] {
-  if (configured)
-    return configured;
+function traceFileRoots(traceUrl: string | undefined): string[] {
   if (traceUrl?.startsWith('file://')) {
     try {
       return [path.dirname(url.fileURLToPath(traceUrl))];

--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -195,7 +195,8 @@ export async function installRootRedirect(server: HttpServer, traceUrl: string |
 
 export async function runTraceViewerApp(traceUrl: string | undefined, browserName: string, options: TraceViewerServerOptions & { headless?: boolean }) {
   traceUrl = validateTraceUrlOrPath(traceUrl);
-  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => traceFileRoots(traceUrl) });
+  const allowedFileRoots = traceFileRoots(traceUrl);
+  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => allowedFileRoots });
   await installRootRedirect(server, traceUrl, options);
   const page = await openTraceViewerApp(server.urlPrefix('precise'), browserName, options);
   page.on('close', () => gracefullyProcessExitDoNotHang(0));
@@ -204,7 +205,8 @@ export async function runTraceViewerApp(traceUrl: string | undefined, browserNam
 
 export async function runTraceInBrowser(traceUrl: string | undefined, options: TraceViewerServerOptions) {
   traceUrl = validateTraceUrlOrPath(traceUrl);
-  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => traceFileRoots(traceUrl) });
+  const allowedFileRoots = traceFileRoots(traceUrl);
+  const server = await startTraceViewerServer({ ...options, allowedFileRoots: () => allowedFileRoots });
   await installRootRedirect(server, traceUrl, options);
   await openTraceInBrowser(server.urlPrefix('human-readable'));
 }

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -104,6 +104,7 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
   private _watchTestDirs = false;
   private _populateDependenciesOnList = false;
   private _startingEnv: NodeJS.ProcessEnv = {};
+  private _lastLoadedConfig: FullConfigInternal | undefined;
 
   constructor(configLocation: ConfigLocation, configCLIOverrides: ipc.ConfigCLIOverrides) {
     super();
@@ -398,10 +399,15 @@ export class TestRunner extends EventEmitter<TestRunnerEventMap> {
       } else {
         config.plugins.splice(0, config.plugins.length, ...this._plugins);
       }
+      this._lastLoadedConfig = config;
       return { config };
     } catch (e) {
       return { config: null, error: serializeError(e) };
     }
+  }
+
+  lastLoadedConfig(): FullConfigInternal | undefined {
+    return this._lastLoadedConfig;
   }
 
   private async _loadConfigOrReportError(reporter: InternalReporter, overrides?: ipc.ConfigCLIOverrides): Promise<FullConfigInternal | null> {

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -59,14 +59,24 @@ class TestServer {
     this._configCLIOverrides = configCLIOverrides;
   }
 
-  async start(options: { host?: string, port?: number, allowedFileRoots: string[] }): Promise<HttpServer> {
+  async start(options: { host?: string, port?: number }): Promise<HttpServer> {
     this._dispatcher = new TestServerDispatcher(this._configLocation, this._configCLIOverrides);
     return await coreServer.startTraceViewerServer({
       host: options.host,
       port: options.port,
-      allowedFileRoots: options.allowedFileRoots,
+      allowedFileRoots: () => this._allowedFileRoots(),
       transport: this._dispatcher.transport,
     });
+  }
+
+  private _allowedFileRoots(): string[] {
+    const roots = new Set<string>([process.cwd(), this._configLocation.configDir]);
+    const config = this._dispatcher?._testRunner.lastLoadedConfig();
+    if (config) {
+      for (const project of config.projects)
+        roots.add(project.project.outputDir);
+    }
+    return [...roots];
   }
 
   async stop() {
@@ -102,7 +112,7 @@ export class TestServerDispatcher implements TestServerInterface {
   readonly transport: Transport;
   private _serializer: string | undefined;
   private _closeOnDisconnect = false;
-  private _testRunner: TestRunner;
+  _testRunner: TestRunner;
   private _globalSetupReport: ReportEntry[] | undefined;
   readonly _dispatchEvent: TestServerInterfaceEventEmitters['dispatchEvent'];
 
@@ -314,8 +324,7 @@ async function innerRunTestServer(configLocation: ConfigLocation, configCLIOverr
   process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
   void sigintWatcher.promise().then(() => cancelPromise.resolve());
   try {
-    const allowedFileRoots = await allowedFileRootsForConfig(configLocation, configCLIOverrides);
-    const server = await testServer.start({ ...options, allowedFileRoots });
+    const server = await testServer.start(options);
     await openUI(server, cancelPromise);
     await cancelPromise;
   } finally {
@@ -323,16 +332,6 @@ async function innerRunTestServer(configLocation: ConfigLocation, configCLIOverr
     sigintWatcher.disarm();
   }
   return sigintWatcher.hadSignal() ? 'interrupted' : 'passed';
-}
-
-async function allowedFileRootsForConfig(configLocation: ConfigLocation, configCLIOverrides: ipc.ConfigCLIOverrides): Promise<string[]> {
-  const roots = new Set<string>([process.cwd(), configLocation.configDir]);
-  const config = await configLoader.loadConfig(configLocation, configCLIOverrides).catch(() => null);
-  if (config) {
-    for (const project of config.projects)
-      roots.add(project.project.outputDir);
-  }
-  return [...roots];
 }
 
 type StdioPayload = {

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -73,8 +73,10 @@ class TestServer {
     const roots = new Set<string>([process.cwd(), this._configLocation.configDir]);
     const config = this._dispatcher?._testRunner.lastLoadedConfig();
     if (config) {
-      for (const project of config.projects)
+      for (const project of config.projects) {
         roots.add(project.project.outputDir);
+        roots.add(project.project.testDir);
+      }
     }
     return [...roots];
   }

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -59,9 +59,14 @@ class TestServer {
     this._configCLIOverrides = configCLIOverrides;
   }
 
-  async start(options: { host?: string, port?: number }): Promise<HttpServer> {
+  async start(options: { host?: string, port?: number, allowedFileRoots: string[] }): Promise<HttpServer> {
     this._dispatcher = new TestServerDispatcher(this._configLocation, this._configCLIOverrides);
-    return await coreServer.startTraceViewerServer({ ...options, transport: this._dispatcher.transport });
+    return await coreServer.startTraceViewerServer({
+      host: options.host,
+      port: options.port,
+      allowedFileRoots: options.allowedFileRoots,
+      transport: this._dispatcher.transport,
+    });
   }
 
   async stop() {
@@ -309,7 +314,8 @@ async function innerRunTestServer(configLocation: ConfigLocation, configCLIOverr
   process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
   void sigintWatcher.promise().then(() => cancelPromise.resolve());
   try {
-    const server = await testServer.start(options);
+    const allowedFileRoots = await allowedFileRootsForConfig(configLocation, configCLIOverrides);
+    const server = await testServer.start({ ...options, allowedFileRoots });
     await openUI(server, cancelPromise);
     await cancelPromise;
   } finally {
@@ -317,6 +323,16 @@ async function innerRunTestServer(configLocation: ConfigLocation, configCLIOverr
     sigintWatcher.disarm();
   }
   return sigintWatcher.hadSignal() ? 'interrupted' : 'passed';
+}
+
+async function allowedFileRootsForConfig(configLocation: ConfigLocation, configCLIOverrides: ipc.ConfigCLIOverrides): Promise<string[]> {
+  const roots = new Set<string>([process.cwd(), configLocation.configDir]);
+  const config = await configLoader.loadConfig(configLocation, configCLIOverrides).catch(() => null);
+  if (config) {
+    for (const project of config.projects)
+      roots.add(project.project.outputDir);
+  }
+  return [...roots];
 }
 
 type StdioPayload = {

--- a/tests/playwright-test/ui-mode-trace.spec.ts
+++ b/tests/playwright-test/ui-mode-trace.spec.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 import { createImage } from './playwright-test-fixtures';
 import { test, expect, retries } from './ui-mode-fixtures';
 
@@ -840,4 +844,37 @@ test('should update state on subsequent run', async ({ runUITest, writeFiles }) 
   await expect(page).toMatchAriaSnapshot(`
     - treeitem /Expect \"toBe\"/
   `);
+});
+
+test('should load trace when outputDir is outside cwd', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40950' },
+}, async ({ runUITest }) => {
+  const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-outputdir-'));
+  try {
+    const { page } = await runUITest({
+      'playwright.config.ts': `
+        import { defineConfig } from '@playwright/test';
+        export default defineConfig({
+          outputDir: ${JSON.stringify(outputDir)},
+        });
+      `,
+      'a.test.ts': `
+        import { test, expect } from '@playwright/test';
+        test('trace test', async ({ page }) => {
+          await page.setContent('<button>Submit</button>');
+        });
+      `,
+    });
+
+    await page.getByText('trace test').dblclick();
+
+    const listItem = page.getByTestId('actions-tree').getByRole('treeitem');
+    await expect(listItem, 'action list').toHaveText([
+      /Before Hooks/,
+      /Set content/,
+      /After Hooks/,
+    ]);
+  } finally {
+    await fs.promises.rm(outputDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- UI mode and the test server were starting the trace viewer without `allowedFileRoots`, so it defaulted to `[process.cwd()]`. When a project's `outputDir` resolved outside cwd (common in monorepos where playwright is invoked from a parent dir) every `/file` request 403'd and the actions panel stayed empty.
- Compute roots from the loaded config (`cwd`, `configDir`, every project `outputDir`) and pass them through.
- Make `allowedFileRoots` required on `startTraceViewerServer` so future call sites do not silently regress.

Fixes https://github.com/microsoft/playwright/issues/40950
