### PR TITLE
fix(trace-viewer): fix font preview loading and viewport tooltip values

### DIFF
--- a/packages/trace-viewer/src/ui/metadataView.tsx
+++ b/packages/trace-viewer/src/ui/metadataView.tsx
@@ -48,8 +48,8 @@ export const MetadataView: React.FunctionComponent<{
       </>
     )}
     <div className='call-section'>Viewport</div>
-    {model.options.viewport && <div className='call-line'>width:<span className='call-value number' title={String(!!model.options.viewport?.width)}>{model.options.viewport.width}</span></div>}
-    {model.options.viewport && <div className='call-line'>height:<span className='call-value number' title={String(!!model.options.viewport?.height)}>{model.options.viewport.height}</span></div>}
+    {model.options.viewport && <div className='call-line'>width:<span className='call-value number' title={String(model.options.viewport?.width)}>{model.options.viewport.width}</span></div>}
+    {model.options.viewport && <div className='call-line'>height:<span className='call-value number' title={String(model.options.viewport?.height)}>{model.options.viewport.height}</span></div>}
     <div className='call-line'>is mobile:<span className='call-value boolean' title={String(!!model.options.isMobile)}>{String(!!model.options.isMobile)}</span></div>
     {model.options.deviceScaleFactor && <div className='call-line'>device scale:<span className='call-value number' title={String(model.options.deviceScaleFactor)}>{String(model.options.deviceScaleFactor)}</span></div>}
     <div className='call-section'>Counts</div>

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -263,10 +263,11 @@ const FontPreview: React.FunctionComponent<{
       // note: constant font family name will lead to bugs
       // when displaying two font previews.
       fontFace = new FontFace('font-preview', font);
-      if (fontFace.status === 'loaded')
+      fontFace.load().then(() => {
         document.fonts.add(fontFace);
-      if (fontFace.status === 'error')
+      }).catch(() => {
         setIsError(true);
+      });
     } catch {
       setIsError(true);
     }


### PR DESCRIPTION
## Summary
- **Font preview**: `FontPreview` component never called `fontFace.load()`. The `FontFace` constructor creates a font in `unloaded` status, so the synchronous `status === 'loaded'` check always failed. Font preview rendered in the default font instead of the actual font.
- **Viewport tooltip**: Width/height title attributes used `String(!!value)` (copy-paste from the boolean `isMobile` line above), showing `"true"`/`"false"` instead of actual numeric values.