### PR TITLE
devops(docker): add Azure DevOps pipeline for Docker release publishing

### DIFF
--- a/.azure-pipelines/publish-docker.yml
+++ b/.azure-pipelines/publish-docker.yml
@@ -1,9 +1,5 @@
-# Publishes Playwright Docker images to playwright.azurecr.io on stable release tags.
-# Azure DevOps port of .github/workflows/publish_release_docker.yml.
-#
-# Trigger: any `v*` tag push (e.g. v1.40.0). Pre-release tags (v1.40.0-beta, -next,
-# -alpha) are excluded — publish_docker.sh also hard-errors on non-stable versions.
-# Can also be queued manually from the ADO UI (the workflow_dispatch equivalent).
+# Trigger: any `v*` release tag (e.g. v1.40.0).
+# Can also be queued manually from the ADO UI.
 trigger:
   tags:
     include:
@@ -12,6 +8,15 @@ trigger:
       - v*-*
 
 pr: none
+
+parameters:
+- name: releaseChannel
+  displayName: "IMPORTANT: set this to 'canary' when triggering manually"
+  type: string
+  default: stable
+  values:
+  - stable
+  - canary
 
 resources:
   repositories:
@@ -88,4 +93,4 @@ extends:
           displayName: "Build & publish Docker images"
           inputs:
             targetType: "inline"
-            script: "./utils/docker/publish_docker.sh stable"
+            script: "./utils/docker/publish_docker.sh ${{ parameters.releaseChannel }}"

--- a/.azure-pipelines/publish-docker.yml
+++ b/.azure-pipelines/publish-docker.yml
@@ -1,0 +1,91 @@
+# Publishes Playwright Docker images to playwright.azurecr.io on stable release tags.
+# Azure DevOps port of .github/workflows/publish_release_docker.yml.
+#
+# Trigger: any `v*` tag push (e.g. v1.40.0). Pre-release tags (v1.40.0-beta, -next,
+# -alpha) are excluded — publish_docker.sh also hard-errors on non-stable versions.
+# Can also be queued manually from the ADO UI (the workflow_dispatch equivalent).
+trigger:
+  tags:
+    include:
+      - v*
+    exclude:
+      - v*-*
+
+pr: none
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: DevDivPlaywrightAzurePipelinesUbuntu2204
+      os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: DevDivPlaywrightAzurePipelinesWindows2022
+        # The image must be windows-based due to restrictions of the SDL tools. See: https://aka.ms/AAo6v8e
+        os: windows
+    stages:
+    - stage: Publish
+      jobs:
+      - job: PublishDocker
+        displayName: "Publish Docker images to ACR"
+        # arm64 images are cross-built under QEMU emulation, which is slow.
+        timeoutInMinutes: 360
+        steps:
+        - checkout: self
+          fetchDepth: 0
+          displayName: "Checkout code"
+
+        - task: UseNode@1
+          inputs:
+            version: '22.x'
+          displayName: "Install Node.js"
+
+        # Relocate the Docker data-root to the large /mnt volume: this job builds
+        # 6 images (jammy/noble/resolute x amd64/arm64) and `docker system prune`s
+        # between them, so the default disk fills up.
+        - task: Bash@3
+          displayName: "Setup docker"
+          inputs:
+            targetType: "inline"
+            script: |
+              set -x
+              sudo service docker stop
+              sudo mkdir -p /etc/docker
+              echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+              sudo service docker start
+
+        # Register QEMU/binfmt handlers so `docker build --platform linux/arm64`
+        # works on the amd64 host. Equivalent to docker/setup-qemu-action@v4.
+        - task: Bash@3
+          displayName: "Set up QEMU for arm64 builds"
+          inputs:
+            targetType: "inline"
+            script: docker run --privileged --rm tonistiigi/binfmt --install arm64
+
+        - script: npm ci
+          displayName: "npm ci"
+
+        - script: npm run build
+          displayName: "npm run build"
+
+        - task: AzureCLI@2
+          displayName: "Login to ACR via OIDC"
+          inputs:
+            azureSubscription: "Playwright-CDN"
+            scriptType: "bash"
+            scriptLocation: "inlineScript"
+            inlineScript: "az acr login --name playwright"
+
+        - task: Bash@3
+          displayName: "Build & publish Docker images"
+          inputs:
+            targetType: "inline"
+            script: "./utils/docker/publish_docker.sh stable"

--- a/utils/docker/publish_docker.sh
+++ b/utils/docker/publish_docker.sh
@@ -15,26 +15,34 @@ if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
     echo "ERROR: cannot publish stable docker with Playwright version '${PW_VERSION}'"
     exit 1
   fi
-else
+elif [[ "${RELEASE_CHANNEL}" != "canary" ]]; then
   echo "ERROR: unknown release channel - ${RELEASE_CHANNEL}"
   echo "Must be either 'stable' or 'canary'"
   exit 1
 fi
 
+VERSION_TAG="v${PW_VERSION}"
+if [[ "${RELEASE_CHANNEL}" == "canary" ]]; then
+  VERSION_TAG="v${PW_VERSION}-canary-$(date -u +'%Y%m%d%H%M%S')"
+  echo "== CANARY build: publishing to ${VERSION_TAG}-* tags =="
+fi
+
 # Ubuntu 22.04
 JAMMY_TAGS=(
-  "v${PW_VERSION}-jammy"
+  "${VERSION_TAG}-jammy"
 )
 
 # Ubuntu 24.04
 NOBLE_TAGS=(
-  "v${PW_VERSION}"
-  "v${PW_VERSION}-noble"
+  "${VERSION_TAG}-noble"
 )
+if [[ "${RELEASE_CHANNEL}" == "stable" ]]; then
+  NOBLE_TAGS+=("${VERSION_TAG}")
+fi
 
 # Ubuntu 26.04
 RESOLUTE_TAGS=(
-  "v${PW_VERSION}-resolute"
+  "${VERSION_TAG}-resolute"
 )
 
 tag_and_push() {


### PR DESCRIPTION
## Summary
- Azure DevOps port of `.github/workflows/publish_release_docker.yml`, using the 1ES Official pipeline template (mirrors the existing `playwright-browsers` ADO pipelines).
- Triggers on `v*` release tags (pre-release tags excluded), builds jammy/noble/resolute for amd64 + arm64 and pushes to `playwright.azurecr.io` via `publish_docker.sh stable`.
