### PR TITLE
fix(test): surface merge reporter errors

### DIFF
--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import { isPathInside } from '@utils/fileUtils';
 import { ZipFile } from '@utils/zipFile';
 
+import { formatError, terminalScreen } from './base';
 import {  currentBlobReportVersion } from './blob';
 import { Multiplexer } from './multiplexer';
 import { JsonStringInternalizer, StringInternPool } from '../isomorphic/stringInternPool';
@@ -112,8 +113,10 @@ export async function createMergedReport(config: FullConfigInternal, dir: string
     });
   }
   await dispatchEvents(eventData.epilogue);
-  // The merged report status is intentionally not surfaced as a failure - the
-  // merge command only fails when a reporter itself errors.
+  // The merged report status is intentionally not surfaced as a failure.
+  // Reporter errors still fail the merge command and should be visible.
+  for (const error of multiplexer.reporterErrors())
+    terminalScreen.stderr.write(formatError(terminalScreen, error).message + '\n');
   return multiplexer.hasReporterErrors() ? 'failed' : 'passed';
 }
 

--- a/packages/playwright/src/reporters/multiplexer.ts
+++ b/packages/playwright/src/reporters/multiplexer.ts
@@ -23,6 +23,7 @@ import type { test } from '../common';
 export class Multiplexer implements ReporterV2 {
   private _reporters: ReporterV2[];
   private _hasReporterErrors = false;
+  private _reporterErrors: TestError[] = [];
 
   constructor(reporters: ReporterV2[]) {
     this._reporters = reporters;
@@ -34,6 +35,10 @@ export class Multiplexer implements ReporterV2 {
 
   hasReporterErrors(): boolean {
     return this._hasReporterErrors;
+  }
+
+  reporterErrors(): TestError[] {
+    return this._reporterErrors;
   }
 
   onConfigure(config: FullConfig) {
@@ -122,9 +127,11 @@ export class Multiplexer implements ReporterV2 {
     try {
       callback();
     } catch (e) {
+      const error = serializeError(e);
       this._hasReporterErrors = true;
+      this._reporterErrors.push(error);
       if (redispatch)
-        this.onError(serializeError(e));
+        this.onError(error);
     }
   }
 
@@ -132,8 +139,10 @@ export class Multiplexer implements ReporterV2 {
     try {
       return await callback();
     } catch (e) {
+      const error = serializeError(e);
       this._hasReporterErrors = true;
-      this.onError(serializeError(e));
+      this._reporterErrors.push(error);
+      this.onError(error);
     }
   }
 }


### PR DESCRIPTION
Fixes #40983

## Summary
- keep reporter-thrown errors separate from normal reported test errors
- print reporter errors when `merge-reports` fails because a reporter throws

## Tests
- `npm run build`
- `npm run ttest -- tests/playwright-test/reporter-blob.spec.ts --grep "should fail merge and report error when reporter throws in onEnd"`
- `npx eslint packages/playwright/src/reporters/merge.ts packages/playwright/src/reporters/multiplexer.ts`
- `npm run tsc -- --pretty false`
- `git diff --check`