### PR TITLE
feat(webkit): support executablePath for the webkit-wsl channel

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -152,7 +152,6 @@ export abstract class BrowserType extends SdkObject {
       ignoreDefaultArgs,
       ignoreAllDefaultArgs,
       args = [],
-      executablePath = null,
     } = options;
     const tempDirectories: string[] = [];
     let artifactsDir: string;
@@ -183,10 +182,9 @@ export abstract class BrowserType extends SdkObject {
       browserArguments.push(...await this.defaultArgs(options, isPersistent, userDataDir));
 
     let executable: string;
-    if (executablePath) {
-      if (!(await existsAsync(executablePath)))
-        throw new Error(`Failed to launch ${this._name} because executable doesn't exist at ${executablePath}`);
-      executable = executablePath;
+    const customExecutablePath = await this.resolveExecutablePath(options);
+    if (customExecutablePath) {
+      executable = customExecutablePath;
     } else {
       const registryExecutable = registry.findExecutable(this.getExecutableName(options));
       if (!registryExecutable || registryExecutable.browserName !== this._name)
@@ -343,6 +341,15 @@ export abstract class BrowserType extends SdkObject {
 
   getExecutableName(options: types.LaunchOptions): string {
     return options.channel || this._name;
+  }
+
+  protected async resolveExecutablePath(options: types.LaunchOptions): Promise<string | undefined> {
+    const { executablePath } = options;
+    if (!executablePath)
+      return undefined;
+    if (!(await existsAsync(executablePath)))
+      throw new Error(`Failed to launch ${this._name} because executable doesn't exist at ${executablePath}`);
+    return executablePath;
   }
 
   abstract defaultArgs(options: types.LaunchOptions, isPersistent: boolean, userDataDir: string): Promise<string[]>;

--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -65,6 +65,16 @@ export class WebKit extends BrowserType {
     return options.channel !== 'webkit-wsl';
   }
 
+  override async resolveExecutablePath(options: types.LaunchOptions): Promise<string | undefined> {
+    if (options.channel !== 'webkit-wsl')
+      return super.resolveExecutablePath(options);
+    // executablePath points inside the WSL distribution and is consumed in defaultArgs; the
+    // host command is wsl.exe from the registry.
+    if (options.executablePath && !await wslPathExists(options.executablePath))
+      throw new Error(`Failed to launch webkit because executable doesn't exist at ${options.executablePath}`);
+    return undefined;
+  }
+
   override async waitForReadyState(options: types.LaunchOptions, browserLogsCollector: RecentLogsCollector): Promise<{ wsEndpoint?: string }> {
     if (options.channel !== 'webkit-wsl')
       return {};
@@ -99,15 +109,13 @@ export class WebKit extends BrowserType {
     const webkitArguments = [isWSL ? '--remote-debugging-port=0' : '--inspector-pipe'];
 
     if (isWSL) {
-      if (options.executablePath)
-        throw new Error('Cannot specify executablePath when using the "webkit-wsl" channel.');
-      // The actual command is `wsl.exe -- <linux executable> <browser args>`.
+      const wslExecutablePath = options.executablePath || registry.findExecutable('webkit-wsl')!.wslExecutablePath!;
       webkitArguments.unshift(
           '-d', kWSLDistribution,
           '-u', kWSLUser,
           '--cd', kWSLHome,
           '--',
-          registry.findExecutable('webkit-wsl')!.wslExecutablePath!,
+          wslExecutablePath,
       );
     }
 
@@ -147,4 +155,9 @@ export class WebKit extends BrowserType {
 export async function translatePathToWSL(path: string): Promise<string> {
   const { stdout } = await spawnAsync('wsl.exe', ['-d', kWSLDistribution, '--cd', kWSLHome, 'wslpath', path.replace(/\\/g, '\\\\')]);
   return stdout.toString().trim();
+}
+
+async function wslPathExists(wslPath: string): Promise<boolean> {
+  const { code } = await spawnAsync('wsl.exe', ['-d', kWSLDistribution, '-u', kWSLUser, '--', 'test', '-e', wslPath]);
+  return code === 0;
 }


### PR DESCRIPTION
## Summary
- Allow `webkit-wsl` launches to point at a specific WebKit build inside the WSL distribution via `executablePath` (e.g. `WKPATH`), instead of only the browser installed by `install_webkit_wsl.ps1`.
- The host command stays `wsl.exe`; `executablePath` is passed as the Linux executable inside the distro. Enables CI (playwright-browsers TryJob) to test a freshly-built Linux WebKit in WSL.

Reference: https://github.com/microsoft/playwright/issues/37036