### PR TITLE
fix(selectors): match `input[type="reset"]` button label as text

### DIFF
--- a/packages/injected/src/selectorUtils.ts
+++ b/packages/injected/src/selectorUtils.ts
@@ -68,7 +68,7 @@ export function elementText(cache: Map<Element | ShadowRoot, ElementText>, root:
     value = { full: '', normalized: '', immediate: [] };
     if (!shouldSkipForTextMatching(root)) {
       let currentImmediate = '';
-      if ((root instanceof HTMLInputElement) && (root.type === 'submit' || root.type === 'button')) {
+      if ((root instanceof HTMLInputElement) && (root.type === 'submit' || root.type === 'button' || root.type === 'reset')) {
         value = { full: root.value, normalized: normalizeWhiteSpace(root.value), immediate: [root.value] };
       } else {
         for (let child = root.firstChild; child; child = child.nextSibling) {

--- a/tests/page/selectors-text.spec.ts
+++ b/tests/page/selectors-text.spec.ts
@@ -362,10 +362,11 @@ it('should skip head, script and style', async ({ page }) => {
   }
 });
 
-it('should match input[type=button|submit]', async ({ page }) => {
-  await page.setContent(`<input type="submit" value="hello"><input type="button" value="world">`);
+it('should match input[type=button|submit|reset]', async ({ page }) => {
+  await page.setContent(`<input type="submit" value="hello"><input type="button" value="world"><input type="reset" value="clear">`);
   expect(await page.$eval(`text=hello`, e => e.outerHTML)).toBe('<input type="submit" value="hello">');
   expect(await page.$eval(`text=world`, e => e.outerHTML)).toBe('<input type="button" value="world">');
+  expect(await page.$eval(`text=clear`, e => e.outerHTML)).toBe('<input type="reset" value="clear">');
 });
 
 it('should work for open shadow roots', async ({ page, server }) => {


### PR DESCRIPTION
`elementText` exposed the value of `<input type="submit">` and `<input type="button"`

`<input type="reset">` also renders its value as a visible button label just like the others