### PR TITLE
test(webkit): update webkit-wsl launch expectations for executablePath

### DIFF
--- a/tests/library/browsertype-launch.spec.ts
+++ b/tests/library/browsertype-launch.spec.ts
@@ -64,18 +64,15 @@ it('should throw if page argument is passed', async ({ browserType, browserName,
 it('should reject if launched browser fails immediately', async ({ mode, browserType, asset, channel }) => {
   const error = await browserType.launch({ executablePath: asset('dummy_bad_browser_executable.js') }).catch(e => e);
   if (channel === 'webkit-wsl')
-    expect(error.message).toContain('Cannot specify executablePath when using the \"webkit-wsl\" channel.');
+    expect(error.message).toContain('Failed to launch');
   else
     expect(error.message).toMatch(/browserType\.launch(.|\n)*(spawn UNKNOWN|spawn EFTYPE|Browser logs:)/gim);
 });
 
-it('should reject if executable path is invalid', async ({ browserType, mode, channel }) => {
+it('should reject if executable path is invalid', async ({ browserType, mode }) => {
   let waitError: Error | undefined;
   await browserType.launch({ executablePath: 'random-invalid-path' }).catch(e => waitError = e);
-  if (channel === 'webkit-wsl')
-    expect(waitError!.message).toContain('Cannot specify executablePath when using the \"webkit-wsl\" channel.');
-  else
-    expect(waitError!.message).toContain('Failed to launch');
+  expect(waitError!.message).toContain('Failed to launch');
 });
 
 it('should handle timeout', async ({ browserType, mode }) => {


### PR DESCRIPTION
## Summary
- `webkit-wsl` now accepts `executablePath` (microsoft/playwright#41325 removed the `Cannot specify executablePath` throw), so `browsertype-launch.spec.ts` should no longer expect that message — an invalid path is now rejected with the standard `Failed to launch … doesn't exist`.

Reference: https://github.com/microsoft/playwright/issues/37036