### PR TITLE
chore(bidi): dispose all sessions when connection is closed

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiConnection.ts
+++ b/packages/playwright-core/src/server/bidi/bidiConnection.ts
@@ -139,9 +139,10 @@ export class BidiConnection {
       this._transport.close();
   }
 
-  createMainFrameBrowsingContextSession(bowsingContextId: bidi.BrowsingContext.BrowsingContext): BidiSession {
-    const result = new BidiSession(this, bowsingContextId, message => this.rawSend(message));
-    this._browsingContextToSession.set(bowsingContextId, result);
+  createMainFrameBrowsingContextSession(browsingContextId: bidi.BrowsingContext.BrowsingContext): BidiSession {
+    const result = new BidiSession(this, browsingContextId, message => this.rawSend(message));
+    this.browserSession._browsingContexts.add(browsingContextId);
+    this._browsingContextToSession.set(browsingContextId, result);
     return result;
   }
 }
@@ -158,7 +159,7 @@ export class BidiSession extends EventEmitter {
   private readonly _rawSend: (message: any) => void;
   private readonly _callbacks = new Map<number, { resolve: (o: any) => void, reject: (e: ProtocolError) => void, error: ProtocolError }>();
   private _crashed: boolean = false;
-  private readonly _browsingContexts = new Set<string>();
+  readonly _browsingContexts = new Set<string>();
 
   override on: <T extends keyof BidiEvents | symbol>(event: T, listener: (payload: T extends symbol ? any : BidiEvents[T extends keyof BidiEvents ? T : never]['params']) => void) => this;
   override addListener: <T extends keyof BidiEvents | symbol>(event: T, listener: (payload: T extends symbol ? any : BidiEvents[T extends keyof BidiEvents ? T : never]['params']) => void) => this;
@@ -217,10 +218,14 @@ export class BidiSession extends EventEmitter {
   }
 
   dispose() {
+    if (this._disposed)
+      return;
     this._disposed = true;
     this.connection._browsingContextToSession.delete(this.sessionId);
-    for (const context of this._browsingContexts)
+    for (const context of this._browsingContexts) {
+      this.connection._browsingContextToSession.get(context)?.dispose();
       this.connection._browsingContextToSession.delete(context);
+    }
     this._browsingContexts.clear();
     for (const callback of this._callbacks.values()) {
       callback.error.type = this._crashed ? 'crashed' : 'closed';

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -1,5 +1,4 @@
 library/agent-perform.spec.ts › retrieve a secret [timeout]
-library/browser.spec.ts › should dispatch page.on(close) upon browser.close and reject evaluate [timeout]
 library/browsercontext-add-cookies.spec.ts › should allow unnamed cookies [fail]
 library/browsercontext-basic.spec.ts › fetch with keepalive should throw when offline [fail]
 library/browsercontext-basic.spec.ts › should disable javascript [fail]
@@ -72,7 +71,6 @@ library/browsertype-connect.spec.ts › run-server › should save download [fai
 library/browsertype-connect.spec.ts › run-server › should save videos to artifactsDir [fail]
 library/browsertype-connect.spec.ts › run-server › should saveAs videos from remote browser [timeout]
 library/browsertype-connect.spec.ts › run-server › should upload a folder [fail]
-library/browsertype-launch.spec.ts › should reject all promises when browser is closed [timeout]
 library/browsertype-launch.spec.ts › should reject if launched browser fails immediately [fail]
 library/capabilities.spec.ts › SharedArrayBuffer should work @smoke [timeout]
 library/capabilities.spec.ts › should play video @smoke [timeout]

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -137,7 +137,6 @@ page/page-screenshot.spec.ts › page screenshot › should allow transparency [
 page/page-set-input-files.spec.ts › should upload a folder [fail]
 page/page-wait-for-load-state.spec.ts › should wait for load state of about:blank popup [timeout]
 page/page-wait-for-load-state.spec.ts › should wait for load state of about:blank popup with noopener [timeout]
-page/page-wait-for-load-state.spec.ts › should wait for load state of about:blank popup with noopener [timeout]
 page/page-wait-for-load-state.spec.ts › should wait for load state of empty url popup [timeout]
 page/wheel.spec.ts › should dispatch wheel events after popup was opened @smoke [timeout]
 page/workers.spec.ts › Page.workers @smoke [timeout]


### PR DESCRIPTION
Fixes "should reject all promises when browser is closed" in `library/browsertype-launch.spec.ts` and "should dispatch page.on(close) upon browser.close and reject evaluate" in `library/browser.spec.ts`.