### PR TITLE
chore: bump vite to 6.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "source-map-support": "0.5.21",
         "ssim.js": "^3.5.0",
         "typescript": "^6.0.3",
-        "vite": "^6.4.1",
+        "vite": "^6.4.3",
         "vite-plugin-static-copy": "^3.1.1",
         "ws": "8.17.1",
         "xml2js": "^0.5.0",
@@ -8777,9 +8777,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -9312,7 +9312,7 @@
       "dependencies": {
         "playwright": "1.62.0-next",
         "playwright-core": "1.62.0-next",
-        "vite": "^6.4.1"
+        "vite": "^6.4.3"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "source-map-support": "0.5.21",
     "ssim.js": "^3.5.0",
     "typescript": "^6.0.3",
-    "vite": "^6.4.1",
+    "vite": "^6.4.3",
     "vite-plugin-static-copy": "^3.1.1",
     "ws": "8.17.1",
     "xml2js": "^0.5.0",

--- a/packages/playwright-ct-core/package.json
+++ b/packages/playwright-ct-core/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "playwright-core": "1.62.0-next",
-    "vite": "^6.4.1",
+    "vite": "^6.4.3",
     "playwright": "1.62.0-next"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `vite` from `6.4.1` to `6.4.3` in the root `package.json` and `packages/playwright-ct-core/package.json`.
- Patch bump within the same minor — no vite plugin bumps required (all plugin peer ranges already include `^6.0.0`).