### PR TITLE
Optimize TestTree construction for large reports

### DIFF
--- a/packages/playwright/src/isomorphic/testTree.ts
+++ b/packages/playwright/src/isomorphic/testTree.ts
@@ -77,6 +77,17 @@ export class TestTree {
     };
     this._treeItemById.set(rootFolder, this.rootItem);
 
+    const groupItemsByTitle = new Map<GroupItem, Map<string, GroupItem>>();
+    const testCaseItemsByTitle = new Map<GroupItem, Map<string, TestCaseItem>>();
+    const lookupOrCreateMap = <T extends TreeItem>(map: Map<GroupItem, Map<string, T>>, parent: GroupItem): Map<string, T> => {
+      let result = map.get(parent);
+      if (!result) {
+        result = new Map();
+        map.set(parent, result);
+      }
+      return result;
+    };
+
     const visitSuite = (project: reporterTypes.FullProject, parentSuite: reporterTypes.Suite, parentGroup: GroupItem, mode: 'tests' | 'suites' | 'all') => {
       for (const suite of mode === 'tests' ? [] : parentSuite.suites) {
         if (!suite.title) {
@@ -85,7 +96,8 @@ export class TestTree {
           continue;
         }
 
-        let group = parentGroup.children.find(item => item.kind === 'group' && item.title === suite.title) as GroupItem | undefined;
+        const groupItems = lookupOrCreateMap(groupItemsByTitle, parentGroup);
+        let group = groupItems.get(suite.title);
         if (!group) {
           group = {
             kind: 'group',
@@ -100,13 +112,15 @@ export class TestTree {
             hasLoadErrors: false,
           };
           this._addChild(parentGroup, group);
+          groupItems.set(suite.title, group);
         }
         visitSuite(project, suite, group, 'all');
       }
 
       for (const test of mode === 'suites' ? [] : parentSuite.tests) {
         const title = test.title;
-        let testCaseItem = parentGroup.children.find(t => t.kind !== 'group' && t.title === title) as TestCaseItem;
+        const testCaseItems = lookupOrCreateMap(testCaseItemsByTitle, parentGroup);
+        let testCaseItem = testCaseItems.get(title);
         if (!testCaseItem) {
           testCaseItem = {
             kind: 'case',
@@ -123,6 +137,7 @@ export class TestTree {
             tags: test.tags,
           };
           this._addChild(parentGroup, testCaseItem);
+          testCaseItems.set(title, testCaseItem);
         }
 
         const result = test.results[0];
@@ -155,7 +170,7 @@ export class TestTree {
         };
         this._addChild(testCaseItem, testItem);
         this._treeItemByTestId.set(test.id, testItem);
-        testCaseItem.duration = (testCaseItem.children as TestItem[]).reduce((a, b) => a + b.duration, 0);
+        testCaseItem.duration += testItem.duration;
       }
     };
 


### PR DESCRIPTION
This improves `TestTree` construction by avoiding repeated sibling scans while merging suite and test-case nodes.

Previously, construction used linear `children.find(...)` lookups for every suite/test title under a parent, and recomputed each test case duration with `reduce()` after every inserted test item. For large reports or UI mode trees with many tests under the same parent, that could become effectively quadratic.

This change keeps temporary per-parent lookup maps during construction and accumulates test case duration incrementally.

Benchmark, constructing `TestTree` for 20k tests, 3 iterations:

```text
main:   2.196 s ± 0.030 s
branch: 97.9 ms ± 1.4 ms
```

Fixes https://github.com/microsoft/playwright/issues/41491

Tests:
- `npm run tsc -- --pretty false`
- `node ./tests/playwright-test/stable-test-runner/node_modules/@playwright/test/cli test tests/playwright-test/ui-mode-test-tree.spec.ts --config=tests/playwright-test/playwright.config.ts --reporter=line`