### PR TITLE
fix(proxy): encode embedded IPv4 tails as SOCKS IPv4

### DIFF
--- a/packages/utils/socksProxy.ts
+++ b/packages/utils/socksProxy.ts
@@ -293,12 +293,17 @@ function hexToNumber(hex: string): number {
   }, 0);
 }
 
-function ipToSocksAddress(address: string): number[] {
-  // Node.js may return IPv4-mapped IPv6 addresses (e.g. "::ffff:10.0.0.1") from
-  // socket.localAddress on dual-stack systems. Unwrap them to plain IPv4.
-  const ipv4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(address);
-  if (ipv4Mapped)
-    address = ipv4Mapped[1];
+function embeddedIPv4Address(address: string): string | undefined {
+  if (!net.isIPv6(address))
+    return;
+  const match = /(?:^|:)(\d{1,3}(?:\.\d{1,3}){3})$/.exec(address);
+  return match && net.isIPv4(match[1]) ? match[1] : undefined;
+}
+
+export function ipToSocksAddress(address: string): number[] {
+  const embeddedIPv4 = embeddedIPv4Address(address);
+  if (embeddedIPv4)
+    address = embeddedIPv4;
   if (net.isIPv4(address)) {
     return [
       0x01, // IPv4

--- a/tests/library/proxy.spec.ts
+++ b/tests/library/proxy.spec.ts
@@ -16,7 +16,14 @@
 
 import { setupSocksForwardingServer } from '../config/proxy';
 import { playwrightTest as it, expect } from '../config/browserTest';
+import { ipToSocksAddress } from '../../packages/utils/socksProxy';
 import net from 'net';
+
+it('should encode IPv6 addresses with embedded IPv4 tails as IPv4 SOCKS addresses', async () => {
+  expect(ipToSocksAddress('::ffff:192.168.0.35')).toEqual([0x01, 192, 168, 0, 35]);
+  expect(ipToSocksAddress('0:0:0:0:0:ffff:192.168.0.35')).toEqual([0x01, 192, 168, 0, 35]);
+  expect(ipToSocksAddress('64:ff9b::192.168.0.35')).toEqual([0x01, 192, 168, 0, 35]);
+});
 
 it('should throw for bad server value', async ({ browserType }) => {
   const error = await browserType.launch({


### PR DESCRIPTION
## Summary
- detect valid IPv6 addresses that end in an embedded IPv4 address
- encode those addresses as SOCKS IPv4 replies instead of malformed IPv6 bytes
- add regression coverage for IPv4-mapped and NAT64-style forms

## Test plan
- `npm install`
- `npm run build`
- `npx playwright test --config=tests/library/playwright.config.ts tests/library/proxy.spec.ts --grep "embedded IPv4"`
- `git diff --check`

Fixes https://github.com/microsoft/playwright/issues/41445