### PR TITLE
fix(chromium): do not forward cookie header on route.continue

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -346,7 +346,7 @@ export class CRNetworkManager {
         headersOverride = redirectedFrom?._originalRequestRoute?._alreadyContinuedParams?.headers;
         if (headersOverride) {
           const originalHeaders = Object.entries(requestPausedEvent.request.headers).map(([name, value]) => ({ name, value }));
-          headersOverride = network.applyHeadersOverrides(originalHeaders, headersOverride);
+          headersOverride = removeCookieHeader(network.applyHeadersOverrides(originalHeaders, headersOverride));
         }
         requestPausedSessionInfo!.session._sendMayFail('Fetch.continueRequest', { requestId: requestPausedEvent.requestId, headers: headersOverride });
       } else {
@@ -663,7 +663,7 @@ class RouteImpl implements network.RouteDelegate {
     this._alreadyContinuedParams = {
       requestId: this._interceptionId!,
       url: overrides.url,
-      headers: overrides.headers,
+      headers: overrides.headers && removeCookieHeader(overrides.headers),
       method: overrides.method,
       postData: overrides.postData ? overrides.postData.toString('base64') : undefined
     };
@@ -713,6 +713,13 @@ async function catchDisallowedErrors(callback: () => Promise<void>) {
   }
 }
 
+
+// Never forward the `cookie` header to Fetch.continueRequest: since Chromium 145 it overrides
+// the cookie store, which leaks the value captured at interception time. Omitting it lets the
+// network stack source the cookie from the store. https://github.com/microsoft/playwright/issues/41428
+function removeCookieHeader(headers: types.HeadersArray): types.HeadersArray {
+  return headers.filter(header => header.name.toLowerCase() !== 'cookie');
+}
 
 function splitSetCookieHeader(headers: types.HeadersArray): types.HeadersArray {
   const index = headers.findIndex(({ name }) => name.toLowerCase() === 'set-cookie');

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -477,6 +477,62 @@ it('continue should not override cookie', {
   expect(serverRequest.headers['custom']).toBe('value');
 });
 
+it('continue with headers should send fresh cookie from the browser cookie store', {
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41428' },
+  ]
+}, async ({ page, server }) => {
+  server.setRoute('/set-cookie', (request, response) => {
+    response.writeHead(200, { 'Set-Cookie': 'foo=v1;' });
+    response.end();
+  });
+  await page.goto(server.PREFIX + '/set-cookie');
+  expect(await page.evaluate(() => document.cookie)).toBe('foo=v1');
+
+  await page.route('**/empty.html', async route => {
+    // Cookie store changes between interception and continuation.
+    await page.context().addCookies([{ name: 'foo', value: 'v2', url: server.PREFIX }]);
+    await route.continue({ headers: route.request().headers() });
+  });
+
+  const [serverRequest] = await Promise.all([
+    server.waitForRequest('/empty.html'),
+    page.goto(server.EMPTY_PAGE)
+  ]);
+  // The fresh cookie from the browser cookie store should be sent, not the stale captured value.
+  expect(serverRequest.headers['cookie']).toBe('foo=v2');
+});
+
+it('continue with headers should send fresh cookie after a redirect', {
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41428' },
+  ]
+}, async ({ page, server }) => {
+  server.setRoute('/set-cookie', (request, response) => {
+    response.writeHead(200, { 'Set-Cookie': 'foo=v1;' });
+    response.end();
+  });
+  await page.goto(server.PREFIX + '/set-cookie');
+  expect(await page.evaluate(() => document.cookie)).toBe('foo=v1');
+
+  // The redirect updates the cookie before bouncing to the final destination.
+  server.setRoute('/redirect', (request, response) => {
+    response.writeHead(302, { 'Set-Cookie': 'foo=v2;', 'location': server.PREFIX + '/empty.html' });
+    response.end();
+  });
+
+  await page.route('**/redirect', route => {
+    void route.continue({ headers: route.request().headers() });
+  });
+
+  const [serverRequest] = await Promise.all([
+    server.waitForRequest('/empty.html'),
+    page.goto(server.PREFIX + '/redirect')
+  ]);
+  // The redirected request should carry the cookie updated by the redirect, not the stale captured value.
+  expect(serverRequest.headers['cookie']).toBe('foo=v2');
+});
+
 it('redirect after continue should be able to delete cookie', {
   annotation: [
     { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35168' },


### PR DESCRIPTION
## Summary
- Since Chromium 145, the `cookie` header sent via `Fetch.continueRequest` overrides the browser cookie store instead of being ignored, so `route.continue({ headers })` leaks the cookie captured at interception time (stale value), breaking auth flows.
- Omit the `cookie` header from `Fetch.continueRequest` so the network stack sources it from the cookie store — matching Firefox/WebKit, which already ignore the forwarded value. `request.headers()` still reports the cookie.

Fixes https://github.com/microsoft/playwright/issues/41428