### PR TITLE
fix(test): load require-reached files as commonjs in sync ESM loader

### DIFF
--- a/packages/playwright/src/transform/esmLoaderSync.ts
+++ b/packages/playwright/src/transform/esmLoaderSync.ts
@@ -56,7 +56,7 @@ const kSupportedFormats = new Map([
   [undefined, undefined]
 ]);
 
-export function load(moduleUrl: string, context: { format?: string }, nextLoad: Function) {
+export function load(moduleUrl: string, context: { format?: string, conditions?: string[] | Set<string> }, nextLoad: Function) {
   // Bail out for wasm, json, etc.
   if (!kSupportedFormats.has(context.format))
     return nextLoad(moduleUrl, context);
@@ -71,8 +71,10 @@ export function load(moduleUrl: string, context: { format?: string }, nextLoad: 
   if (!shouldTransform(filename))
     return nextLoad(moduleUrl, context);
 
-  // Output format is required, so we determine it manually when unknown.
-  const format = kSupportedFormats.get(context.format) || (fileIsModule(filename) ? 'module' : 'commonjs');
+  // A file reached via `require` is loaded as CommonJS. Files reached via `import` keep real ESM semantics.
+  // This is a "bundler" behavior, where we go against Node.js semantics, to support extension-less esm imports, path mapping, etc.
+  const isRequire = !new Set(context.conditions).has('import');
+  const format = isRequire ? 'commonjs' : (kSupportedFormats.get(context.format) || (fileIsModule(filename) ? 'module' : 'commonjs'));
 
   const code = fs.readFileSync(filename, 'utf-8');
   // Pass `moduleUrl` only for ESM. For CommonJS we omit it so that babel

--- a/tests/playwright-test/loader.spec.ts
+++ b/tests/playwright-test/loader.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { test, expect, playwrightCtConfigText } from './playwright-test-fixtures';
+import fs from 'fs';
 import path from 'path';
 import url from 'url';
 
@@ -907,6 +908,44 @@ test('should resolve no-extension import of module into .ts file', async ({ runI
       export function gimmeAOne() {
         return foo - 41;
       }
+    `,
+  });
+  expect(result.passed).toBe(1);
+  expect(result.exitCode).toBe(0);
+});
+
+test('should resolve extensionless .ts subpath import across a workspace symlink in ESM', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41371' },
+}, async ({ runInlineTest }, testInfo) => {
+  const baseDir = testInfo.outputPath();
+  const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+  const link = async (target: string, linkPath: string) => {
+    await fs.promises.mkdir(path.dirname(linkPath), { recursive: true });
+    await fs.promises.symlink(path.join(baseDir, target), linkPath, symlinkType);
+  };
+  // It is important to symlink so that our belongsToNodeModules() check does not trigger.
+  await link('packages/shared', path.join(baseDir, 'packages/core/node_modules/@repro/shared'));
+  await link('packages/core', path.join(baseDir, 'apps/e2e/node_modules/@repro/core'));
+
+  const result = await runInlineTest({
+    // Root package.json is required for workspace:* dependencies to work.
+    'package.json': JSON.stringify({ name: 'repro-root', private: true }),
+    'packages/shared/package.json': JSON.stringify({ name: '@repro/shared', private: true, type: 'module' }),
+    'packages/shared/lib/text.utils.ts': `
+      export function greet(name: string) {
+        return 'Hello, ' + name;
+      }
+    `,
+    'packages/core/package.json': JSON.stringify({ name: '@repro/core', private: true, type: 'module', dependencies: { '@repro/shared': 'workspace:*' } }),
+    'packages/core/lib/conversations.ts': `
+      export { greet } from '@repro/shared/lib/text.utils';
+    `,
+    'apps/e2e/tests/basic.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      import { greet } from '@repro/core/lib/conversations';
+      test('greet returns expected string', () => {
+        expect(greet('world')).toBe('Hello, world');
+      });
     `,
   });
   expect(result.passed).toBe(1);


### PR DESCRIPTION
## Summary
- The synchronous ESM loader loaded `type: module` files reached via `require` as real ESM, so their bare/subpath specifiers fell through to Node's native ESM resolver, which never tries the `.ts` extension. This broke extensionless TypeScript subpath imports across workspace (pnpm) symlinks — a regression from the async loader.
- Fix: load files reached under the `require` condition as CommonJS (read from `context.conditions` in the `load` hook), matching the async loader, so TypeScript extension substitution applies to their child specifiers.

Fixes https://github.com/microsoft/playwright/issues/41371