### PR TITLE
fix(runner): --last-failed should run nothing when previous run had no failures

### DIFF
--- a/packages/playwright/src/runner/lastRun.ts
+++ b/packages/playwright/src/runner/lastRun.ts
@@ -43,14 +43,14 @@ export class LastRunReporter implements ReporterV2 {
     }
   }
 
-  async filterLastFailed(): Promise<string[]> {
+  async filterLastFailed(): Promise<string[] | undefined> {
     if (!this._lastRunFile)
-      return [];
+      return undefined;
     try {
       const lastRunInfo = JSON.parse(await fs.promises.readFile(this._lastRunFile, 'utf8')) as LastRunInfo;
       return lastRunInfo.failedTests;
     } catch {
-      return [];
+      return undefined;
     }
   }
 

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -336,7 +336,7 @@ export function createLoadTask(mode: 'out-of-process' | 'in-process', options: {
         });
       }
 
-      if (testRun.options.lastFailedTestIds?.length) {
+      if (testRun.options.lastFailedTestIds) {
         const failedTestIds = new Set(testRun.options.lastFailedTestIds);
         testRun.postShardTestFilters.push(test => failedTestIds.has(test.id));
       }

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -455,7 +455,7 @@ export async function runAllTestsWithConfig(config: FullConfigInternal, options:
   const lastRun = new LastRunReporter(filteredProjects, options.listMode, options.lastFailedFile);
   if (options.lastFailed) {
     const lastFailedTestIds = await lastRun.filterLastFailed();
-    if (lastFailedTestIds.length)
+    if (lastFailedTestIds)
       options = { ...options, lastFailedTestIds };
   }
 

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -847,6 +847,25 @@ test('should run last failed tests', async ({ runInlineTest }) => {
   expect(result2.failed).toBe(1);
 });
 
+test('should run nothing with --last-failed when previous run had no failures', async ({ runInlineTest }) => {
+  const workspace = {
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('a', async () => {});
+      test('b', async () => {});
+    `
+  };
+  const result1 = await runInlineTest(workspace);
+  expect(result1.exitCode).toBe(0);
+  expect(result1.passed).toBe(2);
+
+  const result2 = await runInlineTest(workspace, {}, {}, { additionalArgs: ['--last-failed', '--pass-with-no-tests'] });
+  expect(result2.exitCode).toBe(0);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(0);
+  expect(result2.didNotRun).toBe(0);
+});
+
 test('should run last failed tests in a shard', async ({ runInlineTest }) => {
   const workspace = {
     'a.spec.js': `


### PR DESCRIPTION
## Summary
- `filterLastFailed()` returned `[]` both when no `.last-run.json` existed and when the previous run had zero failures; the call sites guarded on `.length`, so an empty failure list attached no filter and the whole suite re-ran.
- Now returns `undefined` when there is no readable last-run file (run everything) and `[]` when the previous run had zero failures (filter attached, runs nothing).

Fixes https://github.com/microsoft/playwright/issues/41407