### PR TITLE
chore: fixes uncovered by the .NET 1.61 roll

### DIFF
--- a/docs/src/api/class-credentials.md
+++ b/docs/src/api/class-credentials.md
@@ -281,9 +281,9 @@ Installs the virtual WebAuthn authenticator into the context, overriding
 `navigator.credentials.create()` and `navigator.credentials.get()` in all current
 and future pages. Call this before the page first touches `navigator.credentials`.
 
-Required: until `install()` is called, no interception is in place and the page sees
+Required: until [`method: Credentials.install`] is called, no interception is in place and the page sees
 the platform's native (or absent) WebAuthn behaviour. Seeding credentials with
-[`method: Credentials.create`] without `install()` populates the authenticator, but the
+[`method: Credentials.create`] without installing populates the authenticator, but the
 page will never see those credentials.
 
 ## async method: Credentials.create
@@ -298,13 +298,12 @@ page will never see those credentials.
 
 Seeds a virtual WebAuthn credential and returns it.
 
-With only `rpId`, generates a fresh **ECDSA P-256** keypair, credential id and user handle. The
+With only [`param: Credentials.create.rpId`], generates a fresh **ECDSA P-256** keypair, credential id and user handle. The
 seeded credential is discoverable (resident), so the page can resolve it from both
-username-then-passkey and usernameless passkey flows. The returned object carries the `privateKey` and `publicKey`, so
-it can be persisted to disk and re-seeded in a later test.
+username-then-passkey and usernameless passkey flows. The returned object carries the private and public keys, so it can be persisted to disk and re-seeded in a later test.
 
-To **import a known credential**, supply all four of `id`, `userHandle`, `privateKey` and
-`publicKey` together.
+To **import a known credential**, supply all four of [`option: Credentials.create.id`], [`option: Credentials.create.userHandle`], [`option: Credentials.create.privateKey`] and
+[`option: Credentials.create.publicKey`] together.
 
 Call [`method: Credentials.install`] before navigating to a page that uses WebAuthn.
 
@@ -361,11 +360,11 @@ Base64url-encoded credential id.
   - `privateKey` <[string]>
   - `publicKey` <[string]>
 
-Returns every credential currently held by the authenticator, optionally filtered by `rpId` or
-`id`. This includes both credentials seeded with [`method: Credentials.create`] and credentials
+Returns every credential currently held by the authenticator, optionally filtered by [`option: Credentials.get.rpId`] or
+[`option: Credentials.get.id`]. This includes both credentials seeded with [`method: Credentials.create`] and credentials
 the page registered itself by calling `navigator.credentials.create()`.
 
-Each returned credential includes its `privateKey` and `publicKey`, so a passkey the app just
+Each returned credential includes its private and public keys, so a passkey the app just
 registered can be saved and re-seeded into a later test with [`method: Credentials.create`] — see the second example in the class overview.
 
 ### option: Credentials.get.rpId

--- a/docs/src/api/class-webstorage.md
+++ b/docs/src/api/class-webstorage.md
@@ -37,7 +37,7 @@ page.local_storage.clear()
 page.navigate("https://example.com");
 page.localStorage().setItem("token", "abc");
 String token = page.localStorage().getItem("token");
