### PR TITLE
fix(selectors): accept regexp v flag in locator options

### DIFF
--- a/packages/isomorphic/selectorParser.ts
+++ b/packages/isomorphic/selectorParser.ts
@@ -324,7 +324,7 @@ export function parseAttributeSelector(selector: string, allowUnquotedStrings: b
       syntaxError('parsing regular expression');
     let flags = '';
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-    while (!EOL && next().match(/[dgimsuy]/))
+    while (!EOL && next().match(/[dgimsuvy]/))
       flags += eat1();
     try {
       return new RegExp(source, flags);

--- a/tests/page/selectors-get-by.spec.ts
+++ b/tests/page/selectors-get-by.spec.ts
@@ -286,6 +286,14 @@ it('getByRole escaping', async ({ page }) => {
   ]);
 });
 
+it('getByRole should accept regexp with v flag', async ({ page }) => {
+  // Regression test for https://github.com/microsoft/playwright/issues/41457
+  await page.setContent(`<button>Click me</button><button>Submit</button>`);
+  await expect(page.getByRole('button', { name: /Click me/v })).toHaveCount(1);
+  await expect(page.getByRole('button', { name: /click me/iv })).toHaveCount(1);
+  await expect(page.getByRole('button', { name: /Missing/v })).toHaveCount(0, { timeout: 1000 });
+});
+
 it('getByRole with description', async ({ page }) => {
   await page.setContent(`
     <div role="alert" aria-label="Upload successful" aria-description="File doc-2025.pdf was uploaded successfully">Alert 1</div>


### PR DESCRIPTION
## Summary
- Selector parser dropped the regexp `v` (unicodeSets) flag, so locators like `getByRole(..., { name: /x/v })` failed to parse.
- Added `v` to the accepted regexp flags in the selector parser.

Fixes https://github.com/microsoft/playwright/issues/41457