### PR TITLE
fix(mcp): list a failed network request only once

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -244,7 +244,6 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _handleRequestFailed(request: playwright.Request) {
-    this._requests.push(request);
     const timing = request.timing();
     const wallTime = timing.responseEnd + timing.startTime;
     this._addLogEntry({ type: 'request', wallTime, request });

--- a/tests/mcp/network.spec.ts
+++ b/tests/mcp/network.spec.ts
@@ -207,6 +207,21 @@ test('browser_network_request reports failed requests', async ({ client, server 
   expect(detail!.result).toContain('status:    [404]');
 });
 
+test('browser_network_requests lists a failed request once', async ({ client, server }) => {
+  server.setContent('/', `<img src="http://does-not-exist.invalid/api/x" />`, 'text/html');
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+
+  const list = parseResponse(await client.callTool({
+    name: 'browser_network_requests',
+    arguments: { static: true },
+  }));
+  expect([...list!.result!.matchAll(/\/api\/x =>/g)]).toHaveLength(1);
+});
+
 test('browser_network_request returns individual parts', async ({ client, server }) => {
   server.setContent('/', `
     <button onclick="fetch('/api', { method: 'POST', headers: { 'X-Custom-Header': 'test-value' }, body: JSON.stringify({ key: 'value' }) })">Click me</button>


### PR DESCRIPTION
`_handleRequest` already records every request (and `_handleResponse` does not re-add it)