### PR TITLE
fix(routing): `urlMatches` should reset `lastIndex` if given `/.../g` or `/.../y`

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -181,8 +181,8 @@ export function urlMatches(baseURL: string | undefined, urlString: string, match
   if (isString(match))
     match = new RegExp(resolveGlobToRegexPattern(baseURL, match, webSocketUrl));
   if (isRegExp(match)) {
-    const r = match.test(urlString);
-    return r;
+    match.lastIndex = 0;
+    return match.test(urlString);
   }
   const url = parseURL(urlString);
   if (!url)

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -294,6 +294,19 @@ it('should work with regular expression passed from a different context', async 
   expect(intercepted).toBe(true);
 });
 
+it('should intercept every request matching a global regexp', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  let intercepted = 0;
+  await page.route(/\/intercept-me/g, async route => {
+    ++intercepted;
+    await route.fulfill({ body: 'intercepted' });
+  });
+  const url = server.PREFIX + '/intercept-me';
+  for (let i = 0; i < 3; ++i)
+    expect(await page.evaluate(u => fetch(u, { cache: 'no-store' }).then(r => r.text()), url)).toBe('intercepted');
+  expect(intercepted).toBe(3);
+});
+
 it('should not break remote worker importScripts', async ({ page, server }) => {
   await page.route('**', async route => {
     await route.continue();


### PR DESCRIPTION
global `/.../g` and sticky `/.../y` regular expressions silently adjust `lastIndex`

this means that subsequent uses will miss any matches before the new `lastIndex` (until it wraps around)

as such, we should reset the `lastIndex` before trying to use it