### PR TITLE
fix(mcp): create a browser context when connecting to a remote browser with no contexts

### DIFF
--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -127,7 +127,7 @@ export function decorateMCPCommand(command: Command) {
               const sessionName = count > 1 ? `${clientInfo.clientName} (${count})` : clientInfo.clientName;
               await browser.bind(sessionName, { workspaceDir: clientInfo.cwd });
             }
-            const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
+            const browserContext = config.browser.isolated || !browser.contexts().length ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
             return new BrowserBackend(config, browserContext, tools);
           },
           disposed: async backend => {


### PR DESCRIPTION
### Problem

Driving the Playwright MCP server against a **remote browser** via `--endpoint` connects successfully, but the **first tool call (e.g. `browser_navigate`) throws**:

```
TypeError: Cannot read properties of undefined (reading 'once')
```

### Root cause

In `packages/playwright-core/src/tools/mcp/program.ts`, the backend resolves the context like this:

```ts
const browserContext = config.browser.isolated
  ? await browser.newContext(config.browser.contextOptions)
  : browser.contexts()[0];
```

For the `--endpoint` (remote) transport, config resolution forces `isolated = false`, so the `browser.contexts()[0]` branch is taken. A browser obtained via `browserType.connect()` has **zero contexts** (the caller is expected to create one), so `contexts()[0]` is `undefined`. `BrowserBackend` then dereferences it (`browserContext.once('close', …)`), crashing on the first tool call.

The sibling `cli-daemon/program.ts` already anticipates the empty-contexts case (it throws an explicit error there), but the MCP server path neither guards nor handles it.

### Fix

Create a context when the connected browser has none — a one-condition change, no duplicated `newContext` call:

```ts
const browserContext = config.browser.isolated || !browser.contexts().length
  ? await browser.newContext(config.browser.contextOptions)
  : browser.contexts()[0];
```

Behavior is unchanged for the local/persistent and isolated paths (which already have a context or explicitly create one); it only adds a context for remote-connected browsers that start with none.

### Verification

Reproduced against a remote Playwright endpoint (LambdaTest grid, `wss://cdp.lambdatest.com/playwright`) on `@playwright/mcp` v0.0.76:

- **Before:** first `browser_navigate` throws `Cannot read properties of undefined (reading 'once')`.
- **After:** a context is created and `navigate → type → wait → snapshot` runs end-to-end with no errors.

The same root cause is currently worked around externally by supplying a `contextGetter` to the programmatic `createConnection(config, contextGetter)` API; this change makes the stock `--endpoint` flag work without that workaround.

---