### PR TITLE
fix(webserver): strip ANSI escape codes before matching wait regex

### DIFF
--- a/packages/playwright/src/plugins/webServerPlugin.ts
+++ b/packages/playwright/src/plugins/webServerPlugin.ts
@@ -15,6 +15,7 @@
  */
 import net from 'net';
 import path from 'path';
+import { stripVTControlCharacters } from 'util';
 
 import colors from 'colors/safe';
 import debug from 'debug';
@@ -172,7 +173,7 @@ export class WebServerPlugin implements TestRunnerPlugin {
       launchedProcess[stdio]!.on('data', data => {
         if (!this._options.wait?.[stdio] || stdioWaitCollectors[stdio] === undefined)
           return;
-        stdioWaitCollectors[stdio] += data.toString();
+        stdioWaitCollectors[stdio] += stripVTControlCharacters(data.toString());
         this._options.wait[stdio].lastIndex = 0;
         const result = this._options.wait[stdio].exec(stdioWaitCollectors[stdio]);
         if (result) {

--- a/tests/playwright-test/web-server.spec.ts
+++ b/tests/playwright-test/web-server.spec.ts
@@ -961,6 +961,33 @@ for (const stdio of ['stdout', 'stderr']) {
     expect(result.output).toContain('server started');
   });
 
+  test(`should wait for ${stdio} with ANSI escape codes`, async ({ runInlineTest }) => {
+    const result = await runInlineTest({
+      'test.spec.ts': `
+        import { test, expect } from '@playwright/test';
+        test('pass', async ({}) => {});
+      `,
+      'server.js': `
+        // Emit text wrapped in ANSI color escape codes.
+        setTimeout(() => { console.${stdio === 'stdout' ? 'log' : 'error'}('\\u001b[32mserver started\\u001b[39m'); }, 1000);
+        setTimeout(() => {}, 100000);
+      `,
+      'playwright.config.ts': `
+        module.exports = {
+          webServer: [
+            {
+              command: 'node server.js',
+              stdout: 'pipe',
+              wait: { ${stdio}: /^server started$/m },
+            }
+          ],
+        };
+      `,
+    }, undefined);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('server started');
+  });
+
   test(`should wait for ${stdio} w/group`, async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'test.spec.ts': `


### PR DESCRIPTION
## Summary
- `webServer.wait.stdout`/`wait.stderr` regex was matched against raw output containing ANSI color escape codes (Playwright forces `FORCE_COLOR=1`), causing the match to fail and the server wait to time out.
- Strip VT control characters before running the regex.

Fixes https://github.com/microsoft/playwright/issues/41051