### PR TITLE
fix(mcp): support moz-firefox BiDi channels via --browser

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -264,6 +264,10 @@ function resolveBrowserParam(browserOption: string | undefined): { browserName?:
       return { browserName: 'chromium', channel: 'chrome-for-testing' };
     case 'firefox':
       return { browserName: 'firefox' };
+    case 'moz-firefox':
+    case 'moz-firefox-beta':
+    case 'moz-firefox-nightly':
+      return { browserName: 'firefox', channel: browserOption };
     case 'webkit':
       return { browserName: 'webkit' };
     default:
@@ -465,7 +469,9 @@ function mergeConfig(base: MergedConfig, overrides: Config): MergedConfig {
     },
   };
 
-  if (browser.browserName !== 'chromium' && browser.launchOptions)
+  // Firefox supports the `moz-firefox*` channels via WebDriver BiDi, so keep
+  // those; otherwise channels are a Chromium-only concept and should be dropped.
+  if (browser.browserName !== 'chromium' && browser.launchOptions && !browser.launchOptions.channel?.startsWith('moz-'))
     delete browser.launchOptions.channel;
 
   return {


### PR DESCRIPTION
playwright-core already registers the `moz-firefox`, `moz-firefox-beta` and `moz-firefox-nightly` channels and routes them through WebDriver BiDi (Firefox.launch branches on `channel.startsWith('moz-')`), but the MCP layer never plumbed them through:

- resolveBrowserParam() did not recognize the moz-firefox* values, so `--browser moz-firefox` resolved to no channel.
- mergeConfig() dropped the channel for any non-chromium browser, which also discarded a valid Firefox BiDi channel coming from a config file.

Recognize the moz-firefox* channels in resolveBrowserParam(), and keep moz-* channels in mergeConfig() instead of stripping them.