### PR TITLE
docs: document install-script blocking for browser helper packages

### DIFF
--- a/docs/src/library-js.md
+++ b/docs/src/library-js.md
@@ -206,6 +206,10 @@ Alternatively, you can add `@playwright/browser-chromium`, `@playwright/browser-
 npm install @playwright/browser-chromium
 ```
 
+:::note
+These helper packages download the browser from an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. In that case, allow the script explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install chromium` instead.
+:::
+
 **Download behind a firewall or a proxy**
 
 Pass `HTTPS_PROXY` environment variable to download through a proxy.

--- a/packages/playwright-browser-chromium/README.md
+++ b/packages/playwright-browser-chromium/README.md
@@ -1,3 +1,7 @@
 # @playwright/browser-chromium
 
 This package automatically installs [Chromium](https://www.chromium.org/) browser for [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install chromium` instead.

--- a/packages/playwright-browser-firefox/README.md
+++ b/packages/playwright-browser-firefox/README.md
@@ -1,3 +1,7 @@
 # @playwright/browser-firefox
 
 This package automatically installs [Firefox](https://www.mozilla.org/firefox/) browser for [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install firefox` instead.

--- a/packages/playwright-browser-webkit/README.md
+++ b/packages/playwright-browser-webkit/README.md
@@ -1,3 +1,7 @@
 # @playwright/browser-webkit
 
 This package automatically installs [WebKit](https://www.webkit.org/) browser for [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install webkit` instead.

--- a/packages/playwright-chromium/README.md
+++ b/packages/playwright-chromium/README.md
@@ -1,3 +1,7 @@
 # playwright-chromium
 
 This package contains the [Chromium](https://www.chromium.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install chromium` instead.

--- a/packages/playwright-firefox/README.md
+++ b/packages/playwright-firefox/README.md
@@ -1,3 +1,7 @@
 # playwright-firefox
 
 This package contains the [Firefox](https://www.mozilla.org/firefox/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install firefox` instead.

--- a/packages/playwright-webkit/README.md
+++ b/packages/playwright-webkit/README.md
@@ -1,3 +1,7 @@
 # playwright-webkit
 
 This package contains the [WebKit](https://www.webkit.org/) flavor of the [Playwright](http://github.com/microsoft/playwright) library. If you want to write end-to-end tests, we recommend [@playwright/test](https://playwright.dev/docs/intro).
+
+## Browser download and install scripts
+
+This package downloads the browser using an `install` script that runs during `npm install`. Some package managers (pnpm, Yarn Berry, Bun, Deno, and npm following [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default. If your package manager skips the script, allow it explicitly (for example via the `allowScripts` field in `package.json` or `npm approve-scripts`), or download the browser with `npx playwright install webkit` instead.


### PR DESCRIPTION
## Summary
- Document that some package managers (pnpm, Yarn Berry, Bun, Deno, npm per [RFC #868](https://github.com/npm/rfcs/pull/868)) block dependency install scripts by default, which affects the browser-downloading helper packages.
- Explain how to opt back in (`allowScripts` / `npm approve-scripts`) or fall back to `npx playwright install <browser>`.
- Note added to the docs site and the 6 helper package READMEs.

Fixes https://github.com/microsoft/playwright/issues/41083