### PR TITLE
fix(trace): capture attribute mutations after a popup document swap

### DIFF
--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -92,7 +92,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     private _readingStyleSheet = false;  // To avoid invalidating due to our own reads.
     private _fakeBase: HTMLBaseElement;
     private _observer: MutationObserver;
-    private _observedDocument: Document;
+    private _observedDocument: Document | undefined;
     private _targetGeneration = 0;
 
     constructor() {
@@ -119,9 +119,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       this._fakeBase = document.createElement('base');
 
       this._observer = new MutationObserver(list => this._handleMutations(list));
-      this._observedDocument = document;
-      this._observer.observe(document, kObserverConfig);
-      this._refreshListenersWhenNeeded();
+      this._ensureObservingCurrentDocument();
     }
 
     private _refreshListenersWhenNeeded() {
@@ -214,15 +212,22 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     }
 
     private _ensureObservingCurrentDocument() {
-      // A popup reuses its initial about:blank document, so the observer can be
-      // left bound to a stale document after navigation. Re-bind on swap.
+      // The streamer is installed once per window, but a window can swap its
+      // document without re-running the init script - most notably a popup's
+      // initial about:blank document being replaced by the navigated one (the
+      // initial empty document is reused). In that case our observers and
+      // listeners are left bound to the stale document. Re-attach all
+      // per-document instrumentation whenever the document changes - this also
+      // re-arms the documentElement watcher in _refreshListenersWhenNeeded(),
+      // which on its own cannot recover because it relies on an observer bound
+      // to the same swapped-away document.
       // See https://github.com/microsoft/playwright/issues/40895.
       if (this._observedDocument === document)
         return;
       this._observedDocument = document;
       this._observer.disconnect();
       this._observer.observe(document, kObserverConfig);
-      this._refreshListeners();
+      this._refreshListenersWhenNeeded();
     }
 
     private _invalidateStyleSheet(sheet: CSSStyleSheet) {

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -73,6 +73,8 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     return obj[kCachedData];
   }
 
+  const kObserverConfig: MutationObserverInit = { attributes: true, subtree: true };
+
   function removeHash(url: string) {
     try {
       const u = new URL(url);
@@ -90,6 +92,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     private _readingStyleSheet = false;  // To avoid invalidating due to our own reads.
     private _fakeBase: HTMLBaseElement;
     private _observer: MutationObserver;
+    private _observedDocument: Document;
     private _targetGeneration = 0;
 
     constructor() {
@@ -116,8 +119,8 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       this._fakeBase = document.createElement('base');
 
       this._observer = new MutationObserver(list => this._handleMutations(list));
-      const observerConfig = { attributes: true, subtree: true };
-      this._observer.observe(document, observerConfig);
+      this._observedDocument = document;
+      this._observer.observe(document, kObserverConfig);
       this._refreshListenersWhenNeeded();
     }
 
@@ -208,6 +211,18 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     private _handleMutations(list: MutationRecord[]) {
       for (const mutation of list)
         ensureCachedData(mutation.target).attributesCached = undefined;
+    }
+
+    private _ensureObservingCurrentDocument() {
+      // A popup reuses its initial about:blank document, so the observer can be
+      // left bound to a stale document after navigation. Re-bind on swap.
+      // See https://github.com/microsoft/playwright/issues/40895.
+      if (this._observedDocument === document)
+        return;
+      this._observedDocument = document;
+      this._observer.disconnect();
+      this._observer.observe(document, kObserverConfig);
+      this._refreshListeners();
     }
 
     private _invalidateStyleSheet(sheet: CSSStyleSheet) {
@@ -347,6 +362,7 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
       let shadowDomNesting = 0;
       let headNesting = 0;
 
+      this._ensureObservingCurrentDocument();
       // Ensure we are up to date.
       this._handleMutations(this._observer.takeRecords());
 

--- a/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotterInjected.ts
@@ -212,16 +212,10 @@ export function frameSnapshotStreamer(snapshotStreamer: string, removeNoScript: 
     }
 
     private _ensureObservingCurrentDocument() {
-      // The streamer is installed once per window, but a window can swap its
-      // document without re-running the init script - most notably a popup's
-      // initial about:blank document being replaced by the navigated one (the
-      // initial empty document is reused). In that case our observers and
-      // listeners are left bound to the stale document. Re-attach all
-      // per-document instrumentation whenever the document changes - this also
-      // re-arms the documentElement watcher in _refreshListenersWhenNeeded(),
-      // which on its own cannot recover because it relies on an observer bound
-      // to the same swapped-away document.
-      // See https://github.com/microsoft/playwright/issues/40895.
+      // A window can swap its document without re-running the init script (e.g.
+      // a popup reusing its initial about:blank document), leaving our observers
+      // and listeners bound to the stale one. Re-attach on swap.
+      // https://github.com/microsoft/playwright/issues/40895
       if (this._observedDocument === document)
         return;
       this._observedDocument = document;

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -681,6 +681,32 @@ test('should popup snapshot', async ({ page, runAndTrace, server }) => {
   await expect(popup.frameLocator('iframe').getByText('hello äöü 🙂')).toBeVisible();
 });
 
+test('should capture attribute mutations inside a popup window', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40895' }
+}, async ({ page, server, runAndTrace }) => {
+  server.setRoute('/popup.html', (req, res) => {
+    res.end(`<!DOCTYPE html><html><head>
+      <style>.no-display { display: none !important; }</style>
+      </head><body>
+      <div id="overlay">overlay</div>
+      <button id="hide" type="button" onclick="document.getElementById('overlay').classList.add('no-display')">Hide</button>
+      </body></html>`);
+  });
+
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    const [popup] = await Promise.all([
+      page.waitForEvent('popup'),
+      page.evaluate(url => window.open(url, 'popup', 'popup'), server.PREFIX + '/popup.html'),
+    ]);
+    await popup.getByRole('button', { name: 'Hide' }).click();
+    await expect(popup.locator('#overlay')).toBeHidden();
+  });
+
+  const frame = await traceViewer.snapshotFrame('Click');
+  await expect(frame.locator('#overlay')).toHaveClass('no-display');
+});
+
 test('should capture iframe with sandbox attribute', async ({ page, server, runAndTrace }) => {
   await page.route('**/empty.html', route => {
     void route.fulfill({


### PR DESCRIPTION
## Summary
- A popup reuses its initial `about:blank` document; after it navigates, the snapshotter's `MutationObserver` stayed bound to the stale document and never reported attribute mutations (e.g. a hiding CSS class added via `classList.add`/`setAttribute`), so DOM snapshots showed stale attributes.
- Re-bind the observer to the live document before each capture.

Fixes https://github.com/microsoft/playwright/issues/40895