### PR TITLE
fix(role): also walk `assignedElements` of `<slot>` when querying

### DIFF
--- a/packages/injected/src/roleSelectorEngine.ts
+++ b/packages/injected/src/roleSelectorEngine.ts
@@ -149,7 +149,11 @@ function validateAttributes(attrs: AttributeSelectorPart[], role: string): RoleE
 
 function queryRole(scope: SelectorRoot, options: RoleEngineOptions, internal: boolean): Element[] {
   const result: Element[] = [];
+  const visited = new Set<Element>();
   const match = (element: Element) => {
+    if (visited.has(element))
+      return;
+    visited.add(element);
     if (getAriaRole(element) !== options.role)
       return;
     if (options.selected !== undefined && getAriaSelected(element) !== options.selected)
@@ -204,6 +208,12 @@ function queryRole(scope: SelectorRoot, options: RoleEngineOptions, internal: bo
       match(element);
       if (element.shadowRoot)
         shadows.push(element.shadowRoot);
+      if (element.nodeName === 'SLOT') {
+        for (const assigned of (element as HTMLSlotElement).assignedElements()) {
+          match(assigned);
+          query(assigned);
+        }
+      }
     }
     shadows.forEach(query);
   };

--- a/tests/page/selectors-role.spec.ts
+++ b/tests/page/selectors-role.spec.ts
@@ -476,6 +476,22 @@ test('should filter hidden, unless explicitly asked for', async ({ page }) => {
   ]);
 });
 
+test('should find slotted content when scoping into a shadow subtree', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38166' },
+}, async ({ page }) => {
+  await page.setContent(`
+    <my-dialog>
+      <template shadowrootmode="open">
+        <dialog open><slot></slot></dialog>
+      </template>
+      <div><button>Foo</button></div>
+    </my-dialog>
+  `);
+  await expect(page.getByRole('dialog').getByRole('button', { name: 'Foo' })).toBeVisible();
+  expect(await page.getByRole('dialog').getByRole('button').count()).toBe(1);
+  expect(await page.getByRole('button').count()).toBe(1);
+});
+
 test('should support name', async ({ page }) => {
   await page.setContent(`
     <div role="button" aria-label=" Hello "></div>


### PR DESCRIPTION
also keep track of visited elements to avoid re-traversing an element that's assigned to a `<slot>`

fixes <https://github.com/microsoft/playwright/issues/38166>