### PR TITLE
fix(reporters): do not truncate piped output on exit

### DIFF
--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -86,9 +86,6 @@ class StripAnsiStream extends Writable {
     this._target = target;
   }
 
-  // Forward synchronously to the target stream instead of going through the
-  // Writable internal buffer. Otherwise chunks queued here can be lost when the
-  // process exits via process.exit() before they are flushed to the target.
   override write(chunk: any, encodingOrCallback?: any, callback?: any): boolean {
     const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
     return this._target.write(stripAnsiEscapes(chunk.toString()), cb);

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -86,8 +86,12 @@ class StripAnsiStream extends Writable {
     this._target = target;
   }
 
-  override _write(chunk: any, encoding: any, callback: any) {
-    this._target.write(stripAnsiEscapes(chunk.toString()), callback);
+  // Forward synchronously to the target stream instead of going through the
+  // Writable internal buffer. Otherwise chunks queued here can be lost when the
+  // process exits via process.exit() before they are flushed to the target.
+  override write(chunk: any, encodingOrCallback?: any, callback?: any): boolean {
+    const cb = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback;
+    return this._target.write(stripAnsiEscapes(chunk.toString()), cb);
   }
 }
 


### PR DESCRIPTION
## Summary
- `StripAnsiStream` (added in #40688) buffered output in the `Writable` internal queue and flushed it to the target stream asynchronously via `_write`. On large suites, when output is piped/redirected, `process.exit()` could fire before those chunks were flushed, dropping the tail of the output.
- Forward synchronously to the target stream instead, restoring the pre-1.61 direct-write behavior while still stripping ANSI.

Fixes https://github.com/microsoft/playwright/issues/41449