### PR TITLE
fix(aria): re-number main frame refs on cross-document navigation

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -235,6 +235,7 @@ export class FrameManager {
     const frame = this._frames.get(frameId)!;
     this.removeChildFramesRecursively(frame);
     this._clearWebSockets(frame);
+    const previousUrl = frame._url;
     frame._url = url;
     frame._name = name;
 
@@ -269,6 +270,12 @@ export class FrameManager {
     if (!initial) {
       frame.apiLog(`  navigated to "${url}"`);
       this._page.frameNavigatedToNewDocument(frame);
+      // Re-number the main frame when it navigates away from a real document, so that aria
+      // refs (f<seq>e<n>) minted against the previous document do not accidentally resolve
+      // to elements in the new one. Leaving the initial empty page keeps the base seq, and
+      // same-document navigations never re-number.
+      if (frame === this._mainFrame && previousUrl && previousUrl !== 'about:blank')
+        frame.seq = this._allocateFrameSeq();
     }
     // Restore pending if any - see comments above about keepPending.
     frame._setPendingDocument(keepPending);
@@ -501,7 +508,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   static Events = FrameEvent;
 
   _id: string;
-  readonly seq: number;
+  seq: number;
   _firedLifecycleEvents = new Set<types.LifecycleEvent>();
   private _firedNetworkIdleSelf = false;
   _currentDocument: DocumentInfo;

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -272,8 +272,7 @@ export class FrameManager {
       this._page.frameNavigatedToNewDocument(frame);
       // Re-number the main frame when it navigates away from a real document, so that aria
       // refs (f<seq>e<n>) minted against the previous document do not accidentally resolve
-      // to elements in the new one. Leaving the initial empty page keeps the base seq, and
-      // same-document navigations never re-number.
+      // to elements in the new one.
       if (frame === this._mainFrame && previousUrl && previousUrl !== 'about:blank')
         frame.seq = this._allocateFrameSeq();
     }

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -142,6 +142,36 @@ it('should stitch all frame snapshots', async ({ page, server }) => {
   }
 });
 
+it('should re-number refs across navigations but not same-document navigations', async ({ page, server }) => {
+  server.setRoute('/one.html', (req, res) => {
+    res.setHeader('Content-Type', 'text/html');
+    res.end('<button>One</button>');
+  });
+  server.setRoute('/two.html', (req, res) => {
+    res.setHeader('Content-Type', 'text/html');
+    res.end('<button>Two</button>');
+  });
+
+  // The first committed document keeps the base seq, so the main frame has no prefix.
+  await page.goto(server.PREFIX + '/one.html');
+  const oneRef = (await snapshotForAI(page)).match(/button "One" \[ref=(e\d+)\]/)![1];
+  await expect(page.locator(`aria-ref=${oneRef}`)).toHaveText('One');
+
+  // Cross-document navigation re-numbers the main frame, so its refs gain a frame prefix.
+  await page.goto(server.PREFIX + '/two.html');
+  const twoRef = (await snapshotForAI(page)).match(/button "Two" \[ref=(f\d+e\d+)\]/)![1];
+  await expect(page.locator(`aria-ref=${twoRef}`)).toHaveText('Two');
+
+  // The stale ref from the previous document must not resolve against the new one.
+  const error = await page.locator(`aria-ref=${oneRef}`).normalize().catch(e => e);
+  expect(error.message).toContain(`No element matching aria-ref=${oneRef}`);
+
+  // Same-document navigation keeps refs intact.
+  await page.evaluate(() => history.pushState({}, '', '/pushed.html'));
+  expect(await snapshotForAI(page)).toContain(`button "Two" [ref=${twoRef}]`);
+  await expect(page.locator(`aria-ref=${twoRef}`)).toHaveText('Two');
+});
+
 it('should persist iframe references', async ({ page }) => {
   await page.setContent(`
     <ul>
@@ -337,9 +367,8 @@ it('should auto-wait for navigation', async ({ page, server }) => {
     page.evaluate(() => window.location.reload()),
     snapshotForAI(page)
   ]);
-  expect(snapshot).toContainYaml(`
-    - generic [ref=e2]: Hi, I'm frame
-  `);
+  // The snapshot races the reload, which may re-number the main frame, so accept any ref.
+  expect(snapshot).toMatch(/- generic \[ref=(?:f\d+)?e\d+\]: Hi, I'm frame/);
 });
 
 it('should auto-wait for blocking CSS', async ({ page, server }) => {


### PR DESCRIPTION
## Summary
- Aria snapshot refs (`f<seq>e<n>`) re-used the main frame's `seq` across navigations, so a stale ref could silently resolve to a *different* element on the newly loaded document.
- Re-number the main frame's `seq` when it commits a new document while leaving a real (non-`about:blank`) URL. The initial page keeps the base seq (no prefix), and same-document navigations (pushState/hash) never re-number.
- Stale refs now fail cleanly via the existing `seq`-based frame routing instead of resolving to the wrong element.