### PR TITLE
fix(html-reporter): use selected run for TraceLink instead of first run

### DIFF
--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -132,8 +132,9 @@ export const AttachmentLink: React.FunctionComponent<{
   );
 };
 
-export const TraceLink: React.FC<{ test: TestCaseSummary, trailingSeparator?: boolean, dim?: boolean }> = ({ test, trailingSeparator, dim }) => {
-  const firstTraces = test.results.map(result => result.attachments.filter(attachment => attachment.name === 'trace')).filter(traces => traces.length > 0)[0];
+export const TraceLink: React.FC<{ test: TestCaseSummary, run?: number, trailingSeparator?: boolean, dim?: boolean }> = ({ test, run, trailingSeparator, dim }) => {
+  const resultsToCheck = run !== undefined ? [test.results[run]] : test.results;
+  const firstTraces = resultsToCheck.map(result => result.attachments.filter(attachment => attachment.name === 'trace')).filter(traces => traces.length > 0)[0];
   if (!firstTraces)
     return undefined;
 

--- a/packages/html-reporter/src/links.tsx
+++ b/packages/html-reporter/src/links.tsx
@@ -133,7 +133,7 @@ export const AttachmentLink: React.FunctionComponent<{
 };
 
 export const TraceLink: React.FC<{ test: TestCaseSummary, run?: number, trailingSeparator?: boolean, dim?: boolean }> = ({ test, run, trailingSeparator, dim }) => {
-  const resultsToCheck = run !== undefined ? [test.results[run]] : test.results;
+  const resultsToCheck = run !== undefined && test.results[run] ? [test.results[run]] : test.results;
   const firstTraces = resultsToCheck.map(result => result.attachments.filter(attachment => attachment.name === 'trace')).filter(traces => traces.length > 0)[0];
   if (!firstTraces)
     return undefined;

--- a/packages/html-reporter/src/testCaseView.tsx
+++ b/packages/html-reporter/src/testCaseView.tsx
@@ -62,7 +62,7 @@ export const TestCaseView: React.FC<{
         </CopyToClipboardContainer>
       </div>
       <div style={{ flex: 'auto' }}></div>
-      <TraceLink test={test} trailingSeparator={true} />
+      <TraceLink test={test} run={selectedResultIndex} trailingSeparator={true} />
       <div className='test-case-duration'>{msToString(test.duration)}</div>
     </div>
     <ProjectAndTagLabelsView style={{ marginLeft: '6px' }} projectNames={report.json().projectNames} activeProjectName={test.projectName} otherLabels={test.tags} />


### PR DESCRIPTION
## Rationale

The `TestCaseView` component already tracks which run tab the user has selected via `selectedResultIndex`, but this value was never forwarded to `TraceLink`. The fix adds an optional `run` prop so the component can scope its trace lookup to the active result.

Fixes #41281

## Changes

- add optional `run` prop to `TraceLink`; when set, only check `test.results[run]` for trace attachments
- pass `selectedResultIndex` as `run` to `TraceLink`

Callers that don't pass `run` (e.g. the file list view in `testFileView.tsx`) keep the existing first-result behavior, which is the correct default there since there is no run selection in that context.

## Verification

- ran a flaky test with `--retries=1 --trace=on`, confirmed that switching between `Run` and `Retry #1` tabs produces different trace URLs in the "View Trace" link
