### PR TITLE
test: unflake some tests

### DIFF
--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -32,7 +32,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions> = {
     timeout: 10000,
   },
   timeout: 30000,
-  globalTimeout: 5400000,
+  globalTimeout: 7200000,
   workers: process.env.CI ? 1 : undefined,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -69,8 +69,9 @@ it('should be able to click across browser contexts', async function({ browser }
   await page2.close();
 });
 
-it('should be able to hover across browser contexts in parallel', async function({ browser }) {
+it('should be able to hover across browser contexts in parallel', async function({ browser, browserName, headless }) {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40562' });
+  it.fixme(browserName === 'firefox' && !headless, 'Hover is flaky in headed Firefox');
 
   const html = `
     <style>

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -72,7 +72,7 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions & TestModeW
   },
   maxFailures: 200,
   timeout: video ? 60000 : 30000,
-  globalTimeout: 5400000,
+  globalTimeout: 7200000,
   workers: undefined,
   fullyParallel: !process.env.CI,
   forbidOnly: !!process.env.CI,

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -768,7 +768,7 @@ test('should capture attribute mutations inside a popup window', {
     await expect(popup.locator('#overlay')).toBeHidden();
   });
 
-  const frame = await traceViewer.snapshotFrame('Click');
+  const frame = await traceViewer.snapshotFrame('Expect');
   await expect(frame.locator('#overlay')).toHaveClass('no-display');
 });
 


### PR DESCRIPTION
Also increase the global timeout, since our almost 5k tests do not finish in 90 minutes on the slowest bots anymore.

Fixes: https://github.com/microsoft/playwright-browsers/issues/2322