### PR TITLE
chore: fix leaks and tests

### DIFF
--- a/.github/actions/upload-blob-report/action.yml
+++ b/.github/actions/upload-blob-report/action.yml
@@ -14,7 +14,10 @@ runs:
   steps:
     - name: Integrity check
       shell: bash
-      run: find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;
+      run: |
+        echo "::group::extracting blob archives"
+        find "${{ inputs.report_dir }}" -name "*.zip" -exec unzip -t {} \;
+        echo "::endgroup::"
     - name: Upload blob report to GitHub
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "debug": "^4.3.4",
         "diff": "^8.0.3",
         "dotenv": "^16.4.5",
-        "electron": "^39.8.4",
+        "electron": "^40.10.2",
         "enquirer": "2.3.6",
         "esbuild": "^0.25.0",
         "eslint": "^9.34.0",
@@ -4429,15 +4429,15 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "39.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.4.tgz",
-      "integrity": "sha512-eXYKxr4y+s31xs78keVJYg+XY20tGQMQzyIhZvc5L0XRDH2Gp08mbeFlbR1OjAeM5h5l/T2JYT2MFK2kYe2fMg==",
+      "version": "40.10.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
+      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
+        "@types/node": "^24.9.0",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -4453,19 +4453,19 @@
       "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q=="
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "22.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
-      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/electron/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "debug": "^4.3.4",
     "diff": "^8.0.3",
     "dotenv": "^16.4.5",
