### PR TITLE
chore(mcp): remove dead saveTrace config references

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -48,7 +48,6 @@ export type ContextConfig = {
   outputMaxSize?: number;
   outputMode?: 'file' | 'stdout';
   saveSession?: boolean;
-  saveTrace?: boolean;
   secrets?: Record<string, string>;
   snapshot?: {
     mode?: 'full' | 'none';
@@ -327,19 +326,6 @@ export class Context {
     const browserContext = this._rawBrowserContext;
     await this._setupRequestInterception(browserContext);
 
-    if (this.config.saveTrace) {
-      await browserContext.tracing.start({
-        name: 'trace-' + Date.now(),
-        screenshots: true,
-        snapshots: true,
-        live: true,
-      });
-      this._disposables.push({
-        dispose: async () => {
-          await browserContext.tracing.stop();
-        },
-      });
-    }
     for (const initScript of this.config.browser?.initScript || [])
       this._disposables.push(await browserContext.addInitScript({ path: path.resolve(this.options.cwd, initScript) }));
 

--- a/packages/playwright-core/src/tools/mcp/configIni.ts
+++ b/packages/playwright-core/src/tools/mcp/configIni.ts
@@ -157,7 +157,6 @@ const longhandTypes: Record<string, LonghandType> = {
   'extension': 'boolean',
   'capabilities': 'string[]',
   'saveSession': 'boolean',
-  'saveTrace': 'boolean',
   'saveVideo': 'size',
   'sharedBrowserContext': 'boolean',
   'outputDir': 'string',

--- a/tests/mcp/config.ini.spec.ts
+++ b/tests/mcp/config.ini.spec.ts
@@ -105,7 +105,7 @@ test('ini config boolean values', async ({ startClient }) => {
   const { client } = await startClient({
     config: `
       capabilities = config
-      saveTrace = true
+      saveSession = true
       browser.contextOptions.bypassCSP = true
       browser.contextOptions.javaScriptEnabled = false
     `,
@@ -113,7 +113,7 @@ test('ini config boolean values', async ({ startClient }) => {
 
   const result = await client.callTool({ name: 'browser_get_config' });
   const config = JSON.parse(parseResponse(result).result);
-  expect(config.saveTrace).toBe(true);
+  expect(config.saveSession).toBe(true);
   expect(config.browser.contextOptions.bypassCSP).toBe(true);
   expect(config.browser.contextOptions.javaScriptEnabled).toBe(false);
 });


### PR DESCRIPTION
## Summary
- The `saveTrace` feature was removed in #39538; this removes the remaining dead references.
- Drops the `saveTrace` config option and tracing code in `context.ts`, the config key mapping in `configIni.ts`, and the test reference.