### PR TITLE
feat(installer): support installing Chrome and Edge on RPM-based Linux

### DIFF
--- a/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_beta_linux.sh
@@ -7,6 +7,10 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
+# Default to the Debian/Ubuntu (apt) installation path. When the host platform is
+# overridden we keep this default to preserve the previous behaviour.
+PKG_MANAGER="apt"
+
 if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   if [[ ! -f "/etc/os-release" ]]; then
     echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
@@ -14,10 +18,99 @@ if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   fi
 
   ID=$(bash -c 'source /etc/os-release && echo $ID')
-  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
-    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
-    exit 1
+  ID_LIKE=$(bash -c 'source /etc/os-release && echo $ID_LIKE')
+  case "${ID}" in
+    ubuntu|debian)
+      PKG_MANAGER="apt"
+      ;;
+    opensuse*|sles|sled)
+      PKG_MANAGER="zypper"
+      ;;
+    fedora|rhel|centos|rocky|almalinux|amzn)
+      PKG_MANAGER="redhat"
+      ;;
+    *)
+      if [[ "${ID_LIKE}" == *debian* ]]; then
+        PKG_MANAGER="apt"
+      elif [[ "${ID_LIKE}" == *suse* ]]; then
+        PKG_MANAGER="zypper"
+      elif [[ "${ID_LIKE}" == *rhel* || "${ID_LIKE}" == *fedora* ]]; then
+        PKG_MANAGER="redhat"
+      else
+        echo "ERROR: 'npx playwright install chrome' only supports distributions with an official"
+        echo "Google Chrome package: Ubuntu/Debian (.deb) and openSUSE/Fedora/RHEL (.rpm)."
+        echo "Google does not ship a native package for '$ID'."
+        case "${ID} ${ID_LIKE}" in
+          *arch*|*cachyos*)
+            echo "On Arch-based systems install Chrome from the AUR ('yay -S google-chrome') or use"
+            echo "Chromium ('pacman -S chromium'). Playwright's bundled Chromium also works."
+            ;;
+          *alpine*)
+            echo "Alpine uses musl libc; Google Chrome and Playwright's bundled browsers require glibc"
+            echo "and do not run here. Use the system Chromium instead ('apk add chromium')."
+            ;;
+          *gentoo*)
+            echo "On Gentoo install Chrome via Portage ('emerge www-client/google-chrome') or use"
+            echo "Playwright's bundled Chromium."
+            ;;
+          *nixos*)
+            echo "On NixOS add 'google-chrome' to your configuration declaratively, or use Playwright's"
+            echo "bundled Chromium. Imperative installation into /opt is not supported."
+            ;;
+          *)
+            echo "Use Playwright's bundled Chromium, which works on most glibc-based Linux distributions."
+            ;;
+        esac
+        exit 1
+      fi
+      ;;
+  esac
+
+  # The Red Hat family ships dnf on current releases and yum on older ones (e.g. RHEL 7).
+  if [[ "${PKG_MANAGER}" == "redhat" ]]; then
+    if command -v dnf >/dev/null; then
+      PKG_MANAGER="dnf"
+    else
+      PKG_MANAGER="yum"
+    fi
   fi
+fi
+
+if [[ "${PKG_MANAGER}" != "apt" ]]; then
+  # RPM-based distributions (openSUSE via zypper, Fedora/RHEL via dnf or yum) all
+  # consume the same x86_64 package from dl.google.com.
+  case "${PKG_MANAGER}" in
+    zypper)
+      PKG_REMOVE=(zypper --non-interactive remove)
+      PKG_INSTALL=(zypper --non-interactive install)
+      ;;
+    *)
+      PKG_REMOVE=("${PKG_MANAGER}" remove -y)
+      PKG_INSTALL=("${PKG_MANAGER}" install -y)
+      ;;
+  esac
+
+  # 1. make sure to remove old beta if any.
+  if rpm -q google-chrome-beta >/dev/null 2>&1; then
+    "${PKG_REMOVE[@]}" google-chrome-beta
+  fi
+
+  # 2. Install curl to download chrome
+  if ! command -v curl >/dev/null; then
+    "${PKG_INSTALL[@]}" curl
+  fi
+
+  # 3. Trust Google's signing key so the package manager accepts the package.
+  rpm --import https://dl.google.com/linux/linux_signing_key.pub
+
+  # 4. download chrome beta from dl.google.com and install it.
+  cd /tmp
+  curl -L -O https://dl.google.com/linux/direct/google-chrome-beta_current_x86_64.rpm
+  "${PKG_INSTALL[@]}" ./google-chrome-beta_current_x86_64.rpm
+  rm -rf ./google-chrome-beta_current_x86_64.rpm
+  cd -
+  google-chrome-beta --version
+  exit 0
 fi
 
 # 1. make sure to remove old beta if any.

