### PR TITLE
fix(routing): match URL globs containing '$$' and other replacement patterns

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -249,7 +249,10 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
     let resolved = result.resolved;
     for (const [token, original] of tokenMap) {
       const normalize = result.caseInsensitivePart?.includes(token);
-      resolved = resolved.replace(token, normalize ? original.toLowerCase() : original);
+      const replacement = normalize ? original.toLowerCase() : original;
+      // '$$', '$&', '$`' and "$'" are special in String.prototype.replace with a string argument.
+      // Instead, use the function argument form that treats the string argument literally.
+      resolved = resolved.replace(token, () => replacement);
     }
     match = resolved;
   }

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -122,6 +122,11 @@ it('should work with glob', async () => {
   expect(urlMatches('http://playwright.dev', 'http://playwright.dev/?x=y', '?x=y')).toBeTruthy();
   expect(urlMatches('http://playwright.dev/foo/', 'http://playwright.dev/foo/bar?x=y', './bar?x=y')).toBeTruthy();
 
+  // '$$', '$&', '$`' and "$'" are special in String.prototype.replace with a string argument.
+  expect(urlMatches(undefined, 'http://playwright.dev/foo$$bar', 'http://playwright.dev/foo$$bar')).toBeTruthy();
+  expect(urlMatches(undefined, 'http://playwright.dev/a$&b', 'http://playwright.dev/a$&b')).toBeTruthy();
+  expect(urlMatches('http://playwright.dev', 'http://playwright.dev/p$$q', './p$$q')).toBeTruthy();
+
   // Case insensitive matching
   expect(urlMatches(undefined, 'https://playwright.dev/fooBAR', 'HtTpS://pLaYwRiGhT.dEv/fooBAR')).toBeTruthy();
   expect(urlMatches('http://ignored', 'https://playwright.dev/fooBAR', 'HtTpS://pLaYwRiGhT.dEv/fooBAR')).toBeTruthy();


### PR DESCRIPTION
'$$', '$&', '$`' and "$'" are special in `String.prototype.replace` with a string argument

instead, use the function argument form that treats the string argument literally