-List<NameValue> all = page.localStorage().items();
+List<WebStorageItem> all = page.localStorage().items();
 page.localStorage().removeItem("token");
 page.localStorage().clear();
 ```
@@ -54,16 +54,17 @@ await page.LocalStorage.ClearAsync();
 ## async method: WebStorage.items
 * since: v1.61
 - returns: <[Array]<[Object]>>
+  * alias: WebStorageItem
   - `name` <[string]>
   - `value` <[string]>
 
-Returns all items in the storage as `name`/`value` pairs.
+Returns all items in the storage as name/value pairs.
 
 ## async method: WebStorage.getItem
 * since: v1.61
 - returns: <[null]|[string]>
 
-Returns the value for the given `name`, or `null` if the key is not present.
+Returns the value for the given [`param: WebStorage.getItem.name`] if present.
 
 ### param: WebStorage.getItem.name
 * since: v1.61
@@ -74,7 +75,7 @@ Name of the item to retrieve.
 ## async method: WebStorage.setItem
 * since: v1.61
 
-Sets the value for the given `name`. Overwrites any existing value for that name.
+Sets the value for the given [`param: WebStorage.setItem.name`]. Overwrites any existing value for that name.
 
 ### param: WebStorage.setItem.name
 * since: v1.61
@@ -91,7 +92,7 @@ New value for the item.
 ## async method: WebStorage.removeItem
 * since: v1.61
 
-Removes the item with the given `name`. No-op if the item is absent.
+Removes the item with the given [`param: WebStorage.removeItem.name`]. No-op if the item is absent.
 
 ### param: WebStorage.removeItem.name
 * since: v1.61

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18867,12 +18867,16 @@ export interface Credentials {
   /**
    * Seeds a virtual WebAuthn credential and returns it.
    *
-   * With only `rpId`, generates a fresh **ECDSA P-256** keypair, credential id and user handle. The seeded credential
-   * is discoverable (resident), so the page can resolve it from both username-then-passkey and usernameless passkey
-   * flows. The returned object carries the `privateKey` and `publicKey`, so it can be persisted to disk and re-seeded
-   * in a later test.
+   * With only [`rpId`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-rp-id), generates a
+   * fresh **ECDSA P-256** keypair, credential id and user handle. The seeded credential is discoverable (resident), so
+   * the page can resolve it from both username-then-passkey and usernameless passkey flows. The returned object carries
+   * the private and public keys, so it can be persisted to disk and re-seeded in a later test.
    *
-   * To **import a known credential**, supply all four of `id`, `userHandle`, `privateKey` and `publicKey` together.
+   * To **import a known credential**, supply all four of
+   * [`id`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-id),
+   * [`userHandle`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-user-handle),
+   * [`privateKey`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-private-key) and
+   * [`publicKey`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-public-key) together.
    *
    * Call [credentials.install()](https://playwright.dev/docs/api/class-credentials#credentials-install) before
    * navigating to a page that uses WebAuthn.
@@ -18935,13 +18939,15 @@ export interface Credentials {
   delete(id: string): Promise<void>;
 
   /**
-   * Returns every credential currently held by the authenticator, optionally filtered by `rpId` or `id`. This includes
-   * both credentials seeded with
+   * Returns every credential currently held by the authenticator, optionally filtered by
+   * [`rpId`](https://playwright.dev/docs/api/class-credentials#credentials-get-option-rp-id) or
+   * [`id`](https://playwright.dev/docs/api/class-credentials#credentials-get-option-id). This includes both credentials
+   * seeded with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) and
    * credentials the page registered itself by calling `navigator.credentials.create()`.
    *
-   * Each returned credential includes its `privateKey` and `publicKey`, so a passkey the app just registered can be
-   * saved and re-seeded into a later test with
+   * Each returned credential includes its private and public keys, so a passkey the app just registered can be saved
+   * and re-seeded into a later test with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) — see
    * the second example in the class overview.
    * @param options
@@ -18973,10 +18979,11 @@ export interface Credentials {
    * `navigator.credentials.get()` in all current and future pages. Call this before the page first touches
    * `navigator.credentials`.
    *
-   * Required: until `install()` is called, no interception is in place and the page sees the platform's native (or
-   * absent) WebAuthn behaviour. Seeding credentials with
+   * Required: until [credentials.install()](https://playwright.dev/docs/api/class-credentials#credentials-install) is
+   * called, no interception is in place and the page sees the platform's native (or absent) WebAuthn behaviour. Seeding
+   * credentials with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) without
-   * `install()` populates the authenticator, but the page will never see those credentials.
+   * installing populates the authenticator, but the page will never see those credentials.
    */
   install(): Promise<void>;
 }
@@ -21677,13 +21684,14 @@ export interface WebStorage {
   clear(): Promise<void>;
 
   /**
-   * Returns the value for the given `name`, or `null` if the key is not present.
+   * Returns the value for the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-get-item-option-name) if present.
    * @param name Name of the item to retrieve.
    */
   getItem(name: string): Promise<null|string>;
 
   /**
-   * Returns all items in the storage as `name`/`value` pairs.
+   * Returns all items in the storage as name/value pairs.
    */
   items(): Promise<Array<{
     name: string;
@@ -21692,13 +21700,17 @@ export interface WebStorage {
   }>>;
 
   /**
-   * Removes the item with the given `name`. No-op if the item is absent.
+   * Removes the item with the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-remove-item-option-name). No-op if the item
+   * is absent.
    * @param name Name of the item to remove.
    */
   removeItem(name: string): Promise<void>;
 
   /**
-   * Sets the value for the given `name`. Overwrites any existing value for that name.
+   * Sets the value for the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-set-item-option-name). Overwrites any
+   * existing value for that name.
    * @param name Name of the item to set.
    * @param value New value for the item.
    */

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -69,7 +69,7 @@ export class Snapshotter {
 
   async reset() {
     if (this._started)
-      await this._context.safeNonStallingEvaluateInAllFrames(`window["${this._snapshotStreamer}"].reset()`, 'main');
+      await this._context.safeNonStallingEvaluateInAllFrames(`window["${this._snapshotStreamer}"].resetHistory()`, 'main');
   }
 
   stop() {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18867,12 +18867,16 @@ export interface Credentials {
   /**
    * Seeds a virtual WebAuthn credential and returns it.
    *
-   * With only `rpId`, generates a fresh **ECDSA P-256** keypair, credential id and user handle. The seeded credential
-   * is discoverable (resident), so the page can resolve it from both username-then-passkey and usernameless passkey
-   * flows. The returned object carries the `privateKey` and `publicKey`, so it can be persisted to disk and re-seeded
-   * in a later test.
+   * With only [`rpId`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-rp-id), generates a
+   * fresh **ECDSA P-256** keypair, credential id and user handle. The seeded credential is discoverable (resident), so
+   * the page can resolve it from both username-then-passkey and usernameless passkey flows. The returned object carries
+   * the private and public keys, so it can be persisted to disk and re-seeded in a later test.
    *
-   * To **import a known credential**, supply all four of `id`, `userHandle`, `privateKey` and `publicKey` together.
+   * To **import a known credential**, supply all four of
+   * [`id`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-id),
+   * [`userHandle`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-user-handle),
+   * [`privateKey`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-private-key) and
+   * [`publicKey`](https://playwright.dev/docs/api/class-credentials#credentials-create-option-public-key) together.
    *
    * Call [credentials.install()](https://playwright.dev/docs/api/class-credentials#credentials-install) before
    * navigating to a page that uses WebAuthn.
@@ -18935,13 +18939,15 @@ export interface Credentials {
   delete(id: string): Promise<void>;
 
   /**
-   * Returns every credential currently held by the authenticator, optionally filtered by `rpId` or `id`. This includes
-   * both credentials seeded with
+   * Returns every credential currently held by the authenticator, optionally filtered by
+   * [`rpId`](https://playwright.dev/docs/api/class-credentials#credentials-get-option-rp-id) or
+   * [`id`](https://playwright.dev/docs/api/class-credentials#credentials-get-option-id). This includes both credentials
+   * seeded with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) and
    * credentials the page registered itself by calling `navigator.credentials.create()`.
    *
-   * Each returned credential includes its `privateKey` and `publicKey`, so a passkey the app just registered can be
-   * saved and re-seeded into a later test with
+   * Each returned credential includes its private and public keys, so a passkey the app just registered can be saved
+   * and re-seeded into a later test with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) — see
    * the second example in the class overview.
    * @param options
@@ -18973,10 +18979,11 @@ export interface Credentials {
    * `navigator.credentials.get()` in all current and future pages. Call this before the page first touches
    * `navigator.credentials`.
    *
-   * Required: until `install()` is called, no interception is in place and the page sees the platform's native (or
-   * absent) WebAuthn behaviour. Seeding credentials with
+   * Required: until [credentials.install()](https://playwright.dev/docs/api/class-credentials#credentials-install) is
+   * called, no interception is in place and the page sees the platform's native (or absent) WebAuthn behaviour. Seeding
+   * credentials with
    * [credentials.create(rpId[, options])](https://playwright.dev/docs/api/class-credentials#credentials-create) without
-   * `install()` populates the authenticator, but the page will never see those credentials.
+   * installing populates the authenticator, but the page will never see those credentials.
    */
   install(): Promise<void>;
 }
@@ -21677,13 +21684,14 @@ export interface WebStorage {
   clear(): Promise<void>;
 
   /**
-   * Returns the value for the given `name`, or `null` if the key is not present.
+   * Returns the value for the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-get-item-option-name) if present.
    * @param name Name of the item to retrieve.
    */
   getItem(name: string): Promise<null|string>;
 
   /**
-   * Returns all items in the storage as `name`/`value` pairs.
+   * Returns all items in the storage as name/value pairs.
    */
   items(): Promise<Array<{
     name: string;
@@ -21692,13 +21700,17 @@ export interface WebStorage {
   }>>;
 
   /**
-   * Removes the item with the given `name`. No-op if the item is absent.
+   * Removes the item with the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-remove-item-option-name). No-op if the item
+   * is absent.
    * @param name Name of the item to remove.
    */
   removeItem(name: string): Promise<void>;
 
   /**
-   * Sets the value for the given `name`. Overwrites any existing value for that name.
+   * Sets the value for the given
+   * [`name`](https://playwright.dev/docs/api/class-webstorage#web-storage-set-item-option-name). Overwrites any
+   * existing value for that name.
    * @param name Name of the item to set.
    * @param value New value for the item.
    */

--- a/packages/protocol/spec/electron.yml
+++ b/packages/protocol/spec/electron.yml
@@ -90,8 +90,6 @@ Electron:
 ElectronApplication:
   type: interface
 
-  extends: EventTarget
-
   initializer:
     context: BrowserContext
 

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2237,7 +2237,7 @@ export interface ElectronApplicationEventTarget {
   on(event: 'close', callback: (params: ElectronApplicationCloseEvent) => void): this;
   on(event: 'console', callback: (params: ElectronApplicationConsoleEvent) => void): this;
 }
-export interface ElectronApplicationChannel extends ElectronApplicationEventTarget, EventTargetChannel {
+export interface ElectronApplicationChannel extends ElectronApplicationEventTarget, Channel {
   _type_ElectronApplication: boolean;
   browserWindow(params: ElectronApplicationBrowserWindowParams, progress?: Progress): Promise<ElectronApplicationBrowserWindowResult>;
   evaluateExpression(params: ElectronApplicationEvaluateExpressionParams, progress?: Progress): Promise<ElectronApplicationEvaluateExpressionResult>;

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -2507,6 +2507,26 @@ test('should capture iframe with srcdoc', async ({ page, server, runAndTrace }) 
   await expect(frame.frameLocator('iframe').getByRole('button')).toHaveText('Hello iframe');
 });
 
+test('should render snapshots from the second chunk', async ({ context, page, server, showTraceViewer }, testInfo) => {
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent('<button>Click</button>');
+
+  await context.tracing.startChunk();
+  await page.click('"Click"');
+  await context.tracing.stopChunk({ path: testInfo.outputPath('trace1.zip') });
+
+  await context.tracing.startChunk();
+  await page.hover('"Click"');
+  await context.tracing.stopChunk({ path: testInfo.outputPath('trace2.zip') });
+
+  // Snapshots in the second chunk must be self-contained and not reference
+  // snapshot state from the first chunk.
+  const traceViewer = await showTraceViewer(testInfo.outputPath('trace2.zip'));
+  const frame = await traceViewer.snapshotFrame('Hover');
+  await expect(frame.locator('button')).toHaveText('Click');
+});
+
 test('take trace paths via stdin', async ({ showTraceViewer }) => {
   const traceViewer = await showTraceViewer(undefined, { stdin: true });
   await expect(traceViewer.page).toHaveTitle('Playwright Trace Viewer');


### PR DESCRIPTION
## Summary

Assorted fixes uncovered while rolling playwright-dotnet to 1.61:

- Reset snapshot history when starting a new trace chunk. The injected method was renamed to `resetHistory()` in #40766, but `Snapshotter.reset()` still evaluated the removed `reset()`, silently doing nothing. As a result, snapshots in the second and following chunks referenced state from the previous chunk and rendered blank in the trace viewer. Added a trace viewer regression test.
- Remove dangling `extends: EventTarget` from `electron.yml` — the `EventTarget` interface was removed from the protocol in #40718, and the dangling reference broke the .NET channel generator.
- Name the `WebStorage.items()` return type via an alias, so that generated .NET/Java types are not called `Item`.
- Use option/param links in `Credentials` and `WebStorage` docs.