### PR TITLE
feat(actions): add scroll option to opt out of autoscroll

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -179,6 +179,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.check.force = %%-input-force-%%
 * since: v1.8
 
+### option: ElementHandle.check.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: ElementHandle.check.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
@@ -223,6 +226,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.click.force = %%-input-force-%%
 * since: v1.8
+
+### option: ElementHandle.click.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: ElementHandle.click.noWaitAfter = %%-input-no-wait-after-%%
 * since: v1.8
@@ -279,6 +285,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.dblclick.force = %%-input-force-%%
 * since: v1.8
+
+### option: ElementHandle.dblclick.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: ElementHandle.dblclick.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
@@ -592,6 +601,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.hover.force = %%-input-force-%%
 * since: v1.8
+
+### option: ElementHandle.hover.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: ElementHandle.hover.timeout = %%-input-timeout-%%
 * since: v1.8
@@ -935,6 +947,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: ElementHandle.setChecked.force = %%-input-force-%%
 * since: v1.15
 
+### option: ElementHandle.setChecked.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: ElementHandle.setChecked.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.15
 
@@ -999,6 +1014,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.tap.force = %%-input-force-%%
 * since: v1.8
+
+### option: ElementHandle.tap.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: ElementHandle.tap.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
@@ -1072,6 +1090,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: ElementHandle.uncheck.force = %%-input-force-%%
 * since: v1.8
+
+### option: ElementHandle.uncheck.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: ElementHandle.uncheck.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8

--- a/docs/src/api/class-frame.md
+++ b/docs/src/api/class-frame.md
@@ -209,6 +209,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.check.force = %%-input-force-%%
 * since: v1.8
 
+### option: Frame.check.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Frame.check.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
@@ -261,6 +264,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.click.force = %%-input-force-%%
 * since: v1.8
+
+### option: Frame.click.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Frame.click.modifiers = %%-input-modifiers-%%
 * since: v1.8
@@ -319,6 +325,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.dblclick.force = %%-input-force-%%
 * since: v1.8
+
+### option: Frame.dblclick.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Frame.dblclick.delay = %%-input-down-up-delay-%%
 * since: v1.8
@@ -460,6 +469,9 @@ Optional event-specific initialization properties.
 
 ### option: Frame.dragAndDrop.force = %%-input-force-%%
 * since: v1.13
+
+### option: Frame.dragAndDrop.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Frame.dragAndDrop.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.13
@@ -1151,6 +1163,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.hover.force = %%-input-force-%%
 * since: v1.8
 
+### option: Frame.hover.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Frame.hover.strict = %%-input-strict-%%
 * since: v1.14
 
@@ -1601,6 +1616,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Frame.setChecked.force = %%-input-force-%%
 * since: v1.15
 
+### option: Frame.setChecked.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Frame.setChecked.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.15
 
@@ -1691,6 +1709,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.tap.force = %%-input-force-%%
 * since: v1.8
+
+### option: Frame.tap.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Frame.tap.modifiers = %%-input-modifiers-%%
 * since: v1.8
@@ -1799,6 +1820,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Frame.uncheck.force = %%-input-force-%%
 * since: v1.8
+
+### option: Frame.uncheck.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Frame.uncheck.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -354,6 +354,9 @@ await page.GetByRole(AriaRole.Checkbox).CheckAsync();
 ### option: Locator.check.force = %%-input-force-%%
 * since: v1.14
 
+### option: Locator.check.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Locator.check.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.14
 
