### PR TITLE
chore: PLAYWRIGHT_TRACING_NO_WEBSOCKET_FRAMES and PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES

### DIFF
--- a/docs/src/release-notes-csharp.md
+++ b/docs/src/release-notes-csharp.md
@@ -52,6 +52,7 @@ var items = await page.SessionStorage.ItemsAsync();
 ### 🛠️ Other improvements
 
 - Playwright now supports Ubuntu 26.04.
+- HAR and trace recordings now include WebSocket requests.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-java.md
+++ b/docs/src/release-notes-java.md
@@ -50,6 +50,7 @@ List<NameValue> items = page.sessionStorage().items();
 ### 🛠️ Other improvements
 
 - Playwright now supports Ubuntu 26.04.
+- HAR and trace recordings now include WebSocket requests.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -65,6 +65,7 @@ const items = await page.sessionStorage.items();
 ### 🛠️ Other improvements
 
 - Playwright now supports Ubuntu 26.04.
+- HAR and trace recordings now include WebSocket requests.
 
 ### Browser Versions
 

--- a/docs/src/release-notes-python.md
+++ b/docs/src/release-notes-python.md
@@ -51,6 +51,7 @@ items = page.session_storage.items()
 ### 🛠️ Other improvements
 
 - Playwright now supports Ubuntu 26.04.
+- HAR and trace recordings now include WebSocket requests.
 
 ### Browser Versions
 

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -57,6 +57,7 @@ export class HarRecorder implements HarTracerDelegate {
       recordRequestOverrides: true,
       waitForContentOnStop: true,
       urlFilter: urlFilterRe ?? options.urlGlob,
+      omitWebSocketFrames: !!process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES,
     });
     this._tracer.start({ omitScripts: false });
   }

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -62,6 +62,7 @@ type HarTracerOptions = {
   omitPages?: boolean;
   omitSizes?: boolean;
   omitScripts?: boolean;
+  omitWebSocketFrames?: boolean;
 };
 
 export class HarTracer {
@@ -442,6 +443,8 @@ export class HarTracer {
 
     let sha1: string | undefined = undefined;
     const recordMessage = (type: 'send' | 'receive', opcode: number, data: string, wallTimeMs: number) => {
+      if (this._options.omitWebSocketFrames)
+        return;
       const message = { type, time: this._options.omitTiming ? -1 : wallTimeMs, opcode, data };
       if (this._options.content === 'embed') {
         harEntry._webSocketMessages ??= [];

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -108,6 +108,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       includeTraceInfo: true,
       recordRequestOverrides: false,
       waitForContentOnStop: false,
+      omitWebSocketFrames: !!process.env.PLAYWRIGHT_TRACING_NO_WEBSOCKET_FRAMES,
     });
     const testIdAttributeName = ('selectors' in context) ? context.selectors().testIdAttributeName() : undefined;
     this._contextCreatedEvent = {

--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -448,3 +448,25 @@ it('should still allow routeWebSocket to modify messages when capturing HAR', as
     { type: 'receive', data: 'server-saw-modified-hello' },
   ]);
 });
+
+it('should respect PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES', async ({ contextFactory, server }, testInfo) => {
+  process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES = '1';
+  server.onceWebSocketConnection(ws => {
+    ws.on('message', () => ws.close());
+  });
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  await page.goto(server.EMPTY_PAGE);
+  const wsUrl = `ws://${server.HOST}/ws`;
+  const closed = page.evaluate(url => new Promise<void>(resolve => {
+    const ws = new WebSocket(url);
+    ws.addEventListener('open', () => ws.send('ping'));
+    ws.addEventListener('close', () => resolve());
+  }), wsUrl);
+  await closed;
+  const log = await getLog();
+  const wsEntry = log.entries.filter(e => e.request.url.endsWith(`://${server.HOST}/ws`))[0];
+  expect(wsEntry._resourceType).toBe('websocket');
+  expect(wsEntry._webSocketMessages).toBeUndefined();
+  expect(wsEntry.response.content._file).toBe(undefined);
+  delete process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES;
+});


### PR DESCRIPTION
These environment variables allow opting out of websocket frames in trace and har recordings.