### PR TITLE
docs(cli): document high-resolution screenshots

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -130,7 +130,7 @@ playwright-cli snapshot --filename=f    # save snapshot to specific file
 playwright-cli screenshot               # screenshot of the current page
 playwright-cli screenshot [ref]         # screenshot of a specific element
 playwright-cli screenshot --filename=f  # save with specific filename
-playwright-cli screenshot --hires        # capture using device pixels
+playwright-cli screenshot --hires       # capture using device pixels
 playwright-cli pdf                      # save page as PDF
 ```
 

--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -130,6 +130,7 @@ playwright-cli snapshot --filename=f    # save snapshot to specific file
 playwright-cli screenshot               # screenshot of the current page
 playwright-cli screenshot [ref]         # screenshot of a specific element
 playwright-cli screenshot --filename=f  # save with specific filename
+playwright-cli screenshot --hires        # capture using device pixels
 playwright-cli pdf                      # save page as PDF
 ```
 


### PR DESCRIPTION
## Summary

- Add the recently introduced `--hires` screenshot option to the CLI getting-started guide.

References #41465.