### PR TITLE
fix(download): deny downloads when the browser is not collocated with the server

### DIFF
--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -357,6 +357,7 @@ export class AndroidDevice extends SdkObject {
         persistent: { ...options, noDefaultViewport: true },
         artifactsDir,
         downloadsPath: artifactsDir,
+        isBrowserCollocatedWithServer: false,
         tracesDir: artifactsDir,
         browserProcess: new ClankBrowserProcess(androidBrowser),
         proxy: options.proxy,

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -65,6 +65,7 @@ export type BrowserOptions = {
   originalLaunchOptions: types.LaunchOptions;
   userDataDir?: string;
   noDefaults?: boolean;
+  isBrowserCollocatedWithServer?: boolean,
 };
 
 export abstract class Browser extends SdkObject {
@@ -80,13 +81,14 @@ export abstract class Browser extends SdkObject {
   private _startedClosing = false;
   private _contextForReuse: { context: BrowserContext, hash: string } | undefined;
   _closeReason: string | undefined;
-  _isBrowserCollocatedWithServer: boolean = true;
+  readonly _isBrowserCollocatedWithServer: boolean;
   private _server: BrowserServer;
 
   constructor(parent: SdkObject, options: BrowserOptions) {
     super(parent, 'browser');
     this.attribution.browser = this;
     this.options = options;
+    this._isBrowserCollocatedWithServer = options.isBrowserCollocatedWithServer ?? true;
     this.instrumentation.onBrowserOpen(this);
     this._server = new BrowserServer(this);
   }

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -152,14 +152,13 @@ export class Chromium extends BrowserType {
         browserLogsCollector: new RecentLogsCollector(),
         artifactsDir,
         downloadsPath: options.downloadsPath || artifactsDir,
+        isBrowserCollocatedWithServer: !!options.isLocal,
         tracesDir: options.tracesDir || artifactsDir,
         originalLaunchOptions: {},
         noDefaults: options.noDefaults,
       };
       validateBrowserContextOptions(persistent, browserOptions);
       const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, transport, browserOptions));
-      if (!options.isLocal)
-        browser._isBrowserCollocatedWithServer = false;
       browser.on(Browser.Events.Disconnected, doCleanup);
       return browser;
     } catch (error) {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -62,8 +62,6 @@ export class CRBrowser extends Browser {
     const connection = new CRConnection(parent, transport, options.protocolLogger, options.browserLogsCollector);
     const browser = new CRBrowser(parent, connection, options);
     browser._devtools = devtools;
-    if (browser.isClank())
-      browser._isBrowserCollocatedWithServer = false;
     const session = connection.rootSession;
     if ((options as any).__testHookOnConnectToBrowser)
       await (options as any).__testHookOnConnectToBrowser();
@@ -351,10 +349,11 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
     assert(!Array.from(this._browser._crPages.values()).some(page => page._browserContext === this));
     const promises: Promise<any>[] = [super.initialize()];
     if (this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
+      const isLocal = this._browser._isBrowserCollocatedWithServer;
       promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
-        behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',
+        behavior: (this._options.acceptDownloads === 'accept' && isLocal) ? 'allowAndName' : 'deny',
         browserContextId: this._browserContextId,
-        downloadPath: this._browser.options.downloadsPath,
+        downloadPath: isLocal ? this._browser.options.downloadsPath : undefined,
         eventsEnabled: true,
       }));
     }

--- a/packages/playwright-core/src/server/download.ts
+++ b/packages/playwright-core/src/server/download.ts
@@ -35,7 +35,8 @@ export class Download {
     if (!page.browserContext._browser._isBrowserCollocatedWithServer) {
       this.artifact.markMissingFileErrorMessage(
           `Downloaded file is not accessible from the Playwright server because the browser is running on a different host ` +
-          `(e.g. connected over CDP to a remote browser). Saving downloads requires the browser and the Playwright server to share a filesystem.`);
+          `(e.g. connected over CDP to a remote browser). If the browser has access to the Playwright server's filesystem, ` +
+          `pass { isLocal: true } to connectOverCDP() to enable saving downloads.`);
     }
     this._page = page;
     this.url = url;

--- a/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
@@ -150,6 +150,7 @@ export async function connectOverRDP(progress: Progress, parent: SdkObject, para
       protocolLogger: helper.debugProtocolLogger(),
       browserLogsCollector: new RecentLogsCollector(),
       artifactsDir,
+      isBrowserCollocatedWithServer: !!params.isLocal,
       downloadsPath: artifactsDir,
       tracesDir: artifactsDir,
       originalLaunchOptions: {},
@@ -164,8 +165,6 @@ export async function connectOverRDP(progress: Progress, parent: SdkObject, para
     return created;
   })());
 
-  if (!params.isLocal)
-    browser._isBrowserCollocatedWithServer = false;
   browser.on(Browser.Events.Disconnected, doCleanup);
   return browser;
 }

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -169,6 +169,41 @@ test('should give a clear error for downloads when browser is not co-located wit
   }
 });
 
+test('should cancel downloads when the browser is not co-located with the server', async ({ browserType, server }, testInfo) => {
+  server.setRoute('/downloadWithFilename', (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment; filename=file.txt');
+    res.end(`Hello world`);
+  });
+
+  const downloadFailure = async (isLocal: boolean) => {
+    const port = 9339 + testInfo.workerIndex;
+    const browserServer = await browserType.launch({
+      args: ['--remote-debugging-port=' + port]
+    });
+    try {
+      const browser = await browserType.connectOverCDP({
+        endpointURL: `http://127.0.0.1:${port}/`,
+        isLocal,
+      });
+      const page = await browser.contexts()[0].newPage();
+      await page.setContent(`<a href="${server.PREFIX}/downloadWithFilename">download</a>`);
+      const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        page.click('a')
+      ]);
+      return await download.failure();
+    } finally {
+      await browserServer.close();
+    }
+  };
+
+  // When co-located, the browser shares the filesystem and the download is saved.
+  expect(await downloadFailure(true)).toBe(null);
+  // Otherwise the file would be inaccessible from the server, so the download is denied.
+  expect(await downloadFailure(false)).toBe('canceled');
+});
+
 test('should connect to an existing cdp session twice', async ({ browserType, mode, server }, testInfo) => {
   const port = 9339 + testInfo.workerIndex;
   const browserServer = await browserType.launch({

--- a/tests/playwright-test/ui-mode-fixtures.ts
+++ b/tests/playwright-test/ui-mode-fixtures.ts
@@ -120,7 +120,7 @@ export const test = base
             await testProcess.waitForOutput('DevTools listening on');
             const line = testProcess.output.split('\n').find(l => l.includes('DevTools listening on'));
             const wsEndpoint = line!.split(' ')[3];
-            browser = await chromium.connectOverCDP(wsEndpoint);
+            browser = await chromium.connectOverCDP(wsEndpoint, { isLocal: true });
             const [context] = browser.contexts();
             [page] = context.pages();
           }


### PR DESCRIPTION
## Summary
- When connected over CDP to a remote browser, downloads land on the browser's host and are unreachable from the Playwright server. Deny them via `setDownloadBehavior` instead of writing to an unrelated server-side path.
- The inaccessible-download error now suggests passing `{ isLocal: true }` to `connectOverCDP()` when the browser shares the server's filesystem.
- `_isBrowserCollocatedWithServer` is now passed via `BrowserOptions` (set before contexts initialize) and is `readonly`, fixing a case where the default CDP context initialized before the flag was set.
- UI mode tests connect over CDP to a local browser, so they pass `{ isLocal: true }`.

Relates to https://github.com/microsoft/playwright/issues/41060