### PR TITLE
fix(mcp): wait for next pause or context closure in browser_resume

### DIFF
--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -40,15 +40,19 @@ const resume = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    const pausedPromise = new Promise<void>(resolve => {
-      const listener = () => {
-        if (browserContext.debugger.pausedDetails()) {
-          browserContext.debugger.off('pausedstatechanged', listener);
-          resolve();
-        }
-      };
-      browserContext.debugger.on('pausedstatechanged', listener);
-    });
+    const waitForPause = params.step || params.location;
+    let pausedPromise: Promise<void> | undefined;
+    if (waitForPause) {
+      pausedPromise = new Promise<void>(resolve => {
+        const listener = () => {
+          if (browserContext.debugger.pausedDetails()) {
+            browserContext.debugger.off('pausedstatechanged', listener);
+            resolve();
+          }
+        };
+        browserContext.debugger.on('pausedstatechanged', listener);
+      });
+    }
 
     if (params.location) {
       const [file, lineStr] = params.location.split(':');
@@ -67,7 +71,8 @@ const resume = defineTool({
     } else {
       await browserContext.debugger.resume();
     }
-    await pausedPromise;
+    if (pausedPromise)
+      await pausedPromise;
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -40,19 +40,19 @@ const resume = defineTool({
 
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
-    const waitForPause = params.step || params.location;
-    let pausedPromise: Promise<void> | undefined;
-    if (waitForPause) {
-      pausedPromise = new Promise<void>(resolve => {
-        const listener = () => {
-          if (browserContext.debugger.pausedDetails()) {
-            browserContext.debugger.off('pausedstatechanged', listener);
-            resolve();
-          }
-        };
-        browserContext.debugger.on('pausedstatechanged', listener);
+    const pausedPromise = new Promise<void>(resolve => {
+      const listener = () => {
+        if (browserContext.debugger.pausedDetails()) {
+          browserContext.debugger.off('pausedstatechanged', listener);
+          resolve();
+        }
+      };
+      browserContext.debugger.on('pausedstatechanged', listener);
+      browserContext.once('close', () => {
+        browserContext.debugger.off('pausedstatechanged', listener);
+        resolve();
       });
-    }
+    });
 
     if (params.location) {
       const [file, lineStr] = params.location.split(':');
@@ -71,8 +71,7 @@ const resume = defineTool({
     } else {
       await browserContext.debugger.resume();
     }
-    if (pausedPromise)
-      await pausedPromise;
+    await pausedPromise;
   },
 });
 

--- a/tests/mcp/devtools.spec.ts
+++ b/tests/mcp/devtools.spec.ts
@@ -93,6 +93,27 @@ test('browser_hide_highlight', async ({ boundBrowser, startClient }) => {
   await expect(page.locator('x-pw-highlight')).toHaveCount(0);
 });
 
+test('browser_resume completes without next breakpoint', async ({ boundBrowser, startClient }) => {
+  const page = await boundBrowser.newPage();
+  await page.setContent(`<button>Submit</button>`);
+  const context = boundBrowser.contexts()[0];
+
+  // Pause the debugger before the next action.
+  await context.debugger.requestPause();
+  const clickPromise = page.click('button');
+  await new Promise<void>(resolve => context.debugger.once('pausedstatechanged', resolve));
+  expect(context.debugger.pausedDetails()).toBeTruthy();
+
+  // browser_resume without step or location should return without
+  // waiting for a subsequent pause. Before the fix, this would hang
+  // indefinitely because no subsequent breakpoint exists.
+  const { client } = await startClient({ args: [`--endpoint=default`] });
+  await client.callTool({ name: 'browser_resume' });
+
+  await clickPromise;
+  expect(context.debugger.pausedDetails()).toBeNull();
+});
+
 test('browser_hide_highlight all', async ({ boundBrowser, startClient }) => {
   const page = await boundBrowser.newPage();
   await page.setContent(`<button>Submit</button><a href="#">Go</a>`);

--- a/tests/mcp/devtools.spec.ts
+++ b/tests/mcp/devtools.spec.ts
@@ -93,7 +93,7 @@ test('browser_hide_highlight', async ({ boundBrowser, startClient }) => {
   await expect(page.locator('x-pw-highlight')).toHaveCount(0);
 });
 
-test('browser_resume completes without next breakpoint', async ({ boundBrowser, startClient }) => {
+test('browser_resume completes when context closes', async ({ boundBrowser, startClient }) => {
   const page = await boundBrowser.newPage();
   await page.setContent(`<button>Submit</button>`);
   const context = boundBrowser.contexts()[0];
@@ -104,14 +104,16 @@ test('browser_resume completes without next breakpoint', async ({ boundBrowser, 
   await new Promise<void>(resolve => context.debugger.once('pausedstatechanged', resolve));
   expect(context.debugger.pausedDetails()).toBeTruthy();
 
-  // browser_resume without step or location should return without
-  // waiting for a subsequent pause. Before the fix, this would hang
-  // indefinitely because no subsequent breakpoint exists.
+  // browser_resume without step or location resumes execution and
+  // waits for either the next pause or context close. Closing the
+  // context after resume simulates a test finishing with no further
+  // breakpoints. Before the fix, this would hang indefinitely.
   const { client } = await startClient({ args: [`--endpoint=default`] });
-  await client.callTool({ name: 'browser_resume' });
+  const resumePromise = client.callTool({ name: 'browser_resume' });
 
   await clickPromise;
-  expect(context.debugger.pausedDetails()).toBeNull();
+  await context.close();
+  await resumePromise;
 });
 
 test('browser_hide_highlight all', async ({ boundBrowser, startClient }) => {


### PR DESCRIPTION
## Summary
- `browser_resume` unconditionally awaited a promise that only resolved when the debugger paused again. For a plain resume (no step or location), if execution completed without another breakpoint, the tool hung indefinitely.
- Only create and await the pause promise when `step` or `location` is set.

Introduced in #39717.
Fixes #41304.