### PR TITLE
docs: remove stray HTML comment from webview2 guide

### DIFF
--- a/docs/src/webview2.md
+++ b/docs/src/webview2.md
@@ -68,8 +68,6 @@ By default, the WebView2 control will use the same user data directory for all i
 
 Using the following, Playwright will run your WebView2 application as a sub-process, assign a unique user data directory to it and provide the [Page] instance to your test:
 
-<!-- source code is available here to verify that the examples are working https://github.com/mxschmitt/playwright-webview2-demo -->
-
 ```js title="webView2Test.ts"
 import { test as base } from '@playwright/test';
 import fs from 'fs';


### PR DESCRIPTION
## Summary
- Remove an HTML comment from `docs/src/webview2.md`.

HTML comments (`<!-- ... -->`) are not valid MDX and break downstream MDX-based rendering of these docs (e.g. playwright.dev, which runs on Docusaurus — MDX errors with "Could not parse expression"). The comment only linked the demo source repo and produced no rendered output, so removing it keeps the guide MDX-clean.