### PR TITLE
test: mark test added in PR#41224 as slow

### DIFF
--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -145,6 +145,8 @@ it('should create userDataDir if it does not exist', async ({ createUserDataDir,
 it('should goto about:blank on relaunched persistent context', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41216' },
 }, async ({ browserType, createUserDataDir }) => {
+  it.slow();
+
   const userDataDir = await createUserDataDir();
 
   const context1 = await browserType.launchPersistentContext(userDataDir);


### PR DESCRIPTION
`BrowserType.prototype.launchPersistentContext` often takes ~25s to complete, so having it twice in the same test will exceed the default 30s timeout

match other tests that invoke it more than once by marking this test as slow