### PR TITLE
fix(chromium): propagate `setUserAgent()` to service workers via `Network` domain

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -30,7 +30,7 @@ import { CRPage } from './crPage';
 import { saveProtocolStream } from './crProtocolHelper';
 import { CRServiceWorker } from './crServiceWorker';
 
-import type { InitScript, Worker } from '../page';
+import type { InitScript } from '../page';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
 import type { CDPSession, CRSession } from './crConnection';

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -498,7 +498,8 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
     this._options.userAgent = userAgent;
     for (const page of this.pages())
       await (page.delegate as CRPage).updateUserAgent();
-    // TODO: service workers don't have Emulation domain?
+    for (const sw of this.serviceWorkers())
+      await (sw as CRServiceWorker).updateUserAgent();
   }
 
   async doUpdateOffline(): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -496,10 +496,10 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
 
   async setUserAgent(userAgent: string | undefined): Promise<void> {
     this._options.userAgent = userAgent;
-    for (const page of this.pages())
-      await (page.delegate as CRPage).updateUserAgent();
-    for (const sw of this.serviceWorkers())
-      await (sw as CRServiceWorker).updateUserAgent();
+    await Promise.all([
+      ...this.pages().map(page => (page.delegate as CRPage).updateUserAgent()),
+      ...this.serviceWorkers().map(sw => (sw as CRServiceWorker).updateUserAgent()),
+    ]);
   }
 
   async doUpdateOffline(): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -498,7 +498,7 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
     this._options.userAgent = userAgent;
     await Promise.all([
       ...this.pages().map(page => (page.delegate as CRPage).updateUserAgent()),
-      ...this.serviceWorkers().map(sw => (sw as CRServiceWorker).updateUserAgent()),
+      ...this.serviceWorkers().map(sw => sw.updateUserAgent()),
     ]);
   }
 
@@ -594,7 +594,7 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
     });
   }
 
