### PR TITLE
fix(trace-utils): format timestamps with hours when trace duration ex…

### DIFF
--- a/packages/playwright-core/src/tools/trace/traceUtils.ts
+++ b/packages/playwright-core/src/tools/trace/traceUtils.ts
@@ -99,10 +99,17 @@ export function formatTimestamp(ms: number, base: number): string {
   if (relative < 0)
     return '0:00.000';
   const totalMs = Math.floor(relative);
-  const minutes = Math.floor(totalMs / 60000);
-  const seconds = Math.floor((totalMs % 60000) / 1000);
+  const totalSeconds = Math.floor(totalMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
   const millis = totalMs % 1000;
-  return `${minutes}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`;
+  const mm = minutes.toString().padStart(2, '0');
+  const ss = seconds.toString().padStart(2, '0');
+  const mmm = millis.toString().padStart(3, '0');
+  if (hours > 0)
+    return `${hours}:${mm}:${ss}.${mmm}`;
+  return `${minutes}:${ss}.${mmm}`;
 }
 
 export function actionTitle(action: ActionTraceEventInContext): string {


### PR DESCRIPTION
# fix: format timestamps with hours when trace duration exceeds 60 minutes

## Summary
Fixes #40068 — Trace timeline displays incorrect time format when test or fixture duration exceeds 60 minutes.

## Problem
When a trace session lasts longer than 60 minutes (e.g. an `APIRequestContext` fixture that runs for hours), the trace viewer's CLI timeline shows:
```
120:00.000
```
instead of:
```
2:00:00.000
```

This is confusing and makes it difficult to read long-running test traces.

## Root Cause
`formatTimestamp(ms, base)` in `packages/playwright-core/src/tools/trace/traceUtils.ts` only formats up to `minutes:seconds.millis`. Durations ≥ 60 min overflow into raw minute counts.

## Solution
Updated `formatTimestamp` to:
- Compute hours from the total seconds
- Prefix `H:MM:SS.mmm` when `hours > 0`
- Keep the existing `M:SS.mmm` format for sub-hour traces (backward-compatible)

## Files Changed
- `packages/playwright-core/src/tools/trace/traceUtils.ts` — 10 insertions(+), 3 deletions(-)

## Benefits
- Long-running tests/traces now display correctly in the CLI trace viewer
- No behavior change for traces under 1 hour
- Zero additional dependencies
