### PR TITLE
fix(network): use internal methods in HarTracer

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -321,7 +321,7 @@ export class HarTracer {
     // In WebKit security details and server ip are reported in Network.loadingFinished, so we populate
     // it here to not hang in case of long chunked responses, see https://github.com/microsoft/playwright/issues/21182.
     if (!this._options.omitServerIP) {
-      this._addBarrier(page || request.serviceWorker(), response.serverAddr(nullProgress).then(server => {
+      this._addBarrier(page || request.serviceWorker(), response.internalServerAddr().then(server => {
         if (server?.ipAddress)
           harEntry.serverIPAddress = server.ipAddress;
         if (server?.port)
@@ -329,7 +329,7 @@ export class HarTracer {
       }));
     }
     if (!this._options.omitSecurityDetails) {
-      this._addBarrier(page || request.serviceWorker(), response.securityDetails(nullProgress).then(details => {
+      this._addBarrier(page || request.serviceWorker(), response.internalSecurityDetails().then(details => {
         if (details)
           harEntry._securityDetails = details;
       }));
@@ -374,7 +374,7 @@ export class HarTracer {
     });
     this._addBarrier(page || request.serviceWorker(), promise);
 
-    this._addBarrier(page || request.serviceWorker(), response.httpVersion(nullProgress).then(httpVersion => {
+    this._addBarrier(page || request.serviceWorker(), response.internalHttpVersion().then(httpVersion => {
       harEntry.request.httpVersion = httpVersion;
       harEntry.response.httpVersion = httpVersion;
     }));
@@ -385,7 +385,7 @@ export class HarTracer {
     this._computeHarEntryTotalTime(harEntry);
 
     if (!this._options.omitSizes) {
-      this._addBarrier(page || request.serviceWorker(), response.sizes(nullProgress).then(sizes => {
+      this._addBarrier(page || request.serviceWorker(), response.internalSizes().then(sizes => {
         harEntry.response.bodySize = sizes.responseBodySize;
         harEntry.response.headersSize = sizes.responseHeadersSize;
         harEntry.response._transferSize = sizes.transferSize;
@@ -595,13 +595,13 @@ export class HarTracer {
     }
 
     this._recordRequestOverrides(harEntry, request);
-    this._addBarrier(page || request.serviceWorker(), request.rawRequestHeaders(nullProgress).then(headers => {
+    this._addBarrier(page || request.serviceWorker(), request.internalRawRequestHeaders().then(headers => {
       this._recordRequestHeadersAndCookies(harEntry, headers);
     }));
     // Record available headers including redirect location in case the tracing is stopped before
     // response extra info is received (in Chromium).
     this._recordResponseHeaders(harEntry, response.headers());
-    this._addBarrier(page || request.serviceWorker(), response.rawResponseHeaders(nullProgress).then(headers => {
+    this._addBarrier(page || request.serviceWorker(), response.internalRawResponseHeaders().then(headers => {
       this._recordResponseHeaders(harEntry, headers);
     }));
   }

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -228,7 +228,7 @@ export class Request extends SdkObject {
   }
 
   async rawRequestHeaders(progress: Progress): Promise<HeadersArray> {
-    return await this.raceWithPageClosure(progress, this._rawRequestHeaders());
+    return await this.raceWithPageClosure(progress, this.internalRawRequestHeaders());
   }
 
   async response(progress: Progress): Promise<Response | null> {
@@ -280,7 +280,7 @@ export class Request extends SdkObject {
       this._rawRequestHeadersPromise.resolve(headers || this._headers);
   }
 
-  private async _rawRequestHeaders(): Promise<HeadersArray> {
+  async internalRawRequestHeaders(): Promise<HeadersArray> {
     return this._overrides?.headers || this._rawRequestHeadersPromise;
   }
 
@@ -336,7 +336,7 @@ export class Request extends SdkObject {
   }
 
   async _requestHeadersSize(): Promise<number> {
-    return requestHeadersSize(await this._rawRequestHeaders(), this.url(), this.method());
+    return requestHeadersSize(await this.internalRawRequestHeaders(), this.url(), this.method());
   }
 }
 
@@ -553,19 +553,19 @@ export class Response extends SdkObject {
   }
 
   async serverAddr(progress: Progress): Promise<RemoteAddr | null> {
-    return (await this._request.raceWithPageClosure(progress, this._serverAddrPromise)) || null;
+    return await this._request.raceWithPageClosure(progress, this.internalServerAddr());
   }
 
   async rawResponseHeaders(progress: Progress): Promise<NameValue[]> {
-    return await this._request.raceWithPageClosure(progress, this._rawResponseHeadersPromise);
+    return await this._request.raceWithPageClosure(progress, this.internalRawResponseHeaders());
   }
 
   async httpVersion(progress: Progress): Promise<string> {
-    return await this._request.raceWithPageClosure(progress, this._httpVersion());
+    return await this._request.raceWithPageClosure(progress, this.internalHttpVersion());
   }
 
   async sizes(progress: Progress): Promise<ResourceSizes> {
-    return await this._request.raceWithPageClosure(progress, this._sizes());
+    return await this._request.raceWithPageClosure(progress, this.internalSizes());
   }
 
   _serverAddrFinished(addr?: RemoteAddr) {
@@ -634,6 +634,14 @@ export class Response extends SdkObject {
     return await this._securityDetailsPromise || null;
   }
 
+  async internalServerAddr(): Promise<RemoteAddr | null> {
+    return await this._serverAddrPromise || null;
+  }
+
+  async internalRawResponseHeaders(): Promise<HeadersArray> {
+    return await this._rawResponseHeadersPromise;
+  }
+
   internalBody(): Promise<Buffer> {
     if (!this._contentPromise) {
       this._contentPromise = this._finishedPromise.then(async () => {
@@ -661,7 +669,7 @@ export class Response extends SdkObject {
     return this._request.frame();
   }
 
-  private async _httpVersion(): Promise<string> {
+  async internalHttpVersion(): Promise<string> {
     const httpVersion = await this._httpVersionPromise || null;
     if (!httpVersion)
       return 'HTTP/1.1';
@@ -685,7 +693,7 @@ export class Response extends SdkObject {
     return responseHeadersSize(await this._rawResponseHeadersPromise, this.statusText());
   }
 
-  private async _sizes(): Promise<ResourceSizes> {
+  async internalSizes(): Promise<ResourceSizes> {
     const requestHeadersSize = await this._request._requestHeadersSize();
     const responseHeadersSize = await this.responseHeadersSize();
 


### PR DESCRIPTION
Publicly-facing methods like `Response.sizes()` throw upon page closure. This makes ongoing har recording in the trace to sometimes throw an internal error instead of handling the page closure gracefully.

Fixes the `TargetClosedError: Test ended` flaky error on tracing bots that started after #40893.