### PR TITLE
fix(mcp): use optional chaining for nullable browser() in disposal

### DIFF
--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -138,7 +138,7 @@ export function decorateMCPCommand(command: Command) {
             sharedBrowserPromise = undefined;
             const browserContext = (backend as BrowserBackend).browserContext;
             await browserContext.close().catch(() => { });
-            await browserContext.browser()!.close().catch(() => { });
+            await browserContext.browser()?.close().catch(() => { });
           }
         };
         await mcpServer.start(factory, config.server);


### PR DESCRIPTION
## Summary
- Replace non-null assertion (`!`) with optional chaining (`?.`) on `browserContext.browser()` in the MCP server's `disposed` callback

`browserContext.browser()` returns `Browser | null`. The `!` assertion causes a synchronous `TypeError` when `browser()` returns `null` (e.g. after remote disconnect). The `.catch()` only intercepts Promise rejections, not the synchronous crash.

Introduced in #39449 (2026-03-02).