### PR TITLE
feat(runner): opt-in PWTEST_SHARD_MODE=balanced for even shard distribution

### DIFF
--- a/docs/src/test-sharding-js.md
+++ b/docs/src/test-sharding-js.md
@@ -39,6 +39,14 @@ When `fullyParallel: true` is enabled, Playwright Test runs individual tests in 
 
 Without the fullyParallel setting, Playwright Test defaults to file-level granularity, meaning entire test files are assigned to shards (note that the same file may be assigned to different shards across different projects). In this case, the number of tests per file can greatly influence shard distribution. If your test files are not evenly sized (i.e., some files contain many more tests than others), certain shards may end up running significantly more tests, while others may run fewer or even none.
 
+**Balanced sharding (opt-in)**
+
+When you cannot enable `fullyParallel: true` (for example, when each worker reuses shared setup), set the `PWTEST_SHARD_MODE=balanced` environment variable. Instead of splitting by test index, Playwright bin-packs whole test files across shards by their number of tests (largest file first), so every shard receives work as long as there are at least as many files as shards — avoiding empty shards on unevenly sized files. The assignment is deterministic and requires no coordination between shards. The `--shard=x/y` option is unchanged.
+
+```bash
+PWTEST_SHARD_MODE=balanced npx playwright test --shard=1/3
+```
+
 **Key Takeaways:**
 
 - **With** `fullyParallel: true`: Tests are split at the individual test level, leading to more balanced shard execution.

--- a/packages/playwright/src/cli/testActions.ts
+++ b/packages/playwright/src/cli/testActions.ts
@@ -44,6 +44,7 @@ export async function runTests(args: string[], opts: { [key: string]: any }) {
     testList: opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined,
     testListInvert: opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined,
     shardWeights: resolveShardWeightsOption(),
+    shardMode: resolveShardModeOption(),
   };
 
   // Evaluate project filters against config before starting execution. This enables a consistent error message across run modes
@@ -208,6 +209,15 @@ function resolveShardWeightsOption(): TestRunOptions['shardWeights'] {
       throw new Error(`PWTEST_SHARD_WEIGHTS="${shardWeights}" weights must be non-negative numbers`);
     return weight;
   });
+}
+
+function resolveShardModeOption(): TestRunOptions['shardMode'] {
+  const shardMode = process.env.PWTEST_SHARD_MODE;
+  if (!shardMode)
+    return undefined;
+  if (shardMode !== 'partition' && shardMode !== 'balanced')
+    throw new Error(`PWTEST_SHARD_MODE="${shardMode}" must be "partition" or "balanced"`);
+  return shardMode;
 }
 
 function resolveReporter(id: string) {

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -177,7 +177,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     }
 
     // Shard test groups.
-    const testGroupsInThisShard = filterForShard(config.config.shard, testRun.options.shardWeights, testGroups);
+    const testGroupsInThisShard = filterForShard(config.config.shard, testRun.options.shardWeights, testGroups, testRun.options.shardMode);
     const testsInThisShard = new Set<testNs.TestCase>();
     for (const group of testGroupsInThisShard) {
       for (const test of group.tests)

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -74,6 +74,7 @@ export type TestRunOptions = {
   preserveOutputDir?: boolean;
   additionalReporters?: ReporterDescription[];
   shardWeights?: number[];
+  shardMode?: 'partition' | 'balanced';
 };
 
 export type TestPausedParams = {

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -130,7 +130,30 @@ export function createTestGroups(projectSuite: test.Suite, expectedParallelism: 
   return result;
 }
 
-export function filterForShard(shard: { total: number, current: number }, weights: number[] | undefined, testGroups: TestGroup[]): Set<TestGroup> {
+// Opt-in 'balanced' sharding: bin-pack whole test groups across shards by test count
+// (Longest-Processing-Time: heaviest group → lightest shard). Unlike the default index-range
+// split, this never leaves a shard empty when there are at least as many groups as shards, and
+// keeps every shard's test count close. It is deterministic and stateless: each shard independently
+// computes the same packing (stable order, tie-broken by requireFile), so no coordination is needed.
+function balancedShardGroups(shard: { total: number, current: number }, testGroups: TestGroup[]): Set<TestGroup> {
+  const bins = Array.from({ length: shard.total }, () => ({ weight: 0, groups: [] as TestGroup[] }));
+  const sorted = [...testGroups].sort((a, b) => b.tests.length - a.tests.length || a.requireFile.localeCompare(b.requireFile));
+  for (const group of sorted) {
+    let lightest = bins[0];
+    for (const bin of bins) {
+      if (bin.weight < lightest.weight)
+        lightest = bin;
+    }
+    lightest.groups.push(group);
+    lightest.weight += group.tests.length;
+  }
+  return new Set(bins[shard.current - 1].groups);
+}
+
+export function filterForShard(shard: { total: number, current: number }, weights: number[] | undefined, testGroups: TestGroup[], mode?: 'partition' | 'balanced'): Set<TestGroup> {
+  if (mode === 'balanced')
+    return balancedShardGroups(shard, testGroups);
+
   weights ??= Array.from({ length: shard.total }, () => 1);
   if (weights.length !== shard.total)
     throw new Error(`PWTEST_SHARD_WEIGHTS number of weights must match the shard total of ${shard.total}`);

--- a/tests/playwright-test/shard.spec.ts
+++ b/tests/playwright-test/shard.spec.ts
@@ -357,3 +357,42 @@ test('should respect custom shard weights', async ({ runInlineTest }) => {
     ]);
   });
 });
