### PR TITLE
docs: add Ubuntu 26.04 and Node.js 26.x to system requirements

### DIFF
--- a/docs/src/intro-csharp.md
+++ b/docs/src/intro-csharp.md
@@ -285,8 +285,8 @@ See our doc on [Running and Debugging Tests](./running-tests.md) to learn more a
 
 - Playwright is distributed as a .NET Standard 2.0 library. We recommend .NET 8.
 - Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
-- macOS 14 Sonoma, or later.
-- Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
+- macOS 14 (Sonoma) or later.
+- Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64).
 
 ## What's next
 

--- a/docs/src/intro-java.md
+++ b/docs/src/intro-java.md
@@ -130,8 +130,8 @@ By default browsers launched with Playwright run headless, meaning no browser UI
 
 - Java 8 or higher.
 - Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
-- macOS 14 Sonoma, or later.
-- Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
+- macOS 14 (Sonoma) or later.
+- Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64).
 
 ## What's next
 

--- a/docs/src/intro-js.md
+++ b/docs/src/intro-js.md
@@ -302,10 +302,10 @@ pnpm exec playwright --version
 
 ## System requirements
 
-- Node.js: latest 20.x, 22.x or 24.x.
+- Node.js: latest 22.x, 24.x or 26.x.
 - Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
 - macOS 14 (Sonoma) or later.
-- Debian 12 / 13, Ubuntu 22.04 / 24.04 (x86-64 or arm64).
+- Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64).
 
 ## What's next
 

--- a/docs/src/intro-python.md
+++ b/docs/src/intro-python.md
@@ -137,8 +137,8 @@ uv add --upgrade pytest-playwright playwright
 
 - Python 3.8 or higher.
 - Windows 11+, Windows Server 2019+ or Windows Subsystem for Linux (WSL).
-- macOS 14 Sonoma, or later.
-- Debian 12, Debian 13, Ubuntu 22.04, Ubuntu 24.04, on x86-64 and arm64 architecture.
+- macOS 14 (Sonoma) or later.
+- Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64).
 
 ## What's next
 


### PR DESCRIPTION
## Summary
- Add Ubuntu 26.04 to supported platforms across JS, Python, Java and C# intro docs.
- Add Node.js 26.x and drop Node.js 20.x in the JS docs.
- Align platform/macOS line styling across language docs.