### PR TITLE
test(bidi): remove another fail expectation for Firefox/Bidi

### DIFF
--- a/tests/library/browsercontext-timezone-id.spec.ts
+++ b/tests/library/browsercontext-timezone-id.spec.ts
@@ -118,8 +118,8 @@ it('should affect Intl.DateTimeFormat().resolvedOptions().timeZone', async ({ br
   await context.close();
 });
 
-it('should propagate timezone to workers', async ({ browser, browserName, server }) => {
-  it.fail(browserName === 'firefox', 'https://github.com/microsoft/playwright/issues/38919');
+it('should propagate timezone to workers', async ({ browser, browserName, isBidi, server }) => {
+  it.fail(browserName === 'firefox' && !isBidi, 'https://github.com/microsoft/playwright/issues/38919');
   const context = await browser.newContext({ timezoneId: 'America/Jamaica' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
This test now passes with Firefox/Bidi since https://bugzilla.mozilla.org/show_bug.cgi?id=2015657 has been fixed.
(See also https://github.com/microsoft/playwright/issues/38919)