### PR TITLE
fix(edge): prevent the EdgeUpdater from being launched

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -73,6 +73,7 @@ export const chromiumSwitches = (options?: { android?: boolean }) => [
   '--disable-popup-blocking',
   '--disable-prompt-on-repost',
   '--disable-renderer-backgrounding',
+  '--disable-updater-scheduler', // Prevents Edge-specific updater from being launched when Edge is launched on mac.
   '--force-color-profile=srgb',
   '--metrics-recording-only',
   '--no-first-run',


### PR DESCRIPTION
`--disable-edgeupdater` only prevents the EdgeUpdater from being installed when Edge is installed

`--disable-updater-scheduler` should prevent the EdgeUpdater from launching when Edge is opened

should hopefully fix <https://github.com/microsoft/playwright/issues/41210>