### PR TITLE
fix(tracing): add missing error handlers to createWriteStream pipes

### DIFF
--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -464,11 +464,11 @@ class HtmlBuilder {
 
   private async _writeReportData(filePath: string) {
     fs.appendFileSync(filePath, '<template id="playwrightReportBase64">data:application/zip;base64,');
-    await new Promise(f => {
+    await new Promise<void>((resolve, reject) => {
       this._dataZipFile.end(undefined, () => {
         this._dataZipFile.outputStream
             .pipe(new Base64Encoder())
-            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', f);
+            .pipe(fs.createWriteStream(filePath, { flags: 'a' })).on('close', resolve).on('error', reject);
       });
     });
     fs.appendFileSync(filePath, '</template>');

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -238,9 +238,9 @@ export class TestTracing {
     const traceContent = Buffer.from(this._traceEvents.map(e => JSON.stringify(e)).join('\n'));
     zipFile.addBuffer(traceContent, testTraceEntryName);
 
-    await new Promise(f => {
+    await new Promise<void>((resolve, reject) => {
       zipFile.end(undefined, () => {
-        zipFile.outputStream.pipe(fs.createWriteStream(this._generateNextTraceRecordingPath())).on('close', f);
+        zipFile.outputStream.pipe(fs.createWriteStream(this._generateNextTraceRecordingPath())).on('close', resolve).on('error', reject);
       });
     });
 


### PR DESCRIPTION
## Summary
- Add `.on('error', reject)` to two `createWriteStream` pipe chains that only had `'close'` handlers
- Without error handlers, write failures (disk full, permissions) cause the promise to hang and the unhandled error event to crash the process
- Matches the existing pattern in the same codebase (`testTracing.ts:396`, `blob.ts:88`)