### PR TITLE
Revert "devops(docker): split browser layers and use zstd compression for faster pulls (#40702)"

### DIFF
--- a/utils/docker/Dockerfile.jammy
+++ b/utils/docker/Dockerfile.jammy
@@ -11,6 +11,7 @@ ENV LC_ALL=C.UTF-8
 # === INSTALL Node.js ===
 
 RUN apt-get update && \
+    # Install Node.js
     apt-get install -y curl wget gpg ca-certificates && \
     mkdir -p /etc/apt/keyrings && \
     curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
@@ -26,7 +27,6 @@ RUN apt-get update && \
     adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
-# Browsers are split into separate layers to enable parallel pulls.
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
@@ -34,13 +34,16 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
 
-# 2. Set up playwright-core and install all system dependencies in one layer.
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
 RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
     npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
-    npm exec --no -- playwright-core install-deps && \
+    npm exec --no -- playwright-core install --with-deps && rm -rf /var/lib/apt/lists/* && \
     # Workaround for https://github.com/microsoft/playwright/issues/27313
     # While the gstreamer plugin load process can be in-process, it ended up throwing
     # an error that it can't have libsoup2 and libsoup3 in the same process because
@@ -50,21 +53,7 @@ RUN mkdir /ms-playwright && \
     else \
         rm /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstwebrtc.so; \
     fi && \
-    rm -rf /var/lib/apt/lists/*
-
-# 3. Install each browser binary in its own layer for parallel pulling.
-# Note: installing chromium also installs chromium-headless-shell and ffmpeg.
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install chromium && \
-    chmod -R 777 /ms-playwright/chromium-* /ms-playwright/chromium_headless_shell-* /ms-playwright/ffmpeg-*
-
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install firefox && \
-    chmod -R 777 /ms-playwright/firefox-*
-
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install webkit && \
     rm /tmp/playwright-core.tar.gz && \
     rm -rf /ms-playwright-agent && \
     rm -rf ~/.npm/ && \
-    chmod -R 777 /ms-playwright/webkit-*
+    chmod -R 777 /ms-playwright

--- a/utils/docker/Dockerfile.noble
+++ b/utils/docker/Dockerfile.noble
@@ -11,6 +11,7 @@ ENV LC_ALL=C.UTF-8
 # === INSTALL Node.js ===
 
 RUN apt-get update && \
+    # Install Node.js
     apt-get install -y curl wget gpg ca-certificates && \
     mkdir -p /etc/apt/keyrings && \
     curl -sL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
@@ -26,7 +27,6 @@ RUN apt-get update && \
     adduser pwuser
 
 # === BAKE BROWSERS INTO IMAGE ===
-# Browsers are split into separate layers to enable parallel pulls.
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
@@ -34,28 +34,17 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 #    The package should be built beforehand from tip-of-tree Playwright.
 COPY ./playwright-core.tar.gz /tmp/playwright-core.tar.gz
 
-# 2. Set up playwright-core and install all system dependencies in one layer.
+# 2. Bake in browsers & deps.
+#    Browsers will be downloaded in `/ms-playwright`.
+#    Note: make sure to set 777 to the registry so that any user can access
+#    registry.
 RUN mkdir /ms-playwright && \
     mkdir /ms-playwright-agent && \
     cd /ms-playwright-agent && npm init -y && \
     npm i /tmp/playwright-core.tar.gz && \
     npm exec --no -- playwright-core mark-docker-image "${DOCKER_IMAGE_NAME_TEMPLATE}" && \
-    npm exec --no -- playwright-core install-deps && \
-    rm -rf /var/lib/apt/lists/*
-
-# 3. Install each browser binary in its own layer for parallel pulling.
-# Note: installing chromium also installs chromium-headless-shell and ffmpeg.
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install chromium && \
-    chmod -R 777 /ms-playwright/chromium-* /ms-playwright/chromium_headless_shell-* /ms-playwright/ffmpeg-*
-
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install firefox && \
-    chmod -R 777 /ms-playwright/firefox-*
-
-RUN cd /ms-playwright-agent && \
-    npm exec --no -- playwright-core install webkit && \
+    npm exec --no -- playwright-core install --with-deps && rm -rf /var/lib/apt/lists/* && \
     rm /tmp/playwright-core.tar.gz && \
     rm -rf /ms-playwright-agent && \
     rm -rf ~/.npm/ && \
-    chmod -R 777 /ms-playwright/webkit-*
+    chmod -R 777 /ms-playwright


### PR DESCRIPTION
This reverts commit 5adbc68a33e9c3f931168b7d7e2f21ed6596c29a.

Docker tests fail with the error:
```
[Error: EACCES: permission denied, mkdir '/ms-playwright/__dirlock'] {
  errno: -13,
  code: 'EACCES',
  syscall: 'mkdir',
  path: '/ms-playwright/__dirlock'
}
```

References #40701.