### PR TITLE
fix(mcp): Consider WAYLAND_DISPLAY for headed operation on Linux.

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -127,7 +127,7 @@ export async function resolveCLIConfigForMCP(cliOptions: CLIOptions, env?: NodeJ
 
   const browser = await validateBrowserConfig(result.browser);
   if (browser.launchOptions.headless === undefined)
-    browser.launchOptions.headless = os.platform() === 'linux' && !process.env.DISPLAY;
+    browser.launchOptions.headless = os.platform() === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
 
   validateOutputDir(result.outputDir);
 

--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -103,7 +103,7 @@ export class TestContext {
     if (options?.headless !== undefined)
       this.computedHeaded = !options.headless;
     else
-      this.computedHeaded = !process.env.CI && !(os.platform() === 'linux' && !process.env.DISPLAY);
+      this.computedHeaded = !process.env.CI && !(os.platform() === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY);
   }
 
   private async _enqueue<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
On Linux a minimal(istic) installation might not contain XWayland, as it's no longer required for modern browsers.
Hence the DISPLAY envvar is not set. Thus, fallback to WAYLAND_DISPLAY.