### PR TITLE
docs: clarify local Playwright CLI installation

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -30,6 +30,7 @@ playwright-cli --help
 Alternatively, install `@playwright/cli` as a local dependency and use `npx`:
 
 ```bash
+npm install -D @playwright/cli@latest
 npx playwright-cli --help
 ```
 


### PR DESCRIPTION
## Summary

- Add an explicit local installation command for `@playwright/cli`.
- The documentation currently mentions installing `@playwright/cli` as a local dependency and using `npx`, but the example only shows `npx playwright-cli --help`.
- This makes the local installation flow clearer for users who may not be familiar with npm’s global and local installation patterns.