### PR TITLE
chore(deps): update ws and path-to-regexp security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "typescript": "^6.0.3",
         "vite": "^6.4.3",
         "vite-plugin-static-copy": "^3.1.1",
-        "ws": "8.17.1",
+        "ws": "8.21.0",
         "xml2js": "^0.5.0",
         "yaml": "^2.8.3",
         "yauzl": "3.3.2",
@@ -7205,9 +7205,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9031,9 +9031,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "typescript": "^6.0.3",
     "vite": "^6.4.3",
     "vite-plugin-static-copy": "^3.1.1",
-    "ws": "8.17.1",
+    "ws": "8.21.0",
     "xml2js": "^0.5.0",
     "yaml": "^2.8.3",
     "yauzl": "3.3.2",


### PR DESCRIPTION
## 10-second summary

This PR updates `ws` from `8.17.1` to `8.21.0` and refreshes the resolved `path-to-regexp` lockfile entry from `8.3.0` to `8.4.2` to remove two high-severity denial-of-service advisories from the resolved dependency graph. `ws` is directly listed in the root dev dependency set and is imported by Playwright runtime/server code; `path-to-regexp` is transitive through `router`.

No user-facing behavior change is expected. The change is limited to dependency resolution in `package.json` and `package-lock.json`; `npm audit` no longer reports high-severity findings for `ws` or `path-to-regexp`.

## What Changed

- Updated `ws` from `8.17.1` to `8.21.0`.
- Refreshed `package-lock.json` so `path-to-regexp` resolves from `8.3.0` to `8.4.2`.
- No source code changes.

## What Users Will See

No direct user-facing behavior change is expected. This is preventive dependency remediation for resolved Node dependencies used by the repo.

## Surface Area

- [x] Internal / non-user-facing
- [ ] UI
- [ ] API
- [ ] Default behavior
- [ ] Data/model/schema

Notes: dependency resolution only; no Playwright API or behavior changes are intended.

## Why This Change Is Needed

This PR addresses high-severity advisories affecting the resolved dependency graph:

- `ws@8.17.1` is affected by a memory exhaustion DoS advisory fixed in `8.21.0`.
- `ws@8.17.1` is also below the patched range for an uninitialized memory disclosure advisory fixed in `8.20.1`.
- `path-to-regexp@8.3.0` is affected by ReDoS/DoS advisories fixed in `8.4.0+`; this PR resolves it to `8.4.2`.

This matters when attacker-controlled websocket data or route patterns can reach the vulnerable packages. This PR is not claiming active exploitation in this repository.

## Advisory References

- GitHub Advisory Database, `ws` memory exhaustion DoS: https://github.com/advisories/GHSA-96hv-2xvq-fx4p
- Upstream `ws` advisory: https://github.com/websockets/ws/security/advisories/GHSA-96hv-2xvq-fx4p
- GitHub Advisory Database, `ws` uninitialized memory disclosure: https://github.com/advisories/GHSA-58qx-3vcg-4xpx
- Upstream `ws` advisory: https://github.com/websockets/ws/security/advisories/GHSA-58qx-3vcg-4xpx
- GitHub Advisory Database, `path-to-regexp` DoS: https://github.com/advisories/GHSA-j3q9-mxjg-w52f
- Upstream `path-to-regexp` advisory: https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-j3q9-mxjg-w52f
- NVD, `path-to-regexp`: https://nvd.nist.gov/vuln/detail/CVE-2026-4926

## Where It Appears

Dependency path:

```text
package.json
-> ws@8.17.1

package-lock.json
-> router@2.2.0
-> path-to-regexp@8.3.0
```

Evidence:

- [`package.json`](https://github.com/gateway/playwright/blob/guardian/update-ws-path-to-regexp/package.json#L163): root dependency now pins `ws` to `8.21.0`.
- [`package-lock.json`](https://github.com/gateway/playwright/blob/guardian/update-ws-path-to-regexp/package-lock.json#L121): root lockfile dependency now records `ws` as `8.21.0`.
- [`package-lock.json`](https://github.com/gateway/playwright/blob/guardian/update-ws-path-to-regexp/package-lock.json#L7207): resolved `path-to-regexp` package is now `8.4.2`.
- [`package-lock.json`](https://github.com/gateway/playwright/blob/guardian/update-ws-path-to-regexp/package-lock.json#L9033): resolved `ws` package is now `8.21.0`.

Generated dependency sidecars:

- `package-lock.json`: updated.

## Code Usage Review

Direct vulnerable package imports: `ws` found; `path-to-regexp` not directly imported in source checked.
Direct parent package imports: `router` not directly imported in source checked.
Observed exposure: `ws` is runtime-linked; `path-to-regexp` is transitive tooling/dependency-graph exposure.

Examples of `ws` usage:

- [`packages/playwright-core/src/utilsBundle.ts`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/utilsBundle.ts#L59)
- [`packages/playwright-core/src/server/transport.ts`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/transport.ts#L18)
- [`packages/utils/wsServer.ts`](https://github.com/microsoft/playwright/blob/main/packages/utils/wsServer.ts#L17)

## Fix

This PR updates dependency resolution so the affected packages resolve to patched versions.

Affected:

- `ws@8.17.1`
- `path-to-regexp@8.3.0`

Patched:

- `ws >= 8.21.0` for GHSA-96hv-2xvq-fx4p
- `ws >= 8.20.1` for GHSA-58qx-3vcg-4xpx
- `path-to-regexp >= 8.4.0` for GHSA-j3q9-mxjg-w52f

Target used:

- `ws@8.21.0`
- `path-to-regexp@8.4.2`

## Alternatives Considered

- Update only `ws`: rejected because `npm audit` still reported the high `path-to-regexp` finding and the transitive lockfile refresh is small.
- Run broad `npm audit fix`: rejected to avoid unrelated dependency churn.
- Include lower-priority findings in this PR: rejected to keep the PR focused on high-severity, audit-corroborated findings.

## Risk Assessment

Upgrade risk: low to medium.

Reasoning:

- `ws` stays within the same major version and is pinned exactly to the patched release.
- `path-to-regexp` stays within the existing `router` semver range and changes only the lockfile resolution.
- No source code or API behavior was changed.
- Maintainers should still run the relevant websocket/server tests because `ws` is runtime-linked in Playwright internals.

## Validation

Ran:

- `npm audit --json`: high-severity findings for `ws` and `path-to-regexp` are no longer reported; remaining findings are lower-priority unrelated items.
- Guardian scan with live OSV/GHSA: `ws` and `path-to-regexp` are no longer present in the post-fix top package findings.
- `git diff --check`: passed.

Suggested maintainer validation:

- Run the repo's websocket/server-related test slice or the normal CI suite.

## Notes

This PR is not claiming active exploitation in this repo. It removes known vulnerable dependency versions from the resolved dependency graph and documents the scope of the change.

Powered by Guardian: https://github.com/gateway/guardian
