### PR TITLE
devops: publish stable release on tag push instead of release event

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,8 +7,10 @@ on:
   push:
     branches:
       - release-*
-  release:
-    types: [published]
+    tags:
+      # TODO: revert this to "published release" once github.ref is set there.
+      # See https://github.com/actions/runner/issues/2788 as well.
+      - 'v1.61.1'
 
 jobs:
   publish-npm-and-driver:
@@ -47,7 +49,7 @@ jobs:
         node utils/build/update_canary_version.js --beta --commit-timestamp
         utils/publish_all_packages.sh --beta
     - name: "publish release to NPM"
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: utils/publish_all_packages.sh --release
 
     - name: Azure Login
@@ -58,7 +60,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_PW_CDN_SUBSCRIPTION_ID }}
     - name: build & publish driver
       env:
-        AZ_UPLOAD_FOLDER: ${{ github.event_name == 'release' && 'driver' || 'driver/next' }}
+        AZ_UPLOAD_FOLDER: ${{ startsWith(github.ref, 'refs/tags/v') && 'driver' || 'driver/next' }}
       run: |
         utils/build/build-playwright-driver.sh
         utils/build/upload-playwright-driver.sh
@@ -89,7 +91,7 @@ jobs:
       env:
         GH_SERVICE_ACCOUNT_TOKEN: ${{ steps.app-token.outputs.token }}
     - name: Deploy Stable
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: bash utils/build/deploy-trace-viewer.sh --stable
       env:
         GH_SERVICE_ACCOUNT_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- The stable release publish was triggered by the `release: published` event, which intermittently delivers an empty `github.ref` ([actions/runner#2788](https://github.com/actions/runner/issues/2788)). This broke npm provenance publishing for v1.61.1 with `422 ... Missing SourceRepositoryRef in signing certificate` (the OIDC token's `ref` claim, and thus the cert's `SourceRepositoryRef`, was empty).
- Switch the stable npm / driver / trace-viewer publish to trigger on the tag `push` event (`refs/tags/v*`), where `github.ref` is reliably populated.
- Manual release flow is unchanged: creating a release in the UI with "create a new tag on publish" (as a human) still fires the tag `push` event. The only caveat is that bot/`GITHUB_TOKEN`-created releases would not fire `push`.