### PR TITLE
feat(expect): support AbortSignal on web-first assertions

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -188,6 +188,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.check.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.check.signal = %%-input-signal-%%
+
 ### option: ElementHandle.check.trial = %%-input-trial-%%
 * since: v1.11
 
@@ -232,6 +234,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.click.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.click.signal = %%-input-signal-%%
 
 ### option: ElementHandle.click.trial = %%-input-trial-%%
 * since: v1.11
@@ -288,6 +292,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.dblclick.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.dblclick.signal = %%-input-signal-%%
 
 ### option: ElementHandle.dblclick.trial = %%-input-trial-%%
 * since: v1.11
@@ -551,6 +557,8 @@ Value to set for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: ElementHandle.fill.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.fill.signal = %%-input-signal-%%
+
 ## async method: ElementHandle.focus
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.focus`] instead. Read more about [locators](../locators.md).
@@ -598,6 +606,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.hover.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.hover.signal = %%-input-signal-%%
 
 ### option: ElementHandle.hover.trial = %%-input-trial-%%
 * since: v1.11
@@ -727,6 +737,8 @@ Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 ### option: ElementHandle.press.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.press.signal = %%-input-signal-%%
+
 ## async method: ElementHandle.querySelector
 * since: v1.9
 * discouraged: Use locator-based [`method: Page.locator`] instead. Read more about [locators](../locators.md).
@@ -776,6 +788,8 @@ Returns the buffer with the captured screenshot.
 ### option: ElementHandle.screenshot.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.screenshot.signal = %%-input-signal-%%
+
 ### option: ElementHandle.screenshot.maskColor = %%-screenshot-option-mask-color-%%
 * since: v1.34
 
@@ -800,6 +814,8 @@ See [scrolling](../input.md#scrolling) for alternative ways to scroll.
 
 ### option: ElementHandle.scrollIntoViewIfNeeded.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.scrollIntoViewIfNeeded.signal = %%-input-signal-%%
 
 ## async method: ElementHandle.selectOption
 * since: v1.8
@@ -883,6 +899,8 @@ await handle.SelectOptionAsync(new[] {
 ### option: ElementHandle.selectOption.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.selectOption.signal = %%-input-signal-%%
+
 ### param: ElementHandle.selectOption.element = %%-python-select-options-element-%%
 * since: v1.8
 
@@ -912,6 +930,8 @@ If the element is inside the `<label>` element that has an associated [control](
 
 ### option: ElementHandle.selectText.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.selectText.signal = %%-input-signal-%%
 
 ## async method: ElementHandle.setChecked
 * discouraged: Use locator-based [`method: Locator.setChecked`] instead. Read more about [locators](../locators.md).
@@ -947,6 +967,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.setChecked.timeout = %%-input-timeout-js-%%
 * since: v1.15
 
+### option: ElementHandle.setChecked.signal = %%-input-signal-%%
+
 ### option: ElementHandle.setChecked.trial = %%-input-trial-%%
 * since: v1.15
 
@@ -972,6 +994,8 @@ This method expects [ElementHandle] to point to an
 
 ### option: ElementHandle.setInputFiles.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.setInputFiles.signal = %%-input-signal-%%
 
 ## async method: ElementHandle.tap
 * since: v1.8
@@ -1008,6 +1032,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.tap.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.tap.signal = %%-input-signal-%%
 
 ### option: ElementHandle.tap.trial = %%-input-trial-%%
 * since: v1.11
@@ -1050,6 +1076,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 ### option: ElementHandle.type.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: ElementHandle.type.signal = %%-input-signal-%%
+
 ## async method: ElementHandle.uncheck
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.uncheck`] instead. Read more about [locators](../locators.md).
@@ -1081,6 +1109,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.uncheck.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.uncheck.signal = %%-input-signal-%%
 
 ### option: ElementHandle.uncheck.trial = %%-input-trial-%%
 * since: v1.11
@@ -1114,6 +1144,8 @@ A state to wait for, see below for more details.
 
 ### option: ElementHandle.waitForElementState.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.waitForElementState.signal = %%-input-signal-%%
 
 ## async method: ElementHandle.waitForSelector
 * since: v1.8
@@ -1181,6 +1213,8 @@ This method does not work across navigations, use [`method: Page.waitForSelector
 
 ### option: ElementHandle.waitForSelector.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: ElementHandle.waitForSelector.signal = %%-input-signal-%%
 
 ### option: ElementHandle.waitForSelector.strict = %%-input-strict-%%
 * since: v1.15

--- a/docs/src/api/class-filechooser.md
+++ b/docs/src/api/class-filechooser.md
@@ -73,3 +73,5 @@ they are resolved relative to the current working directory. For empty array, cl
 
 ### option: FileChooser.setFiles.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: FileChooser.setFiles.signal = %%-input-signal-%%

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -224,6 +224,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.check.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.check.signal = %%-input-signal-%%
+
 ### option: Frame.check.trial = %%-input-trial-%%
 * since: v1.11
 
@@ -279,6 +281,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.click.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.click.signal = %%-input-signal-%%
 
 ### option: Frame.click.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
@@ -340,6 +344,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.dblclick.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.dblclick.signal = %%-input-signal-%%
 
 ### option: Frame.dblclick.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
@@ -449,6 +455,8 @@ Optional event-specific initialization properties.
 ### option: Frame.dispatchEvent.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.dispatchEvent.signal = %%-input-signal-%%
+
 ## async method: Frame.dragAndDrop
 * since: v1.13
 
@@ -472,6 +480,8 @@ Optional event-specific initialization properties.
 
 ### option: Frame.dragAndDrop.timeout = %%-input-timeout-js-%%
 * since: v1.13
+
+### option: Frame.dragAndDrop.signal = %%-input-signal-%%
 
 ### option: Frame.dragAndDrop.trial = %%-input-trial-%%
 * since: v1.13
@@ -869,6 +879,8 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Frame.fill.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.fill.signal = %%-input-signal-%%
+
 ## async method: Frame.focus
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.focus`] instead. Read more about [locators](../locators.md).
@@ -887,6 +899,8 @@ This method fetches an element with [`param: selector`] and focuses it. If there
 
 ### option: Frame.focus.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.focus.signal = %%-input-signal-%%
 
 ## async method: Frame.frameElement
 * since: v1.8
@@ -994,6 +1008,8 @@ Attribute name to get the value for.
 
 ### option: Frame.getAttribute.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.getAttribute.signal = %%-input-signal-%%
 
 ## method: Frame.getByAltText
 * since: v1.27
@@ -1115,6 +1131,8 @@ URL to navigate frame to. The url should include scheme, e.g. `https://`.
 ### option: Frame.goto.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
 
+### option: Frame.goto.signal = %%-input-signal-%%
+
 ### option: Frame.goto.referer
 * since: v1.8
 - `referer` <[string]>
@@ -1158,6 +1176,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.hover.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.hover.signal = %%-input-signal-%%
+
 ### option: Frame.hover.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
 
@@ -1183,6 +1203,8 @@ Returns `element.innerHTML`.
 ### option: Frame.innerHTML.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.innerHTML.signal = %%-input-signal-%%
+
 ## async method: Frame.innerText
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.innerText`] instead. Read more about [locators](../locators.md).
@@ -1201,6 +1223,8 @@ Returns `element.innerText`.
 
 ### option: Frame.innerText.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.innerText.signal = %%-input-signal-%%
 
 ## async method: Frame.inputValue
 * since: v1.13
@@ -1223,6 +1247,8 @@ Throws for non-input elements. However, if the element is inside the `<label>` e
 ### option: Frame.inputValue.timeout = %%-input-timeout-js-%%
 * since: v1.13
 
+### option: Frame.inputValue.signal = %%-input-signal-%%
+
 ## async method: Frame.isChecked
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isChecked`] instead. Read more about [locators](../locators.md).
@@ -1241,6 +1267,8 @@ Returns whether the element is checked. Throws if the element is not a checkbox 
 
 ### option: Frame.isChecked.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.isChecked.signal = %%-input-signal-%%
 
 ## method: Frame.isDetached
 * since: v1.8
@@ -1267,6 +1295,8 @@ Returns whether the element is disabled, the opposite of [enabled](../actionabil
 ### option: Frame.isDisabled.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.isDisabled.signal = %%-input-signal-%%
+
 ## async method: Frame.isEditable
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isEditable`] instead. Read more about [locators](../locators.md).
@@ -1286,6 +1316,8 @@ Returns whether the element is [editable](../actionability.md#editable).
 ### option: Frame.isEditable.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.isEditable.signal = %%-input-signal-%%
+
 ## async method: Frame.isEnabled
 * since: v1.8
 - returns: <[boolean]>
@@ -1303,6 +1335,8 @@ Returns whether the element is [enabled](../actionability.md#enabled).
 
 ### option: Frame.isEnabled.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.isEnabled.signal = %%-input-signal-%%
 
 ## async method: Frame.isHidden
 * since: v1.8
@@ -1434,6 +1468,8 @@ Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 ### option: Frame.press.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.press.signal = %%-input-signal-%%
+
 ## async method: Frame.querySelector
 * since: v1.9
 * discouraged: Use locator-based [`method: Frame.locator`] instead. Read more about [locators](../locators.md).
@@ -1560,6 +1596,8 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
 ### option: Frame.selectOption.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.selectOption.signal = %%-input-signal-%%
+
 ### param: Frame.selectOption.element = %%-python-select-options-element-%%
 * since: v1.8
 
@@ -1614,6 +1652,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.setChecked.timeout = %%-input-timeout-js-%%
 * since: v1.15
 
+### option: Frame.setChecked.signal = %%-input-signal-%%
+
 ### option: Frame.setChecked.trial = %%-input-trial-%%
 * since: v1.15
 
@@ -1633,6 +1673,8 @@ HTML markup to assign to the page.
 
 ### option: Frame.setContent.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
+
+### option: Frame.setContent.signal = %%-input-signal-%%
 
 ### option: Frame.setContent.waitUntil = %%-navigation-wait-until-%%
 * since: v1.8
@@ -1664,6 +1706,8 @@ This method expects [`param: selector`] to point to an
 
 ### option: Frame.setInputFiles.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.setInputFiles.signal = %%-input-signal-%%
 
 ## async method: Frame.tap
 * since: v1.8
@@ -1708,6 +1752,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.tap.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.tap.signal = %%-input-signal-%%
+
 ### option: Frame.tap.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
 
@@ -1729,6 +1775,8 @@ Returns `element.textContent`.
 
 ### option: Frame.textContent.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.textContent.signal = %%-input-signal-%%
 
 ## async method: Frame.title
 * since: v1.8
@@ -1774,6 +1822,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 ### option: Frame.type.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Frame.type.signal = %%-input-signal-%%
+
 ## async method: Frame.uncheck
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.uncheck`] instead. Read more about [locators](../locators.md).
@@ -1812,6 +1862,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.uncheck.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.uncheck.signal = %%-input-signal-%%
 
 ### option: Frame.uncheck.trial = %%-input-trial-%%
 * since: v1.11
