### PR TITLE
fix(mcp): never include data: URL payloads in snapshot or network output

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -15,7 +15,7 @@
  */
 
 import * as aria from '@isomorphic/ariaSnapshot';
-import { escapeRegExp, longestCommonSubstring, normalizeWhiteSpace } from '@isomorphic/stringUtils';
+import { escapeRegExp, longestCommonSubstring, normalizeWhiteSpace, truncateDataUrl } from '@isomorphic/stringUtils';
 import { yamlEscapeKeyIfNeeded, yamlEscapeValueIfNeeded } from '@isomorphic/yaml';
 
 import { computeBox, getElementComputedStyle, isElementVisible } from './domUtils';
@@ -184,7 +184,7 @@ export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOp
 
     if (ariaNode.role === 'link' && element.hasAttribute('href')) {
       const href = element.getAttribute('href')!;
-      ariaNode.props['url'] = href;
+      ariaNode.props['url'] = truncateDataUrl(href);
     }
 
     if (ariaNode.role === 'textbox' && element.hasAttribute('placeholder') && element.getAttribute('placeholder') !== ariaNode.name) {

--- a/packages/isomorphic/stringUtils.ts
+++ b/packages/isomorphic/stringUtils.ts
@@ -136,6 +136,17 @@ export function trimStringWithEllipsis(input: string, cap: number): string {
   return trimString(input, cap, '\u2026');
 }
 
+export function truncateDataUrl(url: string): string {
+  // Data URLs can carry megabytes of base64 payload, which is never useful in
+  // human/AI-facing output. Keep the media type prefix for context, drop the data.
+  if (!url.startsWith('data:'))
+    return url;
+  const comma = url.indexOf(',');
+  if (comma === -1)
+    return url;
+  return url.slice(0, comma + 1) + '\u2026';
+}
+
 export function escapeRegExp(s: string) {
   // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string

--- a/packages/playwright-core/src/tools/backend/network.ts
+++ b/packages/playwright-core/src/tools/backend/network.ts
@@ -20,6 +20,7 @@ import * as z from 'zod';
 
 import { getExtensionForMimeType, isTextualMimeType } from '@isomorphic/mimeType';
 import { isRegexString } from '@isomorphic/rtti';
+import { truncateDataUrl } from '@isomorphic/stringUtils';
 
 import { defineTool, defineTabTool } from './tool';
 
@@ -128,7 +129,7 @@ export function isFetch(request: playwright.Request): boolean {
 
 export function renderRequestLine(request: playwright.Request): string {
   const response = request.existingResponse();
-  let line = `[${request.method().toUpperCase()}] ${request.url()}`;
+  let line = `[${request.method().toUpperCase()}] ${truncateDataUrl(request.url())}`;
   if (response)
     line += ` => [${response.status()}] ${response.statusText()}`;
   else if (request.failure())
@@ -140,7 +141,7 @@ function renderRequestDetails(index: number, request: playwright.Request, skillM
   const httpResponse = request.existingResponse();
   const responseHeaders = httpResponse?.headers();
   const lines: string[] = [];
-  lines.push(`#${index} [${request.method().toUpperCase()}] ${request.url()}`);
+  lines.push(`#${index} [${request.method().toUpperCase()}] ${truncateDataUrl(request.url())}`);
 
   lines.push('');
   lines.push('  General');

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -318,6 +318,14 @@ it('should not nest cursor pointer hints', async ({ page }) => {
   `);
 });
 
+it('should truncate data url in link', async ({ page }) => {
+  const base64 = Buffer.from('<p>hello</p>').toString('base64');
+  await page.setContent(`<a href="data:text/html;base64,${base64}">a link</a>`);
+  const snapshot = await snapshotForAI(page);
+  expect(snapshot).toContain('/url: data:text/html;base64,…');
+  expect(snapshot).not.toContain(base64);
+});
+
 it('should gracefully fallback when child frame cant be captured', async ({ page, server }) => {
   await page.setContent(`
     <p>Test</p>


### PR DESCRIPTION
## Summary
- Truncate `data:` URLs in the page snapshot (link `href`) and network request output, keeping only the media type prefix (e.g. `data:image/png;base64,…`).
- Data URL payloads can be megabytes of base64 that bloat output without adding information; regular URLs are unaffected.

Fixes https://github.com/microsoft/playwright/issues/41531