### PR TITLE
fix(expect): clone `pollIntervals` so they are not consumed across calls

### DIFF
--- a/packages/isomorphic/timeoutRunner.ts
+++ b/packages/isomorphic/timeoutRunner.ts
@@ -39,7 +39,7 @@ export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: num
   });
 }
 
-export async function pollAgainstDeadline<T>(callback: () => Promise<{ continuePolling: boolean, result: T }>, deadline: number, pollIntervals: number[] = [100, 250, 500, 1000]): Promise<{ result?: T, timedOut: boolean }> {
+export async function pollAgainstDeadline<T>(callback: () => Promise<{ continuePolling: boolean, result: T }>, deadline: number, [...pollIntervals]: number[] = [100, 250, 500, 1000]): Promise<{ result?: T, timedOut: boolean }> {
   const lastPollInterval = pollIntervals.pop() ?? 1000;
   let lastResult: T|undefined;
   const wrappedCallback = () => Promise.resolve().then(callback);

--- a/tests/playwright-test/expect-to-pass.spec.ts
+++ b/tests/playwright-test/expect-to-pass.spec.ts
@@ -114,6 +114,27 @@ test('should respect interval', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
+test('should not consume the shared toPass intervals across tests', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { expect: { toPass: { intervals: [0, 0, 0] } } };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      for (const name of ['one', 'two']) {
+        test(name, async () => {
+          let probes = 0;
+          await test.expect(() => {
+            ++probes;
+            expect(probes).toBeGreaterThanOrEqual(3);
+          }).toPass({ timeout: 1000 });
+        });
+      }
+    `
+  }, { workers: 1 });
+  expect(result.passed).toBe(2);
+});
+
 test('should compile', async ({ runTSC }) => {
   const result = await runTSC({
     'a.spec.ts': `


### PR DESCRIPTION
`pollAgainstDeadline` mutates the provided `pollIntervals`

both `expect.poll` and `expect.toPass` pass it by reference

the former uses a per-test config, whereas the latter uses a per-project config that's shared by every test (in that worker)