@@ -1962,6 +2014,8 @@ Optional argument to pass to [`param: expression`].
 
 ### option: Frame.waitForFunction.timeout = %%-wait-for-function-timeout-js-%%
 * since: v1.8
+
+### option: Frame.waitForFunction.signal = %%-input-signal-%%
 
 ## async method: Frame.waitForLoadState
 * since: v1.8
@@ -2231,6 +2285,8 @@ class FrameExamples
 
 ### option: Frame.waitForSelector.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Frame.waitForSelector.signal = %%-input-signal-%%
 
 ## async method: Frame.waitForTimeout
 * since: v1.8

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -223,6 +223,8 @@ When set to `"ai"`, returns a snapshot optimized for AI consumption. Defaults to
 ### option: Locator.ariaSnapshot.timeout = %%-input-timeout-js-%%
 * since: v1.49
 
+### option: Locator.ariaSnapshot.signal = %%-input-signal-%%
+
 ### option: Locator.ariaSnapshot.depth
 * since: v1.59
 - `depth` <[int]>
@@ -247,6 +249,8 @@ Calls [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) 
 
 ### option: Locator.blur.timeout = %%-input-timeout-js-%%
 * since: v1.28
+
+### option: Locator.blur.signal = %%-input-signal-%%
 
 ## async method: Locator.boundingBox
 * since: v1.14
@@ -306,6 +310,8 @@ await page.Mouse.ClickAsync(box.X + box.Width / 2, box.Y + box.Height / 2);
 ### option: Locator.boundingBox.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.boundingBox.signal = %%-input-signal-%%
+
 ## async method: Locator.check
 * since: v1.14
 
@@ -363,6 +369,8 @@ await page.GetByRole(AriaRole.Checkbox).CheckAsync();
 ### option: Locator.check.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.check.signal = %%-input-signal-%%
+
 ### option: Locator.check.trial = %%-input-trial-%%
 * since: v1.14
 
@@ -412,6 +420,8 @@ await page.GetByRole(AriaRole.Textbox).ClearAsync();
 
 ### option: Locator.clear.timeout = %%-input-timeout-js-%%
 * since: v1.28
+
+### option: Locator.clear.signal = %%-input-signal-%%
 
 ## async method: Locator.click
 * since: v1.14
@@ -608,6 +618,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.dblclick.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.dblclick.signal = %%-input-signal-%%
 
 ### option: Locator.dblclick.trial = %%-input-trial-with-modifiers-%%
 * since: v1.14
@@ -813,6 +825,8 @@ Optional event-specific initialization properties.
 ### option: Locator.dispatchEvent.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.dispatchEvent.signal = %%-input-signal-%%
+
 ## async method: Locator.dragTo
 * since: v1.18
 
@@ -905,6 +919,8 @@ Locator of the element to drag to.
 ### option: Locator.dragTo.timeout = %%-input-timeout-js-%%
 * since: v1.18
 
+### option: Locator.dragTo.signal = %%-input-signal-%%
+
 ### option: Locator.dragTo.trial = %%-input-trial-%%
 * since: v1.18
 