--- a/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_chrome_stable_linux.sh
@@ -7,6 +7,10 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
+# Default to the Debian/Ubuntu (apt) installation path. When the host platform is
+# overridden we keep this default to preserve the previous behaviour.
+PKG_MANAGER="apt"
+
 if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   if [[ ! -f "/etc/os-release" ]]; then
     echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
@@ -14,10 +18,99 @@ if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   fi
 
   ID=$(bash -c 'source /etc/os-release && echo $ID')
-  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
-    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
-    exit 1
+  ID_LIKE=$(bash -c 'source /etc/os-release && echo $ID_LIKE')
+  case "${ID}" in
+    ubuntu|debian)
+      PKG_MANAGER="apt"
+      ;;
+    opensuse*|sles|sled)
+      PKG_MANAGER="zypper"
+      ;;
+    fedora|rhel|centos|rocky|almalinux|amzn)
+      PKG_MANAGER="redhat"
+      ;;
+    *)
+      if [[ "${ID_LIKE}" == *debian* ]]; then
+        PKG_MANAGER="apt"
+      elif [[ "${ID_LIKE}" == *suse* ]]; then
+        PKG_MANAGER="zypper"
+      elif [[ "${ID_LIKE}" == *rhel* || "${ID_LIKE}" == *fedora* ]]; then
+        PKG_MANAGER="redhat"
+      else
+        echo "ERROR: 'npx playwright install chrome' only supports distributions with an official"
+        echo "Google Chrome package: Ubuntu/Debian (.deb) and openSUSE/Fedora/RHEL (.rpm)."
+        echo "Google does not ship a native package for '$ID'."
+        case "${ID} ${ID_LIKE}" in
+          *arch*|*cachyos*)
+            echo "On Arch-based systems install Chrome from the AUR ('yay -S google-chrome') or use"
+            echo "Chromium ('pacman -S chromium'). Playwright's bundled Chromium also works."
+            ;;
+          *alpine*)
+            echo "Alpine uses musl libc; Google Chrome and Playwright's bundled browsers require glibc"
+            echo "and do not run here. Use the system Chromium instead ('apk add chromium')."
+            ;;
+          *gentoo*)
+            echo "On Gentoo install Chrome via Portage ('emerge www-client/google-chrome') or use"
+            echo "Playwright's bundled Chromium."
+            ;;
+          *nixos*)
+            echo "On NixOS add 'google-chrome' to your configuration declaratively, or use Playwright's"
+            echo "bundled Chromium. Imperative installation into /opt is not supported."
+            ;;
+          *)
+            echo "Use Playwright's bundled Chromium, which works on most glibc-based Linux distributions."
+            ;;
+        esac
+        exit 1
+      fi
+      ;;
+  esac
+
+  # The Red Hat family ships dnf on current releases and yum on older ones (e.g. RHEL 7).
+  if [[ "${PKG_MANAGER}" == "redhat" ]]; then
+    if command -v dnf >/dev/null; then
+      PKG_MANAGER="dnf"
+    else
+      PKG_MANAGER="yum"
+    fi
   fi
