### PR TITLE
test(webkit): update modernizr baseline for font-display descriptor removal

### DIFF
--- a/tests/assets/modernizr/mobile-safari-18.json
+++ b/tests/assets/modernizr/mobile-safari-18.json
@@ -103,7 +103,7 @@
   "flexwrap": true,
   "focusvisible": true,
   "focuswithin": true,
-  "fontdisplay": true,
+  "fontdisplay": false,
   "fontface": true,
   "generatedcontent": true,
   "cssgradients": true,

--- a/tests/assets/modernizr/safari-18.json
+++ b/tests/assets/modernizr/safari-18.json
@@ -103,7 +103,7 @@
   "flexwrap": true,
   "focusvisible": true,
   "focuswithin": true,
-  "fontdisplay": true,
+  "fontdisplay": false,
   "fontface": true,
   "generatedcontent": true,
   "cssgradients": true,


### PR DESCRIPTION
WebKit 314093@main stopped exposing descriptor-only names in element styles, so font-display (a @font-face descriptor) is no longer detectable via testProp().