@@ -965,6 +981,8 @@ await page.locator('#dropzone').drop({
 ### option: Locator.drop.timeout = %%-input-timeout-js-%%
 * since: v1.60
 
+### option: Locator.drop.signal = %%-input-signal-%%
+
 ## async method: Locator.elementHandle
 * since: v1.14
 * discouraged: Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
@@ -977,6 +995,8 @@ Resolves given locator to the first matching DOM element. If there are no matchi
 
 ### option: Locator.elementHandle.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.elementHandle.signal = %%-input-signal-%%
 
 ## async method: Locator.elementHandles
 * since: v1.14
@@ -1255,6 +1275,8 @@ Value to set for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Locator.fill.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.fill.signal = %%-input-signal-%%
+
 ## method: Locator.filter
 * since: v1.22
 - returns: <[Locator]>
@@ -1341,6 +1363,8 @@ Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
 ### option: Locator.focus.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.focus.signal = %%-input-signal-%%
+
 ## method: Locator.frameLocator
 * since: v1.17
 - returns: <[FrameLocator]>
@@ -1399,6 +1423,8 @@ Attribute name to get the value for.
 
 ### option: Locator.getAttribute.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.getAttribute.signal = %%-input-signal-%%
 
 ## method: Locator.getByAltText
 * since: v1.27
@@ -1559,6 +1585,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.hover.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.hover.signal = %%-input-signal-%%
+
 ### option: Locator.hover.trial = %%-input-trial-with-modifiers-%%
 * since: v1.14
 
@@ -1577,6 +1605,8 @@ Returns the [`element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/A
 ### option: Locator.innerHTML.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.innerHTML.signal = %%-input-signal-%%
+
 ## async method: Locator.innerText
 * since: v1.14
 - returns: <[string]>
@@ -1592,6 +1622,8 @@ If you need to assert text on the page, prefer [`method: LocatorAssertions.toHav
 
 ### option: Locator.innerText.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.innerText.signal = %%-input-signal-%%
 
 ## async method: Locator.inputValue
 * since: v1.14
@@ -1635,6 +1667,8 @@ Throws elements that are not an input, textarea or a select. However, if the ele
 ### option: Locator.inputValue.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.inputValue.signal = %%-input-signal-%%
+
 ## async method: Locator.isChecked
 * since: v1.14
 - returns: <[boolean]>
@@ -1672,6 +1706,8 @@ var isChecked = await page.GetByRole(AriaRole.Checkbox).IsCheckedAsync();
 
 ### option: Locator.isChecked.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.isChecked.signal = %%-input-signal-%%
 
 ## async method: Locator.isDisabled
 * since: v1.14
@@ -1711,6 +1747,8 @@ Boolean disabled = await page.GetByRole(AriaRole.Button).IsDisabledAsync();
 ### option: Locator.isDisabled.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.isDisabled.signal = %%-input-signal-%%
+
 ## async method: Locator.isEditable
 * since: v1.14
 - returns: <[boolean]>
@@ -1749,6 +1787,8 @@ Boolean editable = await page.GetByRole(AriaRole.Textbox).IsEditableAsync();
 ### option: Locator.isEditable.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.isEditable.signal = %%-input-signal-%%
+
 ## async method: Locator.isEnabled
 * since: v1.14
 - returns: <[boolean]>
@@ -1786,6 +1826,8 @@ Boolean enabled = await page.GetByRole(AriaRole.Button).IsEnabledAsync();
 
 ### option: Locator.isEnabled.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.isEnabled.signal = %%-input-signal-%%
 
 ## async method: Locator.isHidden
 * since: v1.14
@@ -2095,6 +2137,8 @@ Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 ### option: Locator.press.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.press.signal = %%-input-signal-%%
+
 
 ## async method: Locator.pressSequentially
 * since: v1.38
@@ -2213,6 +2257,8 @@ Use `{{` to type a literal brace character. Defaults to `false`.
 ### option: Locator.pressSequentially.timeout = %%-input-timeout-js-%%
 * since: v1.38
 
+### option: Locator.pressSequentially.signal = %%-input-signal-%%
+
 
 ## async method: Locator.screenshot
 * since: v1.14
@@ -2287,6 +2333,8 @@ Returns the buffer with the captured screenshot.
 ### option: Locator.screenshot.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.screenshot.signal = %%-input-signal-%%
+
 ### option: Locator.screenshot.maskColor = %%-screenshot-option-mask-color-%%
 * since: v1.34
 
@@ -2307,6 +2355,8 @@ See [scrolling](../input.md#scrolling) for alternative ways to scroll.
 
 ### option: Locator.scrollIntoViewIfNeeded.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.scrollIntoViewIfNeeded.signal = %%-input-signal-%%
 
 ## async method: Locator.selectOption
 * since: v1.14
@@ -2396,6 +2446,8 @@ await element.SelectOptionAsync(new[] { "red", "green", "blue" });
 ### option: Locator.selectOption.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.selectOption.signal = %%-input-signal-%%
+
 ### param: Locator.selectOption.element = %%-python-select-options-element-%%
 * since: v1.14
 
@@ -2424,6 +2476,8 @@ If the element is inside the `<label>` element that has an associated [control](
 
 ### option: Locator.selectText.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.selectText.signal = %%-input-signal-%%
 
 ## async method: Locator.setChecked
 * since: v1.15
@@ -2483,6 +2537,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.setChecked.timeout = %%-input-timeout-js-%%
 * since: v1.15
+
+### option: Locator.setChecked.signal = %%-input-signal-%%
 
 ### option: Locator.setChecked.trial = %%-input-trial-%%
 * since: v1.15
@@ -2622,6 +2678,8 @@ This method expects [Locator] to point to an
 ### option: Locator.setInputFiles.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.setInputFiles.signal = %%-input-signal-%%
+
 
 ## async method: Locator.tap
 * since: v1.14
@@ -2662,6 +2720,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.tap.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.tap.signal = %%-input-signal-%%
+
 ### option: Locator.tap.trial = %%-input-trial-with-modifiers-%%
 * since: v1.14
 
@@ -2680,6 +2740,8 @@ If you need to assert text on the page, prefer [`method: LocatorAssertions.toHav
 
 ### option: Locator.textContent.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.textContent.signal = %%-input-signal-%%
 
 ## method: Locator.toString
 * since: v1.57
@@ -2718,6 +2780,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 
 ### option: Locator.type.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.type.signal = %%-input-signal-%%
 
 ## async method: Locator.uncheck
 * since: v1.14
@@ -2775,6 +2839,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.uncheck.timeout = %%-input-timeout-js-%%
 * since: v1.14
+
+### option: Locator.uncheck.signal = %%-input-signal-%%
 
 ### option: Locator.uncheck.trial = %%-input-trial-%%
 * since: v1.14

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -521,6 +521,8 @@ await page.Locator("canvas").ClickAsync(new() {
 ### option: Locator.click.timeout = %%-input-timeout-js-%%
 * since: v1.14
 
+### option: Locator.click.signal = %%-input-signal-%%
+
 ### option: Locator.click.trial = %%-input-trial-with-modifiers-%%
 * since: v1.14
 
@@ -2820,3 +2822,5 @@ orderSent.WaitForAsync();
 
 ### option: Locator.waitFor.timeout = %%-input-timeout-js-%%
 * since: v1.16
+
+### option: Locator.waitFor.signal = %%-input-signal-%%

--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -533,6 +533,9 @@ await Expect(Page.GetByText("Hidden text")).ToBeAttachedAsync();
 ### option: LocatorAssertions.toBeAttached.timeout = %%-js-assertions-timeout-%%
 * since: v1.33
 
+### option: LocatorAssertions.toBeAttached.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toBeAttached.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.33
 
@@ -591,6 +594,9 @@ This option can't be true when [`option: LocatorAssertions.toBeChecked.checked`]
 ### option: LocatorAssertions.toBeChecked.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeChecked.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toBeChecked.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -637,6 +643,9 @@ await Expect(locator).ToBeDisabledAsync();
 
 ### option: LocatorAssertions.toBeDisabled.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeDisabled.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toBeDisabled.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -685,6 +694,9 @@ await Expect(locator).ToBeEditableAsync();
 ### option: LocatorAssertions.toBeEditable.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeEditable.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toBeEditable.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -727,6 +739,9 @@ await Expect(locator).ToBeEmptyAsync();
 
 ### option: LocatorAssertions.toBeEmpty.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeEmpty.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toBeEmpty.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -775,6 +790,9 @@ await Expect(locator).ToBeEnabledAsync();
 ### option: LocatorAssertions.toBeEnabled.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeEnabled.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toBeEnabled.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -818,6 +836,9 @@ await Expect(locator).ToBeFocusedAsync();
 ### option: LocatorAssertions.toBeFocused.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeFocused.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toBeFocused.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -860,6 +881,9 @@ await Expect(locator).ToBeHiddenAsync();
 
 ### option: LocatorAssertions.toBeHidden.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeHidden.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toBeHidden.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -937,6 +961,9 @@ element should intersect viewport at any positive ratio. Defaults to `0`.
 
 ### option: LocatorAssertions.toBeInViewport.timeout = %%-js-assertions-timeout-%%
 * since: v1.31
+
+### option: LocatorAssertions.toBeInViewport.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toBeInViewport.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.31
@@ -1033,6 +1060,9 @@ await Expect(
 
 ### option: LocatorAssertions.toBeVisible.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeVisible.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toBeVisible.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1134,6 +1164,9 @@ A string containing expected class names, separated by spaces, or a list of such
 
 ### option: LocatorAssertions.toContainClass.timeout = %%-js-assertions-timeout-%%
 * since: v1.52
+
+### option: LocatorAssertions.toContainClass.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toContainClass.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.52
@@ -1311,6 +1344,9 @@ Whether to use `element.innerText` instead of `element.textContent` when retriev
 ### option: LocatorAssertions.toContainText.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toContainText.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toContainText.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1357,6 +1393,9 @@ Expected accessible description.
 
 ### option: LocatorAssertions.toHaveAccessibleDescription.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveAccessibleDescription.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveAccessibleDescription.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -1408,6 +1447,9 @@ Expected accessible error message.
 ### option: LocatorAssertions.toHaveAccessibleErrorMessage.timeout = %%-js-assertions-timeout-%%
 * since: v1.50
 
+### option: LocatorAssertions.toHaveAccessibleErrorMessage.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveAccessibleErrorMessage.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.50
 
@@ -1457,6 +1499,9 @@ Expected accessible name.
 
 ### option: LocatorAssertions.toHaveAccessibleName.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveAccessibleName.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveAccessibleName.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -1517,6 +1562,9 @@ Expected attribute value.
 ### option: LocatorAssertions.toHaveAttribute.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveAttribute.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveAttribute.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1545,6 +1593,9 @@ Attribute name.
 
 ### option: LocatorAssertions.toHaveAttribute#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.39
+
+### option: LocatorAssertions.toHaveAttribute#2.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ## async method: LocatorAssertions.toHaveClass
 * since: v1.20
@@ -1646,6 +1697,9 @@ Expected class or RegExp or a list of those.
 ### option: LocatorAssertions.toHaveClass.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveClass.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveClass.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1694,6 +1748,9 @@ Expected count.
 
 ### option: LocatorAssertions.toHaveCount.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveCount.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveCount.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1756,6 +1813,9 @@ Pseudo-element to read computed styles from.
 ### option: LocatorAssertions.toHaveCSS.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveCSS.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveCSS.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1804,6 +1864,9 @@ Element id.
 
 ### option: LocatorAssertions.toHaveId.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveId.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveId.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1861,6 +1924,9 @@ Property value.
 ### option: LocatorAssertions.toHaveJSProperty.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveJSProperty.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveJSProperty.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1906,6 +1972,9 @@ await Expect(locator).ToHaveRoleAsync(AriaRole.Button);
 
 ### option: LocatorAssertions.toHaveRole.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveRole.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveRole.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -2188,6 +2257,9 @@ Whether to use `element.innerText` instead of `element.textContent` when retriev
 ### option: LocatorAssertions.toHaveText.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveText.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveText.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -2238,6 +2310,9 @@ Expected value.
 
 ### option: LocatorAssertions.toHaveValue.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveValue.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toHaveValue.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -2320,6 +2395,9 @@ Expected options currently selected.
 ### option: LocatorAssertions.toHaveValues.timeout = %%-js-assertions-timeout-%%
 * since: v1.23
 
+### option: LocatorAssertions.toHaveValues.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toHaveValues.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.23
 
@@ -2380,6 +2458,9 @@ assertThat(page.locator("body")).matchesAriaSnapshot("""
 ### option: LocatorAssertions.toMatchAriaSnapshot.timeout = %%-js-assertions-timeout-%%
 * since: v1.49
 
+### option: LocatorAssertions.toMatchAriaSnapshot.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: LocatorAssertions.toMatchAriaSnapshot.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.49
 
@@ -2408,6 +2489,9 @@ Generates sequential names if not specified.
 
 ### option: LocatorAssertions.toMatchAriaSnapshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.50
+
+### option: LocatorAssertions.toMatchAriaSnapshot#2.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: LocatorAssertions.toMatchAriaSnapshot#2.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.50

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -760,6 +760,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.check.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.check.signal = %%-input-signal-%%
+
 ### option: Page.check.trial = %%-input-trial-%%
 * since: v1.11
 
@@ -811,6 +813,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.click.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.click.signal = %%-input-signal-%%
 
 ### option: Page.click.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
@@ -914,6 +918,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.dblclick.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.dblclick.signal = %%-input-signal-%%
 
 ### option: Page.dblclick.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
@@ -1022,6 +1028,8 @@ Optional event-specific initialization properties.
 ### option: Page.dispatchEvent.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.dispatchEvent.signal = %%-input-signal-%%
+
 ## async method: Page.dragAndDrop
 * since: v1.13
 
@@ -1099,6 +1107,8 @@ await Page.DragAndDropAsync("#source", "#target", new()
 
 ### option: Page.dragAndDrop.timeout = %%-input-timeout-js-%%
 * since: v1.13
+
+### option: Page.dragAndDrop.signal = %%-input-signal-%%
 
 ### option: Page.dragAndDrop.trial = %%-input-trial-%%
 * since: v1.13
@@ -2061,6 +2071,8 @@ Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
 ### option: Page.fill.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.fill.signal = %%-input-signal-%%
+
 ## async method: Page.focus
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.focus`] instead. Read more about [locators](../locators.md).
@@ -2079,6 +2091,8 @@ This method fetches an element with [`param: selector`] and focuses it. If there
 
 ### option: Page.focus.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.focus.signal = %%-input-signal-%%
 
 ## method: Page.frame
 * since: v1.8
@@ -2236,6 +2250,8 @@ Attribute name to get the value for.
 ### option: Page.getAttribute.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.getAttribute.signal = %%-input-signal-%%
+
 ## method: Page.getByAltText
 * since: v1.27
 - returns: <[Locator]>
@@ -2329,6 +2345,8 @@ Navigate to the previous page in history.
 ### option: Page.goBack.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
 
+### option: Page.goBack.signal = %%-input-signal-%%
+
 ## async method: Page.goForward
 * since: v1.8
 - returns: <[null]|[Response]>
@@ -2399,6 +2417,8 @@ Assert.True(await Page.EvaluateAsync("!globalThis.suspectWeakRef.deref()"));
 ### option: Page.goForward.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
 
+### option: Page.goForward.signal = %%-input-signal-%%
+
 ## async method: Page.goto
 * since: v1.8
 * langs:
@@ -2445,6 +2465,8 @@ it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/We
 
 ### option: Page.goto.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
+
+### option: Page.goto.signal = %%-input-signal-%%
 
 ### option: Page.goto.referer
 * since: v1.8
@@ -2494,6 +2516,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.hover.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.hover.signal = %%-input-signal-%%
+
 ### option: Page.hover.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
 
@@ -2519,6 +2543,8 @@ Returns `element.innerHTML`.
 ### option: Page.innerHTML.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.innerHTML.signal = %%-input-signal-%%
+
 ## async method: Page.innerText
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.innerText`] instead. Read more about [locators](../locators.md).
@@ -2537,6 +2563,8 @@ Returns `element.innerText`.
 
 ### option: Page.innerText.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.innerText.signal = %%-input-signal-%%
 
 ## async method: Page.inputValue
 * since: v1.13
@@ -2559,6 +2587,8 @@ Throws for non-input elements. However, if the element is inside the `<label>` e
 ### option: Page.inputValue.timeout = %%-input-timeout-js-%%
 * since: v1.13
 
+### option: Page.inputValue.signal = %%-input-signal-%%
+
 ## async method: Page.isChecked
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isChecked`] instead. Read more about [locators](../locators.md).
@@ -2577,6 +2607,8 @@ Returns whether the element is checked. Throws if the element is not a checkbox 
 
 ### option: Page.isChecked.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.isChecked.signal = %%-input-signal-%%
 
 ## method: Page.isClosed
 * since: v1.8
@@ -2603,6 +2635,8 @@ Returns whether the element is disabled, the opposite of [enabled](../actionabil
 ### option: Page.isDisabled.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.isDisabled.signal = %%-input-signal-%%
+
 ## async method: Page.isEditable
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isEditable`] instead. Read more about [locators](../locators.md).
@@ -2622,6 +2656,8 @@ Returns whether the element is [editable](../actionability.md#editable).
 ### option: Page.isEditable.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.isEditable.signal = %%-input-signal-%%
+
 ## async method: Page.isEnabled
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isEnabled`] instead. Read more about [locators](../locators.md).
@@ -2640,6 +2676,8 @@ Returns whether the element is [enabled](../actionability.md#enabled).
 
 ### option: Page.isEnabled.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.isEnabled.signal = %%-input-signal-%%
 
 ## async method: Page.isHidden
 * since: v1.8
@@ -3202,6 +3240,8 @@ Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 ### option: Page.press.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.press.signal = %%-input-signal-%%
+
 ## async method: Page.querySelector
 * since: v1.9
 * discouraged: Use locator-based [`method: Page.locator`] instead. Read more about [locators](../locators.md).
@@ -3567,6 +3607,8 @@ last redirect.
 ### option: Page.reload.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
 
+### option: Page.reload.signal = %%-input-signal-%%
+
 ## property: Page.request
 * since: v1.16
 * langs:
@@ -3931,6 +3973,8 @@ Returns the buffer with the captured screenshot.
 ### option: Page.screenshot.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.screenshot.signal = %%-input-signal-%%
+
 ### option: Page.screenshot.fullPage = %%-screenshot-option-full-page-%%
 * since: v1.8
 
@@ -4027,6 +4071,8 @@ await page.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" });
 ### option: Page.selectOption.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.selectOption.signal = %%-input-signal-%%
+
 ### param: Page.selectOption.element = %%-python-select-options-element-%%
 * since: v1.8
 
@@ -4081,6 +4127,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.setChecked.timeout = %%-input-timeout-js-%%
 * since: v1.15
 
+### option: Page.setChecked.signal = %%-input-signal-%%
+
 ### option: Page.setChecked.trial = %%-input-trial-%%
 * since: v1.15
 
@@ -4100,6 +4148,8 @@ HTML markup to assign to the page.
 
 ### option: Page.setContent.timeout = %%-navigation-timeout-js-%%
 * since: v1.8
+
+### option: Page.setContent.signal = %%-input-signal-%%
 
 ### option: Page.setContent.waitUntil = %%-navigation-wait-until-%%
 * since: v1.8
@@ -4186,6 +4236,8 @@ This method expects [`param: selector`] to point to an
 ### option: Page.setInputFiles.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.setInputFiles.signal = %%-input-signal-%%
+
 ## async method: Page.setViewportSize
 * since: v1.8
 
@@ -4269,6 +4321,8 @@ When set to `"ai"`, returns a snapshot optimized for AI consumption: including e
 ### option: Page.ariaSnapshot.timeout = %%-input-timeout-js-%%
 * since: v1.59
 
+### option: Page.ariaSnapshot.signal = %%-input-signal-%%
+
 ### option: Page.ariaSnapshot.depth
 * since: v1.59
 - `depth` <[int]>
@@ -4326,6 +4380,8 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.tap.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.tap.signal = %%-input-signal-%%
+
 ### option: Page.tap.trial = %%-input-trial-with-modifiers-%%
 * since: v1.11
 
@@ -4347,6 +4403,8 @@ Returns `element.textContent`.
 
 ### option: Page.textContent.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.textContent.signal = %%-input-signal-%%
 
 ## async method: Page.title
 * since: v1.8
@@ -4396,6 +4454,8 @@ Time to wait between key presses in milliseconds. Defaults to 0.
 ### option: Page.type.timeout = %%-input-timeout-js-%%
 * since: v1.8
 
+### option: Page.type.signal = %%-input-signal-%%
+
 ## async method: Page.uncheck
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.uncheck`] instead. Read more about [locators](../locators.md).
@@ -4434,6 +4494,8 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.uncheck.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.uncheck.signal = %%-input-signal-%%
 
 ### option: Page.uncheck.trial = %%-input-trial-%%
 * since: v1.11
@@ -4802,6 +4864,8 @@ Optional argument to pass to [`param: expression`].
 
 ### option: Page.waitForFunction.timeout = %%-wait-for-function-timeout-js-%%
 * since: v1.8
+
+### option: Page.waitForFunction.signal = %%-input-signal-%%
 
 ## async method: Page.waitForLoadState
 * since: v1.8
@@ -5412,6 +5476,8 @@ class FrameExamples
 
 ### option: Page.waitForSelector.timeout = %%-input-timeout-js-%%
 * since: v1.8
+
+### option: Page.waitForSelector.signal = %%-input-signal-%%
 
 ## async method: Page.waitForCondition
 * since: v1.32

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -183,6 +183,9 @@ assertThat(page).matchesAriaSnapshot("""
 ### option: PageAssertions.toMatchAriaSnapshot.timeout = %%-js-assertions-timeout-%%
 * since: v1.60
 
+### option: PageAssertions.toMatchAriaSnapshot.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: PageAssertions.toMatchAriaSnapshot.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.60
 
@@ -224,6 +227,9 @@ Generates sequential names if not specified.
 
 ### option: PageAssertions.toMatchAriaSnapshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.60
+
+### option: PageAssertions.toMatchAriaSnapshot#2.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ## async method: PageAssertions.toHaveScreenshot#1
 * since: v1.23
@@ -385,6 +391,9 @@ Expected title or RegExp.
 ### option: PageAssertions.toHaveTitle.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: PageAssertions.toHaveTitle.signal = %%-js-assertions-signal-%%
+* since: v1.61
+
 ### option: PageAssertions.toHaveTitle.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -462,6 +471,9 @@ Whether to perform case-insensitive match. [`option: ignoreCase`] option takes p
 
 ### option: PageAssertions.toHaveURL.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: PageAssertions.toHaveURL.signal = %%-js-assertions-signal-%%
+* since: v1.61
 
 ### option: PageAssertions.toHaveURL.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1020,6 +1020,14 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
 
 Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
 
+## js-assertions-signal
+* langs: js
+* since: v1.61
+- `signal` <[AbortSignal]>
+
+Allows to cancel the assertion using an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the assertion will be aborted and throw an error.
+Note that providing a signal does not disable the default timeout; pass `timeout: 0` to disable the timeout entirely.
+
 ## csharp-java-python-assertions-timeout
 * langs: java, python, csharp
 - `timeout` <[float]>

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -999,6 +999,14 @@ The default value can be changed by using the [`method: BrowserContext.setDefaul
 Allows to cancel the waiting using an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the waiting will be aborted and the operation will throw an error.
 Note that providing a signal does not disable the default timeout; pass `timeout: 0` to disable the timeout entirely.
 
+## input-signal
+* langs: js
+* since: v1.61
+- `signal` <[AbortSignal]>
+
+Allows to cancel the operation using an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the operation will be aborted and throw an error.
+Note that providing a signal does not disable the default timeout; pass `timeout: 0` to disable the timeout entirely.
+
 ## android-timeout
 * langs: js
 - `timeout` <[float]>

--- a/packages/isomorphic/manualPromise.ts
+++ b/packages/isomorphic/manualPromise.ts
@@ -123,6 +123,22 @@ export function signalToPromise(signal: AbortSignal): { promise: Promise<void>, 
   return { promise, dispose: () => {} };
 }
 
+export async function raceAgainstAbortSignal<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal)
+    return await promise;
+  let dispose: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    const abortListener = () => reject(signal.reason);
+    signal.addEventListener('abort', abortListener, { once: true });
+    dispose = () => signal.removeEventListener('abort', abortListener);
+  });
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } finally {
+    dispose?.();
+  }
+}
+
 function cloneError(error: Error, frames: string[]) {
   const clone = new Error();
   clone.name = error.name;

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -13423,6 +13423,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -15383,6 +15391,14 @@ export interface Locator {
    * @param options
    */
   waitFor(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Defaults to `'visible'`. Can be either:
      * - `'attached'` - wait for element to be present in DOM.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2071,6 +2071,14 @@ export interface Page {
     mode?: "ai"|"default";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -2137,6 +2145,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2244,6 +2260,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2385,6 +2409,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2456,6 +2488,14 @@ export interface Page {
    */
   dispatchEvent(selector: string, type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2502,6 +2542,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -2703,6 +2751,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2730,6 +2786,14 @@ export interface Page {
    * @param options
    */
   focus(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -2807,6 +2871,14 @@ export interface Page {
    * @param options
    */
   getAttribute(selector: string, name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3156,6 +3228,14 @@ export interface Page {
    */
   goBack(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
      * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
@@ -3185,6 +3265,14 @@ export interface Page {
    * @param options
    */
   goForward(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -3241,6 +3329,14 @@ export interface Page {
      * [page.setExtraHTTPHeaders(headers)](https://playwright.dev/docs/api/class-page#page-set-extra-http-headers).
      */
     referer?: string;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
@@ -3324,6 +3420,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3357,6 +3461,14 @@ export interface Page {
    */
   innerHTML(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3381,6 +3493,14 @@ export interface Page {
    * @param options
    */
   innerText(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3412,6 +3532,14 @@ export interface Page {
    */
   inputValue(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3436,6 +3564,14 @@ export interface Page {
    * @param options
    */
   isChecked(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3468,6 +3604,14 @@ export interface Page {
    */
   isDisabled(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3494,6 +3638,14 @@ export interface Page {
    */
   isEditable(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3518,6 +3670,14 @@ export interface Page {
    * @param options
    */
   isEnabled(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3913,6 +4073,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3934,6 +4102,14 @@ export interface Page {
    * @param options
    */
   reload(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -4241,6 +4417,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4307,6 +4491,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4334,6 +4526,14 @@ export interface Page {
    * @param options
    */
   setContent(html: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -4458,6 +4658,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4568,6 +4776,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4601,6 +4817,14 @@ export interface Page {
    * @param options
    */
   textContent(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -4650,6 +4874,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -4714,6 +4946,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6237,6 +6477,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6331,6 +6579,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6429,6 +6685,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6500,6 +6764,14 @@ export interface Frame {
    */
   dispatchEvent(selector: string, type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6532,6 +6804,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -6614,6 +6894,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6641,6 +6929,14 @@ export interface Frame {
    * @param options
    */
   focus(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -6706,6 +7002,14 @@ export interface Frame {
    * @param options
    */
   getAttribute(selector: string, name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7079,6 +7383,14 @@ export interface Frame {
     referer?: string;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
      * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
@@ -7155,6 +7467,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7188,6 +7508,14 @@ export interface Frame {
    */
   innerHTML(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7212,6 +7540,14 @@ export interface Frame {
    * @param options
    */
   innerText(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7243,6 +7579,14 @@ export interface Frame {
    */
   inputValue(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7267,6 +7611,14 @@ export interface Frame {
    * @param options
    */
   isChecked(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7299,6 +7651,14 @@ export interface Frame {
    */
   isDisabled(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7325,6 +7685,14 @@ export interface Frame {
    */
   isEditable(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7346,6 +7714,14 @@ export interface Frame {
    * @param options
    */
   isEnabled(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7528,6 +7904,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7623,6 +8007,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7689,6 +8081,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7716,6 +8116,14 @@ export interface Frame {
    * @param options
    */
   setContent(html: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -7793,6 +8201,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7864,6 +8280,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7897,6 +8321,14 @@ export interface Frame {
    * @param options
    */
   textContent(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7946,6 +8378,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -8010,6 +8450,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -11712,6 +12160,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -11794,6 +12250,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11883,6 +12347,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11983,6 +12455,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12057,6 +12537,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12213,6 +12701,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12296,6 +12792,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     scale?: "css"|"device";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make
      * elements invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces
      * the Shadow DOM and applies to the inner frames.
@@ -12332,6 +12836,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    * @param options
    */
   scrollIntoViewIfNeeded(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -12419,6 +12931,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12445,6 +12965,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
     force?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12499,6 +13027,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12569,6 +13105,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12629,6 +13173,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12678,6 +13230,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12733,6 +13293,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12771,6 +13339,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    * @param options
    */
   waitForElementState(state: "visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable", options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13148,6 +13724,14 @@ export interface Locator {
     mode?: "ai"|"default";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13161,6 +13745,14 @@ export interface Locator {
    * @param options
    */
   blur(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13197,6 +13789,14 @@ export interface Locator {
    * @param options
    */
   boundingBox(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13278,6 +13878,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13324,6 +13932,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13554,6 +14170,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -13658,6 +14282,14 @@ export interface Locator {
    */
   dispatchEvent(type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13702,6 +14334,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -13827,6 +14467,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13878,6 +14526,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13959,6 +14615,14 @@ export interface Locator {
    */
   focus(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13993,6 +14657,14 @@ export interface Locator {
    * @param options
    */
   getAttribute(name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14389,6 +15061,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14411,6 +15091,14 @@ export interface Locator {
    */
   innerHTML(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14431,6 +15119,14 @@ export interface Locator {
    * @param options
    */
   innerText(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14463,6 +15159,14 @@ export interface Locator {
    */
   inputValue(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14488,6 +15192,14 @@ export interface Locator {
    */
   isChecked(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14512,6 +15224,14 @@ export interface Locator {
    * @param options
    */
   isDisabled(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14540,6 +15260,14 @@ export interface Locator {
    */
   isEditable(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14564,6 +15292,14 @@ export interface Locator {
    * @param options
    */
   isEnabled(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14787,6 +15523,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14857,6 +15601,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14903,6 +15655,14 @@ export interface Locator {
    * @param options
    */
   scrollIntoViewIfNeeded(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14998,6 +15758,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15020,6 +15788,14 @@ export interface Locator {
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
     force?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15079,6 +15855,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15175,6 +15959,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15237,6 +16029,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15263,6 +16063,14 @@ export interface Locator {
    * @param options
    */
   textContent(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -15298,6 +16106,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15357,6 +16173,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -19897,6 +20721,14 @@ export interface FileChooser {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -24123,6 +24955,14 @@ export interface LocatorScreenshotOptions {
   scale?: "css"|"device";
 
   /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
+  /**
    * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make
    * elements invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces
    * the Shadow DOM and applies to the inner frames.
@@ -24144,6 +24984,14 @@ export interface LocatorScreenshotOptions {
 }
 
 interface ElementHandleWaitForSelectorOptions {
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
   /**
    * Defaults to `'visible'`. Can be either:
    * - `'attached'` - wait for element to be present in DOM.
@@ -24661,6 +25509,14 @@ export interface Cookie {
 
 interface PageWaitForSelectorOptions {
   /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
+  /**
    * Defaults to `'visible'`. Can be either:
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
@@ -24695,6 +25551,14 @@ interface PageWaitForFunctionOptions {
    * is treated as an interval in milliseconds at which the function would be executed. Defaults to `raf`.
    */
   polling?: number|"raf";
+
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
 
   /**
    * Maximum time to wait for in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
@@ -24794,6 +25658,14 @@ export interface PageScreenshotOptions {
    * Defaults to `"device"`.
    */
   scale?: "css"|"device";
+
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
 
   /**
    * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -152,16 +152,17 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
             return async (params: any) => {
               return await this._wrapApiCall(async apiZone => {
                 const validatedParams = validator(params, '', this._validatorToWireContext());
+                const signal = params?.signal as AbortSignal | undefined;
                 if (!apiZone.internal && !apiZone.reported) {
                   // Reporting/tracing/logging this api call for the first time.
                   apiZone.reported = true;
                   this._instrumentation.onApiCallBegin(apiZone, { type: this._type, method: prop, params });
                   logApiCall(this._platform, this._logger, `=> ${apiZone.apiName} started`);
-                  return await this._connection.sendMessageToServer(this, prop, validatedParams, apiZone);
+                  return await this._connection.sendMessageToServer(this, prop, validatedParams, { ...apiZone, signal });
                 }
                 // Since this api call is either internal, or has already been reported/traced once,
                 // passing as internal.
-                return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true });
+                return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true, signal });
               }, { internal });
             };
           }

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -171,7 +171,7 @@ export class Connection extends EventEmitter {
       this._tracingCount--;
   }
 
-  async sendMessageToServer(object: ChannelOwner, method: string, params: any, options: { apiName?: string, title?: string, internal?: boolean, frames?: channels.StackFrame[], stepId?: string }): Promise<any> {
+  async sendMessageToServer(object: ChannelOwner, method: string, params: any, options: { apiName?: string, title?: string, internal?: boolean, frames?: channels.StackFrame[], stepId?: string, signal?: AbortSignal }): Promise<any> {
     // Fire-and-forget: server intentionally never replies to __waitInfo__,
     // so silently drop it after the connection is closed or the object was collected.
     if (method === '__waitInfo__' && (this._closedError || object._wasCollected))
@@ -180,6 +180,10 @@ export class Connection extends EventEmitter {
       throw this._closedError;
     if (object._wasCollected)
       throw new Error('The object has been collected to prevent unbounded heap growth.');
+
+    const signal = options.signal;
+    if (signal?.aborted)
+      throw signal.reason;
 
     const guid = object._guid;
     const type = object._type;
@@ -199,7 +203,20 @@ export class Connection extends EventEmitter {
     // Fire-and-forget: server intentionally never replies to __waitInfo__.
     if (method === '__waitInfo__')
       return;
-    return await new Promise((resolve, reject) => this._callbacks.set(id, { resolve, reject, title: options.title, type, method }));
+    let abortListener: (() => void) | undefined;
+    if (signal) {
+      abortListener = () => {
+        const reason = signal.reason instanceof Error ? signal.reason.message : String(signal.reason);
+        this._platform.zones.empty.run(() => this.onmessage({ guid, method: '__cancel__', params: { id, reason } }));
+      };
+      signal.addEventListener('abort', abortListener, { once: true });
+    }
+    try {
+      return await new Promise((resolve, reject) => this._callbacks.set(id, { resolve, reject, title: options.title, type, method }));
+    } finally {
+      if (abortListener)
+        signal!.removeEventListener('abort', abortListener);
+    }
   }
 
   private _validatorFromWireContext(): ValidatorContext {

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -17,6 +17,7 @@
 
 import { assert } from '@isomorphic/assert';
 import { getByAltTextSelector, getByLabelSelector, getByPlaceholderSelector, getByRoleSelector, getByTestIdSelector, getByTextSelector, getByTitleSelector } from '@isomorphic/locatorUtils';
+import { raceAgainstAbortSignal } from '@isomorphic/manualPromise';
 import { urlMatches } from '@isomorphic/urlMatch';
 import { EventEmitter } from './eventEmitter';
 import { ChannelOwner } from './channelOwner';
@@ -490,10 +491,13 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return (await this._channel.title()).value;
   }
 
-  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'>): Promise<ExpectResult> {
-    const params: channels.FrameExpectParams = { expression, ...options, isNot: !!options.isNot };
+  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'> & { signal?: AbortSignal }): Promise<ExpectResult> {
+    const { signal, ...expectOptions } = options;
+    const params: channels.FrameExpectParams = { expression, ...expectOptions, isNot: !!options.isNot };
     params.expectedValue = serializeArgument(options.expectedValue);
-    const channelResult = await this._channel.expect(params);
+    if (signal?.aborted)
+      throw signal.reason;
+    const channelResult = await raceAgainstAbortSignal(this._channel.expect({ ...params, ...{ signal } }), signal);
     const result: ExpectResult = {
       matches: channelResult.matches,
       log: channelResult.log,

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -74,12 +74,12 @@ export class Locator implements api.Locator {
       (this as any)[this._frame._platform.inspectCustom] = () => this._inspect();
   }
 
-  private async _withElement<R>(task: (handle: ElementHandle<SVGElement | HTMLElement>, timeout?: number) => Promise<R>, options: { title: string, internal?: boolean, timeout?: number }): Promise<R> {
+  private async _withElement<R>(task: (handle: ElementHandle<SVGElement | HTMLElement>, timeout?: number) => Promise<R>, options: { title: string, internal?: boolean, timeout?: number, signal?: AbortSignal }): Promise<R> {
     const timeout = this._frame._timeout({ timeout: options.timeout });
     const deadline = timeout ? monotonicTime() + timeout : 0;
 
     return await this._frame._wrapApiCall<R>(async () => {
-      const result = await this._frame._channel.waitForSelector({ selector: this._selector, strict: true, state: 'attached', timeout });
+      const result = await this._frame._channel.waitForSelector({ selector: this._selector, strict: true, state: 'attached', timeout, ...{ signal: options.signal } });
       const handle = ElementHandle.fromNullable(result.element) as ElementHandle<SVGElement | HTMLElement> | null;
       if (!handle)
         throw new Error(`Could not resolve ${this._selector} to DOM Element`);
@@ -100,7 +100,7 @@ export class Locator implements api.Locator {
   }
 
   async boundingBox(options?: TimeoutOptions): Promise<Rect | null> {
-    return await this._withElement(h => h.boundingBox(), { title: 'Bounding box', timeout: options?.timeout });
+    return await this._withElement(h => h.boundingBox(), { title: 'Bounding box', timeout: options?.timeout, signal: options?.signal });
   }
 
   async check(options: channels.ElementHandleCheckOptions & TimeoutOptions = {}) {
@@ -321,16 +321,16 @@ export class Locator implements api.Locator {
 
   async screenshot(options: Omit<channels.ElementHandleScreenshotOptions, 'mask'> & TimeoutOptions & { path?: string, mask?: api.Locator[] } = {}): Promise<Buffer> {
     const mask = options.mask as Locator[] | undefined;
-    return await this._withElement((h, timeout) => h.screenshot({ ...options, mask, timeout }), { title: 'Screenshot', timeout: options.timeout });
+    return await this._withElement((h, timeout) => h.screenshot({ ...options, mask, timeout }), { title: 'Screenshot', timeout: options.timeout, signal: options.signal });
   }
 
   async ariaSnapshot(options: TimeoutOptions & { mode?: 'ai' | 'default', depth?: number, boxes?: boolean } = {}): Promise<string> {
-    const result = await this._frame._channel.ariaSnapshot({ timeout: this._frame._timeout(options), mode: options.mode, selector: this._selector, depth: options.depth, boxes: options.boxes });
+    const result = await this._frame._channel.ariaSnapshot({ timeout: this._frame._timeout(options), mode: options.mode, selector: this._selector, depth: options.depth, boxes: options.boxes, ...{ signal: options.signal } });
     return result.snapshot;
   }
 
   async scrollIntoViewIfNeeded(options: channels.ElementHandleScrollIntoViewIfNeededOptions & TimeoutOptions = {}) {
-    return await this._withElement((h, timeout) => h.scrollIntoViewIfNeeded({ ...options, timeout }), { title: 'Scroll into view', timeout: options.timeout });
+    return await this._withElement((h, timeout) => h.scrollIntoViewIfNeeded({ ...options, timeout }), { title: 'Scroll into view', timeout: options.timeout, signal: options.signal });
   }
 
   async selectOption(values: string | api.ElementHandle | SelectOption | string[] | api.ElementHandle[] | SelectOption[] | null, options: SelectOptionOptions = {}): Promise<string[]> {
@@ -338,7 +338,7 @@ export class Locator implements api.Locator {
   }
 
   async selectText(options: channels.ElementHandleSelectTextOptions & TimeoutOptions = {}): Promise<void> {
-    return await this._withElement((h, timeout) => h.selectText({ ...options, timeout }), { title: 'Select text', timeout: options.timeout });
+    return await this._withElement((h, timeout) => h.selectText({ ...options, timeout }), { title: 'Select text', timeout: options.timeout, signal: options.signal });
   }
 
   async setChecked(checked: boolean, options?: channels.ElementHandleCheckOptions & TimeoutOptions) {

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -876,7 +876,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   }
 
   async ariaSnapshot(options: TimeoutOptions & { mode?: 'ai' | 'default', depth?: number, boxes?: boolean, _track?: string } = {}): Promise<string> {
-    const result = await this.mainFrame()._channel.ariaSnapshot({ timeout: this._timeoutSettings.timeout(options), track: options._track, mode: options.mode, depth: options.depth, boxes: options.boxes });
+    const result = await this.mainFrame()._channel.ariaSnapshot({ timeout: this._timeoutSettings.timeout(options), track: options._track, mode: options.mode, depth: options.depth, boxes: options.boxes, ...{ signal: options.signal } });
     return result.snapshot;
   }
 

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -146,4 +146,4 @@ export type AnnotateOptions = { duration?: number, position?: AnnotatePosition, 
 export type RemoteAddr = channels.RemoteAddr;
 export type SecurityDetails = channels.SecurityDetails;
 
-export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any };
+export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any, signal?: AbortSignal };

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -55,7 +55,7 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
   private _dispatchers = new Map<string, DispatcherScope>();
   protected _disposed = false;
   protected _eventListeners: RegisteredListener[] = [];
-  private _activeProgressControllers = new Set<ProgressController>();
+  readonly _activeProgressControllers = new Map<string, ProgressController>();
 
   readonly _guid: string;
   readonly _type: string;
@@ -105,11 +105,11 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
 
   async _runCommand(callMetadata: CallMetadata, method: string, validParams: any) {
     const controller = ProgressController.createForSdkObject(this._object, callMetadata);
-    this._activeProgressControllers.add(controller);
+    this._activeProgressControllers.set(callMetadata.id, controller);
     try {
       return await controller.run(progress => (this as any)[method](validParams, progress), validParams?.timeout);
     } finally {
-      this._activeProgressControllers.delete(controller);
+      this._activeProgressControllers.delete(callMetadata.id);
     }
   }
 
@@ -134,7 +134,7 @@ export class Dispatcher<Type extends SdkObject, ChannelType, ParentScopeType ext
   async stopPendingOperations(error: Error) {
     const controllers: ProgressController[] = [];
     const collect = (dispatcher: DispatcherScope) => {
-      controllers.push(...dispatcher._activeProgressControllers);
+      controllers.push(...dispatcher._activeProgressControllers.values());
       for (const child of [...dispatcher._dispatchers.values()])
         collect(child);
     };
@@ -298,6 +298,10 @@ export class DispatcherConnection {
       // Fire-and-forget: silently drop if the target is gone.
       if (dispatcher)
         await this._dispatchWaitInfo(id, dispatcher, params, metadata);
+      return;
+    }
+    if (method === '__cancel__') {
+      await dispatcher?._activeProgressControllers.get(`call@${params.id}`)?.abort(new Error(params.reason));
       return;
     }
     if (!dispatcher) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -13423,6 +13423,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -15383,6 +15391,14 @@ export interface Locator {
    * @param options
    */
   waitFor(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Defaults to `'visible'`. Can be either:
      * - `'attached'` - wait for element to be present in DOM.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2071,6 +2071,14 @@ export interface Page {
     mode?: "ai"|"default";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -2137,6 +2145,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2244,6 +2260,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2385,6 +2409,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2456,6 +2488,14 @@ export interface Page {
    */
   dispatchEvent(selector: string, type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2502,6 +2542,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -2703,6 +2751,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2730,6 +2786,14 @@ export interface Page {
    * @param options
    */
   focus(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -2807,6 +2871,14 @@ export interface Page {
    * @param options
    */
   getAttribute(selector: string, name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3156,6 +3228,14 @@ export interface Page {
    */
   goBack(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
      * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
@@ -3185,6 +3265,14 @@ export interface Page {
    * @param options
    */
   goForward(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -3241,6 +3329,14 @@ export interface Page {
      * [page.setExtraHTTPHeaders(headers)](https://playwright.dev/docs/api/class-page#page-set-extra-http-headers).
      */
     referer?: string;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
@@ -3324,6 +3420,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3357,6 +3461,14 @@ export interface Page {
    */
   innerHTML(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3381,6 +3493,14 @@ export interface Page {
    * @param options
    */
   innerText(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3412,6 +3532,14 @@ export interface Page {
    */
   inputValue(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3436,6 +3564,14 @@ export interface Page {
    * @param options
    */
   isChecked(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3468,6 +3604,14 @@ export interface Page {
    */
   isDisabled(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3494,6 +3638,14 @@ export interface Page {
    */
   isEditable(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3518,6 +3670,14 @@ export interface Page {
    * @param options
    */
   isEnabled(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -3913,6 +4073,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -3934,6 +4102,14 @@ export interface Page {
    * @param options
    */
   reload(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -4241,6 +4417,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4307,6 +4491,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4334,6 +4526,14 @@ export interface Page {
    * @param options
    */
   setContent(html: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -4458,6 +4658,14 @@ export interface Page {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4568,6 +4776,14 @@ export interface Page {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4601,6 +4817,14 @@ export interface Page {
    * @param options
    */
   textContent(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -4650,6 +4874,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -4714,6 +4946,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6237,6 +6477,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6331,6 +6579,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6429,6 +6685,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6500,6 +6764,14 @@ export interface Frame {
    */
   dispatchEvent(selector: string, type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6532,6 +6804,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -6614,6 +6894,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6641,6 +6929,14 @@ export interface Frame {
    * @param options
    */
   focus(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -6706,6 +7002,14 @@ export interface Frame {
    * @param options
    */
   getAttribute(selector: string, name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7079,6 +7383,14 @@ export interface Frame {
     referer?: string;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
      * [browserContext.setDefaultNavigationTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout),
@@ -7155,6 +7467,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7188,6 +7508,14 @@ export interface Frame {
    */
   innerHTML(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7212,6 +7540,14 @@ export interface Frame {
    * @param options
    */
   innerText(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7243,6 +7579,14 @@ export interface Frame {
    */
   inputValue(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7267,6 +7611,14 @@ export interface Frame {
    * @param options
    */
   isChecked(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7299,6 +7651,14 @@ export interface Frame {
    */
   isDisabled(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7325,6 +7685,14 @@ export interface Frame {
    */
   isEditable(selector: string, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7346,6 +7714,14 @@ export interface Frame {
    * @param options
    */
   isEnabled(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7528,6 +7904,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7623,6 +8007,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7689,6 +8081,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7716,6 +8116,14 @@ export interface Frame {
    * @param options
    */
   setContent(html: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum operation time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
      * `navigationTimeout` option in the config, or by using the
@@ -7793,6 +8201,14 @@ export interface Frame {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7864,6 +8280,14 @@ export interface Frame {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7897,6 +8321,14 @@ export interface Frame {
    * @param options
    */
   textContent(selector: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
@@ -7946,6 +8378,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -8010,6 +8450,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -11712,6 +12160,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -11794,6 +12250,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11883,6 +12347,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11983,6 +12455,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12057,6 +12537,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12213,6 +12701,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12296,6 +12792,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     scale?: "css"|"device";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make
      * elements invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces
      * the Shadow DOM and applies to the inner frames.
@@ -12332,6 +12836,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    * @param options
    */
   scrollIntoViewIfNeeded(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -12419,6 +12931,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12445,6 +12965,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
     force?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12499,6 +13027,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12569,6 +13105,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12629,6 +13173,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12678,6 +13230,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12733,6 +13293,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12771,6 +13339,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    * @param options
    */
   waitForElementState(state: "visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable", options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13148,6 +13724,14 @@ export interface Locator {
     mode?: "ai"|"default";
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13161,6 +13745,14 @@ export interface Locator {
    * @param options
    */
   blur(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13197,6 +13789,14 @@ export interface Locator {
    * @param options
    */
   boundingBox(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -13278,6 +13878,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13324,6 +13932,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13554,6 +14170,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -13658,6 +14282,14 @@ export interface Locator {
    */
   dispatchEvent(type: string, eventInit?: EvaluationArgument, options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13702,6 +14334,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -13827,6 +14467,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13878,6 +14526,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13959,6 +14615,14 @@ export interface Locator {
    */
   focus(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13993,6 +14657,14 @@ export interface Locator {
    * @param options
    */
   getAttribute(name: string, options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14389,6 +15061,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14411,6 +15091,14 @@ export interface Locator {
    */
   innerHTML(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14431,6 +15119,14 @@ export interface Locator {
    * @param options
    */
   innerText(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14463,6 +15159,14 @@ export interface Locator {
    */
   inputValue(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14488,6 +15192,14 @@ export interface Locator {
    */
   isChecked(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14512,6 +15224,14 @@ export interface Locator {
    * @param options
    */
   isDisabled(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14540,6 +15260,14 @@ export interface Locator {
    */
   isEditable(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14564,6 +15292,14 @@ export interface Locator {
    * @param options
    */
   isEnabled(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14787,6 +15523,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14857,6 +15601,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -14903,6 +15655,14 @@ export interface Locator {
    * @param options
    */
   scrollIntoViewIfNeeded(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -14998,6 +15758,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15020,6 +15788,14 @@ export interface Locator {
      * Whether to bypass the [actionability](https://playwright.dev/docs/actionability) checks. Defaults to `false`.
      */
     force?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15079,6 +15855,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15175,6 +15959,14 @@ export interface Locator {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15237,6 +16029,14 @@ export interface Locator {
     };
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15263,6 +16063,14 @@ export interface Locator {
    * @param options
    */
   textContent(options?: {
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
@@ -15298,6 +16106,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -15357,6 +16173,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -19897,6 +20721,14 @@ export interface FileChooser {
     noWaitAfter?: boolean;
 
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -24123,6 +24955,14 @@ export interface LocatorScreenshotOptions {
   scale?: "css"|"device";
 
   /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
+  /**
    * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make
    * elements invisible or change their properties to help you creating repeatable screenshots. This stylesheet pierces
    * the Shadow DOM and applies to the inner frames.
@@ -24144,6 +24984,14 @@ export interface LocatorScreenshotOptions {
 }
 
 interface ElementHandleWaitForSelectorOptions {
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
   /**
    * Defaults to `'visible'`. Can be either:
    * - `'attached'` - wait for element to be present in DOM.
@@ -24661,6 +25509,14 @@ export interface Cookie {
 
 interface PageWaitForSelectorOptions {
   /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
+
+  /**
    * Defaults to `'visible'`. Can be either:
    * - `'attached'` - wait for element to be present in DOM.
    * - `'detached'` - wait for element to not be present in DOM.
@@ -24695,6 +25551,14 @@ interface PageWaitForFunctionOptions {
    * is treated as an interval in milliseconds at which the function would be executed. Defaults to `raf`.
    */
   polling?: number|"raf";
+
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
 
   /**
    * Maximum time to wait for in milliseconds. Defaults to `0` - no timeout. The default value can be changed via
@@ -24794,6 +25658,14 @@ export interface PageScreenshotOptions {
    * Defaults to `"device"`.
    */
   scale?: "css"|"device";
+
+  /**
+   * Allows to cancel the operation using an
+   * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+   * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+   * pass `timeout: 0` to disable the timeout entirely.
+   */
+  signal?: AbortSignal;
 
   /**
    * Text of the stylesheet to apply while making the screenshot. This is where you can hide dynamic elements, make

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -61,20 +61,20 @@ interface APIResponseEx extends APIResponse {
 export function toBeAttached(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { attached?: boolean, timeout?: number },
+  options?: { attached?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const attached = !options || options.attached === undefined || options.attached;
   const expected = attached ? 'attached' : 'detached';
   const arg = attached ? '' : '{ attached: false }';
-  return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeChecked(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { checked?: boolean, indeterminate?: boolean, timeout?: number },
+  options?: { checked?: boolean, indeterminate?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const checked = options?.checked;
   const indeterminate = options?.indeterminate;
@@ -91,97 +91,97 @@ export function toBeChecked(
     expected = options?.checked === false ? 'unchecked' : 'checked';
     arg = options?.checked === false ? `{ checked: false }` : '';
   }
-  return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue });
+  return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue, signal });
   }, options);
 }
 
 export function toBeDisabled(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.disabled', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.disabled', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeEditable(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { editable?: boolean, timeout?: number },
+  options?: { editable?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const editable = !options || options.editable === undefined || options.editable;
   const expected = editable ? 'editable' : 'readOnly';
   const arg = editable ? '' : '{ editable: false }';
-  return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeEmpty(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.empty', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.empty', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeEnabled(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { enabled?: boolean, timeout?: number },
+  options?: { enabled?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const enabled = !options || options.enabled === undefined || options.enabled;
   const expected = enabled ? 'enabled' : 'disabled';
   const arg = enabled ? '' : '{ enabled: false }';
-  return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeFocused(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.focused', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.focused', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeHidden(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.hidden', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.hidden', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeVisible(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { visible?: boolean, timeout?: number },
+  options?: { visible?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const visible = !options || options.visible === undefined || options.visible;
   const expected = visible ? 'visible' : 'hidden';
   const arg = visible ? '' : '{ visible: false }';
-  return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout });
+  return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout, signal });
   }, options);
 }
 
 export function toBeInViewport(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number, ratio?: number },
+  options?: { timeout?: number, ratio?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout });
+  return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout, signal });
   }, options);
 }
 
@@ -189,17 +189,17 @@ export function toContainText(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, signal?: AbortSignal } = {},
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout });
+      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
     }, expected, { ...options, contains: true });
   } else {
-    return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout });
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
     }, expected, { ...options, matchSubstring: true });
   }
 }
@@ -208,11 +208,11 @@ export function toHaveAccessibleDescription(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -220,11 +220,11 @@ export function toHaveAccessibleName(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -232,11 +232,11 @@ export function toHaveAccessibleErrorMessage(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number; ignoreCase?: boolean },
+  options?: { timeout?: number; ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout });
+    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -244,8 +244,8 @@ export function toHaveAttribute(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   name: string,
-  expected: string | RegExp | undefined | { timeout?: number },
-  options?: { timeout?: number, ignoreCase?: boolean },
+  expected: string | RegExp | undefined | { timeout?: number, signal?: AbortSignal },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
   if (!options) {
     // Update params for the case toHaveAttribute(name, options);
@@ -255,13 +255,13 @@ export function toHaveAttribute(
     }
   }
   if (expected === undefined) {
-    return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout) => {
-      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout });
+    return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout, signal) => {
+      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout, signal });
     }, options);
   }
-  return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected as (string | RegExp)], { ignoreCase: options?.ignoreCase });
-    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout });
+    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout, signal });
   }, expected as (string | RegExp), options);
 }
 
@@ -269,17 +269,17 @@ export function toHaveClass(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout });
+      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout, signal });
     }, expected, options);
   } else {
-    return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.have.class', { expectedText, isNot, timeout });
+      return await locator._expect('to.have.class', { expectedText, isNot, timeout, signal });
     }, expected, options);
   }
 }
@@ -288,21 +288,21 @@ export function toContainClass(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | string[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
   if (Array.isArray(expected)) {
     if (expected.some(e => isRegExp(e)))
       throw new Error(`"expected" argument in toContainClass cannot contain RegExp values`);
-    return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout });
+      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout, signal });
     }, expected, options);
   } else {
     if (isRegExp(expected))
       throw new Error(`"expected" argument in toContainClass cannot be a RegExp value`);
-    return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.contain.class', { expectedText, isNot, timeout });
+      return await locator._expect('to.contain.class', { expectedText, isNot, timeout, signal });
     }, expected, options);
   }
 }
@@ -311,24 +311,24 @@ export function toHaveCount(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: number,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout) => {
-    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout });
+  return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout, signal) => {
+    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout, signal });
   }, expected, options);
 }
 
-export function toHaveCSS(this: ExpectMatcherStateInternal, locator: LocatorEx, name: string, expected: string | RegExp, options?: { timeout?: number, pseudo?: 'before' | 'after' }): Promise<MatcherResult<any, any>>;
+export function toHaveCSS(this: ExpectMatcherStateInternal, locator: LocatorEx, name: string, expected: string | RegExp, options?: { timeout?: number, pseudo?: 'before' | 'after', signal?: AbortSignal }): Promise<MatcherResult<any, any>>;
 export function toHaveCSS(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   name: string,
   expected: string | RegExp,
-  options?: { timeout?: number, pseudo?: 'before' | 'after' },
+  options?: { timeout?: number, pseudo?: 'before' | 'after', signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout });
+    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout, signal });
   }, expected, options);
 }
 
@@ -336,11 +336,11 @@ export function toHaveId(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.id', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.id', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -349,10 +349,10 @@ export function toHaveJSProperty(
   locator: LocatorEx,
   name: string,
   expected: any,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout) => {
-    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout });
+  return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout, signal) => {
+    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -360,13 +360,13 @@ export function toHaveRole(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
   if (!isString(expected))
     throw new Error(`"role" argument in toHaveRole must be a string`);
-  return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.role', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.role', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -374,17 +374,17 @@ export function toHaveText(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, signal?: AbortSignal } = {},
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
     }, expected, options);
   } else {
-    return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout });
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
     }, expected, options);
   }
 }
@@ -393,11 +393,11 @@ export function toHaveValue(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.value', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.value', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -405,11 +405,11 @@ export function toHaveValues(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: (string | RegExp)[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout) => {
+  return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues(expected);
-    return await locator._expect('to.have.values', { expectedText, isNot, timeout });
+    return await locator._expect('to.have.values', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -417,11 +417,11 @@ export function toHaveTitle(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: string | RegExp,
-  options: { timeout?: number } = {},
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ) {
-  return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout });
+    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -429,7 +429,7 @@ export function toHaveURL(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: string | RegExp | URLPattern | ((url: URL) => boolean),
-  options?: { ignoreCase?: boolean; timeout?: number },
+  options?: { ignoreCase?: boolean; timeout?: number, signal?: AbortSignal },
 ) {
   if (isURLPattern(expected))
     return toHaveURLWithPredicate.call(this, page, url => (expected as URLPattern).test(url.href), options);
@@ -440,9 +440,9 @@ export function toHaveURL(
 
   const baseURL = (page.context() as any)._options.baseURL;
   expected = typeof expected === 'string' ? constructURLBasedOnBaseURL(baseURL, expected) : expected;
-  return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout });
+    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 

--- a/packages/playwright/src/matchers/toBeTruthy.ts
+++ b/packages/playwright/src/matchers/toBeTruthy.ts
@@ -28,14 +28,14 @@ export async function toBeTruthy(
   receiverType: 'Locator',
   expected: string,
   arg: string,
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
-  options: { timeout?: number } = {},
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<any, any>> {
   expectTypes(locator, [receiverType], matcherName);
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, log, timedOut, received, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, log, timedOut, received, errorMessage } = await query(!!this.isNot, timeout, options.signal);
   const receivedValue = received?.value;
 
   if (pass === !this.isNot) {

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -32,15 +32,15 @@ export async function toEqual<T>(
   matcherName: string,
   locator: Locator,
   receiverType: 'Locator',
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
   expected: T,
-  options: { timeout?: number, contains?: boolean } = {},
+  options: { timeout?: number, contains?: boolean, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<any, any>> {
   expectTypes(locator, [receiverType], matcherName);
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout, options.signal);
   const receivedValue = received?.value;
 
   if (pass === !this.isNot) {

--- a/packages/playwright/src/matchers/toHaveURL.ts
+++ b/packages/playwright/src/matchers/toHaveURL.ts
@@ -26,7 +26,7 @@ export async function toHaveURLWithPredicate(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: (url: URL) => boolean,
-  options?: { ignoreCase?: boolean; timeout?: number },
+  options?: { ignoreCase?: boolean; timeout?: number, signal?: AbortSignal },
 ): Promise<MatcherResult<string | RegExp, string>> {
   const matcherName = 'toHaveURL';
   const timeout = options?.timeout ?? this.timeout;
@@ -53,11 +53,12 @@ export async function toHaveURLWithPredicate(
             !this.isNot === urlMatches(baseURL, lastCheckedURLString, expected)
           );
         },
-        { timeout },
+        { timeout, signal: options?.signal },
     );
 
     conditionSucceeded = true;
-  } catch (e) {
+  } catch {
+    options?.signal?.throwIfAborted();
     conditionSucceeded = false;
   }
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -42,7 +42,7 @@ export async function toMatchAriaSnapshot(
   this: ExpectMatcherStateInternal,
   receiver: LocatorEx | Page,
   expectedParam?: ToMatchAriaSnapshotExpected,
-  options: { timeout?: number } = {},
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<string | RegExp, string>> {
   const matcherName = 'toMatchAriaSnapshot';
   expectTypes(receiver, ['Page', 'Locator'], matcherName);
@@ -91,7 +91,7 @@ export async function toMatchAriaSnapshot(
   if (globalChildren && !expected.match(/^- \/children:/m))
     expected = `- /children: ${globalChildren}\n` + expected;
 
-  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout };
+  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout, signal: options.signal };
   const { matches: pass, received, log, timedOut, errorMessage } = locator ?
     await (locator as LocatorEx)._expect('to.match.aria', expectParams) :
     await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams);

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -26,9 +26,9 @@ export async function toMatchText(
   matcherName: string,
   receiver: Locator | Page,
   receiverType: 'Locator' | 'Page',
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
   expected: string | RegExp,
-  options: { timeout?: number, matchSubstring?: boolean } = {},
+  options: { timeout?: number, matchSubstring?: boolean, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<string | RegExp, string>> {
   expectTypes(receiver, [receiverType], matcherName);
   const locator = receiverType === 'Locator' ? receiver as Locator : undefined;
@@ -43,7 +43,7 @@ export async function toMatchText(
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout, options.signal);
 
   if (pass === !this.isNot) {
     return {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8761,6 +8761,14 @@ interface LocatorAssertions {
     attached?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8795,6 +8803,14 @@ interface LocatorAssertions {
     indeterminate?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8818,6 +8834,14 @@ interface LocatorAssertions {
    */
   toBeDisabled(options?: {
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8837,6 +8861,14 @@ interface LocatorAssertions {
    */
   toBeEditable(options?: {
     editable?: boolean;
+
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -8859,6 +8891,14 @@ interface LocatorAssertions {
    */
   toBeEmpty(options?: {
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8880,6 +8920,14 @@ interface LocatorAssertions {
     enabled?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8898,6 +8946,14 @@ interface LocatorAssertions {
    * @param options
    */
   toBeFocused(options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -8918,6 +8974,14 @@ interface LocatorAssertions {
    * @param options
    */
   toBeHidden(options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -8949,6 +9013,14 @@ interface LocatorAssertions {
      * any positive ratio. Defaults to `0`.
      */
     ratio?: number;
+
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -8983,6 +9055,14 @@ interface LocatorAssertions {
    * @param options
    */
   toBeVisible(options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9030,6 +9110,14 @@ interface LocatorAssertions {
    * @param options
    */
   toContainClass(expected: string|ReadonlyArray<string>, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9098,6 +9186,14 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9131,6 +9227,14 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9157,6 +9261,14 @@ interface LocatorAssertions {
      * option takes precedence over the corresponding regular expression flag if specified.
      */
     ignoreCase?: boolean;
+
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -9187,6 +9299,14 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9215,6 +9335,14 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9235,6 +9363,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveAttribute(name: string, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9272,6 +9408,14 @@ interface LocatorAssertions {
    */
   toHaveClass(expected: string|RegExp|ReadonlyArray<string|RegExp>, options?: {
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9291,6 +9435,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveCount(count: number, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9319,6 +9471,14 @@ interface LocatorAssertions {
     pseudo?: "before"|"after";
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9339,6 +9499,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveId(id: string|RegExp, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9361,6 +9529,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveJSProperty(name: string, value: any, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9385,6 +9561,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveRole(role: "alert"|"alertdialog"|"application"|"article"|"banner"|"blockquote"|"button"|"caption"|"cell"|"checkbox"|"code"|"columnheader"|"combobox"|"complementary"|"contentinfo"|"definition"|"deletion"|"dialog"|"directory"|"document"|"emphasis"|"feed"|"figure"|"form"|"generic"|"grid"|"gridcell"|"group"|"heading"|"img"|"insertion"|"link"|"list"|"listbox"|"listitem"|"log"|"main"|"marquee"|"math"|"meter"|"menu"|"menubar"|"menuitem"|"menuitemcheckbox"|"menuitemradio"|"navigation"|"none"|"note"|"option"|"paragraph"|"presentation"|"progressbar"|"radio"|"radiogroup"|"region"|"row"|"rowgroup"|"rowheader"|"scrollbar"|"search"|"searchbox"|"separator"|"slider"|"spinbutton"|"status"|"strong"|"subscript"|"superscript"|"switch"|"tab"|"table"|"tablist"|"tabpanel"|"term"|"textbox"|"time"|"timer"|"toolbar"|"tooltip"|"tree"|"treegrid"|"treeitem", options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9639,6 +9823,14 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9664,6 +9856,14 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveValue(value: string|RegExp, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9697,6 +9897,14 @@ interface LocatorAssertions {
    */
   toHaveValues(values: ReadonlyArray<string|RegExp>, options?: {
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9719,6 +9927,14 @@ interface LocatorAssertions {
    * @param options
    */
   toMatchAriaSnapshot(expected: string, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9746,6 +9962,14 @@ interface LocatorAssertions {
      * specified.
      */
     name?: string;
+
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -9829,6 +10053,14 @@ interface PageAssertions {
    */
   toHaveTitle(titleOrRegExp: string|RegExp, options?: {
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9874,6 +10106,14 @@ interface PageAssertions {
     ignoreCase?: boolean;
 
     /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9896,6 +10136,14 @@ interface PageAssertions {
    * @param options
    */
   toMatchAriaSnapshot(expected: string, options?: {
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9923,6 +10171,14 @@ interface PageAssertions {
      * specified.
      */
     name?: string;
+
+    /**
+     * Allows to cancel the assertion using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * assertion will be aborted and throw an error. Note that providing a signal does not disable the default timeout;
+     * pass `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -120,3 +120,64 @@ test('should not miss element that appears between retries before the deadline',
   });
   await expect(page.locator('#target')).toBeVisible({ timeout: 1800 });
 });
+
+test('should abort assertion via signal', async ({ page }) => {
+  await page.setContent(`<div id=node style="display:none">Text content</div>`);
+  const controller = new AbortController();
+  const promise = expect(page.locator('#node')).toBeVisible({ signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  const error = await promise.catch(e => e);
+  expect(error.message).toBe('Aborted by user');
+  expect(stripAnsi(error.message)).not.toContain('toBeVisible');
+  expect(stripAnsi(error.message)).not.toContain('Received');
+  expect(stripAnsi(error.message)).not.toContain('Call log');
+});
+
+test('should abort assertion via already-aborted signal', async ({ page }) => {
+  await page.setContent(`<div id=node>Text content</div>`);
+  const controller = new AbortController();
+  controller.abort(new Error('Already aborted'));
+  const error = await expect(page.locator('#node')).toBeVisible({ signal: controller.signal }).catch(e => e);
+  expect(error.message).toBe('Already aborted');
+});
+
+test('should abort assertion via signal without a reason', async ({ page }) => {
+  await page.setContent(`<div id=node style="display:none">Text content</div>`);
+  const controller = new AbortController();
+  const promise = expect(page.locator('#node')).toBeVisible({ signal: controller.signal, timeout: 0 });
+  controller.abort();
+  const error = await promise.catch(e => e);
+  expect(error.name).toBe('AbortError');
+});
+
+test('should abort text assertion via signal', async ({ page }) => {
+  await page.setContent(`<div id=node>Text content</div>`);
+  const controller = new AbortController();
+  const promise = expect(page.locator('#node')).toHaveText('never matches', { signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  await expect(promise).rejects.toThrow('Aborted by user');
+});
+
+test('should abort count assertion via signal', async ({ page }) => {
+  await page.setContent(`<div>one</div>`);
+  const controller = new AbortController();
+  const promise = expect(page.locator('div')).toHaveCount(5, { signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  await expect(promise).rejects.toThrow('Aborted by user');
+});
+
+test('should abort aria snapshot assertion via signal', async ({ page }) => {
+  await page.setContent(`<button>hello</button>`);
+  const controller = new AbortController();
+  const promise = expect(page.locator('body')).toMatchAriaSnapshot(`- button "never matches"`, { signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  await expect(promise).rejects.toThrow('Aborted by user');
+});
+
+test('should abort url assertion via signal', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  const controller = new AbortController();
+  const promise = expect(page).toHaveURL(url => url.pathname === '/never-matches', { signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  await expect(promise).rejects.toThrow('Aborted by user');
+});

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1352,3 +1352,11 @@ it('should not wait with noAutoWaiting 3', async ({ page }) => {
   const error = await page.locator('button').click({ __testHookNoAutoWaiting: true } as any).catch(e => e);
   expect(error.message).toContain('locator.click: Element is not enabled');
 });
+
+it('should abort via signal', async ({ page }) => {
+  await page.setContent(`<button style="display:none">click me</button>`);
+  const controller = new AbortController();
+  const promise = page.locator('button').click({ signal: controller.signal, timeout: 0 });
+  controller.abort(new Error('Aborted by user'));
+  await expect(promise).rejects.toThrow('Aborted by user');
+});

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1360,3 +1360,10 @@ it('should abort via signal', async ({ page }) => {
   controller.abort(new Error('Aborted by user'));
   await expect(promise).rejects.toThrow('Aborted by user');
 });
+
+it('should abort via already-aborted signal', async ({ page }) => {
+  await page.setContent(`<button>click me</button>`);
+  const controller = new AbortController();
+  controller.abort(new Error('Already aborted'));
+  await expect(page.locator('button').click({ signal: controller.signal })).rejects.toThrow('Already aborted');
+});


### PR DESCRIPTION
## Summary
- Adds a client-only `signal?: AbortSignal` option to web-first assertions (`toBeVisible`, `toHaveText`, `toHaveCount`, `toMatchAriaSnapshot`, `toHaveURL`, etc.).
- Aborting cancels the in-flight server call via the existing `__cancel__` mechanism and **rejects with `signal.reason`** — a cancellation, not an assertion outcome — matching `AbortSignal` semantics on actions (#41141) and waiters (#41136).
- The retry loop runs server-side; the server returns a (failed) result rather than throwing on abort, so the client races the call against the signal to surface the abort reason instead of an "expect failed" message.

## Notes
- Stacked on #41141 (`feat/abort-signal-server-side`); the first two commits belong to that PR and drop out once it merges.
- `expect.soft` intentionally gets no special handling — this is an automation feature, not a testing one.

Refs https://github.com/microsoft/playwright/issues/40578