### PR TITLE
fix(fileUpload): reject localPaths when client is not collocated with server

### DIFF
--- a/packages/playwright-core/src/inprocess.ts
+++ b/packages/playwright-core/src/inprocess.ts
@@ -25,10 +25,10 @@ import type { Playwright as PlaywrightAPI } from './client/playwright';
 import type { Language } from '@isomorphic/locatorGenerators';
 
 export function createInProcessPlaywright(): PlaywrightAPI {
-  const playwright = createPlaywright({ sdkLanguage: (process.env.PW_LANG_NAME as Language | undefined) || 'javascript' });
+  const playwright = createPlaywright({ sdkLanguage: (process.env.PW_LANG_NAME as Language | undefined) || 'javascript', isClientCollocatedWithServer: true });
   const clientConnection = new Connection(nodePlatform(packageRoot));
   clientConnection.useRawBuffers();
-  const dispatcherConnection = new DispatcherConnection(true /* local */);
+  const dispatcherConnection = new DispatcherConnection(true /* in process */);
 
   // Dispatch synchronously at first.
   dispatcherConnection.onmessage = message => clientConnection.dispatch(message);

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -80,7 +80,7 @@ export abstract class Browser extends SdkObject {
   private _startedClosing = false;
   private _contextForReuse: { context: BrowserContext, hash: string } | undefined;
   _closeReason: string | undefined;
-  _isCollocatedWithServer: boolean = true;
+  _isBrowserCollocatedWithServer: boolean = true;
   private _server: BrowserServer;
 
   constructor(parent: SdkObject, options: BrowserOptions) {

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -159,7 +159,7 @@ export class Chromium extends BrowserType {
       validateBrowserContextOptions(persistent, browserOptions);
       const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, transport, browserOptions));
       if (!options.isLocal)
-        browser._isCollocatedWithServer = false;
+        browser._isBrowserCollocatedWithServer = false;
       browser.on(Browser.Events.Disconnected, doCleanup);
       return browser;
     } catch (error) {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -63,7 +63,7 @@ export class CRBrowser extends Browser {
     const browser = new CRBrowser(parent, connection, options);
     browser._devtools = devtools;
     if (browser.isClank())
-      browser._isCollocatedWithServer = false;
+      browser._isBrowserCollocatedWithServer = false;
     const session = connection.rootSession;
     if ((options as any).__testHookOnConnectToBrowser)
       await (options as any).__testHookOnConnectToBrowser();

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -195,10 +195,10 @@ export class DispatcherConnection {
   readonly _dispatchersByBucket = new Map<string, Set<string>>();
   onmessage = (message: object) => {};
   private _waitOperations = new Map<string, CallMetadata>();
-  private _isLocal: boolean;
+  private _isInProcess: boolean;
 
-  constructor(isLocal?: boolean) {
-    this._isLocal = !!isLocal;
+  constructor(isInProcess?: boolean) {
+    this._isInProcess = !!isInProcess;
   }
 
   sendEvent(dispatcher: DispatcherScope, event: string, params: any) {
@@ -224,7 +224,7 @@ export class DispatcherConnection {
   private _validatorToWireContext(): ValidatorContext {
     return {
       tChannelImpl: this._tChannelImplToWire.bind(this),
-      binary: this._isLocal ? 'buffer' : 'toBase64',
+      binary: this._isInProcess ? 'buffer' : 'toBase64',
       isUnderTest,
     };
   }
@@ -232,7 +232,7 @@ export class DispatcherConnection {
   private _validatorFromWireContext(): ValidatorContext {
     return {
       tChannelImpl: this._tChannelImplFromWire.bind(this),
-      binary: this._isLocal ? 'buffer' : 'fromBase64',
+      binary: this._isInProcess ? 'buffer' : 'fromBase64',
       isUnderTest,
     };
   }

--- a/packages/playwright-core/src/server/fileUploadUtils.ts
+++ b/packages/playwright-core/src/server/fileUploadUtils.ts
@@ -36,6 +36,8 @@ async function filesExceedUploadLimit(files: string[]) {
 export async function prepareFilesForUpload(frame: Frame, params: Omit<channels.ElementHandleSetInputFilesParams, 'timeout'>): Promise<InputFilesItems> {
   const { payloads, streams, directoryStream } = params;
   let { localPaths, localDirectory } = params;
+  if (localPaths && !frame.attribution.playwright.options.isClientCollocatedWithServer)
+    throw new Error('localPaths are not allowed when the client is not local');
 
   if ([payloads, localPaths, localDirectory, streams, directoryStream].filter(Boolean).length !== 1)
     throw new Error('Exactly one of payloads, localPaths and streams must be provided');
@@ -57,7 +59,7 @@ export async function prepareFilesForUpload(frame: Frame, params: Omit<channels.
     lastModifiedMs?: number,
   }[] | undefined = payloads;
 
-  if (!frame._page.browserContext._browser._isCollocatedWithServer) {
+  if (!frame._page.browserContext._browser._isBrowserCollocatedWithServer) {
     // If the browser is on a different machine read files into buffers.
     if (localPaths) {
       if (await filesExceedUploadLimit(localPaths))

--- a/packages/playwright-core/src/server/playwright.ts
+++ b/packages/playwright-core/src/server/playwright.ts
@@ -34,6 +34,7 @@ type PlaywrightOptions = {
   sdkLanguage: Language;
   isInternalPlaywright?: boolean;
   isServer?: boolean;
+  isClientCollocatedWithServer?: boolean;
 };
 
 export class Playwright extends SdkObject {

--- a/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
@@ -165,7 +165,7 @@ export async function connectOverRDP(progress: Progress, parent: SdkObject, para
   })());
 
   if (!params.isLocal)
-    browser._isCollocatedWithServer = false;
+    browser._isBrowserCollocatedWithServer = false;
   browser.on(Browser.Events.Disconnected, doCleanup);
   return browser;
 }

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -609,10 +609,10 @@ test('setInputFiles should use local path when isLocal is set', async ({ browser
   });
   try {
     const cdpBrowser1 = await browserType.connectOverCDP(`http://127.0.0.1:${port}/`);
-    expect(toImpl(cdpBrowser1)._isCollocatedWithServer).toBe(false);
+    expect(toImpl(cdpBrowser1)._isBrowserCollocatedWithServer).toBe(false);
 
     const cdpBrowser2 = await browserType.connectOverCDP(`http://127.0.0.1:${port}/`, { isLocal: true });
-    expect(toImpl(cdpBrowser2)._isCollocatedWithServer).toBe(true);
+    expect(toImpl(cdpBrowser2)._isBrowserCollocatedWithServer).toBe(true);
   } finally {
     await browserServer.close();
   }


### PR DESCRIPTION
## Summary
- Throw in `prepareFilesForUpload` when `localPaths` is provided but the client is not collocated with the server.
- Add `isClientCollocatedWithServer` to Playwright options; rename `Browser._isCollocatedWithServer` → `_isBrowserCollocatedWithServer` and `DispatcherConnection`'s `isLocal` → `isInProcess` to disambiguate collocation flavors.