### PR TITLE
fix(tracing): stop recording websocket frames outside of chunks

### DIFF
--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -57,8 +57,8 @@ export class HarRecorder implements HarTracerDelegate {
       recordRequestOverrides: true,
       waitForContentOnStop: true,
       urlFilter: urlFilterRe ?? options.urlGlob,
-      omitWebSocketFrames: !!process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES,
     });
+    this._tracer.setOmitWebSocketFrames(!!process.env.PLAYWRIGHT_HAR_NO_WEBSOCKET_FRAMES);
     this._tracer.start({ omitScripts: false });
   }
 

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -62,7 +62,6 @@ type HarTracerOptions = {
   omitPages?: boolean;
   omitSizes?: boolean;
   omitScripts?: boolean;
-  omitWebSocketFrames?: boolean;
 };
 
 export class HarTracer {
@@ -77,6 +76,7 @@ export class HarTracer {
   private _pageEntrySymbol: symbol;
   private _baseURL: string | undefined;
   private _page: Page | null;
+  private _omitWebSocketFrames = true;
 
   constructor(context: BrowserContext | APIRequestContext, page: Page | null, delegate: HarTracerDelegate, options: HarTracerOptions) {
     this._context = context;
@@ -94,6 +94,10 @@ export class HarTracer {
     this._entrySymbol = Symbol('requestHarEntry');
     this._pageEntrySymbol = Symbol('pageHarEntry');
     this._baseURL = context instanceof APIRequestContext ? context._defaultOptions().baseURL : context._options.baseURL;
+  }
+
+  setOmitWebSocketFrames(omitWebSocketFrames: boolean) {
+    this._omitWebSocketFrames = omitWebSocketFrames;
   }
 
   start(options: { omitScripts: boolean }) {
@@ -443,7 +447,7 @@ export class HarTracer {
 
     let sha1: string | undefined = undefined;
     const recordMessage = (type: 'send' | 'receive', opcode: number, data: string, wallTimeMs: number) => {
-      if (this._options.omitWebSocketFrames)
+      if (this._omitWebSocketFrames)
         return;
       const message = { type, time: this._options.omitTiming ? -1 : wallTimeMs, opcode, data };
       if (this._options.content === 'embed') {

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -75,7 +75,6 @@ type RecordingState = {
   chunkOrdinal: number,
   networkSha1s: Set<string>,
   traceSha1s: Set<string>,
-  appendableSha1s: Set<string>,
   recording: boolean;
   callIds: Set<string>;
   groupStack: string[];
@@ -109,7 +108,6 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       includeTraceInfo: true,
       recordRequestOverrides: false,
       waitForContentOnStop: false,
-      omitWebSocketFrames: !!process.env.PLAYWRIGHT_TRACING_NO_WEBSOCKET_FRAMES,
     });
     const testIdAttributeName = ('selectors' in context) ? context.selectors().testIdAttributeName() : undefined;
     this._contextCreatedEvent = {
@@ -173,7 +171,6 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       chunkOrdinal: 0,
       traceSha1s: new Set(),
       networkSha1s: new Set(),
-      appendableSha1s: new Set(),
       recording: false,
       callIds: new Set(),
       groupStack: [],
@@ -225,6 +222,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     );
     if (this._state.options.screenshots)
       this._startScreencast();
+    this._harTracer.setOmitWebSocketFrames(!!process.env.PLAYWRIGHT_TRACING_NO_WEBSOCKET_FRAMES);
     if (this._state.options.snapshots)
       await this._snapshotter?.start(progress);
     return { traceName: this._state.traceName };
@@ -396,7 +394,9 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     eventsHelper.removeEventListeners(this._eventListeners);
     if (this._state.options.screenshots)
       this._stopScreencast();
-
+    // We don't need websocket frames outside of the recording window. This also
+    // stops updating websocket content blobs, which we want to stay unchanged for zipping.
+    this._harTracer.setOmitWebSocketFrames(true);
     if (this._state.options.snapshots)
       this._snapshotter?.stop();
 
@@ -413,15 +413,8 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     const entries: NameValue[] = [];
     entries.push({ name: 'trace.trace', value: this._state.traceFile });
     entries.push({ name: 'trace.network', value: newNetworkFile });
-    for (const sha1 of new Set([...this._state.traceSha1s, ...this._state.networkSha1s])) {
-      let value = path.join(this._state.resourcesDir, sha1);
-      if (params.mode === 'entries' && this._state.appendableSha1s.has(sha1)) {
-        const copy = path.join(this._state.tracesDir, `${this._state.traceName}-pwnetcopy-${this._state.chunkOrdinal}-${sha1}`);
-        this._fs.copyFile(value, copy);
-        value = copy;
-      }
-      entries.push({ name: path.join('resources', sha1), value });
-    }
+    for (const sha1 of new Set([...this._state.traceSha1s, ...this._state.networkSha1s]))
+      entries.push({ name: path.join('resources', sha1), value: path.join(this._state.resourcesDir, sha1) });
 
     // Only reset trace sha1s, network resources are preserved between chunks.
     this._state.traceSha1s = new Set();
@@ -552,10 +545,6 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     const event: trace.ResourceSnapshotTraceEvent = { type: 'resource-snapshot', snapshot: entry };
     const visited = visitTraceEvent(event, this._state!.networkSha1s);
     this._fs.appendFile(this._state!.networkFile, JSON.stringify(visited) + '\n', true /* flush */);
-
-    const sha1 = entry.response.content._sha1;
-    if (sha1)
-      this._state!.appendableSha1s.delete(sha1);
   }
 
   flushHarEntries() {
@@ -575,8 +564,8 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
   }
 
   onContentBlobAppend(sha1: string, text: string) {
-    this._allResources.add(sha1);
-    this._state!.appendableSha1s.add(sha1);
+    if (!this._allResources.has(sha1))
+      this._allResources.add(sha1);
     this._fs.appendFile(path.join(this._state!.resourcesDir, sha1), text, this._state!.options.live /* flush */);
   }
 


### PR DESCRIPTION
We do not need to record websocket frames while tracing is not being recorded. This fixes the "file was changed while zipping" problem without making file copies.

This redoes #41382 differently. References #41351.