### PR TITLE
fix: keep GitHub annotations parseable with dot reporter

### DIFF
--- a/packages/playwright/src/reporters/github.ts
+++ b/packages/playwright/src/reporters/github.ts
@@ -36,6 +36,11 @@ type GitHubLogOptions = Partial<{
 }>;
 
 class GitHubLogger {
+  newLine() {
+    // eslint-disable-next-line no-restricted-properties
+    process.stdout.write('\n');
+  }
+
   private _log(message: string, type: GitHubLogType = 'notice', options: GitHubLogOptions = {}) {
     message = message.replace(/\n/g, '%0A');
     const configs = Object.entries(options)
@@ -82,6 +87,7 @@ export class GitHubReporter extends TerminalReporter {
     if (!this._shouldPrintFailureAnnotations(test))
       return;
     this._failedTestCount++;
+    this.githubLogger.newLine();
     for (const r of test.results)
       this._printFailureAnnotation(test, r, this._failedTestCount);
   }

--- a/tests/playwright-test/reporter-github.spec.ts
+++ b/tests/playwright-test/reporter-github.spec.ts
@@ -125,10 +125,7 @@ for (const useIntermediateMergeReport of [false, true] as const) {
           });
         `
       }, { workers: 1, reporter: 'dot,github' }, { GITHUB_WORKSPACE: process.cwd() });
-      const text = result.output;
-      const annotationIndex = text.indexOf('::error file=');
-      expect(annotationIndex).toBeGreaterThan(0);
-      expect(text[annotationIndex - 1]).toBe('\n');
+      expect(result.output).toContain('F\n::error file=');
       expect(result.exitCode).toBe(1);
     });
   });

--- a/tests/playwright-test/reporter-github.spec.ts
+++ b/tests/playwright-test/reporter-github.spec.ts
@@ -115,5 +115,21 @@ for (const useIntermediateMergeReport of [false, true] as const) {
       expect(summaryIndex).toBeGreaterThan(errorIndex);
       expect(result.exitCode).toBe(1);
     });
+
+    test('starts GitHub failure annotation on a new line with dot reporter', async ({ runInlineTest }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          const { test, expect } = require('@playwright/test');
+          test('failing', async ({}) => {
+            expect(1 + 1).toBe(3);
+          });
+        `
+      }, { workers: 1, reporter: 'dot,github' }, { GITHUB_WORKSPACE: process.cwd() });
+      const text = result.output;
+      const annotationIndex = text.indexOf('::error file=');
+      expect(annotationIndex).toBeGreaterThan(0);
+      expect(text[annotationIndex - 1]).toBe('\n');
+      expect(result.exitCode).toBe(1);
+    });
   });
 }


### PR DESCRIPTION
Fixes #41272.

## Summary

This keeps GitHub failure annotations parseable when the GitHub reporter is combined with reporters that leave output on the current line, such as the dot reporter.

The fix emits a line break before per-test GitHub failure annotations, so the `::error` workflow command starts at the beginning of a line. It also adds a regression for `reporter: "dot,github"` to ensure the annotation is not written inline after the dot reporter output.

## Validation

- `npm run ttest -- reporter-github.spec.ts`
- `npx eslint packages/playwright/src/reporters/github.ts tests/playwright-test/reporter-github.spec.ts`
- `npm run tsc -- --pretty false`
- `npm run build`
- `git diff --check`