### PR TITLE
chore: remove unused env var flags (PLAYWRIGHT_LEGACY_SCREENSHOT, PW_CODEGEN_NO_INSPECTOR, PW_DETECT_NESTED_PROGRESS)

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -64,7 +64,7 @@ export const chromiumSwitches = (options?: { android?: boolean }) => [
   '--disable-edgeupdater', // Disables Edge-specific updater on mac.
   '--disable-extensions',
   '--disable-features=' + disabledFeatures.join(','),
-  process.env.PLAYWRIGHT_LEGACY_SCREENSHOT ? '' : '--enable-features=CDPScreenshotNewSurface',
+  '--enable-features=CDPScreenshotNewSurface',
   '--allow-pre-commit-input',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -31,7 +31,6 @@ export interface Progress {
   wait(timeout: number): Promise<void>; // timeout = 0 here means "wait 0 ms", not forever.
   signal: AbortSignal;
   metadata: CallMetadata;
-  setAllowConcurrentOrNestedRaces(allow: boolean): void;
 }
 
 export class ProgressController {
@@ -78,9 +77,6 @@ export class ProgressController {
     this._state = 'running';
     let timer: NodeJS.Timeout | undefined;
 
-    let outerProgress: string | undefined;
-    let allowConcurrent = false;
-
     const progress: Progress = {
       timeout: timeout ?? 0,
       deadline,
@@ -94,26 +90,11 @@ export class ProgressController {
         this._onCallLog?.(message);
       },
       metadata: this.metadata,
-      setAllowConcurrentOrNestedRaces: (allow: boolean) => {
-        allowConcurrent = allow;
-      },
       race: <T>(promise: Promise<T> | Promise<T>[]) => {
-        if (process.env.PW_DETECT_NESTED_PROGRESS) {
-          const innerProgress = new Error().stack;
-          if (outerProgress && !allowConcurrent && outerProgress !== innerProgress) {
-            // eslint-disable-next-line no-console
-            console.error('Cannot call race() inside another race()');
-            // eslint-disable-next-line no-console
-            console.error('<<<<<OUTER>>>>>:', outerProgress);
-            // eslint-disable-next-line no-console
-            console.error('<<<<<INNER>>>>>:', innerProgress);
-          }
-          outerProgress = innerProgress;
-        }
         const promises = Array.isArray(promise) ? promise : [promise];
         if (!promises.length)
           return Promise.resolve();
-        return Promise.race([...promises, this._forceAbortPromise]).finally(() => outerProgress = undefined);
+        return Promise.race([...promises, this._forceAbortPromise]);
       },
       wait: async (timeout: number) => {
         // Timeout = 0 here means nowait. Counter to what it typically is (wait forever).
@@ -195,5 +176,4 @@ export const nullProgress: Progress = {
     log: [],
     internal: true,
   },
-  setAllowConcurrentOrNestedRaces() { },
 };

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -177,8 +177,6 @@ export class RecorderApp {
   }
 
   static async show(context: BrowserContext, params: channels.BrowserContextEnableRecorderParams) {
-    if (process.env.PW_CODEGEN_NO_INSPECTOR)
-      return;
     const recorder = await Recorder.forContext(context, params);
     if (params.recorderMode === 'api') {
       const browserName = context._browser.options.name;
@@ -193,8 +191,6 @@ export class RecorderApp {
   }
 
   static showInspectorNoReply(context: BrowserContext) {
-    if (process.env.PW_CODEGEN_NO_INSPECTOR)
-      return;
     void Recorder.forContext(context, {}).then(recorder => RecorderApp._show(recorder, context, {})).catch(() => {});
   }
 


### PR DESCRIPTION
Remove 3 env var flags that are never set anywhere in the repo, docs, or configs.

- `PLAYWRIGHT_LEGACY_SCREENSHOT` — ternary defaulting to CDP flag; `''` branch never executes
- `PW_CODEGEN_NO_INSPECTOR` — two early-return guards in recorder; dead since Jul 2025 refactor
- `PW_DETECT_NESTED_PROGRESS` — debug-only nested race detection block + cascading dead vars (`outerProgress`, `allowConcurrent`, `setAllowConcurrentOrNestedRaces`)