### PR TITLE
fix(test): pass file:// URL to the ESM resolver in the sync loader

### DIFF
--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -73,33 +73,33 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [20]
+        node-version: [22]
         shardIndex: [1, 2]
         shardTotal: [2]
         shardWeights: ['58:42']
         include:
           - os: windows-latest
-            node-version: 20
+            node-version: 22
             shardIndex: 1
             shardTotal: 3
             shardWeights: '44:33:23'
           - os: windows-latest
-            node-version: 20
+            node-version: 22
             shardIndex: 2
             shardTotal: 3
             shardWeights: '44:33:23'
           - os: windows-latest
-            node-version: 20
+            node-version: 22
             shardIndex: 3
             shardTotal: 3
             shardWeights: '44:33:23'
           - os: ubuntu-latest
-            node-version: 22
+            node-version: 20
             shardIndex: 1
             shardTotal: 2
             shardWeights: '58:42'
           - os: ubuntu-latest
-            node-version: 22
+            node-version: 20
             shardIndex: 2
             shardTotal: 2
             shardWeights: '58:42'

--- a/packages/playwright/src/transform/esmLoaderSync.ts
+++ b/packages/playwright/src/transform/esmLoaderSync.ts
@@ -21,15 +21,19 @@ import { currentFileDepsCollector } from './compilationCache';
 import { resolveHook, shouldTransform, transformHook } from './transform';
 import { fileIsModule } from '../util';
 
-export function resolve(specifier: string, context: { parentURL?: string }, nextResolve: Function) {
+export function resolve(specifier: string, context: { parentURL?: string, conditions?: string[] }, nextResolve: Function) {
   if (context.parentURL && context.parentURL.startsWith('file://')) {
     const filename = url.fileURLToPath(context.parentURL);
     const resolved = resolveHook(filename, specifier);
-    // Pass the resolved absolute path (not a file:// URL) to nextResolve: unlike the
-    // ESM-only asynchronous loader, these hooks also serve require(), whose default
-    // resolver rejects file:// specifiers but accepts absolute paths for both kinds.
-    if (resolved !== undefined)
-      specifier = resolved;
+    if (resolved !== undefined) {
+      // These hooks serve both require() and import. The two default resolvers disagree on
+      // what an already-resolved specifier should look like:
+      // - require()'s resolver wants an absolute path and rejects file:// specifiers;
+      // - the ESM resolver wants a file:// URL and, on Windows, mistakes an absolute path's
+      //   drive letter for a URL scheme ("Received protocol 'c:'").
+      // The `import` condition is present only for ESM resolution, so use it to pick the form.
+      specifier = context.conditions?.includes('import') ? url.pathToFileURL(resolved).toString() : resolved;
+    }
   }
   const result = nextResolve(specifier, context);
   if (result?.url && result.url.startsWith('file://'))

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -289,32 +289,6 @@ test('should load ts from esm when package.json has type module', async ({ runIn
   expect(result.output).not.toContain(`is an experimental feature`);
 });
 
-test('should import a relative .js file from esm when package.json has type module', async ({ runInlineTest }) => {
-  // Regression test for https://github.com/microsoft/playwright/issues/41121:
-  // resolveHook returns an absolute path that is passed to the default ESM resolver,
-  // which on Windows rejects it as an invalid file:// URL ("Received protocol 'c:'").
-  const result = await runInlineTest({
-    'playwright.config.js': `
-      export default { projects: [{name: 'foo'}] };
-    `,
-    'package.json': JSON.stringify({ type: 'module' }),
-    'a.test.js': `
-      import { test, expect } from '@playwright/test';
-      import { dummy } from './lib/lib.js';
-      test('check project name', ({}, testInfo) => {
-        dummy();
-        expect(testInfo.project.name).toBe('foo');
-      });
-    `,
-    'lib/lib.js': `
-      export function dummy() {}
-    `,
-  });
-
-  expect(result.exitCode).toBe(0);
-  expect(result.passed).toBe(1);
-});
-
 test('should filter stack trace for simple expect', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -289,6 +289,32 @@ test('should load ts from esm when package.json has type module', async ({ runIn
   expect(result.output).not.toContain(`is an experimental feature`);
 });
 
+test('should import a relative .js file from esm when package.json has type module', async ({ runInlineTest }) => {
+  // Regression test for https://github.com/microsoft/playwright/issues/41121:
+  // resolveHook returns an absolute path that is passed to the default ESM resolver,
+  // which on Windows rejects it as an invalid file:// URL ("Received protocol 'c:'").
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      export default { projects: [{name: 'foo'}] };
+    `,
+    'package.json': JSON.stringify({ type: 'module' }),
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      import { dummy } from './lib/lib.js';
+      test('check project name', ({}, testInfo) => {
+        dummy();
+        expect(testInfo.project.name).toBe('foo');
+      });
+    `,
+    'lib/lib.js': `
+      export function dummy() {}
+    `,
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
 test('should filter stack trace for simple expect', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'expect-test.spec.ts': `


### PR DESCRIPTION
## Summary
- Fix ESM resolution in the synchronous module customization hooks. These hooks serve both `require()` and `import`: `require()`'s resolver wants an absolute path, while the ESM resolver wants a `file://` URL and, on Windows, mistakes an absolute path's drive letter for a URL scheme (`Received protocol 'c:'`). Pick the form using the `import` condition.
- Default all ttest bots to Node 22 (where the sync hooks are used) and keep Node 20 coverage on ubuntu only. The Windows bots previously ran Node 20, so this regression went uncaught.

Fixes https://github.com/microsoft/playwright/issues/41121