### PR TITLE
fix(chromium): resolve iframe worker response headers

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -733,6 +733,7 @@ type RequestInfo = {
   responses: network.Response[],
   loadingFinished?: Protocol.Network.loadingFinishedPayload,
   loadingFailed?: Protocol.Network.loadingFailedPayload,
+  fallbackTimerScheduled?: boolean,
   servedFromCache?: boolean,
 };
 
@@ -849,7 +850,35 @@ class ResponseExtraInfoTracker {
       return;
     }
 
-    // We are not done yet.
+    if (info.fallbackTimerScheduled)
+      return;
+    info.fallbackTimerScheduled = true;
+    setImmediate(() => this._fallbackToProvisionalHeaders(info));
+  }
+
+  private _fallbackToProvisionalHeaders(info: RequestInfo) {
+    if (this._requests.get(info.requestId) !== info)
+      return;
+    if (!info.loadingFinished && !info.loadingFailed)
+      return;
+    if (!info.responses.length)
+      return;
+    if (info.responses.length <= info.responseReceivedExtraInfo.length) {
+      this._stopTracking(info.requestId);
+      return;
+    }
+
+    // Chromium can report "hasExtraInfo" without ever emitting all extra info
+    // events, for example for worker scripts started from an iframe. Once the
+    // request has finished and the next task still did not bring the missing
+    // events, use provisional headers instead of leaving allHeaders() pending
+    // forever.
+    for (const response of info.responses) {
+      response.request().setRawRequestHeaders(null);
+      response.setResponseHeadersSize(null);
+      response.setRawResponseHeaders(null);
+    }
+    this._stopTracking(info.requestId);
   }
 
   private _stopTracking(requestId: string) {

--- a/tests/page/workers.spec.ts
+++ b/tests/page/workers.spec.ts
@@ -261,6 +261,27 @@ it('should report worker script as network request', {
   expect(text).toContain(`console.log('hello from the worker');`);
 });
 
+it('should resolve response headers for worker script request from iframe', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39948' },
+}, async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  server.setRoute('/iframe-with-worker.html', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<script>window.worker = new Worker('/worker.js');</script>`);
+  });
+  server.setRoute('/worker.js', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/javascript', 'X-Worker-Script': 'true' });
+    res.end(`console.log('hello from the worker');`);
+  });
+
+  const requestFinishedPromise = page.waitForEvent('requestfinished', request => request.url().endsWith('/worker.js'));
+  await attachFrame(page, 'worker-frame', server.PREFIX + '/iframe-with-worker.html');
+  const request = await requestFinishedPromise;
+  const response = await request.response();
+  const headers = await response!.allHeaders();
+  expect(headers).toEqual(expect.objectContaining({ 'x-worker-script': 'true' }));
+});
+
 it('should report worker script as network request after redirect', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35678' },
 }, async ({ page, server, browserName }) => {


### PR DESCRIPTION
Fixes #39948

## Summary
- resolve pending response headers when Chromium reports `hasExtraInfo` but never sends all extra-info events after request completion
- add a regression test for `response.allHeaders()` on a worker script request created inside an iframe

## Tests
- `npm run ctest -- tests/page/workers.spec.ts --grep "response headers for worker script request from iframe"`
- `npm run ctest -- tests/page/workers.spec.ts`
- `npm run test -- tests/page/workers.spec.ts --grep "response headers for worker script request from iframe"`
- `npx eslint packages/playwright-core/src/server/chromium/crNetworkManager.ts tests/page/workers.spec.ts`
- `npm run tsc`
- `git diff --check`