### PR TITLE
fix(trace-viewer): keep snapshot frame centered with margin

### DIFF
--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -211,10 +211,16 @@ const SnapshotWrapper: React.FunctionComponent<React.PropsWithChildren<{
     height: Math.max(snapshotContainerSize.height + windowHeaderHeight, 320),
   };
 
-  const scale = Math.min(measure.width / renderedBrowserFrameSize.width, measure.height / renderedBrowserFrameSize.height, 1);
+  // `measure` is the wrapper's border box (getBoundingClientRect), which includes the
+  // 10px padding on every side. Fit and center the frame within the content box so it
+  // keeps a padding-sized margin (with room for the box-shadow) when squeezed.
+  const padding = 10;
+  const availableWidth = measure.width - 2 * padding;
+  const availableHeight = measure.height - 2 * padding;
+  const scale = Math.min(availableWidth / renderedBrowserFrameSize.width, availableHeight / renderedBrowserFrameSize.height, 1);
   const translate = {
-    x: (measure.width - renderedBrowserFrameSize.width) / 2,
-    y: (measure.height - renderedBrowserFrameSize.height) / 2,
+    x: (measure.width - renderedBrowserFrameSize.width) / 2 - padding,
+    y: (measure.height - renderedBrowserFrameSize.height) / 2 - padding,
   };
 
   return <div ref={ref} className='snapshot-wrapper'>

--- a/packages/trace-viewer/src/ui/timeline.css
+++ b/packages/trace-viewer/src/ui/timeline.css
@@ -28,6 +28,7 @@
   cursor: text;
   user-select: none;
   margin-left: 10px;
+  overflow: hidden;
 }
 
 .timeline-divider {


### PR DESCRIPTION
The snapshot wrapper measures its border box, which includes the 10px padding, but the frame container is laid out inside the content box. This made the frame drift down/right by the padding, and the fit-scale used the full border box so a squeezed frame filled the whole area with no room for the box-shadow. Fit and center the frame within the content box instead.