### PR TITLE
fix(bidi): prevent prototype pollution in BiDi deserialization

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiDeserializer.ts
+++ b/packages/playwright-core/src/server/bidi/bidiDeserializer.ts
@@ -102,7 +102,7 @@ function deserializeBidiMapping(
   bidiValue: bidi.Script.ObjectRemoteValue | bidi.Script.MapRemoteValue,
   internalIdMap: Map<bidi.Script.InternalId, any>
 ) {
-  const result = getValue(bidiValue, internalIdMap, () => ({}));
+  const result = getValue(bidiValue, internalIdMap, () => Object.create(null));
   for (const [serializedKey, serializedValue] of bidiValue.value || []) {
     const key =
       typeof serializedKey === 'string'

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -875,3 +875,15 @@ it('should ignore dangerous object keys', async ({ page }) => {
   const result = await page.evaluate(arg => arg, input);
   expect(result).toEqual({ safeKey: 'safeValue' });
 });
+
+it('should not pollute Object.prototype when returning __proto__ key', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const obj = Object.create(null);
+    Object.defineProperty(obj, '__proto__', { value: { polluted: true }, enumerable: true });
+    obj['safeKey'] = 'safeValue';
+    return obj;
+  });
+  // Verify Object.prototype was not polluted
+  expect(({} as any).polluted).toBeUndefined();
+  expect(result['safeKey']).toBe('safeValue');
+});


### PR DESCRIPTION
## Summary

- Use `Object.create(null)` instead of `{}` in `deserializeBidiMapping` to prevent a `__proto__` key from remote BiDi data from modifying `Object.prototype`
- Add test for the behavioral contract

Introduced in #38587