### PR TITLE
fix(download): clear error when saving downloads from a non-collocated browser

### DIFF
--- a/packages/playwright-core/src/server/artifact.ts
+++ b/packages/playwright-core/src/server/artifact.ts
@@ -29,6 +29,7 @@ type CancelCallback = () => Promise<void>;
 export class Artifact extends SdkObject {
   private _localPath: string;
   private _unaccessibleErrorMessage: string | undefined;
+  private _missingFileErrorMessage: string | undefined;
   private _cancelCallback: CancelCallback | undefined;
   private _finishedPromise = new ManualPromise<void>();
   private _saveCallbacks: SaveCallback[] = [];
@@ -41,6 +42,14 @@ export class Artifact extends SdkObject {
     this._localPath = localPath;
     this._unaccessibleErrorMessage = unaccessibleErrorMessage;
     this._cancelCallback = cancelCallback;
+  }
+
+  markMissingFileErrorMessage(errorMessage: string) {
+    this._missingFileErrorMessage = errorMessage;
+  }
+
+  missingFileErrorMessage(): string | undefined {
+    return this._missingFileErrorMessage;
   }
 
   async localPathAfterFinished(progress: Progress): Promise<string> {

--- a/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
@@ -46,11 +46,13 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
   }
 
   async pathAfterFinished(params: channels.ArtifactPathAfterFinishedParams, progress: Progress): Promise<channels.ArtifactPathAfterFinishedResult> {
+    this._assertFileAccessible();
     const path = await this._object.localPathAfterFinished(progress);
     return { value: path };
   }
 
   async saveAs(params: channels.ArtifactSaveAsParams, progress: Progress): Promise<channels.ArtifactSaveAsResult> {
+    this._assertFileAccessible();
     return await progress.race(new Promise((resolve, reject) => {
       this._object.saveAs(progress, async (localPath, error) => {
         if (error) {
@@ -68,7 +70,14 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
     }));
   }
 
+  private _assertFileAccessible(): void {
+    const errorMessage = this._object.missingFileErrorMessage();
+    if (errorMessage)
+      throw new Error(errorMessage);
+  }
+
   async saveAsStream(params: channels.ArtifactSaveAsStreamParams, progress: Progress): Promise<channels.ArtifactSaveAsStreamResult> {
+    this._assertFileAccessible();
     return await progress.race(new Promise((resolve, reject) => {
       this._object.saveAs(progress, async (localPath, error) => {
         if (error) {
@@ -94,6 +103,7 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
   }
 
   async stream(params: channels.ArtifactStreamParams, progress: Progress): Promise<channels.ArtifactStreamResult> {
+    this._assertFileAccessible();
     const fileName = await this._object.localPathAfterFinished(progress);
     const readable = fs.createReadStream(fileName, { highWaterMark: 1024 * 1024 });
     return { stream: new StreamDispatcher(this, readable) };

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -32,6 +32,11 @@ export class Download {
     if (!downloadPath)
       throw new Error(`Download filename '${downloadFilename}' escapes download directory`);
     this.artifact = new Artifact(page, downloadPath, unaccessibleErrorMessage, () => this.cancel());
+    if (!page.browserContext._browser._isBrowserCollocatedWithServer) {
+      this.artifact.markMissingFileErrorMessage(
+          `Downloaded file is not accessible from the Playwright server because the browser is running on a different host ` +
+          `(e.g. connected over CDP to a remote browser). Saving downloads requires the browser and the Playwright server to share a filesystem.`);
+    }
     this._page = page;
     this.url = url;
     this._uuid = uuid;

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -113,6 +113,7 @@ test('should connectOverCDP and manage downloads in default context', async ({ b
   try {
     const browser = await browserType.connectOverCDP({
       endpointURL: `http://127.0.0.1:${port}/`,
+      isLocal: true,
     });
     const page = await browser.contexts()[0].newPage();
     await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
@@ -129,6 +130,40 @@ test('should connectOverCDP and manage downloads in default context', async ({ b
     await download.saveAs(userPath);
     expect(fs.existsSync(userPath)).toBeTruthy();
     expect(fs.readFileSync(userPath).toString()).toBe('Hello world');
+  } finally {
+    await browserServer.close();
+  }
+});
+
+test('should give a clear error for downloads when browser is not co-located with the server', async ({ browserType, server }, testInfo) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41060' });
+  server.setRoute('/downloadWithFilename', (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
+    res.end(`Hello world`);
+  });
+
+  const port = 9339 + testInfo.workerIndex;
+  const browserServer = await browserType.launch({
+    args: ['--remote-debugging-port=' + port]
+  });
+
+  try {
+    const browser = await browserType.connectOverCDP({
+      endpointURL: `http://127.0.0.1:${port}/`,
+    });
+    const page = await browser.contexts()[0].newPage();
+    await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('a')
+    ]);
+
+    const saveError = await download.saveAs(testInfo.outputPath('download.txt')).catch(e => e);
+    expect(saveError.message).toContain('the browser is running on a different host');
+    const pathError = await download.path().catch(e => e);
+    expect(pathError.message).toContain('the browser is running on a different host');
   } finally {
     await browserServer.close();
   }


### PR DESCRIPTION
## Summary
- When connected over CDP to a browser on a different host, downloaded files live on the browser's filesystem and are unreachable from the server, so `saveAs()`/`path()` failed with a cryptic `ENOENT`.
- The artifact dispatcher now refuses these operations up-front with a clear, actionable error and without touching the local filesystem (the local path could otherwise point at an unrelated file).
- Local `connectOverCDP` continues to support downloads via the existing `{ isLocal: true }` opt-in.

Fixes https://github.com/microsoft/playwright/issues/41060