### PR TITLE
feat(firefox): support mobile mode

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "firefox",
-      "revision": "1528",
+      "revision": "1530",
       "installByDefault": true,
       "browserVersion": "151.0",
       "title": "Firefox"

--- a/packages/playwright-core/src/cli/browserActions.ts
+++ b/packages/playwright-core/src/cli/browserActions.ts
@@ -85,9 +85,6 @@ async function launchContext(options: Options, extraOptions: LaunchOptions): Pro
     delete contextOptions.isMobile;
   }
 
-  if (contextOptions.isMobile && browserType.name() === 'firefox')
-    contextOptions.isMobile = undefined;
-
   if (options.blockServiceWorkers)
     contextOptions.serviceWorkers = 'block';
 

--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -90,8 +90,6 @@ export class FFBrowser extends Browser {
   }
 
   async doCreateNewContext(options: types.BrowserContextOptions): Promise<BrowserContext> {
-    if (options.isMobile)
-      throw new Error('options.isMobile is not supported in Firefox');
     const { browserContextId } = await this.session.send('Browser.createBrowserContext', { removeOnDetach: true });
     const context = new FFBrowserContext(this, browserContextId, options);
     await context.initialize();
@@ -359,7 +357,9 @@ export class FFBrowserContext extends BrowserContext {
       return;
     const viewport = {
       viewportSize: { width: this._options.viewport.width, height: this._options.viewport.height },
+      screenSize: this._options.screen,
       deviceScaleFactor: this._options.deviceScaleFactor || 1,
+      isMobile: !!this._options.isMobile,
     };
     await this._browser.session.send('Browser.setDefaultViewport', { browserContextId: this._browserContextId, viewport });
   }

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -380,8 +380,11 @@ export class FFPage implements PageDelegate {
   }
 
   async updateEmulatedViewportSize(): Promise<void> {
-    const viewportSize = this._page.emulatedSize()?.viewport ?? null;
-    await this._session.send('Page.setViewportSize', { viewportSize });
+    const emulatedSize = this._page.emulatedSize();
+    const viewportSize = emulatedSize?.viewport ?? null;
+    const screenSize = emulatedSize?.screen ?? null;
+    const isMobile = !!this._browserContext._options.isMobile;
+    await this._session.send('Page.setViewportSize', { viewportSize, screenSize, isMobile });
   }
 
   async bringToFront(): Promise<void> {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -381,10 +381,11 @@ export class FFPage implements PageDelegate {
 
   async updateEmulatedViewportSize(): Promise<void> {
     const emulatedSize = this._page.emulatedSize();
-    const viewportSize = emulatedSize?.viewport ?? null;
-    const screenSize = emulatedSize?.screen ?? null;
-    const isMobile = !!this._browserContext._options.isMobile;
-    await this._session.send('Page.setViewportSize', { viewportSize, screenSize, isMobile });
+    await this._session.send('Page.setViewportSize', {
+      viewportSize: emulatedSize?.viewport ?? null,
+      screenSize: emulatedSize?.screen,
+      isMobile: !!this._browserContext._options.isMobile,
+    });
   }
 
   async bringToFront(): Promise<void> {

--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -214,6 +214,11 @@ export namespace Protocol {
           height: number;
         };
         deviceScaleFactor?: number;
+        screenSize?: {
+          width: number;
+          height: number;
+        };
+        isMobile?: boolean;
       }|null;
     };
     export type setDefaultViewportReturnValue = void;
@@ -343,6 +348,11 @@ export namespace Protocol {
         height: number;
       };
       deviceScaleFactor?: number;
+      screenSize?: {
+        width: number;
+        height: number;
+      };
+      isMobile?: boolean;
     };
     export type DOMQuad = {
       p1: {
@@ -523,6 +533,11 @@ export namespace Protocol {
         height: number;
       }|null;
       deviceScaleFactor?: number;
+      screenSize?: {
+        width: number;
+        height: number;
+      };
+      isMobile?: boolean;
     };
     export type setViewportSizeReturnValue = void;
     export type setZoomParameters = {

--- a/tests/library/browsercontext-viewport.spec.ts
+++ b/tests/library/browsercontext-viewport.spec.ts
@@ -130,7 +130,6 @@ browserTest('should support touch with null viewport', async ({ browser, server 
 });
 
 it('should set both screen and viewport options', async ({ contextFactory, browserName, isBidi }) => {
-  it.fail(browserName === 'firefox' && !isBidi, 'Screen size is reset to viewport');
   const context = await contextFactory({
     screen: { 'width': 1280, 'height': 720 },
     viewport: { 'width': 1000, 'height': 600 },
@@ -187,9 +186,8 @@ browserTest('should be able to get correct orientation angle on non-mobile devic
   await context.close();
 });
 
-it('should set window.screen.orientation.type for mobile devices', async ({ contextFactory, browserName, server, isBidi }) => {
+it('should set window.screen.orientation.type for mobile devices', async ({ contextFactory, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/31151' });
-  it.skip(browserName === 'firefox' && !isBidi, 'Firefox does not support mobile emulation');
   const context = await contextFactory(devices['iPhone 14']);
   const page = await context.newPage();
   await page.goto(server.PREFIX + '/index.html');

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -28,8 +28,6 @@ it('should support hasTouch option', async ({ server, launchPersistent }) => {
 });
 
 it('should work in persistent context', async ({ server, launchPersistent, browserName }) => {
-  it.skip(browserName === 'firefox', 'Firefox does not support mobile');
-
   const { page } = await launchPersistent({ viewport: { width: 320, height: 480 }, isMobile: true });
   await page.goto(server.PREFIX + '/empty.html');
   expect(await page.evaluate(() => window.innerWidth)).toBe(980);

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -503,8 +503,6 @@ it.describe('screencast', () => {
   });
 
   it('should emulate an iphone', async ({ contextFactory, playwright, browserName }, testInfo) => {
-    it.skip(browserName === 'firefox', 'isMobile is not supported in Firefox');
-
     const device = playwright.devices['iPhone 6'];
     const context = await contextFactory({
       ...device,


### PR DESCRIPTION
note: this requires [Juggler's support](https://github.com/microsoft/playwright-browsers/pull/2316) for the mobile mode first.

Fixes https://github.com/microsoft/playwright/issues/39841