### PR TITLE
test: cover MCP CDP header env config

### DIFF
--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -248,6 +248,21 @@ test.describe('merge order', () => {
     const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
     expect(config.browser.cdpHeaders).toEqual({ Authorization: 'Bearer token-from-file' });
   });
+
+  test('env browser.cdpHeaders overrides config file and preserves colons in values', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: {
+        cdpEndpoint: 'ws://example.invalid',
+        cdpHeaders: { Authorization: 'Bearer token-from-file' },
+      },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile }, {
+      PLAYWRIGHT_MCP_CDP_HEADERS: 'X-Forwarded-Proto: value:with:colons',
+    });
+    expect(config.browser.cdpHeaders).toEqual({ 'X-Forwarded-Proto': 'value:with:colons' });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add MCP config resolution coverage for `PLAYWRIGHT_MCP_CDP_HEADERS`.

The test verifies that the CDP header env var overrides a config-file value and preserves colons inside the header value.

References #41451
Related docs update: microsoft/playwright-mcp#1661

## Testing

- `npm run ctest-mcp -- tests/mcp/config-resolve.spec.ts -g "env browser.cdpHeaders"`
- `git diff --check`