### PR TITLE
test: skip large file upload test in all non-default modes

### DIFF
--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -145,7 +145,7 @@ test('should upload a file after popup', async ({ page, server, asset }) => {
 
 test('should upload large file', async ({ page, server, isAndroid, mode }, testInfo) => {
   test.skip(isAndroid);
-  test.skip(mode.startsWith('service'));
+  test.skip(mode !== 'default');
   test.slow();
 
   await page.goto(server.PREFIX + '/input/fileupload.html');


### PR DESCRIPTION
## Summary
- Widen the skip condition for `should upload large file` from `service*` modes to any non-default mode — the test times out under driver mode too.