### PR TITLE
fix(firefox): guard against missing location in uncaughtError protocol event

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -114,9 +114,9 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
         error: serializeError(pageError.error),
         page: PageDispatcher.from(this, page),
         location: {
-          url: pageError.location.url,
-          line: pageError.location.lineNumber,
-          column: pageError.location.columnNumber,
+          url: pageError.location?.url ?? '',
+          line: pageError.location?.lineNumber ?? 0,
+          column: pageError.location?.columnNumber ?? 0,
         },
       });
     });

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -392,7 +392,7 @@ export namespace Protocol {
       frameId: string;
       message: string;
       stack: string;
-      location: {
+      location?: {
         columnNumber: number;
         lineNumber: number;
         url: string;

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -160,7 +160,7 @@ const navigationMarkSymbol = Symbol('navigationMark');
 
 export type PageError = {
   error: Error,
-  location: types.ConsoleMessageLocation,
+  location: types.ConsoleMessageLocation | undefined,
 };
 
 export class Page extends SdkObject<PageEventMap> {
@@ -432,7 +432,7 @@ export class Page extends SdkObject<PageEventMap> {
     return marked === -1 ? this._consoleMessages : this._consoleMessages.slice(marked + 1);
   }
 
-  addPageError(error: Error, location: types.ConsoleMessageLocation) {
+  addPageError(error: Error, location: types.ConsoleMessageLocation | undefined) {
     const pageError: PageError = { error, location };
     this._pageErrors.push(pageError);
     ensureArrayLimit(this._pageErrors, 200); // Avoid unbounded memory growth.

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -643,9 +643,9 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       params: {
         error: serializeError(pageError.error),
         location: {
-          url: pageError.location.url,
-          line: pageError.location.lineNumber,
-          column: pageError.location.columnNumber,
+          url: pageError.location?.url ?? '',
+          line: pageError.location?.lineNumber ?? 0,
+          column: pageError.location?.columnNumber ?? 0,
         },
       },
       pageId: page.guid,

--- a/tests/library/browsercontext-events.spec.ts
+++ b/tests/library/browsercontext-events.spec.ts
@@ -278,3 +278,28 @@ test('download event should work @smoke', async ({ page, server }) => {
   expect(download.suggestedFilename()).toBe('file.txt');
   expect(download.page()).toBe(page);
 });
+
+test('weberror event should not crash when Firefox omits location in uncaughtError', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41169' },
+}, async ({ page, toImpl, browserName }) => {
+  // Firefox can omit the location field in Page.uncaughtError protocol events
+  // when an uncaught error fires during mid-navigation. Inject a synthetic event
+  // without location to verify the driver does not crash.
+  test.skip(browserName !== 'firefox', 'Firefox-only: tests FF protocol behaviour');
+  const webErrors: Error[] = [];
+  page.context().on('weberror', e => webErrors.push(e.error()));
+  const pageErrors: Error[] = [];
+  page.on('pageerror', e => pageErrors.push(e));
+
+  (toImpl(page) as any).delegate._session.emit('Page.uncaughtError', {
+    frameId: '',
+    message: 'Error: no-location-error',
+    stack: '',
+    // location intentionally absent — simulates the protocol omitting it
+  });
+
+  await page.waitForTimeout(500);
+  expect(pageErrors).toHaveLength(1);
+  expect(pageErrors[0].message).toBe('no-location-error');
+  expect(webErrors).toHaveLength(1);
+});

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -230,18 +230,3 @@ it('should fire illegal character error', {
   else
     expect(error.message).toContain('illegal character');
 });
-
-it('should emit weberror on context when pageerror fires on firefox', {
-  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41169' },
-}, async ({ page, browserName }) => {
-  // Regression guard: Firefox may omit location in Page.uncaughtError protocol events
-  // (e.g. during navigation interruption). The driver must dispatch the event without crashing.
-  it.skip(browserName !== 'firefox', 'Firefox-only regression guard');
-  const webErrors: any[] = [];
-  page.context().on('weberror', e => webErrors.push(e));
-  await Promise.all([
-    page.waitForEvent('pageerror'),
-    page.goto(server.PREFIX + '/error.html'),
-  ]);
-  expect(webErrors.length).toBeGreaterThan(0);
-});

--- a/tests/page/page-event-pageerror.spec.ts
+++ b/tests/page/page-event-pageerror.spec.ts
@@ -230,3 +230,18 @@ it('should fire illegal character error', {
   else
     expect(error.message).toContain('illegal character');
 });
+
+it('should emit weberror on context when pageerror fires on firefox', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41169' },
+}, async ({ page, browserName }) => {
+  // Regression guard: Firefox may omit location in Page.uncaughtError protocol events
+  // (e.g. during navigation interruption). The driver must dispatch the event without crashing.
+  it.skip(browserName !== 'firefox', 'Firefox-only regression guard');
+  const webErrors: any[] = [];
+  page.context().on('weberror', e => webErrors.push(e));
+  await Promise.all([
+    page.waitForEvent('pageerror'),
+    page.goto(server.PREFIX + '/error.html'),
+  ]);
+  expect(webErrors.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

- Firefox can omit `location` in `Page.uncaughtError` protocol events when an uncaught error fires during mid-navigation (e.g. interrupted by a WAF challenge), crashing the driver with `TypeError: Cannot read properties of undefined (reading 'url')`
- Make `uncaughtErrorPayload.location` optional in `protocol.d.ts` to match actual Firefox behaviour
- Widen `PageError.location` and `addPageError()` to accept `undefined`
- Use `?.` + `??` fallbacks in the dispatcher and tracing recorder — consistent with how Chromium's `stackTraceToLocation` already handles the locationless case
- Add a Firefox-only test that injects a synthetic `Page.uncaughtError` without `location` into the protocol session and verifies `pageerror`/`weberror` fire without crashing

Fixes https://github.com/microsoft/playwright/issues/41169