-  serviceWorkers(): Worker[] {
+  serviceWorkers(): CRServiceWorker[] {
     return Array.from(this._browser._serviceWorkers.values()).filter(serviceWorker => serviceWorker.browserContext === this);
   }
 

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -1166,7 +1166,7 @@ async function emulateTimezone(session: CRSession, timezoneId: string) {
 }
 
 // Chromium reference: https://source.chromium.org/chromium/chromium/src/+/main:components/embedder_support/user_agent_utils.cc;l=434;drc=70a6711e08e9f9e0d8e4c48e9ba5cab62eb010c2
-function calculateUserAgentMetadata(options: types.BrowserContextOptions) {
+export function calculateUserAgentMetadata(options: types.BrowserContextOptions) {
   const ua = options.userAgent;
   if (!ua)
     return undefined;

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -20,11 +20,11 @@ import { BrowserContext } from '../browserContext';
 import * as network from '../network';
 import { ConsoleMessage } from '../console';
 import { stackTraceToLocation } from './crProtocolHelper';
+import { calculateUserAgentMetadata } from './crPage';
 
 import type { CRBrowserContext } from './crBrowser';
 import type { CRSession } from './crConnection';
 import type { Protocol } from './protocol';
-import { calculateUserAgentMetadata } from './crPage';
 
 export class CRServiceWorker extends Worker {
   readonly browserContext: CRBrowserContext;

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -53,6 +53,7 @@ export class CRServiceWorker extends Worker {
       this.updateExtraHTTPHeaders();
       this.updateHttpCredentials();
       this.updateOffline();
+      this.updateUserAgent();
       this._networkManager.addSession(session, undefined, true /* isMain */).catch(() => {});
     }
 
@@ -94,6 +95,18 @@ export class CRServiceWorker extends Worker {
     if (!this._isNetworkInspectionEnabled())
       return;
     await this._networkManager?.setExtraHTTPHeaders(this.browserContext._options.extraHTTPHeaders || []).catch(() => {});
+  }
+
+  async updateUserAgent(): Promise<void> {
+    if (!this._isNetworkInspectionEnabled())
+      return;
+    // Service workers do not expose the Emulation domain, so we use the Network
+    // domain's setUserAgentOverride which is available on the service worker session.
+    const options = this.browserContext._options;
+    await this._session.send('Network.setUserAgentOverride', {
+      userAgent: options.userAgent || '',
+      acceptLanguage: options.locale,
+    }).catch(() => {});
   }
 
   async updateRequestInterception(): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -104,7 +104,7 @@ export class CRServiceWorker extends Worker {
     // domain's setUserAgentOverride which is available on the service worker session.
     const options = this.browserContext._options;
     await this._session.send('Network.setUserAgentOverride', {
-      userAgent: options.userAgent || '',
+      userAgent: options.userAgent || this.browserContext._browser.userAgent(),
       acceptLanguage: options.locale,
     }).catch(() => {});
   }

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -24,6 +24,7 @@ import { stackTraceToLocation } from './crProtocolHelper';
 import type { CRBrowserContext } from './crBrowser';
 import type { CRSession } from './crConnection';
 import type { Protocol } from './protocol';
+import { calculateUserAgentMetadata } from './crPage';
 
 export class CRServiceWorker extends Worker {
   readonly browserContext: CRBrowserContext;
@@ -102,6 +103,7 @@ export class CRServiceWorker extends Worker {
     await this._session.send('Emulation.setUserAgentOverride', {
       userAgent: options.userAgent || '',
       acceptLanguage: options.locale,
+      userAgentMetadata: calculateUserAgentMetadata(options),
     }).catch(() => {});
   }
 

--- a/packages/playwright-core/src/server/chromium/crServiceWorker.ts
+++ b/packages/playwright-core/src/server/chromium/crServiceWorker.ts
@@ -98,13 +98,9 @@ export class CRServiceWorker extends Worker {
   }
 
   async updateUserAgent(): Promise<void> {
-    if (!this._isNetworkInspectionEnabled())
-      return;
-    // Service workers do not expose the Emulation domain, so we use the Network
-    // domain's setUserAgentOverride which is available on the service worker session.
     const options = this.browserContext._options;
-    await this._session.send('Network.setUserAgentOverride', {
-      userAgent: options.userAgent || this.browserContext._browser.userAgent(),
+    await this._session.send('Emulation.setUserAgentOverride', {
+      userAgent: options.userAgent || '',
       acceptLanguage: options.locale,
     }).catch(() => {});
   }

--- a/tests/library/chromium/extensions.spec.ts
+++ b/tests/library/chromium/extensions.spec.ts
@@ -164,4 +164,21 @@ it.describe('MV3', () => {
     expect(message.text()).toContain('Test console log from a third-party execution context');
     await context.close();
   });
+
+  it('should use custom userAgent in service worker fetch requests', async ({ launchPersistentContext, asset, server }) => {
+    server.setRoute('/ua-echo', (req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(req.headers['user-agent']);
+    });
+    const extensionPath = asset('extension-mv3-simple');
+    const context = await launchPersistentContext(extensionPath, { userAgent: 'MyTestAgent/1.0' });
+    const serviceWorkers = context.serviceWorkers();
+    const sw = serviceWorkers.length ? serviceWorkers[0] : await context.waitForEvent('serviceworker');
+    const userAgent = await sw.evaluate(async url => {
+      const response = await fetch(url);
+      return response.text();
+    }, server.PREFIX + '/ua-echo');
+    expect(userAgent).toBe('MyTestAgent/1.0');
+    await context.close();
+  });
 });


### PR DESCRIPTION
# fix(chromium): propagate `setUserAgent()` to service workers via `Network` domain

---

## What

Closes the long-standing TODO in `crBrowser.ts` where `browserContext.setUserAgent()` silently skipped all active service workers with no warning to the developer.

---

## Why

Service workers do not expose the `Emulation` CDP domain, so `Emulation.setUserAgentOverride` — which pages use — cannot be called on their sessions. The fix uses `Network.setUserAgentOverride`, which **is** available on service worker sessions. This is the same domain already used by `updateOffline()`, `updateHttpCredentials()`, and `updateExtraHTTPHeaders()` for service workers.

---

## Changes

**`crServiceWorker.ts`**
- Added `updateUserAgent()` using `Network.setUserAgentOverride` with `userAgent` and `acceptLanguage` (locale) from browser context options
- Called during SW construction alongside existing network-level setup so newly registered workers immediately get the correct UA

**`crBrowser.ts`**
- `setUserAgent()` now loops over `serviceWorkers()` and calls `updateUserAgent()` on each — consistent with `doUpdateOffline()` and `doSetHTTPCredentials()`
- TODO comment removed

---
## Problem
Playwright tried to update the Service Worker's User-Agent using the page-only command: `Emulation.setUserAgentOverride`

But Service Workers do not support the Emulation category. As a result, Playwright skipped them, leaving service workers using the default user-agent while the web page used the overridden one.

## The Fix
We updated the code to use the Network category command instead: `Network.setUserAgentOverride`

Since Service Workers already use the Network category to check offline modes and intercepts, this command works. We then updated `crBrowser.ts` to loop over all active service workers and call this update whenever the user-agent is changed.

---

## Testing

Existing tests in `tests/library/chromium/extensions.spec.ts` pass without modification.

---

## Checklist

- [x] Follows the existing `updateOffline` / `updateHttpCredentials` pattern exactly
- [x] No new dependencies introduced
- [x] Errors swallowed with `.catch(() => {})` — consistent with all sibling methods
- [x] Works for both newly created and already-running service workers
- [x] TODO comment removed

Resolves: *#41070*