### PR TITLE
Revert "fix(firefox): treat `navigationCommitted` events without `navigationId` as same-document URL updates (#41224)"

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -239,18 +239,11 @@ export class FFPage implements PageDelegate {
   }
 
   _onNavigationCommitted(params: Protocol.Page.navigationCommittedPayload) {
-    if (!params.navigationId) {
-      // Firefox replays the current navigation without a navigationId during a process swap (e.g. when restoring a persistent profile).
-      // Treat these as same-document URL updates so they don't interrupt any in-flight new-document navigation in Frame.gotoImpl.
-      this._page.frameManager.frameCommittedSameDocumentNavigation(params.frameId, params.url);
-      return;
-    }
-
     for (const [workerId, worker] of this._workers) {
       if (worker.frameId === params.frameId)
         this._onWorkerDestroyed({ workerId });
     }
-    this._page.frameManager.frameCommittedNewDocumentNavigation(params.frameId, params.url, params.name || '', params.navigationId, false);
+    this._page.frameManager.frameCommittedNewDocumentNavigation(params.frameId, params.url, params.name || '', params.navigationId || '', false);
   }
 
   _onSameDocumentNavigation(params: Protocol.Page.sameDocumentNavigationPayload) {

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -145,7 +145,8 @@ it('should create userDataDir if it does not exist', async ({ createUserDataDir,
 
 it('should goto about:blank on relaunched persistent context', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41216' },
-}, async ({ browserType, createUserDataDir }) => {
+}, async ({ browserType, createUserDataDir, browserName }) => {
+  it.fixme(browserName === 'firefox');
   it.slow();
 
   const userDataDir = await createUserDataDir();


### PR DESCRIPTION
this is a partial revert for commits 81881e2c1ba7c9cb96db3eab97c0a043b32e0725 <https://github.com/microsoft/playwright/pull/41224> and c2ac911d09675c7dc9124bcad0a1cf04748ffa8a <https://github.com/microsoft/playwright/pull/41309>

leep the test added as that's still a valuable scenario to check, though it's skipped for Firefox due to the known issue

fixes <https://github.com/microsoft/playwright/issues/41347>