### PR TITLE
feat(matchers,aria-snapshot): allow disabling number-to-regex substit…

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -42,6 +42,7 @@ export type AriaTreeOptions = {
   doNotRenderActive?: boolean;
   depth?: number;
   boxes?: boolean;
+  numbers?: 'regex' | 'static';
 };
 
 type InternalOptions = {
@@ -57,6 +58,7 @@ type InternalOptions = {
 
 function toInternalOptions(options: AriaTreeOptions): InternalOptions {
   const renderBoxes = options.boxes;
+  const renderStringsAsRegex = options.numbers !== 'static';
   if (options.mode === 'ai') {
     // For AI consumption.
     return {
@@ -66,19 +68,20 @@ function toInternalOptions(options: AriaTreeOptions): InternalOptions {
       includeGenericRole: true,
       renderActive: !options.doNotRenderActive,
       renderCursorPointer: true,
+      renderStringsAsRegex,
       renderBoxes,
     };
   }
   if (options.mode === 'autoexpect') {
     // To auto-generate assertions on visible elements.
-    return { visibility: 'ariaAndVisible', refs: 'none', renderBoxes };
+    return { visibility: 'ariaAndVisible', refs: 'none', renderStringsAsRegex, renderBoxes };
   }
   if (options.mode === 'codegen') {
-    // To generate aria assertion with regex heurisitcs.
+    // To generate aria assertion with regex heuristics.
     return { visibility: 'aria', refs: 'none', renderStringsAsRegex: true, renderBoxes };
   }
   // To match aria snapshot.
-  return { visibility: 'aria', refs: 'none', renderBoxes };
+  return { visibility: 'aria', refs: 'none', renderStringsAsRegex, renderBoxes };
 }
 
 export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOptions): AriaSnapshot {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1276,6 +1276,7 @@ scheme.FrameAriaSnapshotParams = tObject({
   selector: tOptional(tString),
   depth: tOptional(tInt),
   boxes: tOptional(tBoolean),
+  numbers: tOptional(tEnum(['regex', 'static'])),
   timeout: tFloat,
 });
 scheme.FrameAriaSnapshotResult = tObject({

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1812,14 +1812,14 @@ export class Frame extends SdkObject<FrameEventMap> {
     }, { source, arg });
   }
 
-  async ariaSnapshot(progress: Progress, options: { mode?: 'ai' | 'default', track?: string, doNotRenderActive?: boolean, selector?: string, depth?: number, boxes?: boolean } = {}): Promise<{ snapshot: string }> {
+  async ariaSnapshot(progress: Progress, options: { mode?: 'ai' | 'default', track?: string, doNotRenderActive?: boolean, selector?: string, depth?: number, boxes?: boolean, numbers?: 'regex' | 'static' } = {}): Promise<{ snapshot: string }> {
     if (options.selector && options.track)
       throw new Error('Cannot specify both selector and track options');
 
     if (options.selector && options.mode !== 'ai') {
-      // Non-ai locator snapshot is auto-waiting and does not include iframes.
+      const numbers = options.numbers ?? 'regex';
       const snapshot = await this._retryWithProgressIfNotConnected(progress, options.selector, { strict: true, performActionPreChecks: true }, async (progress, handle) => {
-        return await progress.race(handle.evaluateInUtility(([injected, element, opts]) => injected.ariaSnapshot(element, opts), { mode: 'default' as const, depth: options.depth, boxes: options.boxes }));
+        return await progress.race(handle.evaluateInUtility(([injected, element, opts]) => injected.ariaSnapshot(element, opts), { mode: 'default' as const, depth: options.depth, boxes: options.boxes, numbers }));
       });
       return { snapshot };
     }

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1107,7 +1107,7 @@ export class InitScript extends DisposableObject {
   }
 }
 
-export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Frame, options: { mode?: 'ai' | 'default', track?: string, doNotRenderActive?: boolean, info?: SelectorInfo, depth?: number, boxes?: boolean } = {}): Promise<{ full: string[], incremental?: string[] }> {
+export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Frame, options: { mode?: 'ai' | 'default', track?: string, doNotRenderActive?: boolean, info?: SelectorInfo, depth?: number, boxes?: boolean, numbers?: 'regex' | 'static' } = {}): Promise<{ full: string[], incremental?: string[] }> {
   // Only await the topmost navigations, inner frames will be empty when racing.
   const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async (progress, continuePolling) => {
     try {
@@ -1132,6 +1132,7 @@ export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Fra
         info: options.info,
         depth: options.depth,
         boxes: options.boxes,
+        numbers: options.numbers,
       }));
       if (snapshotOrRetry === true)
         return continuePolling;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -139,6 +139,7 @@ export type ExpectConfig = {
   toMatchAriaSnapshot?: {
     pathTemplate?: string;
     children?: 'contain' | 'equal' | 'deep-equal';
+    numbers?: 'regex' | 'static';
   };
   toPass?: { timeout?: number; intervals?: number[] };
 };

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -34,6 +34,7 @@ type ToMatchAriaSnapshotExpected = {
   name?: string;
   path?: string;
   timeout?: number;
+  numbers?: 'regex' | 'static';
 } | string;
 
 const kImpossibleAriaMatch = `- none "Generating new baseline"`;

--- a/packages/protocol/src/channels.d.ts
+++ b/packages/protocol/src/channels.d.ts
@@ -2432,6 +2432,7 @@ export type FrameAriaSnapshotParams = {
   selector?: string,
   depth?: number,
   boxes?: boolean,
+  numbers?: 'regex' | 'static',
   timeout: number,
 };
 export type FrameAriaSnapshotOptions = {


### PR DESCRIPTION
…ution in aria snapshots (#40080)

- Add numbers?: 'regex' | 'static' to ExpectConfig.toMatchAriaSnapshot, MatcherReceived, and protocol channels
- Thread numbers through Frame.ariaSnapshot and ariaSnapshotForFrame into the injected script
- Treat numbers === 'static' as renderStringsAsRegex === false in aria snapshot rendering

Fixes #40080