### PR TITLE
fix: read HTTP header values case-insensitively in HAR and fetch

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -504,7 +504,7 @@ export abstract class APIRequestContext extends SdkObject {
 
         let body: Readable = response;
         let transform: Transform | undefined;
-        const encoding = response.headers['content-encoding'];
+        const encoding = response.headers['content-encoding']?.toLowerCase();
         if (encoding === 'gzip' || encoding === 'x-gzip') {
           transform = zlib.createGunzip({
             flush: zlib.constants.Z_SYNC_FLUSH,

--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -215,7 +215,8 @@ export class HarTracer {
     if (!this._options.omitCookies)
       harEntry.request.cookies = event.cookies;
     harEntry.request.headers = Object.entries(event.headers).map(([name, value]) => ({ name, value }));
-    harEntry.request.postData = this._postDataForBuffer(event.postData || null, event.headers['content-type'],  this._options.content);
+    const contentType = Object.entries(event.headers).find(([name]) => name.toLowerCase() === 'content-type')?.[1];
+    harEntry.request.postData = this._postDataForBuffer(event.postData || null, contentType, this._options.content);
     if (!this._options.omitSizes)
       harEntry.request.bodySize = event.postData?.length || 0;
     (event as any)[this._entrySymbol] = harEntry;
@@ -800,20 +801,29 @@ function parseCookie(c: string): har.Cookie {
       continue;
     }
 
-    if (name === 'Domain')
-      cookie.domain = value;
-    if (name === 'Expires')
-      cookie.expires = safeDateToISOString(value);
-    if (name === 'HttpOnly')
-      cookie.httpOnly = true;
-    if (name === 'Max-Age')
-      cookie.expires = safeDateToISOString(Date.now() + (+value) * 1000);
-    if (name === 'Path')
-      cookie.path = value;
-    if (name === 'SameSite')
-      cookie.sameSite = value;
-    if (name === 'Secure')
-      cookie.secure = true;
+    switch (name.toLowerCase()) {
+      case 'domain':
+        cookie.domain = value;
+        break;
+      case 'expires':
+        cookie.expires = safeDateToISOString(value);
+        break;
+      case 'httponly':
+        cookie.httpOnly = true;
+        break;
+      case 'max-age':
+        cookie.expires = safeDateToISOString(Date.now() + (+value) * 1000);
+        break;
+      case 'path':
+        cookie.path = value;
+        break;
+      case 'samesite':
+        cookie.sameSite = value;
+        break;
+      case 'secure':
+        cookie.secure = true;
+        break;
+    }
   }
   return cookie;
 }

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -786,6 +786,26 @@ it('should support gzip compression', async function({ context, server }) {
   expect(await response.text()).toBe('Hello, world!');
 });
 
+it('should support case-insensitive content-encoding', async function({ context, server }) {
+  server.setRoute('/compressed-uppercase', (req, res) => {
+    res.writeHead(200, {
+      'Content-Encoding': 'GZIP',
+      'Content-Type': 'text/plain',
+    });
+
+    const gzip = zlib.createGzip();
+    pipeline(gzip, res, err => {
+      if (err)
+        console.log(`Server error: ${err}`);
+    });
+    gzip.write('Hello, world!');
+    gzip.end();
+  });
+
+  const response = await context.request.get(server.PREFIX + '/compressed-uppercase');
+  expect(await response.text()).toBe('Hello, world!');
+});
+
 it('should throw informative error on corrupted gzip body', async function({ context, server }) {
   server.setRoute('/corrupted', (req, res) => {
     res.writeHead(200, {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -248,6 +248,18 @@ it('should include set-cookies', async ({ contextFactory, server }, testInfo) =>
   expect(new Date(cookies[2].expires!).valueOf()).toBeGreaterThan(Date.now());
 });
 
+it('should include set-cookies with lowercase attributes', async ({ contextFactory, server }, testInfo) => {
+  const { page, getLog } = await pageWithHar(contextFactory, testInfo);
+  server.setRoute('/empty.html', (req, res) => {
+    res.setHeader('Set-Cookie', ['name=value; path=/; httponly; secure; samesite=Lax']);
+    res.end();
+  });
+  await page.goto(server.EMPTY_PAGE);
+  const log = await getLog();
+  const cookies = log.entries[0].response.cookies;
+  expect(cookies[0]).toEqual({ name: 'name', value: 'value', path: '/', httpOnly: true, secure: true, sameSite: 'Lax' });
+});
+
 it('should skip invalid Expires', async ({ contextFactory, server }, testInfo) => {
   const { page, getLog } = await pageWithHar(contextFactory, testInfo);
   server.setRoute('/empty.html', (req, res) => {
@@ -1089,6 +1101,21 @@ it.describe('tracing.startHar', () => {
     const resources = await parseHar(harPath);
     const log = JSON.parse(resources.get('har.har')!.toString()).log as Log;
     expect(log.entries.some(e => e.request.url === server.PREFIX + '/simple.json')).toBe(true);
+  });
+
+  it('should record mixed-case request content-type for APIRequestContext', async ({ playwright, server }, testInfo) => {
+    server.setRoute('/post', (req, res) => res.end('ok'));
+    const request = await playwright.request.newContext();
+    const harPath = testInfo.outputPath('api-post.har.zip');
+    await request.tracing.startHar(harPath, { content: 'attach' });
+    await request.post(server.PREFIX + '/post', { headers: { 'Content-Type': 'application/json' }, data: Buffer.from('{"a":1}') });
+    await request.tracing.stopHar();
+    await request.dispose();
+
+    const resources = await parseHar(harPath);
+    const log = JSON.parse(resources.get('har.har')!.toString()).log as Log;
+    const entry = log.entries.find(e => e.request.url.endsWith('/post'))!;
+    expect(entry.request.postData!.mimeType).toBe('application/json');
   });
 
   it('should record a HAR with resourcesDir', async ({ contextFactory, server }, testInfo) => {


### PR DESCRIPTION
some servers send lowercase headers, so allow for them (and any other casing) by always lowercasing before lookup