### PR TITLE
devops: link the browser build commit in roll PRs

### DIFF
--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -8,6 +8,7 @@ env:
   BROWSER: ${{ github.event.client_payload.browser }}
   REVISION: ${{ github.event.client_payload.revision }}
   BROWSER_VERSION: ${{ github.event.client_payload.browserVersion }}
+  BUILD_LINK: ${{ github.event.client_payload.buildLink }}
 
 permissions:
   contents: write
@@ -62,12 +63,15 @@ jobs:
       with:
         github-token: ${{ steps.app-token.outputs.token }}
         script: |
+          const buildLink = process.env.BUILD_LINK;
+          const body = buildLink ? `Browser build: ${buildLink}. Build has full platform coverage - check that all tests pass there.` : undefined;
           const response = await github.rest.pulls.create({
             owner: 'microsoft',
             repo: 'playwright',
             head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
             base: 'main',
             title: 'feat(${{ env.BROWSER }}): roll to r${{ env.REVISION }}',
+            body,
           });
           await github.rest.issues.addLabels({
             owner: 'microsoft',


### PR DESCRIPTION
## Summary
- The roll dispatch from `playwright-browsers` now sends a `buildLink` pointing at the commit that produced the build. Surface it in the roll PR body so reviewers can trace the roll back to its source commit.

Companion change: microsoft/playwright-browsers#2361 (dispatch sends `buildLink`).