### PR TITLE
chore(trace): remove retain-all-failures trace and video mode

### DIFF
--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -584,8 +584,8 @@ export default defineConfig({
 
 ## property: TestOptions.trace
 * since: v1.10
-- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"retain-on-first-failure"|"retain-on-failure-and-retries"|"retain-all-failures">>
-  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries"|"retain-all-failures">> Trace recording mode.
+- type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"retain-on-first-failure"|"retain-on-failure-and-retries">>
+  - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
   - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.
   - `snapshots` ?<[boolean]> Whether to capture DOM snapshot on every action. Defaults to true. Optional.
@@ -599,7 +599,6 @@ Whether to record trace for each test. Defaults to `'off'`.
 * `'retain-on-failure'`: Record trace for each test. When test run passes, remove the recorded trace.
 * `'retain-on-first-failure'`: Record trace for the first run of each test, but not for retries. When test run passes, remove the recorded trace.
 * `'retain-on-failure-and-retries'`: Record trace for each test run. Retains all traces when an attempt fails.
-* `'retain-all-failures'`: Record trace for each test run. Retains the trace only for attempts that failed, regardless of the final test outcome.
 
 For more control, pass an object that specifies `mode` and trace features to enable.
 
@@ -634,8 +633,8 @@ export default defineConfig({
 
 ## property: TestOptions.video
 * since: v1.10
-- type: <[Object]|[VideoMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries"|"retain-all-failures">>
-  - `mode` <[VideoMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries"|"retain-all-failures">> Video recording mode.
+- type: <[Object]|[VideoMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries">>
+  - `mode` <[VideoMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries">> Video recording mode.
   - `size` ?<[Object]> Size of the recorded video. Optional.
     - `width` <[int]>
     - `height` <[int]>
@@ -657,7 +656,6 @@ Whether to record video for each test. Defaults to `'off'`.
 * `'retain-on-failure'`: Record video for each test. When test run passes, remove the recorded video.
 * `'retain-on-first-failure'`: Record video for the first run of each test, but not for retries. When test run passes, remove the recorded video.
 * `'retain-on-failure-and-retries'`: Record video for each test run. Retains all videos when an attempt fails.
-* `'retain-all-failures'`: Record video for each test run. Retains the video only for attempts that failed, regardless of the final test outcome.
 
 To control video size, pass an object with `mode` and `size` properties. If video size is not specified, it will be equal to [`property: TestOptions.viewport`] scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
 

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -107,7 +107,7 @@ npx playwright test --ui
 | `--test-list <file>` | Path to a file containing a list of tests to run. See [test list](#test-list) for details. |
 | `--test-list-invert <file>` | Path to a file containing a list of tests to skip. See [test list](#test-list) for details.  |
 | `--timeout <timeout>` | Specify test timeout threshold in milliseconds, zero for unlimited (default: 30 seconds). |
-| `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`, `retain-on-failure-and-retries`, `retain-all-failures`. |
+| `--trace <mode>` | Force tracing mode, can be `on`, `off`, `on-first-retry`, `on-all-retries`, `retain-on-failure`, `retain-on-first-failure`, `retain-on-failure-and-retries`. |
 | `--tsconfig <path>` | Path to a single tsconfig applicable to all imported files (default: look up tsconfig for each imported file separately). |
 | `--ui` | Run tests in interactive UI mode. |
 | `--ui-host <host>` | Host to serve UI on; specifying this option opens UI in a browser tab. |

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -523,7 +523,6 @@ function shouldCaptureVideo(videoMode: VideoMode, testInfo: TestInfo) {
   return videoMode === 'on'
     || videoMode === 'retain-on-failure'
     || videoMode === 'retain-on-failure-and-retries'
-    || videoMode === 'retain-all-failures'
     || (videoMode === 'on-first-retry' && testInfo.retry === 1)
     || (videoMode === 'on-all-retries' && testInfo.retry > 0)
     || (videoMode === 'retain-on-first-failure' && testInfo.retry === 0);
@@ -538,7 +537,6 @@ function shouldPreserveVideo(videoMode: VideoMode, testInfo: TestInfo) {
       return true;
     case 'retain-on-failure':
     case 'retain-on-first-failure':
-    case 'retain-all-failures':
       return testFailed;
     case 'retain-on-failure-and-retries':
       return testFailed || testInfo.retry > 0;

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -183,7 +183,7 @@ function addInitAgentsCommand(program: Command) {
   });
 }
 
-const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure', 'retain-on-failure-and-retries', 'retain-all-failures'];
+const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure', 'retain-on-failure-and-retries'];
 
 // Note: update docs/src/test-cli-js.md when you update this, program is the source of truth.
 

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -90,9 +90,6 @@ export class TestTracing {
     if (this._options?.mode === 'retain-on-failure-and-retries')
       return true;
 
-    if (this._options?.mode === 'retain-all-failures')
-      return true;
-
     return false;
   }
 
@@ -171,8 +168,6 @@ export class TestTracing {
     const testFailed = this._testInfo.status !== this._testInfo.expectedStatus;
     if (this._options.mode === 'retain-on-failure-and-retries')
       return !testFailed && this._testInfo.retry === 0;
-    if (this._options.mode === 'retain-all-failures')
-      return !testFailed;
     return !testFailed && (this._options.mode === 'retain-on-failure' || this._options.mode === 'retain-on-first-failure');
   }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6999,8 +6999,6 @@ export interface PlaywrightWorkerOptions {
    * - `'retain-on-first-failure'`: Record trace for the first run of each test, but not for retries. When test run
    *   passes, remove the recorded trace.
    * - `'retain-on-failure-and-retries'`: Record trace for each test run. Retains all traces when an attempt fails.
-   * - `'retain-all-failures'`: Record trace for each test run. Retains the trace only for attempts that failed,
-   *   regardless of the final test outcome.
    *
    * For more control, pass an object that specifies `mode` and trace features to enable.
    *
@@ -7030,8 +7028,6 @@ export interface PlaywrightWorkerOptions {
    * - `'retain-on-first-failure'`: Record video for the first run of each test, but not for retries. When test run
    *   passes, remove the recorded video.
    * - `'retain-on-failure-and-retries'`: Record video for each test run. Retains all videos when an attempt fails.
-   * - `'retain-all-failures'`: Record video for each test run. Retains the video only for attempts that failed,
-   *   regardless of the final test outcome.
    *
    * To control video size, pass an object with `mode` and `size` properties. If video size is not specified, it will be
    * equal to [testOptions.viewport](https://playwright.dev/docs/api/class-testoptions#test-options-viewport) scaled
@@ -7061,8 +7057,8 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure' | 'on-first-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries' | 'retain-all-failures';
-export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries' | 'retain-all-failures';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries';
+export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries';
 /**
  * Playwright Test provides many options to configure test environment,
  * [Browser](https://playwright.dev/docs/api/class-browser),

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -617,34 +617,6 @@ test('should work with video: retain-on-failure-and-retries', async ({ runInline
   expect(fs.readdirSync(dirRetry).find(file => file.endsWith('webm'))).toBeTruthy();
 });
 
-test('should work with video: retain-all-failures', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { use: { video: 'retain-all-failures' }, retries: 1, name: 'chromium' };
-    `,
-    'a.test.ts': `
-      import { test, expect } from '@playwright/test';
-      test('flaky', async ({ page }) => {
-        await page.setContent('<div>FLAKY</div>');
-        await page.waitForTimeout(1000);
-        test.expect(test.info().retry).toBe(1);
-      });
-    `,
-  }, { workers: 1 });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.flaky).toBe(1);
-
-  // First attempt failed, video retained.
-  const dirFail = test.info().outputPath('test-results', 'a-flaky-chromium');
-  expect(fs.readdirSync(dirFail).find(file => file.endsWith('webm'))).toBeTruthy();
-
-  // Retry passed, so its video is removed.
-  const dirRetry = test.info().outputPath('test-results', 'a-flaky-chromium-retry1');
-  const videoRetry = fs.existsSync(dirRetry) ? fs.readdirSync(dirRetry).find(file => file.endsWith('webm')) : undefined;
-  expect(videoRetry).toBeFalsy();
-});
-
 test('should work with video size', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.js': `

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -386,7 +386,7 @@ test('should respect --trace', async ({ runInlineTest }, testInfo) => {
   expect(fs.existsSync(testInfo.outputPath('test-results', 'a-test-1', 'trace.zip'))).toBeTruthy();
 });
 
-for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'retain-on-first-failure', 'retain-on-failure-and-retries', 'retain-all-failures']) {
+for (const mode of ['off', 'retain-on-failure', 'on-first-retry', 'on-all-retries', 'retain-on-first-failure', 'retain-on-failure-and-retries']) {
   test(`trace:${mode} should not create trace zip artifact if page test passed`, async ({ runInlineTest }) => {
     const result = await runInlineTest({
       'a.spec.ts': `
@@ -1186,48 +1186,6 @@ test('trace:retain-on-failure-and-retries should keep all traces when test fails
       });
     `,
   }, { trace: 'retain-on-failure-and-retries', retries: 1 });
-
-  expect(result.exitCode).toBe(1);
-  expect(result.failed).toBe(1);
-
-  const firstRunTracePath = testInfo.outputPath('test-results', 'a-fail', 'trace.zip');
-  expect(fs.existsSync(firstRunTracePath)).toBeTruthy();
-  const retryTracePath = testInfo.outputPath('test-results', 'a-fail-retry1', 'trace.zip');
-  expect(fs.existsSync(retryTracePath)).toBeTruthy();
-});
-
-test('trace:retain-all-failures should keep traces only for failed attempts when test is flaky', async ({ runInlineTest }, testInfo) => {
-  const result = await runInlineTest({
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('flaky', async ({ page }) => {
-        await page.goto('about:blank');
-        expect(test.info().retry).toBe(2);
-      });
-    `,
-  }, { trace: 'retain-all-failures', retries: 2 });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.flaky).toBe(1);
-
-  const firstRunTracePath = testInfo.outputPath('test-results', 'a-flaky', 'trace.zip');
-  expect(fs.existsSync(firstRunTracePath)).toBeTruthy();
-  const retry1TracePath = testInfo.outputPath('test-results', 'a-flaky-retry1', 'trace.zip');
-  expect(fs.existsSync(retry1TracePath)).toBeTruthy();
-  const retry2TracePath = testInfo.outputPath('test-results', 'a-flaky-retry2', 'trace.zip');
-  expect(fs.existsSync(retry2TracePath)).toBeFalsy();
-});
-
-test('trace:retain-all-failures should keep all traces when test fails on every attempt', async ({ runInlineTest }, testInfo) => {
-  const result = await runInlineTest({
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('fail', async ({ page }) => {
-        await page.goto('about:blank');
-        expect(true).toBe(false);
-      });
-    `,
-  }, { trace: 'retain-all-failures', retries: 1 });
 
   expect(result.exitCode).toBe(1);
   expect(result.failed).toBe(1);

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -267,8 +267,8 @@ export interface PlaywrightWorkerOptions {
 }
 
 export type ScreenshotMode = 'off' | 'on' | 'only-on-failure' | 'on-first-failure';
-export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries' | 'retain-all-failures';
-export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries' | 'retain-all-failures';
+export type TraceMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries';
+export type VideoMode = 'off' | 'on' | 'retain-on-failure' | 'on-first-retry' | 'on-all-retries' | 'retain-on-first-failure' | 'retain-on-failure-and-retries';
 export interface PlaywrightTestOptions {
   acceptDownloads: boolean;
   bypassCSP: boolean;


### PR DESCRIPTION
## Summary
- Remove the `retain-all-failures` mode from both `trace` and `video` options.
- On a closer look it behaves the same as `retain-on-failure`; we'll clarify the distinction in the docs separately.

Reverts `retain-all-failures` added in #40838 (trace) and #41085 (video).

Reverts https://github.com/microsoft/playwright/issues/40832