### PR TITLE
devops(electron): suppress macOS reopen windows prompt in tests

### DIFF
--- a/.github/workflows/tests_others.yml
+++ b/.github/workflows/tests_others.yml
@@ -89,6 +89,11 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         fi
       shell: bash
+    # Prevent stalling when macOS decides to show the reopen windows prompt after killing enough Electron processes.
+    - name: Turn off the reopen windows prompt on macOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: defaults write com.github.Electron ApplePersistenceIgnoreState YES
+      shell: bash
     - uses: ./.github/actions/run-test
       with:
         browsers-to-install: chromium


### PR DESCRIPTION
## Summary
- Disable macOS's persistent-UI machinery for the Electron test bundle so the "reopen windows" modal doesn't hang the fixtures after Electron processes are killed with SIGINT.
- Mirrors electron/electron@c16c6da29cd4688dccf43201a12afbe2f09836d5.