### PR TITLE
fix(fetch): report serverAddr and securityDetails for reused sockets

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -37,6 +37,8 @@ import { isAbortError } from './progress';
 import { getMatchingTLSOptionsForOrigin, rewriteOpenSSLErrorIfNeeded } from './socksClientCertificatesInterceptor';
 import { Tracing } from './trace/recorder/tracing';
 
+import type net from 'net';
+
 import type { Playwright } from './playwright';
 import type { Progress } from './progress';
 import type * as types from './types';
@@ -552,9 +554,26 @@ export abstract class APIRequestContext extends SdkObject {
       );
       request.on('close', () => eventsHelper.removeEventListeners(listeners));
 
+      const captureSecurityDetails = (socket: net.Socket) => {
+        if (!(socket instanceof TLSSocket))
+          return;
+        const peerCertificate = socket.getPeerCertificate();
+        securityDetails = {
+          protocol: socket.getProtocol() ?? undefined,
+          subjectName: peerCertificate.subject.CN,
+          validFrom: new Date(peerCertificate.valid_from).getTime() / 1000,
+          validTo: new Date(peerCertificate.valid_to).getTime() / 1000,
+          issuer: peerCertificate.issuer.CN
+        };
+      };
+
       request.on('socket', socket => {
+        serverIPAddress = socket.remoteAddress;
+        serverPort = socket.remotePort;
+
         if (request.reusedSocket) {
           reusedSocketAt = monotonicTime();
+          captureSecurityDetails(socket);
           return;
         }
 
@@ -569,22 +588,9 @@ export abstract class APIRequestContext extends SdkObject {
             eventsHelper.addEventListener(socket, 'connect', () => { tcpConnectionAt = monotonicTime(); }),
             eventsHelper.addEventListener(socket, 'secureConnect', () => {
               tlsHandshakeAt = monotonicTime();
-
-              if (socket instanceof TLSSocket) {
-                const peerCertificate = socket.getPeerCertificate();
-                securityDetails = {
-                  protocol: socket.getProtocol() ?? undefined,
-                  subjectName: peerCertificate.subject.CN,
-                  validFrom: new Date(peerCertificate.valid_from).getTime() / 1000,
-                  validTo: new Date(peerCertificate.valid_to).getTime() / 1000,
-                  issuer: peerCertificate.issuer.CN
-                };
-              }
+              captureSecurityDetails(socket);
             }),
         );
-
-        serverIPAddress = socket.remoteAddress;
-        serverPort = socket.remotePort;
       });
       request.on('finish', () => { requestFinishAt = monotonicTime(); });
 

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -236,17 +236,23 @@ it('should propagate ignoreHTTPSErrors on redirects', async ({ playwright, https
 
 it('should return server address from response', async ({ playwright, server }) => {
   const request = await playwright.request.newContext();
-  const response = await request.get(server.EMPTY_PAGE);
-  const addr = await response.serverAddr();
-  expect(addr!.ipAddress).toMatch(/^(127\.0\.0\.1|::1)$/);
-  expect(addr!.port).toBe(server.PORT);
+  // The second request reuses the keep-alive socket and should report the address as well.
+  for (let i = 0; i < 2; i++) {
+    const response = await request.get(server.EMPTY_PAGE);
+    const addr = await response.serverAddr();
+    expect(addr!.ipAddress).toMatch(/^(127\.0\.0\.1|::1)$/);
+    expect(addr!.port).toBe(server.PORT);
+  }
   await request.dispose();
 });
 
 it('should return security details from response', async ({ playwright, httpsServer }) => {
   const request = await playwright.request.newContext({ ignoreHTTPSErrors: true });
-  const response = await request.get(httpsServer.EMPTY_PAGE);
-  expect(await response.securityDetails()).toEqual({ issuer: 'playwright-test', protocol: 'TLSv1.3', subjectName: 'playwright-test', validFrom: 1691708270, validTo: 2007068270 });
+  // The second request reuses the keep-alive socket and should report the details as well.
+  for (let i = 0; i < 2; i++) {
+    const response = await request.get(httpsServer.EMPTY_PAGE);
+    expect(await response.securityDetails()).toEqual({ issuer: 'playwright-test', protocol: 'TLSv1.3', subjectName: 'playwright-test', validFrom: 1691708270, validTo: 2007068270 });
+  }
   await request.dispose();
 });
 


### PR DESCRIPTION
## Summary

- `APIResponse.serverAddr()` and `securityDetails()` returned `null` whenever the request reused a keep-alive socket, because both values were only captured on freshly established connections.
- A reused socket is already connected (and its TLS handshake complete), so capture the server address and security details right away in the `reusedSocket` path.
- Updated the corresponding tests to make a second request over the same keep-alive connection.

Uncovered by the .NET 1.61 roll.