### PR TITLE
fix(trace viewer): load trace from a local file

### DIFF
--- a/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
+++ b/packages/playwright-core/src/server/trace/viewer/traceViewer.ts
@@ -218,6 +218,13 @@ function traceFileRoots(traceUrl: string | undefined): string[] {
     } catch {
     }
   }
+  if (traceUrl?.startsWith('file?path=')) {
+    try {
+      const url = new URL(traceUrl, 'http://localhost');
+      return [path.dirname(url.searchParams.get('path')!)];
+    } catch {
+    }
+  }
   return [process.cwd()];
 }
 

--- a/tests/config/traceViewerFixtures.ts
+++ b/tests/config/traceViewerFixtures.ts
@@ -31,7 +31,7 @@ type BaseWorkerFixtures = {
 };
 
 export type TraceViewerFixtures = {
-  showTraceViewer: (trace: string | undefined, options?: {host?: string, port?: number, stdin?: boolean}) => Promise<TraceViewerPage>;
+  showTraceViewer: (trace: string | undefined, options?: {host?: string, port?: number, stdin?: boolean, cwd?: string}) => Promise<TraceViewerPage>;
   runAndTrace: (body: () => Promise<void>, optsOverrides?: Parameters<BrowserContext['tracing']['start']>[0]) => Promise<TraceViewerPage>;
 };
 
@@ -153,7 +153,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
   showTraceViewer: async ({ playwright, childProcess, browserName }, use, testInfo) => {
     const browsers: Browser[] = [];
     const tracings: any[] = [];
-    await use(async (trace: string | undefined, { host, port, stdin } = {}) => {
+    await use(async (trace: string | undefined, { host, port, stdin, cwd } = {}) => {
       const command = [
         'node',
         path.join(__dirname, '../../packages/playwright-core/cli.js'),
@@ -166,7 +166,7 @@ export const traceViewerFixtures: Fixtures<TraceViewerFixtures, {}, BaseTestFixt
         command.push('--stdin');
       if (trace)
         command.push(trace);
-      const cp = childProcess({ command });
+      const cp = childProcess({ command, cwd });
       await cp.waitForOutput('Listening on');
       const browser = await playwright.chromium.launch({
         ...(browserName === 'chromium' ? {} : { channel: 'chromium' }),

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -106,9 +106,16 @@ test('should open two trace viewers', async ({ showTraceViewer }, testInfo) => {
 });
 
 test('should open trace viewer on specific host', async ({ showTraceViewer }, testInfo) => {
-  const traceViewer = await showTraceViewer(testInfo.outputPath(), { host: '127.0.0.1' });
+  const dir = testInfo.outputPath('some-dir');
+  await fs.promises.mkdir(dir, { recursive: true });
+  // Run from a random directory to check that file access works.
+  const traceViewer = await showTraceViewer(traceFile, { host: '127.0.0.1', cwd: dir });
   await expect(traceViewer.page).toHaveTitle('Playwright Trace Viewer');
   await expect(traceViewer.page).toHaveURL(/127.0.0.1/);
+  await expect(traceViewer.actionTitles).toContainText([
+    /Create page/,
+    /Close page/,
+  ]);
 });
 
 test('should show tracing.group in the action list with location', async ({ runAndTrace, page, context }) => {


### PR DESCRIPTION
`npx playwright show-trace /path/to/trace.zip` failed when trace file was outside of current working dir. That's because internally the path is turned into `file?path=...` and we incorrectly defaulted `allowedFileRoots` to `process.cwd`.