### PR TITLE
fix(mcp): assign caps as array for legacy --vision flag

### DIFF
--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -88,7 +88,8 @@ export function decorateMCPCommand(command: Command) {
         if (options.vision) {
           // eslint-disable-next-line no-console
           console.error('The --vision option is deprecated, use --caps=vision instead');
-          options.caps = 'vision';
+          options.caps ??= [];
+          options.caps.push('vision');
         }
 
         if (options.caps?.includes('tracing'))

--- a/tests/mcp/capabilities.spec.ts
+++ b/tests/mcp/capabilities.spec.ts
@@ -75,3 +75,13 @@ test('support for legacy --vision option', async ({ startClient }) => {
   expect(toolNames).toContain('browser_mouse_click_xy');
   expect(toolNames).toContain('browser_mouse_drag_xy');
 });
+
+test('legacy --vision option combined with --caps', async ({ startClient }) => {
+  const { client } = await startClient({
+    args: ['--vision', '--caps=pdf'],
+  });
+  const { tools } = await client.listTools();
+  const toolNames = tools.map(t => t.name);
+  expect(toolNames).toContain('browser_mouse_move_xy');
+  expect(toolNames).toContain('browser_pdf_save');
+});


### PR DESCRIPTION
## Summary

- The `--vision` flag handler sets `options.caps = 'vision'` (a string) where `ToolCapability[]` is expected
- This overwrites any existing `--caps` array and crashes `options.caps.push('devtools')` with `TypeError` when combined with `--caps=tracing`
- Fix: initialize `options.caps` as an empty array when unset and push `'vision'` into it

Introduced in #37316 (2025-09-04), present for ~9 months.