### PR TITLE
feat(web): canonical keyboard traversal and focus rings

### DIFF
--- a/packages/web/src/common.css
+++ b/packages/web/src/common.css
@@ -177,6 +177,11 @@ input[type=text], input[type=search] {
   outline: none;
 }
 
+input[type=text]:focus-visible, input[type=search]:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .codicon-loading {
   animation: spin 1s infinite linear;
 }

--- a/packages/web/src/components/codeMirrorWrapper.css
+++ b/packages/web/src/components/codeMirrorWrapper.css
@@ -20,6 +20,10 @@
   line-height: 18px;
 }
 
+.cm-wrapper:has(textarea:focus-visible) {
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
 .cm-wrapper, .cm-wrapper > div {
   width: 100%;
   height: 100%;

--- a/packages/web/src/components/codeMirrorWrapper.tsx
+++ b/packages/web/src/components/codeMirrorWrapper.tsx
@@ -110,7 +110,9 @@ export const CodeMirrorWrapper: React.FC<SourceProps> = ({
         autoCloseBrackets: true,
         extraKeys: {
           'Ctrl-F': 'findPersistent',
-          'Cmd-F': 'findPersistent'
+          'Cmd-F': 'findPersistent',
+          'Tab': false,
+          'Shift-Tab': false,
         }
       });
       codemirrorRef.current = { cm };

--- a/packages/web/src/components/tabbedPane.css
+++ b/packages/web/src/components/tabbedPane.css
@@ -39,9 +39,18 @@
   align-items: center;
   justify-content: center;
   user-select: none;
+  background: none;
+  border: none;
   border-bottom: 2px solid transparent;
+  color: inherit;
+  font: inherit;
   outline: none;
   height: 100%;
+}
+
+.tabbed-pane-tab:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 .tabbed-pane-tab-label {

--- a/packages/web/src/components/tabbedPane.tsx
+++ b/packages/web/src/components/tabbedPane.tsx
@@ -42,6 +42,7 @@ export const TabbedPane: React.FunctionComponent<{
     selectedTab = tabs[0].id;
   if (!mode)
     mode = 'default';
+
   return <div className='tabbed-pane' data-testid={dataTestId}>
     <div className='vbox'>
       <Toolbar>
@@ -102,7 +103,7 @@ export const TabbedPaneTab: React.FunctionComponent<{
   onSelect?: (id: string) => void,
   ariaControls?: string,
 }> = ({ id, title, count, errorCount, selected, onSelect, ariaControls }) => {
-  return <div className={clsx('tabbed-pane-tab', selected && 'selected')}
+  return <button className={clsx('tabbed-pane-tab', selected && 'selected')}
     onClick={() => onSelect?.(id)}
     role='tab'
     title={title}
@@ -111,5 +112,5 @@ export const TabbedPaneTab: React.FunctionComponent<{
     <div className='tabbed-pane-tab-label'>{title}</div>
     {!!count && <div className='tabbed-pane-tab-counter'>{count}</div>}
     {!!errorCount && <div className='tabbed-pane-tab-counter error'>{errorCount}</div>}
-  </div>;
+  </button>;
 };

--- a/packages/web/src/components/toolbar.css
+++ b/packages/web/src/components/toolbar.css
@@ -68,3 +68,8 @@
   color: var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);
 }
+
+.toolbar input:focus-visible, .toolbar select:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}

--- a/packages/web/src/components/toolbarButton.css
+++ b/packages/web/src/components/toolbarButton.css
@@ -28,6 +28,11 @@
   border-radius: 4px;
 }
 
+.toolbar-button:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .toolbar-button:disabled {
   color: var(--vscode-disabledForeground) !important;
   cursor: default;


### PR DESCRIPTION
## Summary

- Make `TabbedPane` tabs real `<button>`s so every header is a native Tab stop and Space/Enter selects — this also gives the snapshot Action/Before/After tablist the keyboard navigation it was missing.
- Stop CodeMirror from capturing `Tab`/`Shift-Tab`, so focus is no longer trapped inside source/network/locator/aria editors.
- Add keyboard-only `:focus-visible` rings to tabs, toolbar buttons, text/search inputs, toolbar selects, and CodeMirror editors.

Fixes https://github.com/microsoft/playwright/issues/41422