### PR TITLE
chore(html-reporter): use button elements for tabs

### DIFF
--- a/packages/html-reporter/src/tabbedPane.css
+++ b/packages/html-reporter/src/tabbedPane.css
@@ -48,9 +48,18 @@
   align-items: center;
   justify-content: center;
   user-select: none;
+  background: none;
+  border: none;
   border-bottom: 2px solid transparent;
+  color: inherit;
+  font: inherit;
   outline: none;
   height: 100%;
+}
+
+.tabbed-pane-tab-element:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: -1px;
 }
 
 .tabbed-pane-tab-label {

--- a/packages/html-reporter/src/tabbedPane.tsx
+++ b/packages/html-reporter/src/tabbedPane.tsx
@@ -37,14 +37,14 @@ export const TabbedPane: React.FunctionComponent<{
       <div className='hbox' style={{ flex: 'none' }}>
         <div className='tabbed-pane-tab-strip' role='tablist'>{
           tabs.map(tab => (
-            <div className={clsx('tabbed-pane-tab-element', selectedTab === tab.id && 'selected')}
+            <button className={clsx('tabbed-pane-tab-element', selectedTab === tab.id && 'selected')}
               onClick={() => setSelectedTab(tab.id)}
               id={`${idPrefix}-${tab.id}`}
               key={tab.id}
               role='tab'
               aria-selected={selectedTab === tab.id}>
               <div className='tabbed-pane-tab-label'>{tab.title}</div>
-            </div>
+            </button>
           ))
         }</div>
       </div>


### PR DESCRIPTION
## Rationale
The html-reporter has its own `TabbedPane` that was still using `<div role="tab">` for tab elements. Since those aren't natively focusable, keyboard users couldn't really reach the retry tabs (`Run`, `Retry #1`, etc.) when viewing test results. This converts them to `<button>` and adds `:focus-visible` styling, following the same approach from #41434.