+fi
+
+if [[ "${PKG_MANAGER}" != "apt" ]]; then
+  # RPM-based distributions (openSUSE via zypper, Fedora/RHEL via dnf or yum) all
+  # consume the same x86_64 package from dl.google.com.
+  case "${PKG_MANAGER}" in
+    zypper)
+      PKG_REMOVE=(zypper --non-interactive remove)
+      PKG_INSTALL=(zypper --non-interactive install)
+      ;;
+    *)
+      PKG_REMOVE=("${PKG_MANAGER}" remove -y)
+      PKG_INSTALL=("${PKG_MANAGER}" install -y)
+      ;;
+  esac
+
+  # 1. make sure to remove old stable if any.
+  if rpm -q google-chrome-stable >/dev/null 2>&1; then
+    "${PKG_REMOVE[@]}" google-chrome-stable
+  fi
+
+  # 2. Install curl to download chrome
+  if ! command -v curl >/dev/null; then
+    "${PKG_INSTALL[@]}" curl
+  fi
+
+  # 3. Trust Google's signing key so the package manager accepts the package.
+  rpm --import https://dl.google.com/linux/linux_signing_key.pub
+
+  # 4. download chrome stable from dl.google.com and install it.
+  cd /tmp
+  curl -L -O https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+  "${PKG_INSTALL[@]}" ./google-chrome-stable_current_x86_64.rpm
+  rm -rf ./google-chrome-stable_current_x86_64.rpm
+  cd -
+  google-chrome --version
+  exit 0
 fi
 
 # 1. make sure to remove old stable if any.

--- a/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_beta_linux.sh
@@ -8,6 +8,10 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
+# Default to the Debian/Ubuntu (apt) installation path. When the host platform is
+# overridden we keep this default to preserve the previous behaviour.
+PKG_MANAGER="apt"
+
 if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   if [[ ! -f "/etc/os-release" ]]; then
     echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
@@ -15,10 +19,90 @@ if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   fi
 
   ID=$(bash -c 'source /etc/os-release && echo $ID')
-  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
-    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
-    exit 1
+  ID_LIKE=$(bash -c 'source /etc/os-release && echo $ID_LIKE')
+  case "${ID}" in
+    ubuntu|debian)
+      PKG_MANAGER="apt"
+      ;;
+    opensuse*|sles|sled)
+      PKG_MANAGER="zypper"
+      ;;
+    fedora|rhel|centos|rocky|almalinux|amzn)
+      PKG_MANAGER="redhat"
+      ;;
+    *)
+      if [[ "${ID_LIKE}" == *debian* ]]; then
+        PKG_MANAGER="apt"
+      elif [[ "${ID_LIKE}" == *suse* ]]; then
+        PKG_MANAGER="zypper"
+      elif [[ "${ID_LIKE}" == *rhel* || "${ID_LIKE}" == *fedora* ]]; then
+        PKG_MANAGER="redhat"
+      else
+        echo "ERROR: 'npx playwright install msedge-beta' only supports distributions with an official"
+        echo "Microsoft Edge package: Ubuntu/Debian (.deb) and openSUSE/Fedora/RHEL (.rpm)."
+        echo "Microsoft does not ship a native package for '$ID'."
+        case "${ID} ${ID_LIKE}" in
+          *arch*|*cachyos*)
+            echo "On Arch-based systems install Microsoft Edge from the AUR ('yay -S microsoft-edge-beta-bin')."
+            ;;
+          *)
+            echo "Use Playwright's bundled Chromium, which works on most glibc-based Linux distributions."
+            ;;
+        esac
+        exit 1
+      fi
+      ;;
+  esac
+
+  # The Red Hat family ships dnf on current releases and yum on older ones (e.g. RHEL 7).
+  if [[ "${PKG_MANAGER}" == "redhat" ]]; then
+    if command -v dnf >/dev/null; then
+      PKG_MANAGER="dnf"
+    else
+      PKG_MANAGER="yum"
+    fi
   fi
