### PR TITLE
test(webview): add a timeout for `clearCookies` in teardown so a busy page can't stall it

### DIFF
--- a/tests/webview/expectations/webkit-webview-page.txt
+++ b/tests/webview/expectations/webkit-webview-page.txt
@@ -709,3 +709,11 @@ page/page-wait-for-url.spec.ts › should work with history.replaceState() [fail
 page/page-wait-for-url.spec.ts › should work with url match for same document navigations [fail]
 page/retarget.spec.ts › should check the box outside shadow dom label [fail]
 
+# ============================================================================
+# busy-main-thread  (1 test)
+# This test deliberately infinite loops the WebProcess, which the shared MobileSafari
+# can't recover from without a full process restart. Left to run, its teardown would
+# exhaust the page fixture timeout and expensively recycle the worker on every shard.
+# ============================================================================
+page/page-set-content.spec.ts › should handle timeout properly 2 [fail]
+

--- a/tests/webview/webviewTest.ts
+++ b/tests/webview/webviewTest.ts
@@ -25,6 +25,11 @@ export { expect } from '@playwright/test';
 
 const PROXY_BASE = process.env.PW_WEBVIEW_PROXY_BASE || 'http://localhost:9222';
 
+// Limit the page fixture's setup and teardown in case the test infinitely loops.
+// All tests use a single shared MobileSafari, so we cannot recover if its busy.
+// As such, kill the worker to ensure that the next test has a reachable page.
+const WEBVIEW_PAGE_TIMEOUT = 20000;
+
 type WebViewWorkerFixtures = PageWorkerFixtures & {
   webviewExpectations: Map<string, WebViewExpectation>;
   webviewEndpoint: string;
@@ -138,7 +143,7 @@ export const webviewTest = baseTest.extend<WebViewTestFixtures, WebViewWorkerFix
     await run(endpoint);
   }, { scope: 'worker', timeout: 180000 }],
 
-  page: async ({ playwright, webviewEndpoint }, run) => {
+  page: [async ({ playwright, webviewEndpoint }, run) => {
     const browser = await playwright.webkit.connectOverCDP(webviewEndpoint);
     const [context] = browser.contexts();
     const pages = context.pages();
@@ -152,7 +157,7 @@ export const webviewTest = baseTest.extend<WebViewTestFixtures, WebViewWorkerFix
     // while still on the test's domain (webview cookies are domain-scoped).
     await page.context().clearCookies().catch(() => {});
     await browser.close();
-  },
+  }, { scope: 'test', timeout: WEBVIEW_PAGE_TIMEOUT }],
 
   _autoSkipWebView: [async ({ webviewExpectations }, run, testInfo) => {
     if (process.env.PWTEST_DISABLE_WEBVIEW_EXPECTATIONS !== undefined) {


### PR DESCRIPTION
`tests/page/page-set-content.spec.ts:153:3 › should handle timeout properly` will infinitely loop the page
    
as a result, none of the WebKit inspector protocol messages are handled
    
`context.clearCookies` performs multiple round-trips using the WebKit inspector protocol (`Page.getCookies` and then `Page.deleteCookie` for each)
    
as such, give the page fixture a `timeout` so that if `clearCookies` hangs then the worker will be killed and restarted instead of waiting forever