@@ -512,6 +515,9 @@ await page.Locator("canvas").ClickAsync(new() {
 ### option: Locator.click.force = %%-input-force-%%
 * since: v1.14
 
+### option: Locator.click.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Locator.click.noWaitAfter = %%-input-no-wait-after-%%
 * since: v1.14
 
@@ -597,6 +603,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.dblclick.force = %%-input-force-%%
 * since: v1.14
+
+### option: Locator.dblclick.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Locator.dblclick.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.14
@@ -893,6 +902,9 @@ Locator of the element to drag to.
 
 ### option: Locator.dragTo.force = %%-input-force-%%
 * since: v1.18
+
+### option: Locator.dragTo.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Locator.dragTo.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.18
@@ -1552,6 +1564,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.hover.force = %%-input-force-%%
 * since: v1.14
+
+### option: Locator.hover.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Locator.hover.timeout = %%-input-timeout-%%
 * since: v1.14
@@ -2446,6 +2461,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.setChecked.force = %%-input-force-%%
 * since: v1.15
 
+### option: Locator.setChecked.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Locator.setChecked.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.15
 
@@ -2627,6 +2645,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Locator.tap.force = %%-input-force-%%
 * since: v1.14
 
+### option: Locator.tap.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Locator.tap.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.14
 
@@ -2740,6 +2761,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Locator.uncheck.force = %%-input-force-%%
 * since: v1.14
+
+### option: Locator.uncheck.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Locator.uncheck.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.14

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -745,6 +745,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.check.force = %%-input-force-%%
 * since: v1.8
 
+### option: Page.check.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Page.check.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8
 
@@ -793,6 +796,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.click.force = %%-input-force-%%
 * since: v1.8
+
+### option: Page.click.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Page.click.modifiers = %%-input-modifiers-%%
 * since: v1.8
@@ -893,6 +899,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.dblclick.force = %%-input-force-%%
 * since: v1.8
+
+### option: Page.dblclick.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Page.dblclick.delay = %%-input-down-up-delay-%%
 * since: v1.8
@@ -1087,6 +1096,9 @@ await Page.DragAndDropAsync("#source", "#target", new()
 
 ### option: Page.dragAndDrop.force = %%-input-force-%%
 * since: v1.13
+
+### option: Page.dragAndDrop.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Page.dragAndDrop.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.13
@@ -2480,6 +2492,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.hover.force = %%-input-force-%%
 * since: v1.8
+
+### option: Page.hover.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Page.hover.modifiers = %%-input-modifiers-%%
 * since: v1.8
@@ -4068,6 +4083,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.setChecked.force = %%-input-force-%%
 * since: v1.15
 
+### option: Page.setChecked.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Page.setChecked.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.15
 
@@ -4310,6 +4328,9 @@ When all steps combined have not finished during the specified [`option: timeout
 ### option: Page.tap.force = %%-input-force-%%
 * since: v1.8
 
+### option: Page.tap.scroll = %%-input-scroll-%%
+* since: v1.62
+
 ### option: Page.tap.modifiers = %%-input-modifiers-%%
 * since: v1.8
 
@@ -4421,6 +4442,9 @@ When all steps combined have not finished during the specified [`option: timeout
 
 ### option: Page.uncheck.force = %%-input-force-%%
 * since: v1.8
+
+### option: Page.uncheck.scroll = %%-input-scroll-%%
+* since: v1.62
 
 ### option: Page.uncheck.noWaitAfter = %%-input-no-wait-after-removed-%%
 * since: v1.8

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -80,6 +80,14 @@ This option has no effect.
 
 Whether to bypass the [actionability](../actionability.md) checks. Defaults to `false`.
 
+## input-scroll
+- `scroll` <[ScrollMode]<"auto"|"none">>
+
+Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`,
+which scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+`"none"`, Playwright does not scroll the element and the action fails if the element is not already in the viewport.
+This is useful to assert that an element is reachable by the user without additional scrolling.
+
 ## input-selector
 - `selector` <[string]>
 

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -2139,6 +2139,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2244,6 +2252,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2385,6 +2401,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2502,6 +2526,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -3329,6 +3361,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -4314,6 +4354,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4575,6 +4623,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4721,6 +4777,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6244,6 +6308,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6340,6 +6412,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6434,6 +6514,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6539,6 +6627,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -7169,6 +7265,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7703,6 +7807,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7878,6 +7990,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -8024,6 +8144,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -11742,6 +11870,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -11824,6 +11960,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11913,6 +12057,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -12087,6 +12239,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12531,6 +12691,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12659,6 +12827,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12761,6 +12937,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13245,6 +13429,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13390,6 +13582,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -13511,6 +13711,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -13661,6 +13869,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -14355,6 +14571,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15027,6 +15251,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15183,6 +15415,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15303,6 +15543,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -2462,6 +2462,7 @@ export type FrameCheckParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
@@ -2469,6 +2470,7 @@ export type FrameCheckParams = {
 export type FrameCheckOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
@@ -2477,6 +2479,7 @@ export type FrameClickParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -2490,6 +2493,7 @@ export type FrameClickParams = {
 export type FrameClickOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -2509,6 +2513,7 @@ export type FrameDragAndDropParams = {
   source: string,
   target: string,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   timeout: number,
   trial?: boolean,
   sourcePosition?: Point,
@@ -2518,6 +2523,7 @@ export type FrameDragAndDropParams = {
 };
 export type FrameDragAndDropOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   trial?: boolean,
   sourcePosition?: Point,
   targetPosition?: Point,
@@ -2562,6 +2568,7 @@ export type FrameDblclickParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -2573,6 +2580,7 @@ export type FrameDblclickParams = {
 export type FrameDblclickOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -2693,6 +2701,7 @@ export type FrameHoverParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -2701,6 +2710,7 @@ export type FrameHoverParams = {
 export type FrameHoverOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -2912,6 +2922,7 @@ export type FrameTapParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -2920,6 +2931,7 @@ export type FrameTapParams = {
 export type FrameTapOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -2957,6 +2969,7 @@ export type FrameUncheckParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
@@ -2964,6 +2977,7 @@ export type FrameUncheckParams = {
 export type FrameUncheckOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
@@ -3191,18 +3205,21 @@ export type ElementHandleBoundingBoxResult = {
 };
 export type ElementHandleCheckParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
 };
 export type ElementHandleCheckOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
 export type ElementHandleCheckResult = void;
 export type ElementHandleClickParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -3215,6 +3232,7 @@ export type ElementHandleClickParams = {
 };
 export type ElementHandleClickOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -3232,6 +3250,7 @@ export type ElementHandleContentFrameResult = {
 };
 export type ElementHandleDblclickParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -3242,6 +3261,7 @@ export type ElementHandleDblclickParams = {
 };
 export type ElementHandleDblclickOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -3281,6 +3301,7 @@ export type ElementHandleGetAttributeResult = {
 };
 export type ElementHandleHoverParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -3288,6 +3309,7 @@ export type ElementHandleHoverParams = {
 };
 export type ElementHandleHoverOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -3470,6 +3492,7 @@ export type ElementHandleSetInputFilesOptions = {
 export type ElementHandleSetInputFilesResult = void;
 export type ElementHandleTapParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -3477,6 +3500,7 @@ export type ElementHandleTapParams = {
 };
 export type ElementHandleTapOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -3498,12 +3522,14 @@ export type ElementHandleTypeOptions = {
 export type ElementHandleTypeResult = void;
 export type ElementHandleUncheckParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
 };
 export type ElementHandleUncheckOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1296,6 +1296,7 @@ scheme.FrameCheckParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   position: tOptional(tType('Point')),
   timeout: tFloat,
   trial: tOptional(tBoolean),
@@ -1305,6 +1306,7 @@ scheme.FrameClickParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   noWaitAfter: tOptional(tBoolean),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
@@ -1324,6 +1326,7 @@ scheme.FrameDragAndDropParams = tObject({
   source: tString,
   target: tString,
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   timeout: tFloat,
   trial: tOptional(tBoolean),
   sourcePosition: tOptional(tType('Point')),
@@ -1354,6 +1357,7 @@ scheme.FrameDblclickParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   delay: tOptional(tFloat),
@@ -1442,6 +1446,7 @@ scheme.FrameHoverParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   timeout: tFloat,
@@ -1587,6 +1592,7 @@ scheme.FrameTapParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   timeout: tFloat,
@@ -1617,6 +1623,7 @@ scheme.FrameUncheckParams = tObject({
   selector: tString,
   strict: tOptional(tBoolean),
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   position: tOptional(tType('Point')),
   timeout: tFloat,
   trial: tOptional(tBoolean),
@@ -1751,6 +1758,7 @@ scheme.ElementHandleBoundingBoxResult = tObject({
 });
 scheme.ElementHandleCheckParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   position: tOptional(tType('Point')),
   timeout: tFloat,
   trial: tOptional(tBoolean),
@@ -1758,6 +1766,7 @@ scheme.ElementHandleCheckParams = tObject({
 scheme.ElementHandleCheckResult = tOptional(tObject({}));
 scheme.ElementHandleClickParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   noWaitAfter: tOptional(tBoolean),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
@@ -1775,6 +1784,7 @@ scheme.ElementHandleContentFrameResult = tObject({
 });
 scheme.ElementHandleDblclickParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   delay: tOptional(tFloat),
@@ -1805,6 +1815,7 @@ scheme.ElementHandleGetAttributeResult = tObject({
 });
 scheme.ElementHandleHoverParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   timeout: tFloat,
@@ -1927,6 +1938,7 @@ scheme.ElementHandleSetInputFilesParams = tObject({
 scheme.ElementHandleSetInputFilesResult = tOptional(tObject({}));
 scheme.ElementHandleTapParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   modifiers: tOptional(tArray(tEnum(['Alt', 'Control', 'ControlOrMeta', 'Meta', 'Shift']))),
   position: tOptional(tType('Point')),
   timeout: tFloat,
@@ -1945,6 +1957,7 @@ scheme.ElementHandleTypeParams = tObject({
 scheme.ElementHandleTypeResult = tOptional(tObject({}));
 scheme.ElementHandleUncheckParams = tObject({
   force: tOptional(tBoolean),
+  scroll: tOptional(tEnum(['auto', 'none'])),
   position: tOptional(tType('Point')),
   timeout: tFloat,
   trial: tOptional(tBoolean),

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -2465,6 +2465,7 @@ export type FrameCheckParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
@@ -2472,6 +2473,7 @@ export type FrameCheckParams = {
 export type FrameCheckOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
@@ -2480,6 +2482,7 @@ export type FrameClickParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -2493,6 +2496,7 @@ export type FrameClickParams = {
 export type FrameClickOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -2512,6 +2516,7 @@ export type FrameDragAndDropParams = {
   source: string,
   target: string,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   timeout: number,
   trial?: boolean,
   sourcePosition?: Point,
@@ -2521,6 +2526,7 @@ export type FrameDragAndDropParams = {
 };
 export type FrameDragAndDropOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   trial?: boolean,
   sourcePosition?: Point,
   targetPosition?: Point,
@@ -2565,6 +2571,7 @@ export type FrameDblclickParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -2576,6 +2583,7 @@ export type FrameDblclickParams = {
 export type FrameDblclickOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -2696,6 +2704,7 @@ export type FrameHoverParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -2704,6 +2713,7 @@ export type FrameHoverParams = {
 export type FrameHoverOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -2915,6 +2925,7 @@ export type FrameTapParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -2923,6 +2934,7 @@ export type FrameTapParams = {
 export type FrameTapOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -2960,6 +2972,7 @@ export type FrameUncheckParams = {
   selector: string,
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
@@ -2967,6 +2980,7 @@ export type FrameUncheckParams = {
 export type FrameUncheckOptions = {
   strict?: boolean,
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
@@ -3194,18 +3208,21 @@ export type ElementHandleBoundingBoxResult = {
 };
 export type ElementHandleCheckParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
 };
 export type ElementHandleCheckOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };
 export type ElementHandleCheckResult = void;
 export type ElementHandleClickParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -3218,6 +3235,7 @@ export type ElementHandleClickParams = {
 };
 export type ElementHandleClickOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   noWaitAfter?: boolean,
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
@@ -3235,6 +3253,7 @@ export type ElementHandleContentFrameResult = {
 };
 export type ElementHandleDblclickParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -3245,6 +3264,7 @@ export type ElementHandleDblclickParams = {
 };
 export type ElementHandleDblclickOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   delay?: number,
@@ -3284,6 +3304,7 @@ export type ElementHandleGetAttributeResult = {
 };
 export type ElementHandleHoverParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -3291,6 +3312,7 @@ export type ElementHandleHoverParams = {
 };
 export type ElementHandleHoverOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -3473,6 +3495,7 @@ export type ElementHandleSetInputFilesOptions = {
 export type ElementHandleSetInputFilesResult = void;
 export type ElementHandleTapParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   timeout: number,
@@ -3480,6 +3503,7 @@ export type ElementHandleTapParams = {
 };
 export type ElementHandleTapOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   modifiers?: ('Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift')[],
   position?: Point,
   trial?: boolean,
@@ -3501,12 +3525,14 @@ export type ElementHandleTypeOptions = {
 export type ElementHandleTypeResult = void;
 export type ElementHandleUncheckParams = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   timeout: number,
   trial?: boolean,
 };
 export type ElementHandleUncheckOptions = {
   force?: boolean,
+  scroll?: 'auto' | 'none',
   position?: Point,
   trial?: boolean,
 };

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -404,9 +404,11 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     forceScrollOptions: ScrollIntoViewOptions | undefined,
     options: { waitAfter: boolean | 'disabled' } & types.PointerActionOptions & types.PointerActionWaitOptions,
   ): Promise<PerformActionResult> {
-    const { force = false, position } = options;
+    const { force = false, position, scroll } = options;
 
-    const doScrollIntoView = async (progress: Progress) => {
+    const doScrollIntoView = async (progress: Progress): Promise<'error:notvisible' | 'error:notconnected' | 'done'> => {
+      if (scroll === 'none')
+        return 'done';
       if (forceScrollOptions) {
         return await progress.race(this.evaluateInUtility(([injected, node, options]) => {
           if (node.nodeType === 1 /* Node.ELEMENT_NODE */)

--- a/packages/playwright-core/src/server/types.ts
+++ b/packages/playwright-core/src/server/types.ts
@@ -38,6 +38,7 @@ export type NavigateOptions = {
 export type CommonActionOptions = StrictOptions & {
   force?: boolean,
   noAutoWaiting?: boolean,
+  scroll?: 'auto' | 'none',
 };
 
 export type PointerActionWaitOptions = CommonActionOptions & {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -2139,6 +2139,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2244,6 +2252,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -2385,6 +2401,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -2502,6 +2526,14 @@ export interface Page {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -3329,6 +3361,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -4314,6 +4354,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4575,6 +4623,14 @@ export interface Page {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -4721,6 +4777,14 @@ export interface Page {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6244,6 +6308,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6340,6 +6412,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -6434,6 +6514,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -6539,6 +6627,14 @@ export interface Frame {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -7169,6 +7265,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7703,6 +7807,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -7878,6 +7990,14 @@ export interface Frame {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
      * element, the call throws an exception.
      */
@@ -8024,6 +8144,14 @@ export interface Frame {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * When true, the call requires selector to resolve to a single element. If given selector resolves to more than one
@@ -11742,6 +11870,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -11824,6 +11960,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -11913,6 +12057,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -12087,6 +12239,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -12531,6 +12691,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12659,6 +12827,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -12761,6 +12937,14 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
@@ -13245,6 +13429,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -13390,6 +13582,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
      * position and the provided destination. When set to 1, emits a single `mousemove` event at the destination location.
      */
@@ -13511,6 +13711,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Defaults to 1. Sends `n` interpolated `mousemove` events to represent travel between Playwright's current cursor
@@ -13661,6 +13869,14 @@ export interface Locator {
      * @deprecated This option has no effect.
      */
     noWaitAfter?: boolean;
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not
@@ -14355,6 +14571,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15027,6 +15251,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15183,6 +15415,14 @@ export interface Locator {
     };
 
     /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
@@ -15303,6 +15543,14 @@ export interface Locator {
 
       y: number;
     };
+
+    /**
+     * Controls whether Playwright scrolls the element into view before performing the action. Defaults to `"auto"`, which
+     * scrolls the element into view when necessary, including scrolling nested scrollable containers. When set to
+     * `"none"`, Playwright does not scroll the element and the action fails if the element is not already in the
+     * viewport. This is useful to assert that an element is reachable by the user without additional scrolling.
+     */
+    scroll?: "auto"|"none";
 
     /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`

--- a/packages/protocol/spec/frame.yml
+++ b/packages/protocol/spec/frame.yml
@@ -110,6 +110,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         position: Point?
         timeout: float
         trial: boolean?
@@ -126,6 +131,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         noWaitAfter: boolean?
         modifiers:
           type: array?
@@ -170,6 +180,11 @@ Frame:
         source: string
         target: string
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         timeout: float
         trial: boolean?
         sourcePosition: Point?
@@ -225,6 +240,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -374,6 +394,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -634,6 +659,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -694,6 +724,11 @@ Frame:
         selector: string
         strict: boolean?
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         position: Point?
         timeout: float
         trial: boolean?

--- a/packages/protocol/spec/handles.yml
+++ b/packages/protocol/spec/handles.yml
@@ -125,6 +125,11 @@ ElementHandle:
       title: Check
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         position: Point?
         timeout: float
         trial: boolean?
@@ -139,6 +144,11 @@ ElementHandle:
       title: Click
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         noWaitAfter: boolean?
         modifiers:
           type: array?
@@ -179,6 +189,11 @@ ElementHandle:
       title: Double click
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -252,6 +267,11 @@ ElementHandle:
       title: Hover
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -490,6 +510,11 @@ ElementHandle:
       title: Tap
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         modifiers:
           type: array?
           items:
@@ -536,6 +561,11 @@ ElementHandle:
       title: Uncheck
       parameters:
         force: boolean?
+        scroll:
+          type: enum?
+          literals:
+          - auto
+          - none
         position: Point?
         timeout: float
         trial: boolean?

--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -104,3 +104,55 @@ it('should scroll into view element in iframe', async ({ page, isAndroid, server
   `);
   await page.frameLocator('iframe').getByRole('button').click({ timeout: 5000 });
 });
+
+it('should not scroll the page when scroll is "none"', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41421' });
+  await page.setContent(`
+    <div style="height: 2000px;"></div>
+    <button onclick="window._clicked=true">click me</button>
+  `);
+  const error = await page.locator('button').click({ scroll: 'none', timeout: 2000 }).catch(e => e);
+  expect(error.message).toContain('element is outside of the viewport');
+  expect(await page.evaluate('window._clicked')).toBeFalsy();
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+it('should click in-viewport element when scroll is "none"', async ({ page }) => {
+  await page.setContent(`
+    <button onclick="window._clicked=true">click me</button>
+    <div style="height: 2000px;"></div>
+  `);
+  await page.locator('button').click({ scroll: 'none', timeout: 2000 });
+  expect(await page.evaluate('window._clicked')).toBe(true);
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+it('should not scroll nested container when scroll is "none"', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41421' });
+  await page.setContent(`
+    <div style="height: 100px; width: 100px; overflow-y: scroll;">
+      <div style="height: 50px;">A</div>
+      <div style="height: 50px;">B</div>
+      <button style="height: 50px; width: 100px;" onclick="window._clicked=true">C</button>
+    </div>
+  `);
+  const button = page.locator('button');
+  // The button is scrolled out of the nested overflow container.
+  const error = await button.click({ scroll: 'none', timeout: 2000 }).catch(e => e);
+  expect(error).toBeTruthy();
+  expect(await page.evaluate('window._clicked')).toBeFalsy();
+  // Default behavior scrolls the nested container into view and succeeds.
+  await button.click({ timeout: 2000 });
+  expect(await page.evaluate('window._clicked')).toBe(true);
+});
+
+it('should not scroll on hover when scroll is "none"', async ({ page }) => {
+  await page.setContent(`
+    <div style="height: 2000px;"></div>
+    <div onmouseover="window._hovered=true" style="width: 50px; height: 50px;">hover me</div>
+  `);
+  const error = await page.locator('div >> text=hover me').hover({ scroll: 'none', timeout: 2000 }).catch(e => e);
+  expect(error.message).toContain('element is outside of the viewport');
+  expect(await page.evaluate('window._hovered')).toBeFalsy();
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Adds a `scroll` option (`"auto"` | `"none"`, default `"auto"`) to pointer-based actions (`click`, `dblclick`, `hover`, `tap`, `dragTo`/`dragAndDrop`, `check`, `uncheck`, `setChecked`) on `Locator`, `Page`, `Frame` and `ElementHandle`.
- `scroll: 'none'` skips scrolling the element into view (including nested overflow containers); the action fails if the element is not already in the viewport. Useful to assert an element is reachable without extra scrolling.

Fixes https://github.com/microsoft/playwright/issues/41421