### PR TITLE
fix(mcp): retry list roots request over streamable http

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -133,11 +133,17 @@ const initializeServer = async (server: ServerType, factory: ServerBackendFactor
   const capabilities = server.getClientCapabilities();
   let clientRoots: Root[] = [];
   if (capabilities?.roots) {
-    const { roots } = await server.listRoots().catch(e => {
-      serverDebug(e);
-      return { roots: [] };
-    });
-    clientRoots = roots;
+    // mcp sdk opens the standalone SSE channel lazily after sending `initialized`.
+    // If the first tool call comes before, `listRoots` is dropped on the server with no stream to send it on.
+    for (let i = 0; i < 2; i++) {
+      try {
+        const { roots } = await server.listRoots(undefined, { timeout: 2_000 });
+        clientRoots = roots;
+        break;
+      } catch (e) {
+        serverDebug(e);
+      }
+    }
   }
 
   const clientInfo: ClientInfo = {


### PR DESCRIPTION
Restores #37324, which was removed in #37399. This still happens on the bots, see the flaky test `tests/mcp/http.spec.ts:349 > client should receive list roots request`.

Fixes a race: the MCP SDK delivers `listRoots` only over the client's standalone SSE channel, which the client opens lazily after sending `initialized`. If the first tool call reaches the server's `listRoots()` before that channel registers, the SDK silently drops the request and the client never receives it.
