### PR TITLE
fix(registry): restore static require for browsers.json (#41248)

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1561,6 +1561,6 @@ function lowercaseAllKeys(json: any): any {
   return result;
 }
 
-export const registry = new Registry(require(path.join(packageRoot, 'browsers.json')));
+export const registry = new Registry(require('../../../browsers.json'));
 
 export { runOopDownloadBrowserMain } from './oopDownloadBrowserMain';


### PR DESCRIPTION
Static analysis tools such as Next.js standalone output and @vercel/nft cannot follow require(path.join(packageRoot, 'browsers.json')), which causes browsers.json to be omitted from bundled deployments.

Restore the v1.59.1 static require path so bundlers can include browsers.json reliably while preserving runtime behavior.

Fixes #41248