### PR TITLE
fix(firefox): disable app updates with policies

### DIFF
--- a/packages/playwright-core/src/server/firefox/firefox.ts
+++ b/packages/playwright-core/src/server/firefox/firefox.ts
@@ -22,6 +22,7 @@ import { ManualPromise } from '@isomorphic/manualPromise';
 import { wrapInASCIIBox } from '@utils/ascii';
 import { FFBrowser } from './ffBrowser';
 import { kBrowserCloseMessageId } from './ffConnection';
+import { amendFirefoxPoliciesEnv, prepareFirefoxPolicies } from './firefoxPolicies';
 import { BrowserType, kNoXServerRunningError } from '../browserType';
 
 import type { Browser, BrowserOptions } from '../browser';
@@ -57,6 +58,10 @@ export class Firefox extends BrowserType {
     return FFBrowser.connect(this.attribution.playwright, transport, options);
   }
 
+  override async prepareUserDataDir(options: types.LaunchOptions, userDataDir: string): Promise<void> {
+    await prepareFirefoxPolicies(options, userDataDir);
+  }
+
   override doRewriteStartupLog(logs: string): string {
     // https://github.com/microsoft/playwright/issues/6500
     if (logs.includes(`as root in a regular user's session is not supported.`))
@@ -66,7 +71,8 @@ export class Firefox extends BrowserType {
     return logs;
   }
 
-  override amendEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  override amendEnvironment(env: NodeJS.ProcessEnv, userDataDir: string): NodeJS.ProcessEnv {
+    env = amendFirefoxPoliciesEnv(env, userDataDir);
     if (!path.isAbsolute(os.homedir()))
       throw new Error(`Cannot launch Firefox with relative home directory. Did you set ${os.platform() === 'win32' ? 'USERPROFILE' : 'HOME'} to a relative path?`);
     if (os.platform() === 'linux') {

--- a/packages/playwright-core/src/server/firefox/firefoxPolicies.ts
+++ b/packages/playwright-core/src/server/firefox/firefoxPolicies.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { envArrayToObject } from '@utils/processLauncher';
+
+export const kFirefoxPoliciesEnvName = 'PLAYWRIGHT_FIREFOX_POLICIES_JSON';
+
+type FirefoxPoliciesOptions = {
+  env?: { name: string, value: string }[];
+};
+
+type FirefoxPolicies = {
+  policies?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export function firefoxPoliciesPath(userDataDir: string): string {
+  return path.join(userDataDir, 'playwright-policies.json');
+}
+
+export async function prepareFirefoxPolicies(options: FirefoxPoliciesOptions, userDataDir: string): Promise<void> {
+  const env = options.env ? envArrayToObject(options.env) : process.env;
+  const userPolicies = await readFirefoxPolicies(env[kFirefoxPoliciesEnvName]);
+  const policies: FirefoxPolicies = {
+    ...userPolicies,
+    policies: {
+      ...userPolicies.policies,
+      DisableAppUpdate: true,
+    },
+  };
+  await fs.promises.writeFile(firefoxPoliciesPath(userDataDir), JSON.stringify(policies));
+}
+
+export function amendFirefoxPoliciesEnv(env: NodeJS.ProcessEnv, userDataDir: string): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    [kFirefoxPoliciesEnvName]: firefoxPoliciesPath(userDataDir),
+  };
+}
+
+async function readFirefoxPolicies(policiesPath: string | undefined): Promise<FirefoxPolicies> {
+  if (!policiesPath)
+    return {};
+  return JSON.parse(await fs.promises.readFile(policiesPath, 'utf8'));
+}

--- a/tests/library/firefox/launcher.spec.ts
+++ b/tests/library/firefox/launcher.spec.ts
@@ -15,9 +15,11 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 import { playwrightTest as it, expect } from '../../config/browserTest';
 import { TestServer } from '../../config/testserver';
 import { inheritAndCleanEnv } from '../../config/utils';
+import { kFirefoxPoliciesEnvName, prepareFirefoxPolicies } from '../../../packages/playwright-core/src/server/firefox/firefoxPolicies';
 
 it('should pass firefox user preferences', async ({ browserType, mode }) => {
   const browser = await browserType.launch({
@@ -72,4 +74,40 @@ it('should support custom firefox policies', async ({ browserType, mode, asset, 
   await expect(page.locator('body')).toHaveText(`Hi, I'm frame`);
   await browser.close();
   await server.stop();
+});
+
+it('should merge custom firefox policies with disabled app updates', async ({}, testInfo) => {
+  const defaultUserDataDir = testInfo.outputPath('default-profile');
+  await fs.promises.mkdir(defaultUserDataDir);
+  await prepareFirefoxPolicies({}, defaultUserDataDir);
+  expect(JSON.parse(await fs.promises.readFile(path.join(defaultUserDataDir, 'playwright-policies.json'), 'utf8'))).toEqual({
+    policies: {
+      DisableAppUpdate: true,
+    },
+  });
+
+  const policiesPath = testInfo.outputPath('policies.json');
+  await fs.promises.writeFile(policiesPath, JSON.stringify({
+    policies: {
+      Certificates: {
+        Install: ['cert.pem'],
+      },
+    },
+  }));
+
+  const userDataDir = testInfo.outputPath('profile');
+  await fs.promises.mkdir(userDataDir);
+  await prepareFirefoxPolicies({
+    env: [{ name: kFirefoxPoliciesEnvName, value: policiesPath }],
+  }, userDataDir);
+
+  const generatedPolicies = JSON.parse(await fs.promises.readFile(path.join(userDataDir, 'playwright-policies.json'), 'utf8'));
+  expect(generatedPolicies).toEqual({
+    policies: {
+      Certificates: {
+        Install: ['cert.pem'],
+      },
+      DisableAppUpdate: true,
+    },
+  });
 });


### PR DESCRIPTION
Closes #41356

## Summary
- write a per-profile Firefox policies file that disables app updates for Playwright-managed Firefox launches
- preserve a user-provided `PLAYWRIGHT_FIREFOX_POLICIES_JSON` file by copying its policies and adding `DisableAppUpdate`
- point Firefox at the generated per-profile policies file during launch

## Testing
- npm run build
- npm run ftest -- tests/library/firefox/launcher.spec.ts
- npm run ftest -- tests/library/firefox/launcher.spec.ts -g "policies"
- npm run eslint -- packages/playwright-core/src/server/firefox/firefoxPolicies.ts packages/playwright-core/src/server/firefox/firefox.ts tests/library/firefox/launcher.spec.ts
- npm run tsc -- --pretty false
- git diff --check
