### PR TITLE
feat(webview): support `page.goBack` and `page.goForward`

### DIFF
--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -144,11 +144,24 @@ export class WVPage implements PageDelegate {
   }
 
   goBack(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    return this._navigateHistory(false);
   }
 
   goForward(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    return this._navigateHistory(true);
+  }
+
+  private async _navigateHistory(forward: boolean): Promise<boolean> {
+    const response = await this._session.sendMayFail('Runtime.evaluate', {
+      expression: `(function() {
+        const canNavigate = window.navigation?.${forward ? 'canGoForward' : 'canGoBack'} ?? window.history.length > 1;
+        if (canNavigate)
+          window.history.${forward ? 'forward' : 'back'}();
+        return canNavigate;
+      })()`,
+      returnByValue: true,
+    } as any);
+    return !!response?.result?.value;
   }
 
   async requestGC(): Promise<void> {

--- a/tests/webview/expectations/webkit-webview-page.txt
+++ b/tests/webview/expectations/webkit-webview-page.txt
@@ -452,7 +452,6 @@ page/page-wait-for-load-state.spec.ts › should work for frame [fail]
 # Page.goBack/goForward and we have not yet driven the back/forward list via
 # Runtime.evaluate(history.back()).
 # ============================================================================
-page/interception.spec.ts › should disable memory cache when intercepting [fail]
 page/page-history.spec.ts › goBack/goForward should work with bfcache-able pages [fail]
 page/page-history.spec.ts › page.goBack should work @smoke [fail]
 


### PR DESCRIPTION
unfortunately WebKit does not have an upstream `Page.goBack` or `Page.goForward`

luckily, there exist JS APIs we can leverage in the meantime