### PR TITLE
fix(har): `WebSocket` message timestamps should be in milliseconds

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -549,7 +549,7 @@ export class CRNetworkManager {
 
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.wallTime * 1000;
-    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp);
+    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
     this._page!.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers, '\n'), wallTimeMs);
   }
 
@@ -559,7 +559,7 @@ export class CRNetworkManager {
   }
 
   _timestampToWallTimeMsForWebSocket(requestId: string, timestamp: number): number {
-    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp;
+    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp * 1000;
   }
 
   private _maybeUpdateRequestSession(sessionInfo: SessionInfo, request: InterceptableRequest) {

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -1016,7 +1016,7 @@ export class WVPage implements PageDelegate {
 
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.walltime * 1000;
-    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp);
+    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
     this._page.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers), wallTimeMs);
   }
 
@@ -1026,7 +1026,7 @@ export class WVPage implements PageDelegate {
   }
 
   _timestampToWallTimeMsForWebSocket(requestId: string, timestamp: number): number {
-    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp;
+    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp * 1000;
   }
 
   shouldToggleStyleSheetToSyncAnimations(): boolean {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -1209,7 +1209,7 @@ export class WKPage implements PageDelegate {
 
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.walltime * 1000;
-    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp);
+    this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
     this._page.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers), wallTimeMs);
   }
 
@@ -1219,7 +1219,7 @@ export class WKPage implements PageDelegate {
   }
 
   _timestampToWallTimeMsForWebSocket(requestId: string, timestamp: number): number {
-    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp;
+    return this._timestampBaselineForWebSocket.get(requestId)! + timestamp * 1000;
   }
 
   async _grantPermissions(origin: string, permissions: string[]) {

--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -100,6 +100,7 @@ it('should include websocket handshake headers and status', async ({ contextFact
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   await page.goto(server.EMPTY_PAGE);
 
+  const beforeMs = Date.now();
   const wsUrl = `ws://${server.HOST}/ws`;
   const closed = page.evaluate(url => new Promise<void>(resolve => {
     const ws = new WebSocket(url);
@@ -108,6 +109,7 @@ it('should include websocket handshake headers and status', async ({ contextFact
   }), wsUrl);
   await closed;
   const log = await getLog();
+  const afterMs = Date.now();
 
   const wsEntry = log.entries.find(e => e.request.url === wsUrl)! as Entry;
   expect(wsEntry._resourceType).toBe('websocket');
@@ -115,6 +117,10 @@ it('should include websocket handshake headers and status', async ({ contextFact
   expect(wsEntry.response.status).toBe(101);
   expect(wsEntry.response.statusText).toBe('Switching Protocols');
   expect(wsEntry.response.headersSize).toBe(responseHeadersSize(wsEntry.response.headers));
+
+  const wallTimeMs = new Date(wsEntry.startedDateTime).getTime();
+  expect(wallTimeMs).toBeGreaterThanOrEqual(beforeMs);
+  expect(wallTimeMs).toBeLessThanOrEqual(afterMs);
 
   const requestHeaderNames = wsEntry.request.headers.map(h => h.name.toLowerCase());
   expect(requestHeaderNames).toContain('upgrade');
@@ -135,12 +141,19 @@ async function testWebSocketMessages(contextFactory, server, testInfo, content, 
   const incomingBinary = [(new Array(125)).fill(0x01), (new Array(126)).fill(0x01), (new Array(2 ** 16)).fill(0x01)];
   const outgoingText =   ['y'.repeat(125),             'y'.repeat(126),             'y'.repeat(2 ** 16)];
   const outgoingBinary = [(new Array(125)).fill(0x02), (new Array(126)).fill(0x02), (new Array(2 ** 16)).fill(0x02)];
+  const incomingCount = incomingText.length + incomingBinary.length;
+  const outgoingCount = outgoingText.length + outgoingBinary.length;
+  const delayMs = 100;
 
-  server.onceWebSocketConnection(ws => {
-    for (const text of incomingText)
+  server.onceWebSocketConnection(async ws => {
+    for (const text of incomingText) {
       ws.send(text);
-    for (const binary of incomingBinary)
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    for (const binary of incomingBinary) {
+      await new Promise(resolve => setTimeout(resolve, delayMs));
       ws.send(Buffer.from(binary));
+    }
   });
 
   const outputPath = content === 'embed' ? undefined : 'test.har.zip';
@@ -149,20 +162,24 @@ async function testWebSocketMessages(contextFactory, server, testInfo, content, 
 
   const beforeMs = Date.now();
   const wsUrl = `ws://${server.HOST}/ws`;
-  const closed = page.evaluate(({ url, incomingCount, outgoingText, outgoingBinary }) => new Promise<void>(resolve => {
+  const closed = page.evaluate(({ url, incomingCount, outgoingText, outgoingBinary, delayMs }) => new Promise<void>(resolve => {
     let count = 0;
     const ws = new WebSocket(url);
-    ws.addEventListener('message', () => {
+    ws.addEventListener('message', async () => {
       if (++count < incomingCount)
         return;
-      for (const text of outgoingText)
+      for (const text of outgoingText) {
         ws.send(text);
-      for (const binary of outgoingBinary)
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+      for (const binary of outgoingBinary) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
         ws.send(new Uint8Array(binary));
+      }
       ws.close();
     });
     ws.addEventListener('close', () => resolve());
-  }), { url: wsUrl, incomingCount: incomingText.length + incomingBinary.length, outgoingText, outgoingBinary });
+  }), { url: wsUrl, incomingCount, outgoingText, outgoingBinary, delayMs });
   await closed;
   const afterMs = Date.now();
 
@@ -208,6 +225,7 @@ async function testWebSocketMessages(contextFactory, server, testInfo, content, 
   }
   expect(messages[0].time).toBeLessThanOrEqual(messages[1].time);
   expect(wsEntry.time).toBeGreaterThanOrEqual(messages[messages.length - 1].time - messages[0].time);
+  expect(wsEntry.time).toBeGreaterThanOrEqual(delayMs * (incomingCount + outgoingCount));
 }
 
 it('should embed websocket messages', async ({ contextFactory, server, channel }, testInfo) => {


### PR DESCRIPTION
the `timestamp` should also be multipled by 1000 just like the `walltime`

fixes <https://github.com/microsoft/playwright/issues/41360>