### PR TITLE
fix(html-reporter): prevent 'undefined' in annotation search index

### DIFF
--- a/packages/html-reporter/src/filter.ts
+++ b/packages/html-reporter/src/filter.ts
@@ -204,7 +204,7 @@ function cacheSearchValues(test: TestCaseSummary & { [searchValuesSymbol]?: Sear
     line: String(test.location.line),
     column: String(test.location.column),
     labels: test.tags.map(tag => tag.toLowerCase()),
-    annotations: test.annotations.map(a => a.type.toLowerCase() + '=' + a.description?.toLocaleLowerCase())
+    annotations: test.annotations.map(a => a.type.toLowerCase() + '=' + (a.description ?? '').toLowerCase())
   };
   test[searchValuesSymbol] = searchValues;
   return searchValues;


### PR DESCRIPTION
## Summary
- Annotations without descriptions produced `"type=undefined"` in the search index because `a.description?.toLocaleLowerCase()` returns `undefined` which concatenates as the literal string `"undefined"`.
- Use `(a.description ?? '').toLowerCase()` to fall back to empty string.
- Also normalizes `toLocaleLowerCase()` to `toLowerCase()` for consistency with the rest of the file.