### PR TITLE
chore(chromium): reenable RenderDocument again

### DIFF
--- a/docs/src/api/class-coverage.md
+++ b/docs/src/api/class-coverage.md
@@ -54,9 +54,10 @@ will have `__playwright_evaluation_script__` as their URL.
 
 ### option: Coverage.startJSCoverage.resetOnNavigation
 * since: v1.11
+* discouraged: Settings this to `false` may still reset on navigations.
 - `resetOnNavigation` <[boolean]>
 
-Whether to reset coverage on every navigation. Defaults to `true`.
+Whether to reset coverage on every navigation. Defaults to `true`. Note that passing `false` does not guarantee that coverage persists through navigations, due to browser architecture limitations.
 
 ### option: Coverage.startJSCoverage.reportAnonymousScripts
 * since: v1.11

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -19024,7 +19024,10 @@ export interface Coverage {
     reportAnonymousScripts?: boolean;
 
     /**
-     * Whether to reset coverage on every navigation. Defaults to `true`.
+     * **NOTE** Settings this to `false` may still reset on navigations.
+     *
+     * Whether to reset coverage on every navigation. Defaults to `true`. Note that passing `false` does not guarantee
+     * that coverage persists through navigations, due to browser architecture limitations.
      */
     resetOnNavigation?: boolean;
   }): Promise<void>;

--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -40,8 +40,6 @@ const disabledFeatures = [
   'Translate',
   // See https://issues.chromium.org/u/1/issues/435410220
   'AutoDeElevate',
-  // See https://github.com/microsoft/playwright/issues/37714
-  'RenderDocument',
   // Prevents downloading optimization hints on startup.
   'OptimizationHints',
   // Disables forced sign-in in Edge.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -19024,7 +19024,10 @@ export interface Coverage {
     reportAnonymousScripts?: boolean;
 
     /**
-     * Whether to reset coverage on every navigation. Defaults to `true`.
+     * **NOTE** Settings this to `false` may still reset on navigations.
+     *
+     * Whether to reset coverage on every navigation. Defaults to `true`. Note that passing `false` does not guarantee
+     * that coverage persists through navigations, due to browser architecture limitations.
      */
     resetOnNavigation?: boolean;
   }): Promise<void>;

--- a/tests/library/chromium/js-coverage.spec.ts
+++ b/tests/library/chromium/js-coverage.spec.ts
@@ -63,14 +63,6 @@ it('should report multiple scripts', async function({ page, server }) {
   expect(coverage[1].url).toContain('/jscoverage/script2.js');
 });
 
-it('should report scripts across navigations when disabled', async function({ page, server }) {
-  await page.coverage.startJSCoverage({ resetOnNavigation: false });
-  await page.goto(server.PREFIX + '/jscoverage/multiple.html');
-  await page.goto(server.EMPTY_PAGE);
-  const coverage = await page.coverage.stopJSCoverage();
-  expect(coverage.length).toBe(2);
-});
-
 it('should NOT report scripts across navigations when enabled', async function({ page, server }) {
   await page.coverage.startJSCoverage(); // Enabled by default.
   await page.goto(server.PREFIX + '/jscoverage/multiple.html');


### PR DESCRIPTION
Note: this also deprecates `Coverage.startJSCoverage.resetOnNavigation` option, since it's not compatible with the new architecture.

Closes #37714.