### PR TITLE
fix(webview): adjust UserAgent test to work with mobile

### DIFF
--- a/tests/page/page-basic.spec.ts
+++ b/tests/page/page-basic.spec.ts
@@ -151,8 +151,10 @@ it('should have sane user agent', async ({ page, browserName, isElectron, isAndr
   expect(part3.startsWith('AppleWebKit/')).toBe(true);
   expect(part4).toBe('KHTML, like Gecko');
   // 5th part encodes real browser name and engine version.
-  const [engine, browser] = part5.split(' ');
-  expect(browser.startsWith('Safari/')).toBe(true);
+  const tokens = part5.split(' ');
+  const engine = tokens[0];
+  const browser = tokens.find(t => t.startsWith('Safari/'));
+  expect(browser?.startsWith('Safari/')).toBe(true);
   if (browserName === 'chromium')
     expect(engine.includes('Chrome/')).toBe(true);
   else

--- a/tests/webview/expectations/webkit-webview-page.txt
+++ b/tests/webview/expectations/webkit-webview-page.txt
@@ -231,7 +231,6 @@ page/page-autowaiting-basic.spec.ts › should work with waitForLoadState(load) 
 page/page-basic.spec.ts › async stacks should work [fail]
 page/page-basic.spec.ts › has navigator.webdriver set to true [fail]
 page/page-basic.spec.ts › page.url should include hashes [fail]
-page/page-basic.spec.ts › should have sane user agent [fail]
 page/page-click-react.spec.ts › should not retarget when element is recycled on hover [fail]
 page/page-click-scroll.spec.ts › should scroll into view span element [fail]
 page/page-click-timeout-2.spec.ts › should timeout waiting for display:none to be gone [fail]


### PR DESCRIPTION
iOS has the same UserAgent "prefix" as macOS, only adding `Mobile/15E148` at the very end