### PR TITLE
fix(mcp): bind extension relay to IPv4 loopback for WSL2

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -73,7 +73,14 @@ export class CDPRelayServer {
   private _extensionConnectionPromise = new ManualPromise<void>();
 
   constructor(server: http.Server, browserChannel: string, executablePath?: string) {
-    this._wsHost = addressToString(server.address(), { protocol: 'ws' });
+    // Normalize IPv6 loopback ([::1]) to IPv4 loopback (127.0.0.1) so the relay URL
+    // is reachable from Windows Edge when the relay server runs inside WSL2.
+    const addr = server.address();
+    if (addr && typeof addr === 'object' && addr.address === '::1') {
+      addr.address = '127.0.0.1';
+      addr.family = 'IPv4';
+    }
+    this._wsHost = addressToString(addr, { protocol: 'ws' });
     this._browserChannel = browserChannel;
     this._executablePath = executablePath;
     this._protocolVersion = parseInt(process.env.PLAYWRIGHT_EXTENSION_PROTOCOL ?? protocol.DEFAULT_VERSION.toString(), 10);

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -34,7 +34,7 @@ export async function createExtensionBrowser(channel: string, executablePath: st
   }
 
   const httpServer = createHttpServer();
-  await startHttpServer(httpServer, {});
+  await startHttpServer(httpServer, { host: '127.0.0.1' });
   const relay = new CDPRelayServer(httpServer, channel, executablePath);
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);
 


### PR DESCRIPTION
## Description

Fixes #41180 

**The Problem:**
When launching a Windows browser (like Microsoft Edge) via `PLAYWRIGHT_MCP_EXECUTABLE_PATH` from a WSL2 environment, the Playwright Extension relay fails to establish a connection and times out. 

By default, Node's `startHttpServer` without a specified host binds to `::` (IPv6), resulting in a generated extension URL containing `ws://[::1]:<port>`. WSL2 does not automatically forward Windows IPv6 localhost traffic into the Linux container, breaking the connection.

**The Fix:**
1. Explicitly initialized the MCP relay `httpServer` with `host: '127.0.0.1'` in `extensionContextFactory.ts`.
2. Added normalization in `CDPRelayServer` constructor to map `::1` to `127.0.0.1` so the generated `mcpRelayUrl` query parameter strictly uses an IPv4 address, which WSL2 successfully forwards from Windows.

**Testing:**
- Verified the fix locally; the extension successfully connects to the relay across the WSL/Windows boundary.
- Ran local MCP and Extension test suites.