### PR TITLE
fix(trace-viewer): use button elements for network filter tabs

### DIFF
--- a/packages/trace-viewer/src/ui/networkFilters.css
+++ b/packages/trace-viewer/src/ui/networkFilters.css
@@ -39,6 +39,16 @@
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}
+
+.network-filters-resource-type:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 .network-filters-resource-type.selected {

--- a/packages/trace-viewer/src/ui/networkFilters.tsx
+++ b/packages/trace-viewer/src/ui/networkFilters.tsx
@@ -41,16 +41,18 @@ export const NetworkFilters = ({ filterState, onFilterStateChange }: {
       />
 
       <div className='network-filters-resource-types' role='tablist' aria-multiselectable='true'>
-        <div
+        <button
           title='All'
           onClick={() => onFilterStateChange({ ...filterState, resourceTypes: new Set() })}
           className={`network-filters-resource-type ${filterState.resourceTypes.size === 0 ? 'selected' : ''}`}
+          role='tab'
+          aria-selected={filterState.resourceTypes.size === 0}
         >
           All
-        </div>
+        </button>
 
         {resourceTypes.map(resourceType => (
-          <div
+          <button
             key={resourceType}
             title={resourceType}
             onClick={event => {
@@ -67,7 +69,7 @@ export const NetworkFilters = ({ filterState, onFilterStateChange }: {
             aria-selected={filterState.resourceTypes.has(resourceType)}
           >
             {resourceType}
-          </div>
+          </button>
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Rationale

The trace viewer's `NetworkFilters` is still using `<div>` elements for the resource type tabs (All, Fetch, JS, CSS, etc.) which aren't keyboard focusable. this converts them to `<button>` and adds `:focus-visible` styling, same approach as #41434.