### PR TITLE
fix(trace-viewer): keep snapshot frame centered with margin

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -211,10 +211,16 @@ const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
     height: Math.max(snapshotContainerSize.height + windowHeaderHeight, 320),
   };
 
-  const scale = Math.min(measure.width / renderedBrowserFrameSize.width, measure.height / renderedBrowserFrameSize.height, 1);
+  // `measure` is the wrapper's border box (getBoundingClientRect), which includes the
+  // 10px padding on every side. Fit and center the frame within the content box so it
+  // keeps a padding-sized margin (with room for the box-shadow) when squeezed.
+  const padding = 10;
+  const availableWidth = measure.width - 2 * padding;
+  const availableHeight = measure.height - 2 * padding;
+  const scale = Math.min(availableWidth / renderedBrowserFrameSize.width, availableHeight / renderedBrowserFrameSize.height, 1);
   const translate = {
-    x: (measure.width - renderedBrowserFrameSize.width) / 2,
-    y: (measure.height - renderedBrowserFrameSize.height) / 2,
+    x: (measure.width - renderedBrowserFrameSize.width) / 2 - padding,
+    y: (measure.height - renderedBrowserFrameSize.height) / 2 - padding,
   };
 
   return <div ref={ref} className='snapshot-wrapper'>


### PR DESCRIPTION
## Summary
- The snapshot wrapper measures its border box (includes 10px padding) but the frame is laid out in the content box, so it drifted down/right by the padding.
- The fit-scale used the full border box, so a squeezed frame filled the whole area with no room for the box-shadow.
- Now the frame is fit and centered within the content box, keeping a 10px margin with visible shadow on every side.