### PR TITLE
feat(test runner): add -G alias for grep-invert

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -86,7 +86,7 @@ npx playwright test --ui
 | `--fully-parallel` | Run all tests in parallel (default: false). |
 | `--global-timeout <timeout>` | Maximum time this test suite can run in milliseconds (default: unlimited). |
 | `-g <grep>` or `--grep <grep>` | Only run tests matching this regular expression (default: ".*"). |
-| `--grep-invert <grep>` | Only run tests that do not match this regular expression. |
+| `-G <grep>` or `--grep-invert <grep>` | Only run tests that do not match this regular expression. |
 | `--headed` | Run tests in headed browsers (default: headless). |
 | `--ignore-snapshots` | Ignore screenshot and snapshot expectations. |
 | `-j <workers>` or `--workers <workers>` | Number of concurrent workers or percentage of logical CPU cores, use 1 to run in a single worker (default: 50%). |

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -196,7 +196,7 @@ const testOptions: [string, { description: string, choices?: string[], preset?: 
   ['--fully-parallel', { description: `Run all tests in parallel (default: false)` }],
   ['--global-timeout <timeout>', { description: `Maximum time this test suite can run in milliseconds (default: unlimited)` }],
   ['-g, --grep <grep>', { description: `Only run tests matching this regular expression (default: ".*")` }],
-  ['--grep-invert <grep>', { description: `Only run tests that do not match this regular expression` }],
+  ['-G, --grep-invert <grep>', { description: `Only run tests that do not match this regular expression` }],
   ['--headed', { description: `Run tests in headed browsers (default: headless)` }],
   ['--ignore-snapshots', { description: `Ignore screenshot and snapshot expectations` }],
   ['--last-failed', { description: `Only re-run the failures` }],

--- a/tests/playwright-test/match-grep.spec.ts
+++ b/tests/playwright-test/match-grep.spec.ts
@@ -88,6 +88,13 @@ test('should grep invert test name', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should grep invert test name with short option', async ({ runInlineTest }) => {
+  const result = await runInlineTest(files, undefined, undefined, { additionalArgs: ['-G', 'BB'] });
+  expect(result.passed).toBe(6);
+  expect(result.skipped).toBe(0);
+  expect(result.exitCode).toBe(0);
+});
+
 test('should be case insensitive by default', async ({ runInlineTest }) => {
   const result = await runInlineTest(files, { 'grep': 'TesT Cc' });
   expect(result.passed).toBe(3);


### PR DESCRIPTION
Problem
- Closes #41036.
- `--grep` has the short form `-g`, but `--grep-invert` does not have a matching short form.

Root cause
- The test runner CLI only registered the long `--grep-invert <grep>` option.

Solution
- Register `-G` as the short option for `--grep-invert`.
- Update the CLI documentation table.
- Add test runner coverage that exercises `-G` through the real CLI path.

Tests run
- `npm ci`
- `npm run build`
- `npm run ttest -- tests/playwright-test/match-grep.spec.ts`
- `npx eslint packages/playwright/src/program.ts tests/playwright-test/match-grep.spec.ts`
- `node utils/doclint/cli.js docs/src/test-cli-js.md`
- `node packages/playwright/cli.js test --help`
- `git diff --check`