### PR TITLE
fix: tolerate page errors without location

### DIFF
--- a/packages/playwright-core/src/server/firefox/protocol.d.ts
+++ b/packages/playwright-core/src/server/firefox/protocol.d.ts
@@ -402,7 +402,7 @@ export namespace Protocol {
       frameId: string;
       message: string;
       stack: string;
-      location: {
+      location?: {
         columnNumber: number;
         lineNumber: number;
         url: string;

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -163,6 +163,8 @@ export type PageError = {
   location: types.ConsoleMessageLocation,
 };
 
+const emptyConsoleMessageLocation: types.ConsoleMessageLocation = { url: '', lineNumber: 0, columnNumber: 0 };
+
 export class Page extends SdkObject<PageEventMap> {
   static Events = PageEvent;
 
@@ -432,7 +434,8 @@ export class Page extends SdkObject<PageEventMap> {
     return marked === -1 ? this._consoleMessages : this._consoleMessages.slice(marked + 1);
   }
 
-  addPageError(error: Error, location: types.ConsoleMessageLocation) {
+  addPageError(error: Error, location: types.ConsoleMessageLocation | undefined) {
+    location ??= emptyConsoleMessageLocation;
     const pageError: PageError = { error, location };
     this._pageErrors.push(pageError);
     ensureArrayLimit(this._pageErrors, 200); // Avoid unbounded memory growth.

--- a/tests/library/browsercontext-events.spec.ts
+++ b/tests/library/browsercontext-events.spec.ts
@@ -209,6 +209,19 @@ test('weberror event should include location', async ({ page, server }) => {
   expect(location.column).toBeGreaterThan(0); // column is not consistent across browsers
 });
 
+test('weberror event should tolerate missing location', async ({ page, toImpl }) => {
+  const [webError, pageError] = await Promise.all([
+    page.context().waitForEvent('weberror'),
+    page.waitForEvent('pageerror'),
+    Promise.resolve().then(() => toImpl(page).addPageError(new Error('boom'), undefined)),
+  ]);
+
+  expect(webError.page()).toBe(page);
+  expect(webError.error().message).toBe('boom');
+  expect(webError.location()).toEqual({ url: '', line: 0, column: 0 });
+  expect(pageError.message).toBe('boom');
+});
+
 test('pageload event should work @smoke', async ({ page, server }) => {
   const [eventPage] = await Promise.all([
     page.context().waitForEvent('pageload'),


### PR DESCRIPTION
Fixes #41169.

When a browser reports a page error without source location metadata, normalize it to an empty location before storing and dispatching the error. This keeps both `pageerror` and `weberror` events flowing instead of crashing the driver while preserving the existing event payload shape.

The Firefox protocol type now reflects that `Page.uncaughtError.location` can be omitted.

Validation:
- `npm run build`
- `node packages/playwright-test/cli.js test --config=tests/library/playwright.config.ts browsercontext-events.spec.ts -g "weberror event should tolerate missing location"`
- `npm run tsc -- --pretty false`
- `npm run eslint -- packages/playwright-core/src/server/page.ts tests/library/browsercontext-events.spec.ts`
- `git diff --check`