### PR TITLE
chore(webkit): extract webview dialog bridge into an injected source

### DIFF
--- a/packages/injected/src/webview/webViewDialog.ts
+++ b/packages/injected/src/webview/webViewDialog.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function toMessage(message: any): string {
+  return String(message === undefined || message === null ? '' : message);
+}
+
+// Stock WebKit RDP has no dialog API. We override window.alert/confirm/prompt
+// to tunnel calls through a synchronous XHR to our DialogBridge HTTP server,
+// which holds the response until the host-side Dialog handler resolves.
+export function installDialogBridge(window: Window & typeof globalThis, endpoint: string) {
+  function post(type: string, message: string, defaultValue: string): any {
+    const xhr = new window.XMLHttpRequest();
+    try { xhr.open('POST', endpoint, false); } catch (e) { return null; }
+    // text/plain body keeps this a "simple" CORS request — no preflight.
+    try { xhr.send(JSON.stringify({ type, message, defaultValue })); } catch (e) { return null; }
+    if (xhr.status !== 200)
+      return null;
+    try { return JSON.parse(xhr.responseText); } catch (e) { return null; }
+  }
+  Object.defineProperty(window, 'alert', {
+    configurable: true, writable: false,
+    value: function(message: any) { post('alert', toMessage(message), ''); },
+  });
+  Object.defineProperty(window, 'confirm', {
+    configurable: true, writable: false,
+    value: function(message: any) {
+      const r = post('confirm', toMessage(message), '');
+      return !!(r && r.accept);
+    },
+  });
+  Object.defineProperty(window, 'prompt', {
+    configurable: true, writable: false,
+    value: function(message: any, defaultValue: any) {
+      const def = toMessage(defaultValue);
+      const r = post('prompt', toMessage(message), def);
+      if (!r || !r.accept)
+        return null;
+      return typeof r.promptText === 'string' ? r.promptText : def;
+    },
+  });
+}

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -29,6 +29,7 @@ import { TargetClosedError } from '../../errors';
 import { helper } from '../../helper';
 import { saveGlobalsSnapshotSource } from '../../javascript';
 import * as rawWebViewInputSource from '../../../generated/webViewInputSource';
+import * as rawWebViewDialogSource from '../../../generated/webViewDialogSource';
 import * as network from '../../network';
 import { Page, PageBinding } from '../../page';
 import { WVSession } from './wvConnection';
@@ -1015,42 +1016,10 @@ const bindingBridgeSource = `
   }
 `;
 
-// Stock WebKit RDP has no dialog API. We override window.alert/confirm/prompt
-// to tunnel calls through a synchronous XHR to our DialogBridge HTTP server,
-// which holds the response until the host-side Dialog handler resolves.
 function dialogBridgeSource(endpoint: string): string {
-  return `
-    (function() {
-      const URL = ${JSON.stringify(endpoint)};
-      function post(type, message, defaultValue) {
-        const xhr = new XMLHttpRequest();
-        try { xhr.open('POST', URL, false); } catch (e) { return null; }
-        // text/plain body keeps this a "simple" CORS request — no preflight.
-        try { xhr.send(JSON.stringify({ type: type, message: message, defaultValue: defaultValue })); }
-        catch (e) { return null; }
-        if (xhr.status !== 200) return null;
-        try { return JSON.parse(xhr.responseText); } catch (e) { return null; }
-      }
-      Object.defineProperty(window, 'alert', {
-        configurable: true, writable: false,
-        value: function(message) { post('alert', String(message == null ? '' : message), ''); },
-      });
-      Object.defineProperty(window, 'confirm', {
-        configurable: true, writable: false,
-        value: function(message) {
-          const r = post('confirm', String(message == null ? '' : message), '');
-          return !!(r && r.accept);
-        },
-      });
-      Object.defineProperty(window, 'prompt', {
-        configurable: true, writable: false,
-        value: function(message, defaultValue) {
-          const def = defaultValue == null ? '' : String(defaultValue);
-          const r = post('prompt', String(message == null ? '' : message), def);
-          if (!r || !r.accept) return null;
-          return typeof r.promptText === 'string' ? r.promptText : def;
-        },
-      });
-    })();
-  `;
+  return `(() => {
+  const module = {};
+  ${rawWebViewDialogSource.source}
+  module.exports.installDialogBridge()(window, ${JSON.stringify(endpoint)});
+})()`;
 }

--- a/utils/generate_injected.js
+++ b/utils/generate_injected.js
@@ -81,6 +81,12 @@ const injectedScripts = [
     true,
   ],
   [
+    path.join(ROOT, 'packages', 'injected', 'src', 'webview', 'webViewDialog.ts'),
+    path.join(ROOT, 'packages', 'injected', 'lib'),
+    path.join(ROOT, 'packages', 'playwright-core', 'src', 'generated'),
+    true,
+  ],
+  [
     path.join(ROOT, 'packages', 'playwright-ct-core', 'src', 'injected', 'index.ts'),
     path.join(ROOT, 'packages', 'playwright-ct-core', 'lib', 'injected', 'packed'),
     path.join(ROOT, 'packages', 'playwright-ct-core', 'src', 'generated'),


### PR DESCRIPTION
## Summary
- Move the inline `window.alert/confirm/prompt` override out of `wvPage.ts` into `packages/injected/src/webview/webViewDialog.ts`, following the existing `webViewInput.ts` injected-source pattern.
- The script is now a real `installDialogBridge(window, endpoint)` function bundled by `generate_injected.js` and invoked with the endpoint as a parameter.