### PR TITLE
fix(mcp): pass action timeout to browser_wait_for waitFor calls

### DIFF
--- a/packages/playwright-core/src/tools/backend/wait.ts
+++ b/packages/playwright-core/src/tools/backend/wait.ts
@@ -47,12 +47,12 @@ const wait = defineTool({
 
     if (goneLocator) {
       response.addCode(`await page.getByText(${JSON.stringify(params.textGone)}).first().waitFor({ state: 'hidden' });`);
-      await goneLocator.waitFor({ state: 'hidden' });
+      await goneLocator.waitFor({ state: 'hidden', ...tab.actionTimeoutOptions });
     }
 
     if (locator) {
       response.addCode(`await page.getByText(${JSON.stringify(params.text)}).first().waitFor({ state: 'visible' });`);
-      await locator.waitFor({ state: 'visible' });
+      await locator.waitFor({ state: 'visible', ...tab.actionTimeoutOptions });
     }
 
     response.addTextResult(`Waited for ${params.text || params.textGone || params.time}`);

--- a/tests/mcp/timeouts.spec.ts
+++ b/tests/mcp/timeouts.spec.ts
@@ -76,6 +76,56 @@ test('action timeout (custom)', async ({ startClient, server }) => {
   });
 });
 
+test('wait_for text timeout', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: [`--timeout-action=1234`] });
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <div>Hello World</div>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: server.PREFIX,
+    },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_wait_for',
+    arguments: { text: 'This text will never appear' },
+  })).toHaveResponse({
+    error: expect.stringContaining(`Timeout 1234ms exceeded.`),
+    isError: true,
+  });
+});
+
+test('wait_for textGone timeout', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: [`--timeout-action=1234`] });
+  server.setContent('/', `
+    <!DOCTYPE html>
+    <html>
+      <div>Permanent text</div>
+    </html>
+  `, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: {
+      url: server.PREFIX,
+    },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_wait_for',
+    arguments: { textGone: 'Permanent text' },
+  })).toHaveResponse({
+    error: expect.stringContaining(`Timeout 1234ms exceeded.`),
+    isError: true,
+  });
+});
+
 test('navigation timeout', async ({ startClient, server }) => {
   const { client } = await startClient({ args: [`--timeout-navigation=1234`] });
   server.setRoute('/slow', async () => {


### PR DESCRIPTION
## Summary
- Pass `tab.actionTimeoutOptions` to `waitFor()` in `browser_wait_for` text/textGone branches
- Without this, if text never appears or disappears, the tool hangs indefinitely, blocking the MCP session
- Every other MCP tool passes `tab.actionTimeoutOptions`; this aligns `browser_wait_for` with the established pattern
- Bug introduced in #37286