### PR TITLE
fix(test): clarify error for test() after await in async describe

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -85,6 +85,8 @@ export class TestTypeImpl {
         `- You are calling ${title} in a file that is imported by the configuration file.`,
         `- You have two different versions of @playwright/test. This usually happens`,
         `  when one of the dependencies in your package.json depends on @playwright/test.`,
+        `- You are calling ${title} after an "await" in an async test.describe() callback.`,
+        `  Declare tests before any "await", or move async work into a hook.`,
       ].join('\n'));
     }
     return suite;

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -85,8 +85,7 @@ export class TestTypeImpl {
         `- You are calling ${title} in a file that is imported by the configuration file.`,
         `- You have two different versions of @playwright/test. This usually happens`,
         `  when one of the dependencies in your package.json depends on @playwright/test.`,
-        `- You are calling ${title} after an "await" in an async test.describe() callback.`,
-        `  Declare tests before any "await", or move async work into a hook.`,
+        `- You have an async test.describe() block. Only sync ones are supported.`,
       ].join('\n'));
     }
     return suite;

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -85,7 +85,7 @@ export class TestTypeImpl {
         `- You are calling ${title} in a file that is imported by the configuration file.`,
         `- You have two different versions of @playwright/test. This usually happens`,
         `  when one of the dependencies in your package.json depends on @playwright/test.`,
-        `- You have an async test.describe() block. Only sync ones are supported.`,
+        `- You are calling ${title} from an async test.describe() block. Only sync ones are supported.`,
       ].join('\n'));
     }
     return suite;

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -425,7 +425,7 @@ test('should hint at async describe() callbacks when test() is called too late',
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Playwright Test did not expect test() to be called here.');
-  expect(result.output).toContain('after an "await" in an async test.describe() callback');
+  expect(result.output).toContain('You have an async test.describe() block. Only sync ones are supported.');
 });
 
 test('should allow async describe() callback that registers tests synchronously', async ({ runInlineTest }) => {

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -411,6 +411,37 @@ test('should support describe() without a title', async ({ runInlineTest }) => {
   expect(result.output).toContain('a.spec.ts:6:17 › suite1 › suite2 › my test');
 });
 
+test('should hint at async describe() callbacks when test() is called too late', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'data.json': `{"entries":{"a":{"id":"a","title":"A"},"b":{"id":"b","title":"B"}}}`,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe('theme', async () => {
+        const { default: data } = await import('./data.json', { with: { type: 'json' } });
+        for (const entry of Object.values(data.entries))
+          test(entry.title, async () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Playwright Test did not expect test() to be called here.');
+  expect(result.output).toContain('after an "await" in an async test.describe() callback');
+});
+
+test('should allow async describe() callback that registers tests synchronously', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test.describe('theme', async () => {
+        test('one', async () => {});
+        test('two', async () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
 test('test.{skip,fixme} should define a skipped test', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -425,7 +425,7 @@ test('should hint at async describe() callbacks when test() is called too late',
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('Playwright Test did not expect test() to be called here.');
-  expect(result.output).toContain('You have an async test.describe() block. Only sync ones are supported.');
+  expect(result.output).toContain('You are calling test() from an async test.describe() block. Only sync ones are supported.');
 });
 
 test('should allow async describe() callback that registers tests synchronously', async ({ runInlineTest }) => {


### PR DESCRIPTION
## Summary
- `test()` calls made after an `await` in an `async test.describe()` callback run after test collection has finished, producing the misleading "Playwright Test did not expect test() to be called here" error.
- Add an explicit reason to that error covering this case, with a hint to declare tests before any `await` or move async work into a hook.

Fixes https://github.com/microsoft/playwright/issues/41132