### PR TITLE
fix(connect): wrong parameter used when passed as an object

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -127,7 +127,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
     if (typeof optionsOrEndpoint === 'string')
       return await this._connect({ ...options, endpoint: optionsOrEndpoint });
     assert(optionsOrEndpoint.wsEndpoint, 'options.wsEndpoint is required');
-    return await this._connect({ ...options, endpoint: optionsOrEndpoint.wsEndpoint });
+    return await this._connect({ ...optionsOrEndpoint, endpoint: optionsOrEndpoint.wsEndpoint });
   }
 
   async _connect(params: ConnectOptions): Promise<Browser> {

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -264,6 +264,21 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       expect(request.headers['foo']).toBe('bar');
     });
 
+    test('should send extra headers with connect request in object form', async ({ browserType, server }) => {
+      const requestPromise = server.waitForWebSocketConnectionRequest();
+      browserType.connect({
+        wsEndpoint: `ws://localhost:${server.PORT}/ws`,
+        headers: {
+          'User-Agent': 'Playwright',
+          'foo': 'bar',
+        },
+        timeout: 3000,
+      }).catch(() => {});
+      const request = await requestPromise;
+      expect(request.headers['user-agent']).toBe('Playwright');
+      expect(request.headers['foo']).toBe('bar');
+    });
+
     test('should send default User-Agent and X-Playwright-Browser headers with connect request', async ({ connect, browserName, server, isFrozenWebkit }) => {
       test.skip(isFrozenWebkit);
 


### PR DESCRIPTION
the TS overloads make it so that `options` is only set when `optionsOrEndpoint` is a string

otherwise, `optionsOrEndpoint` is the options object