### PR TITLE
fix(install): follow redirects when downloading Chrome/Edge

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -35,7 +35,7 @@ fi
 
 # 4. download chrome beta from dl.google.com and install it.
 cd /tmp
-curl -O https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+curl -L -O https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
 apt-get install -y ./google-chrome-beta_current_amd64.deb
 rm -rf ./google-chrome-beta_current_amd64.deb
 cd -

--- a/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_mac.sh
@@ -4,7 +4,7 @@ set -x
 
 rm -rf "/Applications/Google Chrome Beta.app"
 cd /tmp
-curl --retry 3 -o ./googlechromebeta.dmg https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg
+curl -L --retry 3 -o ./googlechromebeta.dmg https://dl.google.com/chrome/mac/universal/beta/googlechromebeta.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechromebeta.dmg ./googlechromebeta.dmg
 cp -pR "/Volumes/googlechromebeta.dmg/Google Chrome Beta.app" /Applications
 hdiutil detach /Volumes/googlechromebeta.dmg

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -35,7 +35,7 @@ fi
 
 # 4. download chrome stable from dl.google.com and install it.
 cd /tmp
-curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+curl -L -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 apt-get install -y ./google-chrome-stable_current_amd64.deb
 rm -rf ./google-chrome-stable_current_amd64.deb
 cd -

--- a/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_mac.sh
@@ -4,7 +4,7 @@ set -x
 
 rm -rf "/Applications/Google Chrome.app"
 cd /tmp
-curl --retry 3 -o ./googlechrome.dmg https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg
+curl -L --retry 3 -o ./googlechrome.dmg https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg
 hdiutil attach -nobrowse -quiet -noautofsck -noautoopen -mountpoint /Volumes/googlechrome.dmg ./googlechrome.dmg
 cp -pR "/Volumes/googlechrome.dmg/Google Chrome.app" /Applications
 hdiutil detach /Volumes/googlechrome.dmg

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -39,7 +39,7 @@ if ! command -v gpg >/dev/null; then
 fi
 
 # 3. Add the GPG key, the apt repo, update the apt cache, and install the package
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
+curl -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
 install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
 sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
 rm /tmp/microsoft.gpg

--- a/packages/playwright-core/bin/reinstall_msedge_beta_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_mac.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 cd /tmp
-curl --retry 3 -o ./msedge_beta.pkg "$1"
+curl -L --retry 3 -o ./msedge_beta.pkg "$1"
 # Note: there's no way to uninstall previously installed MSEdge.
 # However, running PKG again seems to update installation.
 sudo installer -pkg /tmp/msedge_beta.pkg -target /

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -39,7 +39,7 @@ if ! command -v gpg >/dev/null; then
 fi
 
 # 3. Add the GPG key, the apt repo, update the apt cache, and install the package
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
+curl -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
 install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
 sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-dev.list'
 rm /tmp/microsoft.gpg

--- a/packages/playwright-core/bin/reinstall_msedge_dev_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_mac.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 cd /tmp
-curl --retry 3 -o ./msedge_dev.pkg "$1"
+curl -L --retry 3 -o ./msedge_dev.pkg "$1"
 # Note: there's no way to uninstall previously installed MSEdge.
 # However, running PKG again seems to update installation.
 sudo installer -pkg /tmp/msedge_dev.pkg -target /

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -39,7 +39,7 @@ if ! command -v gpg >/dev/null; then
 fi
 
 # 3. Add the GPG key, the apt repo, update the apt cache, and install the package
-curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
+curl -L https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
 install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
 sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge-stable.list'
 rm /tmp/microsoft.gpg

--- a/packages/playwright-core/bin/reinstall_msedge_stable_mac.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_mac.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 cd /tmp
-curl --retry 3 -o ./msedge_stable.pkg "$1"
+curl -L --retry 3 -o ./msedge_stable.pkg "$1"
 # Note: there's no way to uninstall previously installed MSEdge.
 # However, running PKG again seems to update installation.
 sudo installer -pkg /tmp/msedge_stable.pkg -target /


### PR DESCRIPTION
## Summary
- Google flipped the macOS Chrome/Edge download URLs to a 302 redirect. `curl` without `-L` saved the redirect stub instead of the dmg/pkg, so `hdiutil`/`installer` failed.
- Added `-L` to all macOS reinstall scripts (Chrome stable/beta, Edge stable/beta/dev).
- Added `-L` defensively to the Linux Chrome `.deb` downloads and the Edge signing-key fetch, so the same kind of silent redirect flip won't break Linux.
- Windows uses PowerShell `WebClient.DownloadFile`, which already follows redirects.

Fixes https://github.com/microsoft/playwright/issues/41185