### PR TITLE
perf(utils): remove unused async from eventsHelper dispose callback

### DIFF
--- a/packages/isomorphic/disposable.ts
+++ b/packages/isomorphic/disposable.ts
@@ -15,7 +15,7 @@
  */
 
 export interface Disposable {
-  dispose: () => Promise<void>;
+  dispose: () => void;
 }
 
 export async function disposeAll(disposables: Disposable[]) {

--- a/packages/utils/eventsHelper.ts
+++ b/packages/utils/eventsHelper.ts
@@ -24,7 +24,7 @@ export type RegisteredListener = {
   emitter: EventEmitterLike;
   eventName: (string | symbol);
   handler: (...args: any[]) => void;
-  dispose: () => Promise<void>;
+  dispose: () => void;
 };
 
 class EventsHelper {
@@ -33,7 +33,7 @@ class EventsHelper {
     eventName: (string | symbol),
     handler: (...args: any[]) => void): RegisteredListener {
     emitter.on(eventName, handler);
-    return { emitter, eventName, handler, dispose: async () => { emitter.removeListener(eventName, handler); } };
+    return { emitter, eventName, handler, dispose: () => { emitter.removeListener(eventName, handler); } };
   }
 
   static removeEventListeners(listeners: Array<{


### PR DESCRIPTION
`emitter.removeListener()` is synchronous. Wrapping the dispose callback in `async` creates an unnecessary Promise and microtask on every cleanup.

Changes:
- `RegisteredListener.dispose`: `() => Promise<void>` → `() => void`
- `Disposable.dispose` in isomorphic/disposable.ts: same type change for assignability
- Remove `async` keyword from the dispose arrow function

Zero callers `await` the dispose result — no behavior change.