### PR TITLE
fix(webview): dispatch mouse events in their own tasks

### DIFF
--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -111,7 +111,6 @@ export class WebViewInput {
   private _window: Window & typeof globalThis;
   private _document: Document;
   private _hoverTarget: Element | null = null;
-  private _queueTail: Promise<void> = Promise.resolve();
   private _setTimeout: typeof globalThis.setTimeout;
 
   constructor(window: Window & typeof globalThis, document: Document) {
@@ -120,9 +119,11 @@ export class WebViewInput {
     this._setTimeout = ((window as any).__pwSnapshotGlobals || window).setTimeout;
   }
 
-  // Run each event in its own task (like real input) and serialize them.
-  private _postTask(task: () => void): void {
-    this._queueTail = new Promise<void>(resolve => {
+  // Run each event in its own task (like real input). Same-delay setTimeout
+  // callbacks fire in scheduling order, so awaiting the last posted task waits
+  // for every task posted before it too.
+  private _postTask(task: () => void): Promise<void> {
+    return new Promise<void>(resolve => {
       this._setTimeout.call(this._window, () => {
         try {
           task();
@@ -131,10 +132,6 @@ export class WebViewInput {
         }
       });
     });
-  }
-
-  private _drained(): Promise<void> {
-    return this._queueTail;
   }
 
   // Descend through open shadow roots so synthetic events land on the actual
@@ -196,20 +193,20 @@ export class WebViewInput {
     };
     let notPrevented = true;
     let charNotPrevented = true;
-    this._postTask(() => {
+    let lastTask = this._postTask(() => {
       notPrevented = dispatchKeyEvent(target, 'keydown', init, params.keyCode, params.key);
     });
     // Non-text keys produce only keydown; a cancelled keydown also suppresses the
     // keypress and the default text insertion.
     if (params.text !== undefined) {
       const text = params.text;
-      this._postTask(() => {
+      void this._postTask(() => {
         if (!notPrevented)
           return;
         const charCode = text.charCodeAt(0);
         charNotPrevented = markAndDispatch(target, new KeyboardEvent('keypress', { ...init, charCode, keyCode: charCode, which: charCode }));
       });
-      this._postTask(() => {
+      lastTask = this._postTask(() => {
         if (!notPrevented || !charNotPrevented)
           return;
         // Real WebKit fires a `textInput` (TextEvent) whose default action performs
@@ -219,7 +216,7 @@ export class WebViewInput {
         this._dispatchTextInput(target, text === '\r' ? '\n' : text);
       });
     }
-    return this._drained();
+    return lastTask;
   }
 
   private _dispatchTextInput(target: EventTarget, text: string) {
@@ -234,7 +231,7 @@ export class WebViewInput {
     const target = this._deepActiveElement() || this._document.body;
     if (!target)
       return Promise.resolve();
-    this._postTask(() => {
+    return this._postTask(() => {
       dispatchKeyEvent(target, 'keyup', {
         bubbles: true,
         cancelable: true,
@@ -250,12 +247,10 @@ export class WebViewInput {
         metaKey: params.metaKey,
       }, params.keyCode, params.key);
     });
-    return this._drained();
   }
 
   insertText(text: string): Promise<void> {
-    this._postTask(() => this._insertText(this._deepActiveElement(), text));
-    return this._drained();
+    return this._postTask(() => this._insertText(this._deepActiveElement(), text));
   }
 
   mouseMove(params: MouseMoveParams): Promise<void> {
@@ -279,26 +274,25 @@ export class WebViewInput {
     const prev = this._hoverTarget;
     if (prev !== target) {
       if (prev && prev.isConnected) {
-        this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerout', { ...pointer, relatedTarget: target })));
-        this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseout', { ...base, relatedTarget: target })));
-        this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerleave', { ...pointer, bubbles: false, cancelable: false, relatedTarget: target })));
-        this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseleave', { ...base, bubbles: false, cancelable: false, relatedTarget: target })));
+        void this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerout', { ...pointer, relatedTarget: target })));
+        void this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseout', { ...base, relatedTarget: target })));
+        void this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerleave', { ...pointer, bubbles: false, cancelable: false, relatedTarget: target })));
+        void this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseleave', { ...base, bubbles: false, cancelable: false, relatedTarget: target })));
       }
-      this._postTask(() => markAndDispatch(target, new PointerEvent('pointerover', { ...pointer, relatedTarget: prev })));
-      this._postTask(() => markAndDispatch(target, new MouseEvent('mouseover', { ...base, relatedTarget: prev })));
-      this._postTask(() => markAndDispatch(target, new PointerEvent('pointerenter', { ...pointer, bubbles: false, cancelable: false, relatedTarget: prev })));
-      this._postTask(() => markAndDispatch(target, new MouseEvent('mouseenter', { ...base, bubbles: false, cancelable: false, relatedTarget: prev })));
+      void this._postTask(() => markAndDispatch(target, new PointerEvent('pointerover', { ...pointer, relatedTarget: prev })));
+      void this._postTask(() => markAndDispatch(target, new MouseEvent('mouseover', { ...base, relatedTarget: prev })));
+      void this._postTask(() => markAndDispatch(target, new PointerEvent('pointerenter', { ...pointer, bubbles: false, cancelable: false, relatedTarget: prev })));
+      void this._postTask(() => markAndDispatch(target, new MouseEvent('mouseenter', { ...base, bubbles: false, cancelable: false, relatedTarget: prev })));
       this._hoverTarget = target;
     }
-    this._postTask(() => markAndDispatch(target, new PointerEvent('pointermove', pointer)));
-    this._postTask(() => markAndDispatch(target, new MouseEvent('mousemove', base)));
-    return this._drained();
+    void this._postTask(() => markAndDispatch(target, new PointerEvent('pointermove', pointer)));
+    return this._postTask(() => markAndDispatch(target, new MouseEvent('mousemove', base)));
   }
 
   mouseEvent(params: MouseEventParams): Promise<void> {
     // Resolve the hit target at dispatch time, not enqueue time: a queued move
     // ahead of this may reveal an overlay that should receive the press.
-    this._postTask(() => {
+    return this._postTask(() => {
       const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
       markAndDispatch(target, new MouseEvent(params.type, {
         bubbles: true,
@@ -317,11 +311,10 @@ export class WebViewInput {
         metaKey: params.metaKey,
       }));
     });
-    return this._drained();
   }
 
   wheel(params: WheelParams): Promise<void> {
-    this._postTask(() => {
+    return this._postTask(() => {
       const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
       markAndDispatch(target, new WheelEvent('wheel', {
         bubbles: true,
@@ -341,7 +334,6 @@ export class WebViewInput {
       }));
       this._window.scrollBy(params.deltaX, params.deltaY);
     });
-    return this._drained();
   }
 
   tap(params: TapParams): Promise<void> {
@@ -361,14 +353,13 @@ export class WebViewInput {
     };
     try {
       const touch = new Touch({ identifier: 0, target, clientX: params.x, clientY: params.y, screenX: params.x, screenY: params.y, pageX: params.x, pageY: params.y, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 });
-      this._postTask(() => markAndDispatch(target, new TouchEvent('touchstart', { ...init, touches: [touch], targetTouches: [touch], changedTouches: [touch] })));
-      this._postTask(() => markAndDispatch(target, new TouchEvent('touchend', { ...init, touches: [], targetTouches: [], changedTouches: [touch] })));
+      void this._postTask(() => markAndDispatch(target, new TouchEvent('touchstart', { ...init, touches: [touch], targetTouches: [touch], changedTouches: [touch] })));
+      void this._postTask(() => markAndDispatch(target, new TouchEvent('touchend', { ...init, touches: [], targetTouches: [], changedTouches: [touch] })));
     } catch {
     }
-    this._postTask(() => markAndDispatch(target, new MouseEvent('mousedown', { ...init, button: 0, buttons: 1, detail: 1 })));
-    this._postTask(() => markAndDispatch(target, new MouseEvent('mouseup', { ...init, button: 0, buttons: 0, detail: 1 })));
-    this._postTask(() => markAndDispatch(target, new MouseEvent('click', { ...init, button: 0, buttons: 0, detail: 1 })));
-    return this._drained();
+    void this._postTask(() => markAndDispatch(target, new MouseEvent('mousedown', { ...init, button: 0, buttons: 1, detail: 1 })));
+    void this._postTask(() => markAndDispatch(target, new MouseEvent('mouseup', { ...init, button: 0, buttons: 0, detail: 1 })));
+    return this._postTask(() => markAndDispatch(target, new MouseEvent('click', { ...init, button: 0, buttons: 0, detail: 1 })));
   }
 }
 

--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -112,29 +112,25 @@ export class WebViewInput {
   private _document: Document;
   private _hoverTarget: Element | null = null;
   private _queueTail: Promise<void> = Promise.resolve();
-  // Snapshotted setTimeout, immune to a page overriding window.setTimeout.
-  private _schedule: typeof globalThis.setTimeout;
+  private _setTimeout: typeof globalThis.setTimeout;
 
   constructor(window: Window & typeof globalThis, document: Document) {
     this._window = window;
     this._document = document;
-    this._schedule = ((window as any).__pwSnapshotGlobals || window).setTimeout;
+    this._setTimeout = ((window as any).__pwSnapshotGlobals || window).setTimeout;
   }
 
-  // Run each event in its own task (like real input) and serialize them: the
-  // driver fires a click's move/down/up without awaiting each, relying on
-  // submission order, so a later synchronous command must not race ahead of an
-  // earlier one still draining its tasks.
+  // Run each event in its own task (like real input) and serialize them.
   private _postTask(task: () => void): void {
-    this._queueTail = this._queueTail.then(() => new Promise<void>(resolve => {
-      this._schedule.call(this._window, () => {
+    this._queueTail = new Promise<void>(resolve => {
+      this._setTimeout.call(this._window, () => {
         try {
           task();
         } finally {
           resolve();
         }
       });
-    }));
+    });
   }
 
   private _drained(): Promise<void> {

--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -111,21 +111,34 @@ export class WebViewInput {
   private _window: Window & typeof globalThis;
   private _document: Document;
   private _hoverTarget: Element | null = null;
+  private _queueTail: Promise<void> = Promise.resolve();
+  // Snapshotted setTimeout, immune to a page overriding window.setTimeout.
+  private _schedule: typeof globalThis.setTimeout;
 
   constructor(window: Window & typeof globalThis, document: Document) {
     this._window = window;
     this._document = document;
+    this._schedule = ((window as any).__pwSnapshotGlobals || window).setTimeout;
   }
 
-  // Real input events are each delivered in their own event-loop task; dispatch
-  // a sequence the same way so handlers that schedule work between events behave
-  // as they would on a real device. Timers come from the globals snapshot (taken
-  // at bootstrap), so a page overriding setTimeout cannot break scheduling.
-  private _nextTask(): Promise<void> {
-    const builtins = (this._window as any).__pwSnapshotGlobals || this._window;
-    // setImmediate avoids setTimeout's clamping, but WebKit does not implement it.
-    const schedule = builtins.setImmediate || builtins.setTimeout;
-    return new Promise(resolve => schedule.call(this._window, resolve));
+  // Run each event in its own task (like real input) and serialize them: the
+  // driver fires a click's move/down/up without awaiting each, relying on
+  // submission order, so a later synchronous command must not race ahead of an
+  // earlier one still draining its tasks.
+  private _postTask(task: () => void): void {
+    this._queueTail = this._queueTail.then(() => new Promise<void>(resolve => {
+      this._schedule.call(this._window, () => {
+        try {
+          task();
+        } finally {
+          resolve();
+        }
+      });
+    }));
+  }
+
+  private _drained(): Promise<void> {
+    return this._queueTail;
   }
 
   // Descend through open shadow roots so synthetic events land on the actual
@@ -166,10 +179,10 @@ export class WebViewInput {
     }
   }
 
-  keydown(params: KeyEventParams): void | Promise<void> {
+  keydown(params: KeyEventParams): Promise<void> {
     const target = this._deepActiveElement() || this._document.body;
     if (!target)
-      return;
+      return Promise.resolve();
     const init: KeyboardEventInit = {
       bubbles: true,
       cancelable: true,
@@ -185,26 +198,32 @@ export class WebViewInput {
       altKey: params.altKey,
       metaKey: params.metaKey,
     };
-    const notPrevented = dispatchKeyEvent(target, 'keydown', init, params.keyCode, params.key);
+    let notPrevented = true;
+    let charNotPrevented = true;
+    this._postTask(() => {
+      notPrevented = dispatchKeyEvent(target, 'keydown', init, params.keyCode, params.key);
+    });
     // Non-text keys produce only keydown; a cancelled keydown also suppresses the
     // keypress and the default text insertion.
-    if (params.text === undefined || !notPrevented)
-      return;
-    return this._typeCharacter(target, init, params.text);
-  }
-
-  private async _typeCharacter(target: EventTarget, init: KeyboardEventInit, text: string) {
-    await this._nextTask();
-    const charCode = text.charCodeAt(0);
-    const charNotPrevented = markAndDispatch(target, new KeyboardEvent('keypress', { ...init, charCode, keyCode: charCode, which: charCode }));
-    if (!charNotPrevented)
-      return;
-    await this._nextTask();
-    // Real WebKit fires a `textInput` (TextEvent) whose default action performs
-    // the insertion (and the subsequent beforeinput/input). Replicate it; the
-    // event's default does the insertion, so we do not insert manually. Enter's
-    // text is '\r' but the inserted/textInput data is a newline.
-    this._dispatchTextInput(target, text === '\r' ? '\n' : text);
+    if (params.text !== undefined) {
+      const text = params.text;
+      this._postTask(() => {
+        if (!notPrevented)
+          return;
+        const charCode = text.charCodeAt(0);
+        charNotPrevented = markAndDispatch(target, new KeyboardEvent('keypress', { ...init, charCode, keyCode: charCode, which: charCode }));
+      });
+      this._postTask(() => {
+        if (!notPrevented || !charNotPrevented)
+          return;
+        // Real WebKit fires a `textInput` (TextEvent) whose default action performs
+        // the insertion (and the subsequent beforeinput/input). Replicate it; the
+        // event's default does the insertion, so we do not insert manually. Enter's
+        // text is '\r' but the inserted/textInput data is a newline.
+        this._dispatchTextInput(target, text === '\r' ? '\n' : text);
+      });
+    }
+    return this._drained();
   }
 
   private _dispatchTextInput(target: EventTarget, text: string) {
@@ -215,31 +234,35 @@ export class WebViewInput {
     markAndDispatch(target, event);
   }
 
-  keyup(params: KeyEventParams) {
+  keyup(params: KeyEventParams): Promise<void> {
     const target = this._deepActiveElement() || this._document.body;
     if (!target)
-      return;
-    dispatchKeyEvent(target, 'keyup', {
-      bubbles: true,
-      cancelable: true,
-      view: this._window,
-      code: params.code,
-      key: params.key,
-      keyCode: params.keyCode,
-      which: params.keyCode,
-      location: params.location,
-      ctrlKey: params.ctrlKey,
-      shiftKey: params.shiftKey,
-      altKey: params.altKey,
-      metaKey: params.metaKey,
-    }, params.keyCode, params.key);
+      return Promise.resolve();
+    this._postTask(() => {
+      dispatchKeyEvent(target, 'keyup', {
+        bubbles: true,
+        cancelable: true,
+        view: this._window,
+        code: params.code,
+        key: params.key,
+        keyCode: params.keyCode,
+        which: params.keyCode,
+        location: params.location,
+        ctrlKey: params.ctrlKey,
+        shiftKey: params.shiftKey,
+        altKey: params.altKey,
+        metaKey: params.metaKey,
+      }, params.keyCode, params.key);
+    });
+    return this._drained();
   }
 
-  insertText(text: string) {
-    this._insertText(this._deepActiveElement(), text);
+  insertText(text: string): Promise<void> {
+    this._postTask(() => this._insertText(this._deepActiveElement(), text));
+    return this._drained();
   }
 
-  mouseMove(params: MouseMoveParams) {
+  mouseMove(params: MouseMoveParams): Promise<void> {
     const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
     const base: MouseEventInit = {
       bubbles: true,
@@ -260,65 +283,72 @@ export class WebViewInput {
     const prev = this._hoverTarget;
     if (prev !== target) {
       if (prev && prev.isConnected) {
-        markAndDispatch(prev, new PointerEvent('pointerout', { ...pointer, relatedTarget: target }));
-        markAndDispatch(prev, new MouseEvent('mouseout', { ...base, relatedTarget: target }));
-        markAndDispatch(prev, new PointerEvent('pointerleave', { ...pointer, bubbles: false, cancelable: false, relatedTarget: target }));
-        markAndDispatch(prev, new MouseEvent('mouseleave', { ...base, bubbles: false, cancelable: false, relatedTarget: target }));
+        this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerout', { ...pointer, relatedTarget: target })));
+        this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseout', { ...base, relatedTarget: target })));
+        this._postTask(() => markAndDispatch(prev, new PointerEvent('pointerleave', { ...pointer, bubbles: false, cancelable: false, relatedTarget: target })));
+        this._postTask(() => markAndDispatch(prev, new MouseEvent('mouseleave', { ...base, bubbles: false, cancelable: false, relatedTarget: target })));
       }
-      markAndDispatch(target, new PointerEvent('pointerover', { ...pointer, relatedTarget: prev }));
-      markAndDispatch(target, new MouseEvent('mouseover', { ...base, relatedTarget: prev }));
-      markAndDispatch(target, new PointerEvent('pointerenter', { ...pointer, bubbles: false, cancelable: false, relatedTarget: prev }));
-      markAndDispatch(target, new MouseEvent('mouseenter', { ...base, bubbles: false, cancelable: false, relatedTarget: prev }));
+      this._postTask(() => markAndDispatch(target, new PointerEvent('pointerover', { ...pointer, relatedTarget: prev })));
+      this._postTask(() => markAndDispatch(target, new MouseEvent('mouseover', { ...base, relatedTarget: prev })));
+      this._postTask(() => markAndDispatch(target, new PointerEvent('pointerenter', { ...pointer, bubbles: false, cancelable: false, relatedTarget: prev })));
+      this._postTask(() => markAndDispatch(target, new MouseEvent('mouseenter', { ...base, bubbles: false, cancelable: false, relatedTarget: prev })));
       this._hoverTarget = target;
     }
-    markAndDispatch(target, new PointerEvent('pointermove', pointer));
-    markAndDispatch(target, new MouseEvent('mousemove', base));
+    this._postTask(() => markAndDispatch(target, new PointerEvent('pointermove', pointer)));
+    this._postTask(() => markAndDispatch(target, new MouseEvent('mousemove', base)));
+    return this._drained();
   }
 
-  mouseEvent(params: MouseEventParams) {
-    const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
-    const event = new MouseEvent(params.type, {
-      bubbles: true,
-      cancelable: true,
-      view: this._window,
-      clientX: params.x,
-      clientY: params.y,
-      screenX: params.x,
-      screenY: params.y,
-      button: params.button,
-      buttons: params.buttons,
-      detail: params.clickCount,
-      ctrlKey: params.ctrlKey,
-      shiftKey: params.shiftKey,
-      altKey: params.altKey,
-      metaKey: params.metaKey,
+  mouseEvent(params: MouseEventParams): Promise<void> {
+    // Resolve the hit target at dispatch time, not enqueue time: a queued move
+    // ahead of this may reveal an overlay that should receive the press.
+    this._postTask(() => {
+      const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
+      markAndDispatch(target, new MouseEvent(params.type, {
+        bubbles: true,
+        cancelable: true,
+        view: this._window,
+        clientX: params.x,
+        clientY: params.y,
+        screenX: params.x,
+        screenY: params.y,
+        button: params.button,
+        buttons: params.buttons,
+        detail: params.clickCount,
+        ctrlKey: params.ctrlKey,
+        shiftKey: params.shiftKey,
+        altKey: params.altKey,
+        metaKey: params.metaKey,
+      }));
     });
-    markAndDispatch(target, event);
+    return this._drained();
   }
 
-  wheel(params: WheelParams) {
-    const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
-    const event = new WheelEvent('wheel', {
-      bubbles: true,
-      cancelable: true,
-      view: this._window,
-      clientX: params.x,
-      clientY: params.y,
-      screenX: params.x,
-      screenY: params.y,
-      deltaX: params.deltaX,
-      deltaY: params.deltaY,
-      deltaMode: 0,
-      ctrlKey: params.ctrlKey,
-      shiftKey: params.shiftKey,
-      altKey: params.altKey,
-      metaKey: params.metaKey,
+  wheel(params: WheelParams): Promise<void> {
+    this._postTask(() => {
+      const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
+      markAndDispatch(target, new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        view: this._window,
+        clientX: params.x,
+        clientY: params.y,
+        screenX: params.x,
+        screenY: params.y,
+        deltaX: params.deltaX,
+        deltaY: params.deltaY,
+        deltaMode: 0,
+        ctrlKey: params.ctrlKey,
+        shiftKey: params.shiftKey,
+        altKey: params.altKey,
+        metaKey: params.metaKey,
+      }));
+      this._window.scrollBy(params.deltaX, params.deltaY);
     });
-    markAndDispatch(target, event);
-    this._window.scrollBy(params.deltaX, params.deltaY);
+    return this._drained();
   }
 
-  tap(params: TapParams) {
+  tap(params: TapParams): Promise<void> {
     const target = this._deepElementFromPoint(params.x, params.y) || this._document.documentElement;
     const init: MouseEventInit = {
       bubbles: true,
@@ -335,13 +365,14 @@ export class WebViewInput {
     };
     try {
       const touch = new Touch({ identifier: 0, target, clientX: params.x, clientY: params.y, screenX: params.x, screenY: params.y, pageX: params.x, pageY: params.y, radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1 });
-      markAndDispatch(target, new TouchEvent('touchstart', { ...init, touches: [touch], targetTouches: [touch], changedTouches: [touch] }));
-      markAndDispatch(target, new TouchEvent('touchend', { ...init, touches: [], targetTouches: [], changedTouches: [touch] }));
+      this._postTask(() => markAndDispatch(target, new TouchEvent('touchstart', { ...init, touches: [touch], targetTouches: [touch], changedTouches: [touch] })));
+      this._postTask(() => markAndDispatch(target, new TouchEvent('touchend', { ...init, touches: [], targetTouches: [], changedTouches: [touch] })));
     } catch {
     }
-    markAndDispatch(target, new MouseEvent('mousedown', { ...init, button: 0, buttons: 1, detail: 1 }));
-    markAndDispatch(target, new MouseEvent('mouseup', { ...init, button: 0, buttons: 0, detail: 1 }));
-    markAndDispatch(target, new MouseEvent('click', { ...init, button: 0, buttons: 0, detail: 1 }));
+    this._postTask(() => markAndDispatch(target, new MouseEvent('mousedown', { ...init, button: 0, buttons: 1, detail: 1 })));
+    this._postTask(() => markAndDispatch(target, new MouseEvent('mouseup', { ...init, button: 0, buttons: 0, detail: 1 })));
+    this._postTask(() => markAndDispatch(target, new MouseEvent('click', { ...init, button: 0, buttons: 0, detail: 1 })));
+    return this._drained();
   }
 }
 

--- a/packages/injected/src/webview/webViewInput.ts
+++ b/packages/injected/src/webview/webViewInput.ts
@@ -119,9 +119,7 @@ export class WebViewInput {
     this._setTimeout = ((window as any).__pwSnapshotGlobals || window).setTimeout;
   }
 
-  // Run each event in its own task (like real input). Same-delay setTimeout
-  // callbacks fire in scheduling order, so awaiting the last posted task waits
-  // for every task posted before it too.
+  // Run each event in its own task (like real input).
   private _postTask(task: () => void): Promise<void> {
     return new Promise<void>(resolve => {
       this._setTimeout.call(this._window, () => {

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -380,8 +380,8 @@ const snapshottedObjectBuiltins = ['JSON', 'Math'];
 // Timer builtins are routinely overridden by frameworks and fake-timer shims; the
 // snapshot lets injected code schedule real tasks regardless. They are only added
 // to the snapshot object below, not to the main-world `const` block, so they never
-// shadow timers inside the injected bundle. (setImmediate is absent in most engines.)
-const snapshottedTimerBuiltins = ['setTimeout', 'setImmediate'];
+// shadow timers inside the injected bundle.
+const snapshottedTimerBuiltins = ['setTimeout'];
 
 export const saveGlobalsSnapshotSource = `window.__pwSnapshotGlobals = {
 ${[...snapshottedFunctionBuiltins, ...snapshottedObjectBuiltins, ...snapshottedTimerBuiltins].map(n => `  ${n}: window.${n}`).join(',\n')}


### PR DESCRIPTION
## Summary
- Serialize all synthetic WebView input through a single page-side task queue: each event is delivered in its own event-loop task while keeping strict submission order.
- The driver fires a click's move/down/up concurrently and relies on the backend preserving order. Without the queue, a synchronous later command (mousedown) raced ahead of an earlier command (move) still spread across tasks, so a hover interstitial raised during the move wasn't present when mousedown's hit-target check ran — breaking `addLocatorHandler`.
- Keyboard input moved onto the same queue, replacing the previous ad-hoc `_nextTask`/`_typeCharacter`.