+fi
+
+if [[ "${PKG_MANAGER}" != "apt" ]]; then
+  # RPM-based distributions (openSUSE via zypper, Fedora/RHEL via dnf or yum) install
+  # Microsoft Edge from the same rpm repository at packages.microsoft.com.
+  case "${PKG_MANAGER}" in
+    zypper)
+      PKG_REMOVE=(zypper --non-interactive remove)
+      PKG_INSTALL=(zypper --non-interactive --gpg-auto-import-keys install)
+      REPO_DIR="/etc/zypp/repos.d"
+      ;;
+    *)
+      PKG_REMOVE=("${PKG_MANAGER}" remove -y)
+      PKG_INSTALL=("${PKG_MANAGER}" install -y)
+      REPO_DIR="/etc/yum.repos.d"
+      ;;
+  esac
+
+  # 1. Trust Microsoft's signing key and register the Edge repository.
+  rpm --import https://packages.microsoft.com/keys/microsoft.asc
+  cat > "${REPO_DIR}/microsoft-edge.repo" <<'REPO'
+[microsoft-edge]
+name=Microsoft Edge
+baseurl=https://packages.microsoft.com/yumrepos/edge
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+REPO
+
+  # 2. make sure to remove old beta if any.
+  if rpm -q microsoft-edge-beta >/dev/null 2>&1; then
+    "${PKG_REMOVE[@]}" microsoft-edge-beta
+  fi
+
+  # 3. refresh metadata (zypper) and install.
+  if [[ "${PKG_MANAGER}" == "zypper" ]]; then
+    zypper --non-interactive --gpg-auto-import-keys refresh
+  fi
+  "${PKG_INSTALL[@]}" microsoft-edge-beta
+  microsoft-edge-beta --version
+  exit 0
 fi
 
 # 1. make sure to remove old beta if any.

--- a/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_dev_linux.sh
@@ -8,6 +8,10 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
+# Default to the Debian/Ubuntu (apt) installation path. When the host platform is
+# overridden we keep this default to preserve the previous behaviour.
+PKG_MANAGER="apt"
+
 if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   if [[ ! -f "/etc/os-release" ]]; then
     echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
@@ -15,10 +19,90 @@ if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   fi
 
   ID=$(bash -c 'source /etc/os-release && echo $ID')
-  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
-    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
-    exit 1
+  ID_LIKE=$(bash -c 'source /etc/os-release && echo $ID_LIKE')
+  case "${ID}" in
+    ubuntu|debian)
+      PKG_MANAGER="apt"
+      ;;
+    opensuse*|sles|sled)
+      PKG_MANAGER="zypper"
+      ;;
+    fedora|rhel|centos|rocky|almalinux|amzn)
+      PKG_MANAGER="redhat"
+      ;;
+    *)
+      if [[ "${ID_LIKE}" == *debian* ]]; then
+        PKG_MANAGER="apt"
+      elif [[ "${ID_LIKE}" == *suse* ]]; then
+        PKG_MANAGER="zypper"
+      elif [[ "${ID_LIKE}" == *rhel* || "${ID_LIKE}" == *fedora* ]]; then
+        PKG_MANAGER="redhat"
+      else
+        echo "ERROR: 'npx playwright install msedge-dev' only supports distributions with an official"
+        echo "Microsoft Edge package: Ubuntu/Debian (.deb) and openSUSE/Fedora/RHEL (.rpm)."
+        echo "Microsoft does not ship a native package for '$ID'."
+        case "${ID} ${ID_LIKE}" in
+          *arch*|*cachyos*)
+            echo "On Arch-based systems install Microsoft Edge from the AUR ('yay -S microsoft-edge-dev-bin')."
+            ;;
+          *)
+            echo "Use Playwright's bundled Chromium, which works on most glibc-based Linux distributions."
+            ;;
+        esac
+        exit 1
+      fi
+      ;;
+  esac
+
+  # The Red Hat family ships dnf on current releases and yum on older ones (e.g. RHEL 7).
+  if [[ "${PKG_MANAGER}" == "redhat" ]]; then
+    if command -v dnf >/dev/null; then
+      PKG_MANAGER="dnf"
+    else
+      PKG_MANAGER="yum"
+    fi
   fi