+
+test.describe('PWTEST_SHARD_MODE=balanced', () => {
+  // Uneven, non-parallel files (sharded whole-file). Named so discovery order puts the largest
+  // file last, which makes the default index-range split leave a shard empty.
+  const mkSpec = (name: string, count: number) =>
+    `import { test } from '@playwright/test';\n` +
+    Array.from({ length: count }, (_, i) => `test('${name}${i}', async () => { console.log('\\n%%${name}${i}'); });`).join('\n');
+  const unevenFiles = {
+    'a-small.spec.ts': mkSpec('small', 1),
+    'b-mid.spec.ts': mkSpec('mid', 5),
+    'c-big.spec.ts': mkSpec('big', 8),
+  };
+
+  test('default split leaves a shard empty for uneven files', async ({ runInlineTest }) => {
+    const passed: number[] = [];
+    for (let i = 1; i <= 3; i++)
+      passed.push((await runInlineTest(unevenFiles, { shard: `${i}/3`, workers: 1 })).passed);
+    expect(passed).toContain(0);
+    expect(passed.reduce((a, b) => a + b, 0)).toBe(14);
+  });
+
+  test('balanced split fills every shard and runs each test once', async ({ runInlineTest }) => {
+    const env = { PWTEST_SHARD_MODE: 'balanced' };
+    const passed: number[] = [];
+    for (let i = 1; i <= 3; i++) {
+      const result = await runInlineTest(unevenFiles, { shard: `${i}/3`, workers: 1 }, env);
+      expect(result.exitCode).toBe(0);
+      passed.push(result.passed);
+    }
+    expect(passed).not.toContain(0);
+    expect(passed.reduce((a, b) => a + b, 0)).toBe(14);
+  });
+
+  test('rejects an invalid mode', async ({ runInlineTest }) => {
+    const result = await runInlineTest(unevenFiles, { shard: '1/3', workers: 1 }, { PWTEST_SHARD_MODE: 'nope' });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('PWTEST_SHARD_MODE="nope" must be "partition" or "balanced"');
+  });
+});


### PR DESCRIPTION
### Problem
The docs recommend `fullyParallel: true` for balanced shards, but some suites can't enable it — e.g. each worker reuses expensive shared setup/state, so whole files must stay on one worker. With `fullyParallel: false`, `--shard` splits by test index and assigns each whole file to the shard containing its first test. On unevenly-sized files this leaves shards empty (documented behavior). As a real-world example, in one suite we measured **5 of 150 shard jobs running 0 tests** on a single CI run (~6 min of runner time wasted, recurring every run). Refs #30253, #17969.

### Proposal (opt-in, default unchanged)
`PWTEST_SHARD_MODE=balanced` bin-packs whole test groups across shards by test count (largest first, into the lightest shard). Guarantees no empty shard when there are at least as many groups as shards. It's deterministic and stateless - each shard computes the same packing, no coordination, no external data. `--shard=x/y` is untouched.

```bash
PWTEST_SHARD_MODE=balanced npx playwright test --shard=1/3
```

### Changes
- `filterForShard` gains a `mode`; new `balancedShardGroups` (LPT bin-packing)
- plumbed `shardMode` through `TestRunOptions` → `loadUtils` → reads `PWTEST_SHARD_MODE`
- tests in `shard.spec.ts` (default leaves a shard empty / balanced fills all / invalid mode errors)
- docs: Balancing Shards section

### Test plan
- `shard.spec.ts`: 17/17 pass (14 existing + 3 new) - **default split behavior unchanged**.
- New tests confirm: default leaves a shard empty on uneven files; `balanced` fills every shard and runs each test exactly once.

Opening as a draft for discussion - happy to adjust the surface (env var vs config option) or scope.