### PR TITLE
fix(dashboard): route the --port dashboard through the singleton

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -42,7 +42,7 @@ declare const __PW_HMR__: boolean;
 
 type DashboardServer = {
   url: string;
-  reveal: (options: DashboardOptions) => Promise<void>;
+  reveal: (options: DashboardOptions) => void;
   triggerAnnotate: (signal: AbortSignal) => Promise<AnnotateResult>;
   close: () => Promise<void>;
 };
@@ -86,21 +86,22 @@ async function startDashboardServer(provider: SessionProvider, options: Dashboar
     attachDashboardStaticServer(httpServer, dashboardDir);
   await httpServer.start({ port: options.port, host: options.host });
 
-  const reveal = async (next: DashboardOptions): Promise<void> => {
-    await connectionLanded;
-    await Promise.all([...connections].map(async c => {
-      if (next.pageId)
-        await c.revealPage(next.pageId);
-      else if (next.sessionName)
-        await c.revealSession(next.sessionName, next.workspaceDir);
-    }));
+  const reveal = (next: DashboardOptions): void => {
+    void connectionLanded.then(() => {
+      for (const c of connections) {
+        if (next.pageId)
+          c.revealPage(next.pageId);
+        else if (next.sessionName)
+          c.revealSession(next.sessionName, next.workspaceDir);
+      }
+    });
   };
 
   const triggerAnnotate = async (cancellation: AbortSignal): Promise<AnnotateResult> => {
     await connectionLanded;
     if (cancellation.aborted || connections.size === 0)
       return { type: 'cancelled' };
-    // Multiple dashboard connections is theoretical today (one UI per daemon), server mode does not support annotate.
+    // Multiple dashboard connections is theoretical today (one UI per daemon).
     // If two ever land, the first to submit wins but the losers stay in
     // annotation mode until their UI reloads — revisit if that becomes a real
     // scenario.
@@ -135,13 +136,7 @@ async function attachDashboardDevServer(httpServer: HttpServer) {
 }
 // HMR end
 
-async function innerOpenDashboardApp(options: DashboardOptions): Promise<{ page: api.Page; server: DashboardServer }> {
-  const server = await startDashboardServer(new RegistrySessionProvider(), options);
-  void server.reveal(options).catch(() => {});
-  const { page } = await launchApp('dashboard', { onClose: () => gracefullyProcessExitDoNotHang(0) });
-  await page.goto(server.url);
-  return { page, server };
-}
+type AppState = { page?: api.Page; server: DashboardServer };
 
 async function launchApp(appName: string, options?: { onClose?: () => void }) {
   const channel = findChromiumChannelBestEffort('javascript');
@@ -240,13 +235,15 @@ type AcquireResult =
   | { role: 'winner', server: net.Server }
   | { role: 'loser', daemonPid: number };
 
-async function acquireSingleton(options: DashboardOptions): Promise<AcquireResult> {
+async function acquireSingleton(options: DashboardOptions, onConnection: (socket: net.Socket) => void): Promise<AcquireResult> {
   const socketPath = dashboardSocketPath();
   if (process.platform !== 'win32')
     await fs.promises.mkdir(path.dirname(socketPath), { recursive: true });
 
   return await new Promise((resolve, reject) => {
-    const server = net.createServer();
+    // Attach the connection handler at creation — before listen() — so a loser
+    // that connects the instant we win the socket is never dropped.
+    const server = net.createServer(onConnection);
     server.listen(socketPath, () => resolve({ role: 'winner', server }));
     server.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code !== 'EADDRINUSE' && err.code !== 'EEXIST')
@@ -287,20 +284,13 @@ export async function openDashboardApp() {
     // eslint-disable-next-line no-console
     console.error('Unhandled promise rejection:', error);
   });
-  if (options.port !== undefined) {
-    const server = await startDashboardServer(new RegistrySessionProvider(), options);
-    void server.reveal(options).catch(() => {});
-    // eslint-disable-next-line no-console
-    console.log(`Listening on ${server.url}`);
-    // eslint-disable-next-line no-restricted-properties
-    await new Promise(f => process.stdout.write('', f));  // Make sure stdout is flushed.
-    selfDestructOnParentGone();
-    return;
-  }
+
   // Self-destruct if the parent CLI dies before we signal READY. Unregistered
   // before we signal so the daemon outlives the parent.
   const stopSelfDestruct = selfDestructOnParentGone();
-  const acquired = await acquireSingleton(options);
+
+  const statePromise = new ManualPromise<AppState>();
+  const acquired = await acquireSingleton(options, socket => handleConnection(socket, statePromise));
   if (acquired.role === 'loser') {
     // Another daemon is already running, signal success.
     stopSelfDestruct();
@@ -313,10 +303,24 @@ export async function openDashboardApp() {
   const { server } = acquired;
   process.on('exit', () => server.close());
   try {
-    await startApp(server, options);
-    stopSelfDestruct();
-    // eslint-disable-next-line no-console
-    console.log(`Dashboard is running pid=${process.pid}`);
+    const dashboard = await startDashboardServer(new RegistrySessionProvider(), options);
+    dashboard.reveal(options);
+    if (options.port !== undefined) {
+      // Server mode serves HTTP in the foreground and stays tied to the parent CLI.
+      statePromise.resolve({ server: dashboard });
+      // eslint-disable-next-line no-console
+      console.log(`Listening on ${dashboard.url}`);
+    } else {
+      // Windowed daemon launches a browser window and detaches from the parent CLI.
+      const { page } = await launchApp('dashboard', { onClose: () => gracefullyProcessExitDoNotHang(0) });
+      await page.goto(dashboard.url);
+      statePromise.resolve({ page, server: dashboard });
+      stopSelfDestruct();
+      // eslint-disable-next-line no-console
+      console.log(`Dashboard is running pid=${process.pid}`);
+    }
+    // eslint-disable-next-line no-restricted-properties
+    await new Promise(f => process.stdout.write('', f));  // Make sure stdout is flushed.
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);
@@ -324,55 +328,47 @@ export async function openDashboardApp() {
   }
 }
 
-async function startApp(server: net.Server, options: DashboardOptions) {
-  const statePromise = innerOpenDashboardApp(options);
-  server.on('connection', socket => {
-    let buffer = '';
-    socket.on('data', async data => {
-      buffer += data.toString();
-      const newlineIndex = buffer.indexOf('\n');
-      if (newlineIndex === -1)
-        return;
-      const line = buffer.slice(0, newlineIndex);
-      buffer = buffer.slice(newlineIndex + 1);
-      let parsed: DashboardOptions | undefined;
+function handleConnection(socket: net.Socket, statePromise: Promise<AppState>) {
+  let buffer = '';
+  socket.on('data', async data => {
+    buffer += data.toString();
+    const newlineIndex = buffer.indexOf('\n');
+    if (newlineIndex === -1)
+      return;
+    const line = buffer.slice(0, newlineIndex);
+    buffer = buffer.slice(newlineIndex + 1);
+    let parsed: DashboardOptions | undefined;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // no-op
+    }
+    if (!parsed) {
+      socket.end();
+      return;
+    }
+    const { page, server: dashboard } = await statePromise;
+    if (parsed.annotate) {
+      const cancellation = new AbortController();
+      socket.on('close', () => cancellation.abort());
+      socket.on('error', () => cancellation.abort());
       try {
-        parsed = JSON.parse(line);
-      } catch {
-        // no-op
+        await page?.bringToFront();
+        dashboard.reveal(parsed);
+        const result = await dashboard.triggerAnnotate(cancellation.signal);
+        socket.end(JSON.stringify(result));
+      } catch (e) {
+        socket.end(e);
       }
-      if (!parsed) {
-        socket.end();
-        return;
-      }
-      const { page, server: dashboard } = await statePromise;
-      if (parsed.annotate) {
-        const cancellation = new AbortController();
-        socket.on('close', () => cancellation.abort());
-        socket.on('error', () => cancellation.abort());
-        try {
-          await page?.bringToFront();
-          await dashboard.reveal(parsed);
-          const result = await dashboard.triggerAnnotate(cancellation.signal);
-          socket.end(JSON.stringify(result));
-        } catch (e) {
-          socket.end(e);
-        }
-      } else if (parsed.kill) {
-        await dashboard.close().catch(() => {});
-        gracefullyProcessExitDoNotHang(0, () => new Promise(r => socket.end(r)));
-      } else {
-        try {
-          await page?.bringToFront();
-          await dashboard.reveal(parsed);
-          socket.end(JSON.stringify({ pid: process.pid }) + '\n');
-        } catch (e) {
-          socket.end(e);
-        }
-      }
-    });
+    } else if (parsed.kill) {
+      await dashboard.close().catch(() => {});
+      gracefullyProcessExitDoNotHang(0, () => new Promise(r => socket.end(r)));
+    } else {
+      void page?.bringToFront().catch(() => {});
+      dashboard.reveal(parsed);
+      socket.end(JSON.stringify({ pid: process.pid }) + '\n');
+    }
   });
-  await statePromise;
 }
 
 export async function openDashboardForContext(context: api.BrowserContext): Promise<void> {

--- a/packages/playwright-core/src/tools/dashboard/dashboardController.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardController.ts
@@ -20,7 +20,6 @@ import fs from 'fs';
 import crypto from 'crypto';
 import { execFile } from 'child_process';
 import { Disposable } from '@isomorphic/disposable';
-import { ManualPromise } from '@isomorphic/manualPromise';
 import { eventsHelper } from '@utils/eventsHelper';
 import { createClientInfo } from '../cli-client/registry';
 
@@ -46,7 +45,7 @@ export class DashboardConnection implements Transport {
   private _onconnected?: () => void;
   private _pushTabsScheduled = false;
   private _visible = true;
-  private _pendingReveal: { sessionName?: string; workspaceDir?: string; pageId?: string; done: ManualPromise<void> } | undefined;
+  private _pendingReveal: { sessionName?: string; workspaceDir?: string; pageId?: string } | undefined;
   private _pendingAnnotate: { resolve: (result: AnnotateResult) => void; dispose: () => void } | undefined;
 
   _recordingDir: string;
@@ -83,8 +82,6 @@ export class DashboardConnection implements Transport {
     this._provider.dispose();
     this._attachedPage?.dispose();
     this._attachedPage = undefined;
-    // Reject any in-flight reveal so callers awaiting it don't hang.
-    this._pendingReveal?.done.reject(new Error('Dashboard connection closed'));
     this._pendingReveal = undefined;
     this._resolvePendingAnnotate({ type: 'cancelled' });
     for (const stream of this._streams.values()) {
@@ -144,29 +141,14 @@ export class DashboardConnection implements Transport {
     await this._attachedPage?.setScreencastActive(params.visible);
   }
 
-  revealSession(sessionName: string, workspaceDir?: string): Promise<void> {
-    const existing = this._pendingReveal;
-    if (existing
-        && existing.pageId === undefined
-        && existing.sessionName === sessionName
-        && existing.workspaceDir === workspaceDir)
-      return existing.done;
-    existing?.done.reject(new Error('Reveal superseded'));
-    const done = new ManualPromise<void>();
-    this._pendingReveal = { sessionName, workspaceDir, done };
+  revealSession(sessionName: string, workspaceDir?: string) {
+    this._pendingReveal = { sessionName, workspaceDir };
     void this._tryRevealPending();
-    return done;
   }
 
-  revealPage(pageId: string): Promise<void> {
-    const existing = this._pendingReveal;
-    if (existing && existing.pageId === pageId)
-      return existing.done;
-    existing?.done.reject(new Error('Reveal superseded'));
-    const done = new ManualPromise<void>();
-    this._pendingReveal = { pageId, done };
+  revealPage(pageId: string) {
+    this._pendingReveal = { pageId };
     void this._tryRevealPending();
-    return done;
   }
 
   private async _tryRevealPending() {
@@ -188,10 +170,8 @@ export class DashboardConnection implements Transport {
     try {
       await this._switchAttachedTo(page);
       this._pushTabs();
-      pending.done.resolve();
-    } catch (e) {
-      pending.done.reject(e instanceof Error ? e : new Error(String(e)));
-      throw e;
+    } catch {
+      // Best-effort: a failed reveal leaves the dashboard on its current page.
     }
   }
 

--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -248,6 +248,24 @@ test('should capture annotations via show --annotate', async ({ connectToDashboa
   verifyAnnotateOutput(output, 'hello', test.info().outputDir);
 });
 
+test('should route annotate to a running port dashboard', async ({ cli, server, startDashboardServer }) => {
+  await cli('open', server.EMPTY_PAGE);
+
+  const dashboard = await startDashboardServer();
+  await dashboard.getByRole('navigation', { name: 'Sessions' }).getByRole('option').first().click();
+
+  const annotatePromise = cli('show', '--annotate');
+  let done = false;
+  void annotatePromise.finally(() => { done = true; });
+
+  await drawAndSubmitAnnotation(dashboard, 'routed');
+
+  const { output, exitCode } = await annotatePromise;
+  expect(done).toBe(true);
+  expect(exitCode).toBe(0);
+  verifyAnnotateOutput(output, 'routed', test.info().outputDir);
+});
+
 test('should start dashboard and annotate when no dashboard is running', async ({ connectToDashboard, cli, server }) => {
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
   await cli('open', server.EMPTY_PAGE, { bindTitle });

--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -48,13 +48,7 @@ export const test = baseTest.extend<{
   },
   startDashboardServer: async ({ childProcess, page }, use) => {
     await use(async (options?: { cwd?: string, session?: string }) => {
-      const testInfo = test.info();
-      const showArgs = options?.session ? [`-s=${options.session}`, 'show'] : ['show'];
-      const serverProcess = childProcess({
-        command: [process.execPath, require.resolve('../../packages/playwright-core/lib/tools/cli-client/cli.js'), ...showArgs, '--port=0'],
-        cwd: options?.cwd ?? testInfo.outputPath(),
-        env: inheritAndCleanEnv(cliEnv()),
-      });
+      const serverProcess = spawnDashboardServer(childProcess, options);
       await serverProcess.waitForOutput('Listening on ');
       await page.goto(serverProcess.output.match(/Listening on (http:\/\/\S+)/)![1]);
       return page;
@@ -116,6 +110,15 @@ export const test = baseTest.extend<{
     await browser.close();
   },
 });
+
+export function spawnDashboardServer(childProcess: CommonFixtures['childProcess'], options?: { cwd?: string, session?: string }) {
+  const showArgs = options?.session ? [`-s=${options.session}`, 'show'] : ['show'];
+  return childProcess({
+    command: [process.execPath, require.resolve('../../packages/playwright-core/lib/tools/cli-client/cli.js'), ...showArgs, '--port=0'],
+    cwd: options?.cwd ?? test.info().outputPath(),
+    env: inheritAndCleanEnv(cliEnv()),
+  });
+}
 
 function cliEnv() {
   return {

--- a/tests/mcp/dashboard.spec.ts
+++ b/tests/mcp/dashboard.spec.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { test, expect, installSaveFilePickerMock } from './cli-fixtures';
+import { test, expect, installSaveFilePickerMock, spawnDashboardServer } from './cli-fixtures';
 
 function displayPath(p: string): string {
   const home = os.homedir();
@@ -93,6 +93,8 @@ test('should show current workspace sessions first', async ({ cli, server, start
   await test.step('open dashboard in workspace A', async () => {
     await checkOrder(wsA, wsB);
   });
+
+  await cli('show', '--kill');
 
   await test.step('open dashboard in workspace B', async () => {
     await checkOrder(wsB, wsA);
@@ -184,4 +186,12 @@ test('two concurrent cli show invocations both succeed', async ({ cli }) => {
   const [first, second] = await Promise.all([cli('show', { bindTitle }), cli('show', { bindTitle })]);
   expect(first.dashboardPid).toBe(second.dashboardPid);
   await cli('show', '--kill');
+});
+
+test('port dashboard owns the singleton and receives kill', async ({ cli, childProcess }) => {
+  const serverProcess = spawnDashboardServer(childProcess);
+  await serverProcess.waitForOutput('Listening on ');
+  await cli('show', '--kill');
+  const { exitCode } = await serverProcess.exited;
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Route both windowed and headless (`--port`) dashboards through `acquireSingleton` + `startApp` via an injected opener, so the port daemon owns the singleton socket and receives `kill`/`reveal`/`annotate` signals.
- `browser_annotate` now routes to a running port dashboard instead of spawning a second, windowed one.
- Make `reveal` synchronous fire-and-forget, dropping the `ManualPromise` plumbing in the controller.

Fixes https://github.com/microsoft/playwright-cli/issues/428