### PR TITLE
fix(mcp): use waitUntil commit for browser_navigate_back/forward

### DIFF
--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -50,7 +50,7 @@ const goBack = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    await tab.page.goBack(tab.navigationTimeoutOptions);
+    await tab.page.goBack({ ...tab.navigationTimeoutOptions, waitUntil: 'commit' });
     response.setIncludeSnapshot();
     response.addCode(`await page.goBack();`);
   },
@@ -68,7 +68,7 @@ const goForward = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    await tab.page.goForward(tab.navigationTimeoutOptions);
+    await tab.page.goForward({ ...tab.navigationTimeoutOptions, waitUntil: 'commit' });
     response.setIncludeSnapshot();
     response.addCode(`await page.goForward();`);
   },


### PR DESCRIPTION
## Summary
- Pass `waitUntil: 'commit'` to `page.goBack()` and `page.goForward()` in MCP navigation tools
- Avoids false timeouts when history restore completes without a `load` event (bfcache)

Fixes https://github.com/microsoft/playwright-mcp/issues/1635

## Test plan
- [ ] Manual: example.com → iana.org → `browser_navigate_back` completes without MCP timeout

Made with [Cursor](https://cursor.com)