### PR TITLE
added handling for windows on webkit for mouse right click

### DIFF
--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -13399,6 +13399,22 @@ index 0000000000000000000000000000000000000000..a29ae94cda78928fab928bbdd250f8cd
 +        eventModifiers,
 +        timestamp);
 +    m_page.handleMouseEvent(event);
++
++    // WebKit swallows mousedown for right-click internally to handle contextmenu.
++    // Explicitly re-dispatch so page JS handlers receive it, matching behaviour on Mac
++    if (eventType == WebEventType::MouseDown && eventButton == WebMouseEventButton::Right) {
++        NativeWebMouseEvent contextMenuEvent(
++            WebEventType::MouseDown,
++            eventButton,
++            eventButtons,
++            {x, y},
++            WebCore::IntPoint(),
++            0, 0, 0,
++            eventClickCount,
++            eventModifiers,
++            timestamp);
++        m_page.handleMouseEvent(contextMenuEvent);
++    }
 +#endif
 +}
 +


### PR DESCRIPTION
### Current Behaviour
When a right click is done on webkit in windows, it opens up the "_Inspect Element_" option without propagating the click unlike in other browsers and platform.
### New Behaviour
The right click will be propagated and the "_Inspect Element_" options will be opened too

fixes #39246
