### PR TITLE
feat(har): use engine timestamps instead of server `Date`

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
+++ b/packages/playwright-core/src/server/bidi/bidiNetworkManager.ts
@@ -287,7 +287,7 @@ class BidiRequest {
     const postDataBuffer = null;
     this.request = new network.Request(frame._page.browserContext, frame, null, redirectedFrom ? redirectedFrom.request : null, payload.navigation ?? undefined,
         payload.request.url, resourceTypeFromBidi(payload.request.destination, payload.request.initiatorType, payload.initiator?.type), payload.request.method,
-        postDataBuffer, headersOverride || fromBidiHeaders(payload.request.headers));
+        postDataBuffer, headersOverride || fromBidiHeaders(payload.request.headers), payload.timestamp);
     // "raw" headers are the same as "provisional" headers in Bidi.
     this.request.setRawRequestHeaders(null);
     this.request._setBodySize(payload.request.bodySize || 0);

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -76,7 +76,7 @@ export class CRNetworkManager {
     if (this._page) {
       sessionInfo.eventListeners.push(...[
         eventsHelper.addEventListener(session, 'Network.webSocketCreated', e => this._page!.frameManager.onWebSocketCreated(e.requestId, e.url)),
-        eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', e => this._page!.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers, '\n'), e.wallTime, e.timestamp)),
+        eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', e => this._page!.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers, '\n'), e.wallTime * 1000, e.timestamp)),
         eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page!.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, '\n'))),
         eventsHelper.addEventListener(session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page!.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),
         eventsHelper.addEventListener(session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page!.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),
@@ -605,7 +605,7 @@ class InterceptableRequest {
     if (entries && entries.length)
       postDataBuffer = Buffer.concat(entries.map(entry => Buffer.from(entry.bytes!, 'base64')));
 
-    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || headersObjectToArray(headers));
+    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || headersObjectToArray(headers), requestWillBeSentEvent.wallTime * 1000);
   }
 }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -178,11 +178,11 @@ export class FFPage implements PageDelegate {
   }
 
   _onWebSocketFrameReceived(event: Protocol.Page.webSocketFrameReceivedPayload) {
-    this._page.frameManager.webSocketFrameReceived(webSocketId(event.frameId, event.wsid), event.opcode, event.data, event.timestamp);
+    this._page.frameManager.webSocketFrameReceived(webSocketId(event.frameId, event.wsid), event.opcode, event.data, event.timestamp * 1000);
   }
 
   _onWebSocketFrameSent(event: Protocol.Page.webSocketFrameSentPayload) {
-    this._page.frameManager.onWebSocketFrameSent(webSocketId(event.frameId, event.wsid), event.opcode, event.data, event.timestamp);
+    this._page.frameManager.onWebSocketFrameSent(webSocketId(event.frameId, event.wsid), event.opcode, event.data, event.timestamp * 1000);
   }
 
   _onExecutionContextCreated(payload: Protocol.Runtime.executionContextCreatedPayload) {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -408,10 +408,12 @@ export class FrameManager {
     if (!ws)
       return;
 
+    ws.setRequestTiming(wallTime, timestamp);
+
     if (ws.markAsNotified())
       this._page.emit(Page.Events.WebSocket, ws);
 
-    ws.requestSent(headers, wallTime, timestamp);
+    ws.requestSent(headers);
   }
 
   onWebSocketResponse(requestId: string, status: number, statusText: string, headers: types.HeadersArray) {

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -284,7 +284,7 @@ export class HarTracer {
       return;
 
     const pageEntry = this._createPageEntryIfNeeded(page);
-    const harEntry = createHarEntry(pageEntry?.id, request.method(), url, request.frame()?.guid, this._options);
+    const harEntry = createHarEntry(pageEntry?.id, request.method(), url, request.frame()?.guid, this._options, request.wallTimeMs());
     harEntry._resourceType = request.resourceType();
     this._recordRequestHeadersAndCookies(harEntry, request.headers());
     harEntry.request.postData = this._postDataForRequest(request, this._options.content);
@@ -441,7 +441,7 @@ export class HarTracer {
       return;
 
     const pageEntry = this._createPageEntryIfNeeded(page);
-    const harEntry = createHarEntry(pageEntry?.id, 'GET', url, page.mainFrame().guid, this._options);
+    const harEntry = createHarEntry(pageEntry?.id, 'GET', url, page.mainFrame().guid, this._options, webSocket.wallTimeMs());
     harEntry._resourceType = 'websocket';
     harEntry._webSocketMessages = [];
 
@@ -535,6 +535,11 @@ export class HarTracer {
       const timing = response.timing();
       if (pageEntry && startDateTime > timing.startTime)
         pageEntry.startedDateTime = new Date(timing.startTime).toISOString();
+      if (request.wallTimeMs() === undefined && timing.startTime > 0) {
+        const startedDateTime = safeDateToISOString(timing.startTime);
+        if (startedDateTime)
+          harEntry.startedDateTime = startedDateTime;
+      }
       const dns = timing.domainLookupEnd !== -1 ? helper.millisToRoundishMillis(timing.domainLookupEnd - timing.domainLookupStart) : -1;
       const connect = timing.connectEnd !== -1 ? helper.millisToRoundishMillis(timing.connectEnd - timing.connectStart) : -1;
       const ssl = timing.connectEnd !== -1 ? helper.millisToRoundishMillis(timing.connectEnd - timing.secureConnectionStart) : -1;
@@ -670,10 +675,11 @@ export class HarTracer {
 
 }
 
-function createHarEntry(pageRef: string | undefined, method: string, url: URL, frameref: string | undefined, options: HarTracerOptions): har.Entry {
+function createHarEntry(pageRef: string | undefined, method: string, url: URL, frameref: string | undefined, options: HarTracerOptions, wallTime?: number): har.Entry {
+  const startedDateTime = (wallTime && safeDateToISOString(wallTime)) || new Date().toISOString();
   const harEntry: har.Entry = {
     pageref: pageRef,
-    startedDateTime: new Date().toISOString(),
+    startedDateTime,
     time: -1,
     request: {
       method: method,

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -189,6 +189,7 @@ export class Request extends SdkObject {
   _responseEndTiming = -1;
   private _overrides: NormalizedContinueOverrides | undefined;
   private _bodySize: number | undefined;
+  private _wallTimeMs: number | undefined;
   _responseBodyOverride: { body: string; isBase64: boolean; } | undefined;
 
   static Events = {
@@ -196,7 +197,7 @@ export class Request extends SdkObject {
   };
 
   constructor(context: contexts.BrowserContext, frame: frames.Frame | null, serviceWorker: pages.Worker | null, redirectedFrom: Request | null, documentId: string | undefined,
-    url: string, resourceType: ResourceType, method: string, postData: Buffer | null, headers: HeadersArray) {
+    url: string, resourceType: ResourceType, method: string, postData: Buffer | null, headers: HeadersArray, wallTimeMs?: number) {
     super(frame || context, 'request');
     assert(!url.startsWith('data:'), 'Data urls should not fire requests');
     this._context = context;
@@ -211,7 +212,12 @@ export class Request extends SdkObject {
     this._method = method;
     this._postData = postData;
     this._headers = headers;
+    this._wallTimeMs = wallTimeMs;
     this._isFavicon = url.endsWith('/favicon.ico') || !!redirectedFrom?._isFavicon;
+  }
+
+  wallTimeMs(): number | undefined {
+    return this._wallTimeMs;
   }
 
   async raceWithPageClosure<T>(progress: Progress, promise: Promise<T>): Promise<T> {
@@ -725,7 +731,7 @@ export class Response extends SdkObject {
 export class WebSocket extends SdkObject {
   private _url: string;
   private _notified = false;
-  private _requestWallTime: number | undefined;
+  private _requestWallTimeMs: number | undefined;
   private _requestTimestamp: number | undefined;
   private _status: number | undefined;
   private _statusText: string | undefined;
@@ -760,10 +766,16 @@ export class WebSocket extends SdkObject {
     return this._url;
   }
 
-  requestSent(headers: HeadersArray, wallTime?: number, timestamp?: number) {
-    this._requestWallTime = wallTime;
-    this._requestTimestamp = timestamp;
+  wallTimeMs(): number | undefined {
+    return this._requestWallTimeMs;
+  }
 
+  setRequestTiming(wallTimeMs: number | undefined, timestamp: number | undefined) {
+    this._requestWallTimeMs = wallTimeMs;
+    this._requestTimestamp = timestamp;
+  }
+
+  requestSent(headers: HeadersArray) {
     this.emit(WebSocket.Events.Request, { headers });
   }
 
@@ -773,8 +785,8 @@ export class WebSocket extends SdkObject {
 
   private _toWallTime(timestamp: number): number {
     // The timestamp of each frame is relative to the timestamp (and walltime) of the initial request in Chromium and WebKit.
-    if (this._requestWallTime !== undefined && this._requestTimestamp !== undefined)
-      return this._requestWallTime + (timestamp - this._requestTimestamp);
+    if (this._requestWallTimeMs !== undefined && this._requestTimestamp !== undefined)
+      return this._requestWallTimeMs + (timestamp - this._requestTimestamp);
 
     // The timestamp is already a walltime in Firefox.
     return timestamp;

--- a/packages/playwright-core/src/server/webkit/webview/wvInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvInterceptableRequest.ts
@@ -62,7 +62,7 @@ export class WVInterceptableRequest {
       postDataBuffer = Buffer.from(event.request.postData, 'utf8');
     }
     this.request = new network.Request(frame._page.browserContext, frame, null, redirectedFrom?.request || null, documentId, event.request.url,
-        resourceType, event.request.method, postDataBuffer, headersObjectToArray(event.request.headers));
+        resourceType, event.request.method, postDataBuffer, headersObjectToArray(event.request.headers), this._wallTime);
   }
 
   adoptRequestFromNewProcess(newSession: WVSession, requestId: string) {

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -326,7 +326,7 @@ export class WVPage implements PageDelegate {
       eventsHelper.addEventListener(session, 'Network.loadingFinished', e => this._onLoadingFinished(e)),
       eventsHelper.addEventListener(session, 'Network.loadingFailed', e => this._onLoadingFailed(session, e)),
       eventsHelper.addEventListener(session, 'Network.webSocketCreated', e => this._page.frameManager.onWebSocketCreated(e.requestId, e.url)),
-      eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', e => this._page.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers), e.walltime, e.timestamp)),
+      eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', e => this._page.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers), e.walltime * 1000, e.timestamp)),
       eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, ','))),
       eventsHelper.addEventListener(session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),
       eventsHelper.addEventListener(session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),

--- a/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
+++ b/packages/playwright-core/src/server/webkit/wkInterceptableRequest.ts
@@ -61,7 +61,7 @@ export class WKInterceptableRequest {
     if (event.request.postData)
       postDataBuffer = Buffer.from(event.request.postData, 'base64');
     this.request = new network.Request(frame._page.browserContext, frame, null, redirectedFrom?.request || null, documentId, event.request.url,
-        resourceType, event.request.method, postDataBuffer, headersObjectToArray(event.request.headers));
+        resourceType, event.request.method, postDataBuffer, headersObjectToArray(event.request.headers), this._wallTime);
   }
 
   adoptRequestFromNewProcess(newSession: WKSession, requestId: string) {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -397,7 +397,7 @@ export class WKPage implements PageDelegate {
       eventsHelper.addEventListener(this._session, 'Network.loadingFinished', e => this._onLoadingFinished(e)),
       eventsHelper.addEventListener(this._session, 'Network.loadingFailed', e => this._onLoadingFailed(this._session, e)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketCreated', e => this._page.frameManager.onWebSocketCreated(e.requestId, e.url)),
-      eventsHelper.addEventListener(this._session, 'Network.webSocketWillSendHandshakeRequest', e => this._page.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers), e.walltime, e.timestamp)),
+      eventsHelper.addEventListener(this._session, 'Network.webSocketWillSendHandshakeRequest', e => this._page.frameManager.onWebSocketRequest(e.requestId, headersObjectToArray(e.request.headers), e.walltime * 1000, e.timestamp)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, ',', wkSetCookieSeparator))),
       eventsHelper.addEventListener(this._session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, e.timestamp)),

--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -124,8 +124,8 @@ it('should include websocket messages', async ({ contextFactory, server }, testI
     { type: 'receive', opcode: 1, data: 'incoming' },
   ]);
   for (const m of messages) {
-    expect(m.time).toBeGreaterThanOrEqual(beforeMs / 1000 - 1);
-    expect(m.time).toBeLessThanOrEqual(afterMs / 1000 + 1);
+    expect(m.time).toBeGreaterThanOrEqual(beforeMs - 1);
+    expect(m.time).toBeLessThanOrEqual(afterMs + 1);
   }
   expect(messages[0].time).toBeLessThanOrEqual(messages[1].time);
 });

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -106,6 +106,39 @@ it('should include request', async ({ contextFactory, server }, testInfo) => {
   expect(entry.request.bodySize).toBe(0);
 });
 
+it('should populate entry startedDateTime from the browser', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.EMPTY_PAGE);
+
+  // The browser issues a request after a short delay, then we deliberately
+  // block Node's event loop. The protocol event for the request therefore
+  // queues up while Node is busy and is only processed by the harTracer after
+  // the block ends. If `startedDateTime` is populated from Node's clock at
+  // observation time it will land inside the busy-loop window (i.e. close to
+  // `unblockedAt`); if it comes from the browser via the debugging protocol
+  // it will be tied to when the browser actually sent the request.
+  await page.evaluate(() => {
+    setTimeout(() => { void fetch('/delayed-fetch'); }, 50);
+  });
+
+  const blockUntil = Date.now() + 300;
+  while (Date.now() < blockUntil) {
+    // Busy loop to prevent Node from processing protocol events.
+  }
+  const unblockedAt = Date.now();
+
+  await page.waitForResponse('**/delayed-fetch');
+  const log = await getLog();
+
+  const entry = log.entries.find(e => e.request.url.endsWith('/delayed-fetch'))!;
+  const startedAt = new Date(entry.startedDateTime).valueOf();
+  expect(Number.isFinite(startedAt)).toBe(true);
+  // The recorded time should be tied to when the browser actually sent the
+  // request (during the busy loop), not to when Node observed the protocol
+  // event (after the busy loop).
+  expect(startedAt).toBeLessThan(unblockedAt - 100);
+});
+
 it('should include response', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
whether it be from a dedicated protocol `timestamp` or the more general `timing` , we should use a value from the engine for `startDateTime` instead of the playwright server `Date`