-    "electron": "^39.8.4",
+    "electron": "^40.10.2",
     "enquirer": "2.3.6",
     "esbuild": "^0.25.0",
     "eslint": "^9.34.0",

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -64,6 +64,8 @@ const BrowserContextEvent = {
   RecorderEvent: 'recorderevent',
   PageClosed: 'pageclosed',
   InternalFrameNavigatedToNewDocument: 'internalframenavigatedtonewdocument',
+  FrameAttached: 'frameattached',
+  WebSocket: 'websocket',
 } as const;
 
 export type BrowserContextEventMap = {
@@ -81,7 +83,9 @@ export type BrowserContextEventMap = {
   [BrowserContextEvent.BeforeClose]: [];
   [BrowserContextEvent.RecorderEvent]: [event: { event: 'actionAdded' | 'actionUpdated' | 'signalAdded', data: any, page: Page, code: string }];
   [BrowserContextEvent.PageClosed]: [page: Page];
-  [BrowserContextEvent.InternalFrameNavigatedToNewDocument]: [frame: frames.Frame, page: Page];
+  [BrowserContextEvent.InternalFrameNavigatedToNewDocument]: [frame: frames.Frame];
+  [BrowserContextEvent.FrameAttached]: [frame: frames.Frame];
+  [BrowserContextEvent.WebSocket]: [webSocket: network.WebSocket, page: Page];
 };
 
 export abstract class BrowserContext<EM extends EventMap = EventMap> extends SdkObject<BrowserContextEventMap | EM> {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -168,6 +168,7 @@ export class FrameManager {
       const frame = new Frame(this._page, frameId, parentFrame);
       this._frames.set(frameId, frame);
       this._page.emit(Page.Events.FrameAttached, frame);
+      this._page.browserContext.emit(BrowserContext.Events.FrameAttached, frame);
       return frame;
     }
   }
@@ -410,8 +411,10 @@ export class FrameManager {
 
     ws.setWallTimeMs(wallTimeMs);
 
-    if (ws.markAsNotified())
+    if (ws.markAsNotified()) {
       this._page.emit(Page.Events.WebSocket, ws);
+      this._page.browserContext.emit(BrowserContext.Events.WebSocket, ws, this._page);
+    }
 
     ws.requestSent(headers);
   }
@@ -441,8 +444,10 @@ export class FrameManager {
   webSocketClosed(requestId: string) {
     const ws = this._webSockets.get(requestId);
     if (ws) {
-      if (ws.markAsNotified())
+      if (ws.markAsNotified()) {
         this._page.emit(Page.Events.WebSocket, ws);
+        this._page.browserContext.emit(BrowserContext.Events.WebSocket, ws, this._page);
+      }
       ws.closed();
     }
     this._webSockets.delete(requestId);
@@ -451,8 +456,10 @@ export class FrameManager {
   webSocketError(requestId: string, errorMessage: string): void {
     const ws = this._webSockets.get(requestId);
     if (ws) {
-      if (ws.markAsNotified())
+      if (ws.markAsNotified()) {
         this._page.emit(Page.Events.WebSocket, ws);
+        this._page.browserContext.emit(BrowserContext.Events.WebSocket, ws, this._page);
+      }
       ws.error(errorMessage);
     }
   }

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -68,10 +68,11 @@ export class HarTracer {
   private _barrierPromises = new Set<Promise<void>>();
   private _delegate: HarTracerDelegate;
   private _options: HarTracerOptions;
-  private _pageEntries = new Map<Page, har.Page>();
+  private _pageEntries: har.Page[] = [];
   private _eventListeners: RegisteredListener[] = [];
   private _started = false;
   private _entrySymbol: symbol;
+  private _pageEntrySymbol: symbol;
   private _baseURL: string | undefined;
   private _page: Page | null;
 
@@ -89,6 +90,7 @@ export class HarTracer {
       options.omitPages = true;
     }
     this._entrySymbol = Symbol('requestHarEntry');
+    this._pageEntrySymbol = Symbol('pageHarEntry');
     this._baseURL = context instanceof APIRequestContext ? context._defaultOptions().baseURL : context._options.baseURL;
   }
 
@@ -104,10 +106,7 @@ export class HarTracer {
     ];
     if (this._context instanceof BrowserContext) {
       this._eventListeners.push(
-          eventsHelper.addEventListener(this._context, BrowserContext.Events.Page, (page: Page) => {
-            this._addPageEventListeners(page);
-            this._createPageEntryIfNeeded(page);
-          }),
+          eventsHelper.addEventListener(this._context, BrowserContext.Events.Page, (page: Page) => this._createPageEntryIfNeeded(page)),
           eventsHelper.addEventListener(this._context, BrowserContext.Events.Request, (request: network.Request) => this._onRequest(request)),
           eventsHelper.addEventListener(this._context, BrowserContext.Events.RequestFinished, ({ request, response }) => this._onRequestFinished(request, response).catch(() => {})),
           eventsHelper.addEventListener(this._context, BrowserContext.Events.RequestFailed, request => this._onRequestFailed(request)),
@@ -115,20 +114,11 @@ export class HarTracer {
           eventsHelper.addEventListener(this._context, BrowserContext.Events.RequestAborted, request => this._onRequestAborted(request)),
           eventsHelper.addEventListener(this._context, BrowserContext.Events.RequestFulfilled, request => this._onRequestFulfilled(request)),
           eventsHelper.addEventListener(this._context, BrowserContext.Events.RequestContinued, request => this._onRequestContinued(request)),
+          eventsHelper.addEventListener(this._context, BrowserContext.Events.WebSocket, (webSocket: network.WebSocket, page: Page) => this._onWebSocket(page, webSocket)),
       );
-      for (const page of this._context.pages()) {
-        this._addPageEventListeners(page);
+      for (const page of this._context.pages())
         this._createPageEntryIfNeeded(page);
-      }
     }
-  }
-
-  private _addPageEventListeners(page: Page) {
-    if (this._page && page !== this._page)
-      return;
-    this._eventListeners.push(
-        eventsHelper.addEventListener(page, Page.Events.WebSocket, (webSocket: network.WebSocket) => this._onWebSocket(page, webSocket)),
-    );
   }
 
   private _shouldIncludeEntryWithUrl(urlString: string) {
@@ -146,7 +136,7 @@ export class HarTracer {
       return;
     if (this._page && page !== this._page)
       return;
-    let pageEntry = this._pageEntries.get(page);
+    let pageEntry = (page as any)[this._pageEntrySymbol] as har.Page | undefined;
     if (!pageEntry) {
       const date = new Date();
       pageEntry = {
@@ -167,7 +157,8 @@ export class HarTracer {
           this._onDOMContentLoaded(page, pageEntry!);
       });
 
-      this._pageEntries.set(page, pageEntry);
+      (page as any)[this._pageEntrySymbol] = pageEntry;
+      this._pageEntries.push(pageEntry);
     }
     return pageEntry;
   }
@@ -435,6 +426,8 @@ export class HarTracer {
   }
 
   private _onWebSocket(page: Page, webSocket: network.WebSocket) {
+    if (this._page && page !== this._page)
+      return;
     if (!this._shouldIncludeEntryWithUrl(webSocket.url()))
       return;
     const url = network.parseURL(webSocket.url());
@@ -655,7 +648,7 @@ export class HarTracer {
         name: context?._browser.options.name || '',
         version: context?._browser.version() || ''
       },
-      pages: this._pageEntries.size ? Array.from(this._pageEntries.values()) : undefined,
+      pages: this._pageEntries.length ? this._pageEntries.slice() : undefined,
       entries: [],
     };
     if (!this._options.omitTiming) {
@@ -671,7 +664,7 @@ export class HarTracer {
           pageEntry.pageTimings.onLoad = -1;
       }
     }
-    this._pageEntries.clear();
+    this._pageEntries = [];
     return log;
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -894,7 +894,7 @@ export class Page extends SdkObject<PageEventMap> {
 
   frameNavigatedToNewDocument(frame: frames.Frame) {
     this.emit(Page.Events.InternalFrameNavigatedToNewDocument, frame);
-    this.browserContext.emit(BrowserContext.Events.InternalFrameNavigatedToNewDocument, frame, this);
+    this.browserContext.emit(BrowserContext.Events.InternalFrameNavigatedToNewDocument, frame);
     const origin = frame.origin();
     if (origin)
       this.browserContext.addVisitedOrigin(origin);

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -90,6 +90,7 @@ export class Snapshotter {
       this._onPage(page);
     this._eventListeners = [
       eventsHelper.addEventListener(this._context, BrowserContext.Events.Page, this._onPage.bind(this)),
+      eventsHelper.addEventListener(this._context, BrowserContext.Events.FrameAttached, frame => this._annotateFrameHierarchy(frame)),
     ];
 
     const { javaScriptEnabled } = this._context._options;
@@ -161,7 +162,6 @@ export class Snapshotter {
     // Annotate frame hierarchy so that snapshots could include frame ids.
     for (const frame of page.frames())
       this._annotateFrameHierarchy(frame);
-    this._eventListeners.push(eventsHelper.addEventListener(page, Page.Events.FrameAttached, frame => this._annotateFrameHierarchy(frame)));
   }
 
   private _annotateFrameHierarchy(frame: Frame) {

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -623,6 +623,8 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       params: { pageId: page.guid },
     };
     this._appendTraceEvent(event);
+    this._pageTracingRecorders.get(page)?.dispose();
+    this._pageTracingRecorders.delete(page);
   }
 
   dispose(params: TracingTracingStopChunkParams) {

--- a/tests/android/androidTest.ts
+++ b/tests/android/androidTest.ts
@@ -83,6 +83,6 @@ export const androidTest = baseTest.extend<PageTestFixtures & AndroidTestFixture
       await androidContext.pages()[1].close();
     const page = await androidContext.newPage();
     await run(page);
-    await androidContext.clearCookies();
+    await androidContext.setStorageState({ cookies: [], origins: [] });
   },
 });

--- a/tests/electron/electron-window-app.js
+++ b/tests/electron/electron-window-app.js
@@ -4,6 +4,7 @@ app.whenReady().then(() => {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
+    webPreferences: { sandbox: true },
   });
   win.loadURL('about:blank');
 })

--- a/tests/electron/electronTest.ts
+++ b/tests/electron/electronTest.ts
@@ -101,6 +101,7 @@ export const electronTest = baseTest
         await use(page);
         for (const window of sharedApp.windows())
           await window.close().catch(() => {});
+        await sharedApp.context().clearCookies();
       },
 
       launchElectronApp: async ({ createUserDataDir }, use) => {

--- a/tests/installation/playwright-electron-should-work.spec.ts
+++ b/tests/installation/playwright-electron-should-work.spec.ts
@@ -19,7 +19,7 @@ import { expect } from '../../packages/playwright-test';
 import path from 'path';
 
 test('electron should work', async ({ exec, tsc, writeFiles }) => {
-  await exec('npm i @playwright/test electron@39.8.4');
+  await exec('npm i @playwright/test electron@40.10.2');
   await exec('node sanity-electron.js');
   await writeFiles({
     'test.ts':
@@ -32,7 +32,7 @@ test('electron should work with special characters in path', async ({ exec, tmpW
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30755' });
   const folderName = path.join(tmpWorkspace, '!@#$% тест with spaces and 😊');
 
-  await exec('npm i @playwright/test electron@39.8.4');
+  await exec('npm i @playwright/test electron@40.10.2');
   await fs.promises.mkdir(folderName);
   for (const file of ['electron-app.js', 'sanity-electron.js'])
     await fs.promises.copyFile(path.join(tmpWorkspace, file), path.join(folderName, file));
@@ -42,7 +42,7 @@ test('electron should work with special characters in path', async ({ exec, tmpW
 });
 
 test('should work when wrapped inside @playwright/test and trace is enabled', async ({ exec, tmpWorkspace, writeFiles }) => {
-  await exec('npm i -D @playwright/test electron@39.8.4');
+  await exec('npm i -D @playwright/test electron@40.10.2');
   await writeFiles({
     'electron-with-tracing.spec.ts': `
       import { test, expect, _electron as electron } from '@playwright/test';

--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -357,7 +357,8 @@ test.describe('browser', () => {
     });
     const response = await page.goto(httpsServer.EMPTY_PAGE);
     expect(response.ok()).toBe(true);
-    expect((await response.securityDetails()).subjectName).toBe('playwright-test');
+    // This is "CN=playwright-test" in some ubuntu webkits, and "playwright-test" in other browsers.
+    expect((await response.securityDetails()).subjectName).toContain('playwright-test');
     await page.close();
   });
 

--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -321,11 +321,13 @@ it('should record websocket connection failure', async ({ contextFactory, server
   await page.goto(server.EMPTY_PAGE);
 
   const wsUrl = `ws://127.0.0.1:${port}/ws-connect-fail`;
+  const wsPromise = page.waitForEvent('websocket');
   await page.evaluate(url => new Promise<void>(resolve => {
     const ws = new WebSocket(url);
     ws.addEventListener('close', () => resolve());
     ws.addEventListener('error', () => resolve());
   }), wsUrl);
+  await wsPromise;
   const log = await getLog();
 
   const wsEntry = log.entries.find(e => e.request.url === wsUrl)! as Entry;

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -118,7 +118,7 @@ it('should populate entry startedDateTime from the browser', async ({ contextFac
   // `unblockedAt`); if it comes from the browser via the debugging protocol
   // it will be tied to when the browser actually sent the request.
   await page.evaluate(() => {
-    setTimeout(() => { void fetch('/delayed-fetch'); }, 50);
+    window.builtins.setTimeout(() => { void fetch('/delayed-fetch'); }, 50);
   });
 
   const blockUntil = Date.now() + 300;
@@ -1068,6 +1068,24 @@ it.describe('tracing.startHar', () => {
     expect(urls).toEqual([server.PREFIX + '/one-style.css']);
     // Minimal mode drops body sizes.
     expect(log.entries[0].request.bodySize).toBe(-1);
+  });
+
+  it('should include pages', async ({ contextFactory, server }, testInfo) => {
+    const context = await contextFactory();
+    const harPath = testInfo.outputPath('tracing.har');
+    await context.tracing.startHar(harPath);
+    const page = await context.newPage();
+    await page.goto(server.PREFIX + '/title.html');
+    const page2 = await context.newPage();
+    await page2.goto(server.PREFIX + '/empty.html');
+    await page.close(); // Close the page before stopping - it should still be in the har.
+    await context.tracing.stopHar();
+    await context.close();
+
+    const log = JSON.parse(fs.readFileSync(harPath).toString()).log as Log;
+    expect(log.pages.length).toBe(2);
+    expect(log.pages[0].title).toBe('Woof-Woof');
+    expect(log.pages[1].title).toBe('');
   });
 
   it('should record a zipped HAR for APIRequestContext', async ({ playwright, server }, testInfo) => {

--- a/tests/library/heap.spec.ts
+++ b/tests/library/heap.spec.ts
@@ -18,6 +18,7 @@ import { contextTest as test, expect } from '../config/browserTest';
 import { server as coreServer } from '../../packages/playwright-core/lib/coreBundle';
 
 test.describe.configure({ mode: 'serial' });
+test.skip(({ mode }) => mode !== 'default');
 
 // Force a separate worker to start from a clean heap.
 test.use({ launchOptions: [async ({ launchOptions }, use) => use(launchOptions), { scope: 'worker' }] });
@@ -186,7 +187,7 @@ test.describe(() => {
         const frame = document.createElement('iframe');
         frame.src = url;
         document.body.appendChild(frame);
-        await new Promise(f => setTimeout(f, 10));
+        await new Promise(f => window.builtins.setTimeout(f, 10));
         frame.remove();
       }
     }, { url: server.PREFIX + '/one-style.html', count: kFrameCount }).catch(() => {});
@@ -200,6 +201,8 @@ test.describe(() => {
 });
 
 test('cycle handles', async ({ page, server }) => {
+  test.slow();
+
   await page.goto(server.EMPTY_PAGE);
   await page.setContent(`<div><span>hi</span></div>`.repeat(2000));
   const divs = await page.$$('div');

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -212,10 +212,11 @@ browserTest.describe('page screenshot', () => {
     expect(pixel(0, 999).b).toBeGreaterThan(128);
   });
 
-  browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page }) => {
+  browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page, trace }) => {
+    browserTest.skip(trace === 'on', 'taking a snapshot hangs when the page is blocked');
     browserTest.setTimeout(5000);
     await page.evaluate(() => {
-      setTimeout(() => {
+      window.builtins.setTimeout(() => {
         while (true) {}
       }, 10);
     });

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -441,8 +441,10 @@ it('should throw for too deep reference chain', {
 
 it('should throw for too deep reference chain 2', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40940' }
-}, async ({ page, browserName }) => {
+}, async ({ page, browserName, isAndroid }) => {
   it.skip(browserName !== 'chromium', 'this is a chromium-only limitation');
+  it.skip(isAndroid, 'something fails there');
+
   await expect(page.evaluate(depth => {
     let node = {};
     for (let i = 0; i < depth; i++)

--- a/tests/page/page-localstorage.spec.ts
+++ b/tests/page/page-localstorage.spec.ts
@@ -16,6 +16,8 @@
 
 import { test as it, expect } from './pageTest';
 
+it.skip(({ isElectron }) => !!isElectron, 'Electron shares a single context between tests');
+
 it('localStorage.items returns empty array on fresh origin', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
   expect(await page.localStorage.items()).toEqual([]);
@@ -96,7 +98,9 @@ it('localStorage and sessionStorage are independent', async ({ page, server }) =
   expect(await page.sessionStorage.getItem('shared')).toBe('session');
 });
 
-it('storage methods are scoped to the current origin', async ({ page, server }) => {
+it('storage methods are scoped to the current origin', async ({ page, server, isAndroid }) => {
+  it.skip(isAndroid, 'these are same origins on Android due to our test server limitation');
+
   await page.goto(server.PREFIX + '/empty.html');
   await page.localStorage.setItem('k', 'origin-1');
 


### PR DESCRIPTION
- Fix Page objects being leaked in HarTracer, Snapshotter and Tracing recorder.
- Bump electron version for tests to 40.10.2.
- Pass "isClientCollocatedWithServer" in driver mode.
- Various test fixes.