### PR TITLE
chore(mcp): proper cleanup for signalToPromise

### DIFF
--- a/packages/isomorphic/manualPromise.ts
+++ b/packages/isomorphic/manualPromise.ts
@@ -114,13 +114,15 @@ export class LongStandingScope {
 }
 
 export function signalToPromise(signal: AbortSignal): { promise: Promise<void>, dispose: () => void } {
+  if (signal.aborted)
+    return { promise: Promise.resolve(), dispose: () => {} };
+  let dispose: (() => void) | undefined;
   const promise = new Promise<void>(resolve => {
-    if (signal.aborted)
-      resolve();
-    else
-      signal.addEventListener('abort', () => resolve(), { once: true });
+    const onAbort = () => resolve();
+    signal.addEventListener('abort', onAbort, { once: true });
+    dispose = () => signal.removeEventListener('abort', onAbort);
   });
-  return { promise, dispose: () => {} };
+  return { promise, dispose: dispose! };
 }
 
 function cloneError(error: Error, frames: string[]) {

--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -233,8 +233,9 @@ export class TestContext {
       }
     };
 
-    const abortPromise = signal
-      ? signalToPromise(signal).promise.then(() => 'interrupted' as const)
+    const abort = signal ? signalToPromise(signal) : undefined;
+    const abortPromise = abort
+      ? abort.promise.then(() => 'interrupted' as const)
       : new Promise<never>(() => {});
 
     try {
@@ -263,6 +264,8 @@ export class TestContext {
       testRunnerAndScreen.output.push(String(e));
       await cleanup();
       return { output: testRunnerAndScreen.output.join('\n'), status };
+    } finally {
+      abort?.dispose();
     }
 
     await cleanup();


### PR DESCRIPTION
## Summary
- `signalToPromise` returned a no-op `dispose`, leaking the `'abort'` listener it adds to the `AbortSignal`.
- Implement `dispose` to remove the listener (with an early `signal.aborted` fast path).
- Call `dispose()` in a `finally` at the single caller in the test MCP context so the listener is cleaned up on every exit path.