### PR TITLE
fix(mcp): keep remoteHeaders working for remote browser endpoint

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -120,9 +120,12 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   // `timeout`. Normalize once so the rest of the function deals with a single
   // shape.
   const remote = config.browser.remoteEndpoint!;
+  // `remoteHeaders` is for back-compat, `remoteEndpoint.headers` takes precedence.
+  // eslint-disable-next-line no-restricted-syntax
+  const remoteHeaders = (config.browser as any).remoteHeaders as Record<string, string> | undefined;
   const remoteOptions = typeof remote === 'string'
-    ? { endpoint: remote }
-    : remote;
+    ? { endpoint: remote, headers: remoteHeaders }
+    : { ...remote, headers: { ...remoteHeaders, ...remote.headers } };
 
   const descriptor = await serverRegistry.find(remoteOptions.endpoint);
   if (descriptor) {

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -64,6 +64,7 @@ export type CLIOptions = {
   port?: number;
   proxyBypass?: string;
   proxyServer?: string;
+  remoteHeader?: Record<string, string>;
   saveSession?: boolean;
   secrets?: Record<string, string>;
   sharedBrowserContext?: boolean;
@@ -364,6 +365,11 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
     },
   };
 
+  // `remoteHeaders` is for back-compat, assign it here so it survives config merging.
+  if (cliOptions.remoteHeader)
+    // eslint-disable-next-line no-restricted-syntax
+    (config.browser as any).remoteHeaders = cliOptions.remoteHeader;
+
   return { ...config, configFile: cliOptions.config };
 }
 
@@ -405,6 +411,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   options.port = numberParser(e.PLAYWRIGHT_MCP_PORT);
   options.proxyBypass = envToString(e.PLAYWRIGHT_MCP_PROXY_BYPASS);
   options.proxyServer = envToString(e.PLAYWRIGHT_MCP_PROXY_SERVER);
+  options.remoteHeader = headerParser(envToString(e.PLAYWRIGHT_MCP_REMOTE_HEADERS));
   options.secrets = dotenvFileLoader(e.PLAYWRIGHT_MCP_SECRETS_FILE);
   options.storageState = envToString(e.PLAYWRIGHT_MCP_STORAGE_STATE);
   options.testIdAttribute = envToString(e.PLAYWRIGHT_MCP_TEST_ID_ATTRIBUTE);

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -64,6 +64,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--port <port>', 'port to listen on for SSE transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')
+      .addOption(new ProgramOption('--remote-header <headers...>', 'headers to send with the remote endpoint connect request, multiple can be specified.').argParser(headerParser).hideHelp())
       .option('--sandbox', 'enable the sandbox for all process types that are normally not sandboxed.')
       .option('--save-session', 'Whether to save the Playwright MCP session into the output directory.')
       .option('--secrets <path>', 'path to a file containing secrets in the dotenv format', dotenvFileLoader)

--- a/tests/mcp/remote-endpoint.spec.ts
+++ b/tests/mcp/remote-endpoint.spec.ts
@@ -59,3 +59,23 @@ test('remoteEndpoint accepts ConnectOptions object with headers', async ({ start
     page: expect.stringContaining('Page Title: Title'),
   });
 });
+
+test('back-compat: remoteHeaders config still selects the browser on run-server endpoint', async ({ startClient, server, runServerEndpoint }) => {
+  const { client } = await startClient({
+    config: {
+      browser: {
+        remoteEndpoint: runServerEndpoint,
+        remoteHeaders: { 'x-playwright-browser': 'chromium' },
+        isolated: true,
+      },
+    } as any,
+  });
+
+  const response = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+  expect(response).toHaveResponse({
+    page: expect.stringContaining('Page Title: Title'),
+  });
+});


### PR DESCRIPTION
## Summary
- #40964 dropped the `remoteHeaders` config field, the `--remote-header` CLI flag, and the `PLAYWRIGHT_MCP_REMOTE_HEADERS` env var, regressing existing remote-endpoint setups.
- Restore all three as an undocumented back-compat shim (kept out of the public `Config` type). `remoteEndpoint.headers` takes precedence over `remoteHeaders`; the `--remote-header` flag is hidden from help.
- Re-added the regression test in `tests/mcp/remote-endpoint.spec.ts`.