### PR TITLE
chore(github): add issue templates for Playwright CLI and MCP

### DIFF
--- a/.github/ISSUE_TEMPLATE/playwright-cli.yml
+++ b/.github/ISSUE_TEMPLATE/playwright-cli.yml
@@ -1,0 +1,28 @@
+name: Playwright CLI 🖥️
+description: Report a bug or request a feature for the Playwright CLI
+title: '[CLI]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for filing a Playwright CLI issue!
+
+        Describe what's going on in your own words — there's no strict format. The more detail (commands you ran, output you saw, what you expected), the faster we can help.
+  - type: textarea
+    id: details
+    attributes:
+      label: What's going on?
+      description: |
+        Describe the bug or feature request. Include anything that helps us understand and reproduce it — the exact command you ran, the output, what you expected, and your environment if relevant.
+      placeholder: |
+        e.g. `npx playwright ...` does X, but I expected Y.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of Playwright are you using? (optional, but helpful)
+      placeholder: ex. 1.41.1
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/playwright-mcp.yml
+++ b/.github/ISSUE_TEMPLATE/playwright-mcp.yml
@@ -1,0 +1,28 @@
+name: Playwright MCP 🤖
+description: Report a bug or request a feature for the Playwright MCP server
+title: '[MCP]: '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for filing a Playwright MCP issue!
+
+        Describe what's going on in your own words — there's no strict format. Telling us which MCP client you use (Claude, VS Code, Cursor, etc.) and the tool call or config involved helps a lot.
+  - type: textarea
+    id: details
+    attributes:
+      label: What's going on?
+      description: |
+        Describe the bug or feature request. Include anything that helps us understand and reproduce it — the MCP client and config you use, the tool that misbehaved, the output you saw, and what you expected.
+      placeholder: |
+        e.g. Calling the `browser_click` tool from <client> does X, but I expected Y.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of Playwright / the MCP server are you using? (optional, but helpful)
+      placeholder: ex. 1.41.1
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add free-flow issue templates for the **Playwright CLI** and **Playwright MCP** projects.
- Each has a single open-text field (covering both bugs and feature requests) plus an optional version input — kept intentionally light so they're easy to draft.