### PR TITLE
test: fix android tests

### DIFF
--- a/tests/android/androidTest.ts
+++ b/tests/android/androidTest.ts
@@ -81,8 +81,14 @@ export const androidTest = baseTest.extend<PageTestFixtures & AndroidTestFixture
     // Retain default page, otherwise Clank will re-create it.
     while (androidContext.pages().length > 1)
       await androidContext.pages()[1].close();
-    const page = await androidContext.newPage();
-    await run(page);
+    await run(await androidContext.newPage());
+    const pages = androidContext.pages();
+    // Keep one fresh page - Clank does not like having zero pages.
+    await androidContext.newPage();
+    // Close all existing pages that could be stuck in a navigation, have an open dialog, etc.
+    for (const page of pages)
+      await page.close();
+    // Cleanup as much as we can. This requires a non-stuck page that can respond to CDP.
     await androidContext.setStorageState({ cookies: [], origins: [] });
   },
 });

--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -449,7 +449,9 @@ it('should still allow routeWebSocket to modify messages when capturing HAR', as
   ]);
 });
 
-it('should respect PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES', async ({ contextFactory, server }, testInfo) => {
+it('should respect PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES', async ({ contextFactory, server, mode }, testInfo) => {
+  it.skip(mode !== 'default', 'no env vars in non-default mode');
+
   process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES = '1';
   server.onceWebSocketConnection(ws => {
     ws.on('message', () => ws.close());

--- a/tests/page/page-wait-for-selector-2.spec.ts
+++ b/tests/page/page-wait-for-selector-2.spec.ts
@@ -343,7 +343,7 @@ it('should succeed if element handle was detached while waiting for hidden', asy
   await page.setContent(`<button>hello</button>`);
   const button = await page.$('button');
   const promise = button.waitForSelector('something', { state: 'hidden' });
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(1000);
   await page.evaluate(() => document.body.innerText = '');
   await promise;
 });
@@ -352,7 +352,7 @@ it('should succeed if element handle was detached while waiting for detached', a
   await page.setContent(`<button>hello</button>`);
   const button = await page.$('button');
   const promise = button.waitForSelector('something', { state: 'detached' });
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(1000);
   await page.evaluate(() => document.body.innerText = '');
   await promise;
 });


### PR DESCRIPTION
Tests that leave page in non-working state fail to cleanup via `context.setStorageState()` because the page does not respond to CDP commands.

Work around by closing existing pages and opening a new one.

Drive-by: skip new env-using test on the mode=driver bot.