### PR TITLE
fix(socks): handle IPv4-mapped IPv6 addresses in ipToSocksAddress

### DIFF
--- a/packages/utils/socksProxy.ts
+++ b/packages/utils/socksProxy.ts
@@ -294,6 +294,11 @@ function hexToNumber(hex: string): number {
 }
 
 function ipToSocksAddress(address: string): number[] {
+  // Node.js may return IPv4-mapped IPv6 addresses (e.g. "::ffff:10.0.0.1") from
+  // socket.localAddress on dual-stack systems. Unwrap them to plain IPv4.
+  const ipv4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(address);
+  if (ipv4Mapped)
+    address = ipv4Mapped[1];
   if (net.isIPv4(address)) {
     return [
       0x01, // IPv4


### PR DESCRIPTION
## Summary
- `socket.localAddress` returns IPv4-mapped IPv6 addresses (e.g. `::ffff:10.0.0.1`) on dual-stack systems, which fail `net.isIPv4()` and fell into the IPv6 branch of `ipToSocksAddress`, producing a malformed SOCKS address.
- Unwrap the `::ffff:` prefix to a plain IPv4 dotted-quad before the `isIPv4` check.

Fixes https://github.com/microsoft/playwright/issues/41107