### PR TITLE
fix(chromium): do not steal OS focus when creating pages

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -370,7 +370,7 @@ export class CRBrowserContext extends BrowserContext<CREventsMap> {
   }
 
   override async doCreateNewPage(): Promise<Page> {
-    const { targetId } = await this._browser._session.send('Target.createTarget', { url: 'about:blank', browserContextId: this._browserContextId });
+    const { targetId } = await this._browser._session.send('Target.createTarget', { url: 'about:blank', browserContextId: this._browserContextId, background: false, focus: false });
     return this._browser._crPages.get(targetId)!._page;
   }
 


### PR DESCRIPTION
## Summary
- Pass `background: false, focus: false` to `Target.createTarget` so creating a page no longer activates the headed Chromium window and steals OS focus from the user.

Fixes https://github.com/microsoft/playwright/issues/41306