### PR TITLE
feat(playwright): fail tests on page error

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -228,6 +228,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
     await use(connectOptionsFromEnv() || _optionConnectOptions);
   }, { scope: 'worker', option: true, box: true }],
   video: ['off', { scope: 'worker', option: true, box: true }],
+  failOnPageError: [false, { option: true, box: true }],
 
   _browserOptions: [async ({ playwright, headless, channel, launchOptions }, use) => {
     const options: LaunchOptions = {
@@ -392,7 +393,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
     playwright._defaultContextNavigationTimeout = undefined;
   }, { auto: 'all-hooks-included',  title: 'context configuration', box: true } as any],
 
-  _contextFactory: [async ({ browser, video, _reuseContext, _combinedContextOptions /** mitigate dep-via-auto lack of traceability */ }, use, testInfo) => {
+  _contextFactory: [async ({ browser, video, _reuseContext, _combinedContextOptions, failOnPageError /** mitigate dep-via-auto lack of traceability */ }, use, testInfo) => {
     const testInfoImpl = testInfo as TestInfoImpl;
     const videoMode = normalizeVideoMode(video);
     const captureVideo = shouldCaptureVideo(videoMode, testInfo) && !_reuseContext;
@@ -435,6 +436,15 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
           return;
         closed = true;
         const closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
+        // Remove pageerror listeners if attached.
+        const ctxData = contexts.get(context) as { _pageErrorHandler?: (error: Error) => void, _pageAddedHandler?: (page: Page) => void } | undefined;
+        if (ctxData && ctxData._pageErrorHandler) {
+          const handler = ctxData._pageErrorHandler;
+          for (const p of context.pages())
+            p.off('pageerror', handler);
+          if (ctxData._pageAddedHandler)
+            context.off('page', ctxData._pageAddedHandler);
+        }
         await context.close({ reason: closeReason });
         const preserveVideo = captureVideo && shouldPreserveVideo(videoMode, testInfo);
         if (preserveVideo) {
@@ -453,9 +463,36 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         }
       };
 
-      const contextData = { close, pagesWithVideo: [] as Page[] };
+      const contextData: { close: () => Promise<void>, pagesWithVideo: Page[], _pageErrorHandler?: (error: Error) => void, _pageAddedHandler?: (page: Page) => void } = { close, pagesWithVideo: [] as Page[] };
       if (captureVideo)
         context.on('page', page => contextData.pagesWithVideo.push(page));
+
+      if (failOnPageError) {
+        const pageErrorHandler = (error: Error) => {
+          const currentTestInfo = globals.currentTestInfo() as TestInfoImpl | undefined;
+          if (!currentTestInfo)
+            return;
+          // Mark and fail the test with an explicit message, then interrupt execution.
+          if (!currentTestInfo._hasUnhandledError) {
+            currentTestInfo._hasUnhandledError = true;
+            const wrappedError = new Error(`Test stopped due to page error: ${error.message}`);
+            (wrappedError as any).cause = error;
+            if ((error as any).stack)
+              wrappedError.stack = `${wrappedError.name}: ${wrappedError.message}\n${(error as any).stack}`;
+            currentTestInfo._failWithError(wrappedError);
+          }
+          currentTestInfo._interrupt();
+        };
+        // Attach to existing pages.
+        for (const p of context.pages())
+          p.on('pageerror', pageErrorHandler);
+        // Attach to future pages.
+        const pageAddedHandler = (p: Page) => p.on('pageerror', pageErrorHandler);
+        context.on('page', pageAddedHandler);
+        contextData._pageErrorHandler = pageErrorHandler;
+        contextData._pageAddedHandler = pageAddedHandler;
+      }
+
       contexts.set(context, contextData);
       return { context, close };
     });

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7313,6 +7313,22 @@ export interface PlaywrightTestOptions {
    */
   ignoreHTTPSErrors: boolean;
   /**
+   * When set to `true`, the test will fail immediately when the page emits a `pageerror` event.
+   * Defaults to `false`.
+   *
+   * **Usage**
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   use: { failOnPageError: true },
+   * });
+   * ```
+   */
+  failOnPageError?: boolean;
+  /**
    * Whether the `meta viewport` tag is taken into account and touch events are enabled. isMobile is a part of device,
    * so you don't actually need to set it manually. Defaults to `false` and is not supported in Firefox. Learn more
    * about [mobile emulation](https://playwright.dev/docs/emulation#ismobile).

--- a/tests/playwright-test/fail-on-page-error.spec.ts
+++ b/tests/playwright-test/fail-on-page-error.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from './playwright-test-fixtures';
+
+test('should fail test on page error when configured via use option', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { failOnPageError: true } };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('page error', async ({ page }) => {
+        // throw inside setTimeout to simulate an async page error
+        await page.evaluate(() => setTimeout(() => { throw new Error('boom from page') }, 0));
+        // give the page a moment to fire the event
+        await new Promise(f => setTimeout(f, 50));
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.output).toContain('Test stopped due to page error');
+  expect(result.output).toContain('boom from page');
+});


### PR DESCRIPTION
Add failOnPageError option to stop the test when the page emits pageerror.

[Feature Request](https://github.com/microsoft/playwright/issues/40880)