+fi
+
+if [[ "${PKG_MANAGER}" != "apt" ]]; then
+  # RPM-based distributions (openSUSE via zypper, Fedora/RHEL via dnf or yum) install
+  # Microsoft Edge from the same rpm repository at packages.microsoft.com.
+  case "${PKG_MANAGER}" in
+    zypper)
+      PKG_REMOVE=(zypper --non-interactive remove)
+      PKG_INSTALL=(zypper --non-interactive --gpg-auto-import-keys install)
+      REPO_DIR="/etc/zypp/repos.d"
+      ;;
+    *)
+      PKG_REMOVE=("${PKG_MANAGER}" remove -y)
+      PKG_INSTALL=("${PKG_MANAGER}" install -y)
+      REPO_DIR="/etc/yum.repos.d"
+      ;;
+  esac
+
+  # 1. Trust Microsoft's signing key and register the Edge repository.
+  rpm --import https://packages.microsoft.com/keys/microsoft.asc
+  cat > "${REPO_DIR}/microsoft-edge.repo" <<'REPO'
+[microsoft-edge]
+name=Microsoft Edge
+baseurl=https://packages.microsoft.com/yumrepos/edge
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+REPO
+
+  # 2. make sure to remove old dev if any.
+  if rpm -q microsoft-edge-dev >/dev/null 2>&1; then
+    "${PKG_REMOVE[@]}" microsoft-edge-dev
+  fi
+
+  # 3. refresh metadata (zypper) and install.
+  if [[ "${PKG_MANAGER}" == "zypper" ]]; then
+    zypper --non-interactive --gpg-auto-import-keys refresh
+  fi
+  "${PKG_INSTALL[@]}" microsoft-edge-dev
+  microsoft-edge-dev --version
+  exit 0
 fi
 
 # 1. make sure to remove old dev if any.

--- a/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
+++ b/packages/playwright-core/bin/reinstall_msedge_stable_linux.sh
@@ -8,6 +8,10 @@ if [[ $(arch) == "aarch64" ]]; then
   exit 1
 fi
 
+# Default to the Debian/Ubuntu (apt) installation path. When the host platform is
+# overridden we keep this default to preserve the previous behaviour.
+PKG_MANAGER="apt"
+
 if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   if [[ ! -f "/etc/os-release" ]]; then
     echo "ERROR: cannot install on unknown linux distribution (/etc/os-release is missing)"
@@ -15,10 +19,90 @@ if [ -z "$PLAYWRIGHT_HOST_PLATFORM_OVERRIDE" ]; then
   fi
 
   ID=$(bash -c 'source /etc/os-release && echo $ID')
-  if [[ "${ID}" != "ubuntu" && "${ID}" != "debian" ]]; then
-    echo "ERROR: cannot install on $ID distribution - only Ubuntu and Debian are supported"
-    exit 1
+  ID_LIKE=$(bash -c 'source /etc/os-release && echo $ID_LIKE')
+  case "${ID}" in
+    ubuntu|debian)
+      PKG_MANAGER="apt"
+      ;;
+    opensuse*|sles|sled)
+      PKG_MANAGER="zypper"
+      ;;
+    fedora|rhel|centos|rocky|almalinux|amzn)
+      PKG_MANAGER="redhat"
+      ;;
+    *)
+      if [[ "${ID_LIKE}" == *debian* ]]; then
+        PKG_MANAGER="apt"
+      elif [[ "${ID_LIKE}" == *suse* ]]; then
+        PKG_MANAGER="zypper"
+      elif [[ "${ID_LIKE}" == *rhel* || "${ID_LIKE}" == *fedora* ]]; then
+        PKG_MANAGER="redhat"
+      else
+        echo "ERROR: 'npx playwright install msedge' only supports distributions with an official"
+        echo "Microsoft Edge package: Ubuntu/Debian (.deb) and openSUSE/Fedora/RHEL (.rpm)."
+        echo "Microsoft does not ship a native package for '$ID'."
+        case "${ID} ${ID_LIKE}" in
+          *arch*|*cachyos*)
+            echo "On Arch-based systems install Microsoft Edge from the AUR ('yay -S microsoft-edge-stable-bin')."
+            ;;
+          *)
+            echo "Use Playwright's bundled Chromium, which works on most glibc-based Linux distributions."
+            ;;
+        esac
+        exit 1
+      fi
+      ;;
+  esac
+
+  # The Red Hat family ships dnf on current releases and yum on older ones (e.g. RHEL 7).
+  if [[ "${PKG_MANAGER}" == "redhat" ]]; then
+    if command -v dnf >/dev/null; then
+      PKG_MANAGER="dnf"
+    else
+      PKG_MANAGER="yum"
+    fi
   fi
