### PR TITLE
feat(cli): show 'cli' subcommand in --help output

### DIFF
--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -242,7 +242,8 @@ export function decorateProgram(program: Command) {
   addTraceCommands(program, logErrorAndExit);
 
   program
-      .command('cli', { hidden: true })
+      .command('cli')
+      .description("run playwright mcp commands from terminal")
       .allowExcessArguments(true)
       .allowUnknownOption(true)
       .helpOption(false)

--- a/tests/installation/playwright-cli.spec.ts
+++ b/tests/installation/playwright-cli.spec.ts
@@ -99,3 +99,9 @@ test('cli should work', async ({ exec, tmpWorkspace }) => {
     expect(result).toContain(`No report found at "${path.join(fs.realpathSync(tmpWorkspace), 'playwright-report')}"`);
   });
 });
+
+test('npx playwright --help should show cli subcommand', async ({ exec }) => {
+  const result = await exec('npx playwright --help');
+  expect(result).toContain(`cli`);
+  expect(result).toContain('run playwright mcp commands from terminal');
+});


### PR DESCRIPTION
The `cli` subcommand was not listed when running `npx playwright --help`,
making it undiscoverable even though `npx playwright cli --version` works.

This fix shows the output and the description
Fixes #41279