+fi
+
+if [[ "${PKG_MANAGER}" != "apt" ]]; then
+  # RPM-based distributions (openSUSE via zypper, Fedora/RHEL via dnf or yum) install
+  # Microsoft Edge from the same rpm repository at packages.microsoft.com.
+  case "${PKG_MANAGER}" in
+    zypper)
+      PKG_REMOVE=(zypper --non-interactive remove)
+      PKG_INSTALL=(zypper --non-interactive --gpg-auto-import-keys install)
+      REPO_DIR="/etc/zypp/repos.d"
+      ;;
+    *)
+      PKG_REMOVE=("${PKG_MANAGER}" remove -y)
+      PKG_INSTALL=("${PKG_MANAGER}" install -y)
+      REPO_DIR="/etc/yum.repos.d"
+      ;;
+  esac
+
+  # 1. Trust Microsoft's signing key and register the Edge repository.
+  rpm --import https://packages.microsoft.com/keys/microsoft.asc
+  cat > "${REPO_DIR}/microsoft-edge.repo" <<'REPO'
+[microsoft-edge]
+name=Microsoft Edge
+baseurl=https://packages.microsoft.com/yumrepos/edge
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+REPO
+
+  # 2. make sure to remove old stable if any.
+  if rpm -q microsoft-edge-stable >/dev/null 2>&1; then
+    "${PKG_REMOVE[@]}" microsoft-edge-stable
+  fi
+
+  # 3. refresh metadata (zypper) and install.
+  if [[ "${PKG_MANAGER}" == "zypper" ]]; then
+    zypper --non-interactive --gpg-auto-import-keys refresh
+  fi
+  "${PKG_INSTALL[@]}" microsoft-edge-stable
+  microsoft-edge-stable --version
+  exit 0
 fi
 
 # 1. make sure to remove old stable if any.


### PR DESCRIPTION
## Summary
- `npx playwright install chrome` / `install msedge` previously failed on every
  non-Debian distribution with *"cannot install on … distribution — only Ubuntu
  and Debian are supported"*.
- The `reinstall_chrome_*` and `reinstall_msedge_*` scripts now detect the
  distribution from `/etc/os-release` and install through the matching package
  manager:
  - `apt` / `.deb` — Debian, Ubuntu (unchanged)
  - `zypper` / `.rpm` — openSUSE, SLES
  - `dnf` (fallback `yum`) / `.rpm` — Fedora, RHEL, CentOS, Rocky, AlmaLinux, Amazon Linux
- Microsoft Edge registers Microsoft's official Edge yum/zypper repository and
  installs `microsoft-edge-{stable,beta,dev}`; Chrome imports Google's signing
  key and installs the official `google-chrome-{stable,beta}` RPM.
- Distributions with no vendor package (Arch/CachyOS, Alpine, Gentoo, NixOS, …)
  now print a clear, actionable hint (e.g. the AUR package name, or "use the
  bundled Chromium") instead of a hard failure.

## Notes
- Package sources verified to exist (Google Chrome RPM + `linux_signing_key.pub`;
  `packages.microsoft.com/yumrepos/edge` + `microsoft.asc`).
- The actual install runs as root via Playwright's existing `sudo` wrapper, so it
  cannot be exercised non-interactively in CI; manual verification was done on
  openSUSE Tumbleweed.
