### PR TITLE
fix(networkidle): do not wait for open EventSource (SSE) connections

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -384,7 +384,7 @@ export class FrameManager {
 
   private _inflightRequestFinished(request: network.Request) {
     const frame = request.frame();
-    if (request._isFavicon || !frame)
+    if (this._isExcludedFromNetworkIdle(request) || !frame)
       return;
     if (!frame._inflightRequests.has(request))
       return;
@@ -395,11 +395,25 @@ export class FrameManager {
 
   private _inflightRequestStarted(request: network.Request) {
     const frame = request.frame();
-    if (request._isFavicon || !frame)
+    if (this._isExcludedFromNetworkIdle(request) || !frame)
       return;
     frame._inflightRequests.add(request);
     if (frame._inflightRequests.size === 1)
       frame._stopNetworkIdleTimer();
+  }
+
+  private _isExcludedFromNetworkIdle(request: network.Request): boolean {
+    // Favicons are aborted during interception and should never gate networkidle.
+    if (request._isFavicon)
+      return true;
+    // Server-sent events (EventSource) keep the response open indefinitely, so the
+    // request never "finishes" from the browser's perspective. Counting it as an
+    // inflight request would prevent networkidle from ever firing. WebSockets are
+    // already excluded since they are tracked separately and never enter the
+    // inflight set. See https://github.com/microsoft/playwright/issues/37226.
+    if (request.resourceType() === 'eventsource')
+      return true;
+    return false;
   }
 
   interceptConsoleMessage(message: ConsoleMessage): boolean {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -403,14 +403,8 @@ export class FrameManager {
   }
 
   private _isExcludedFromNetworkIdle(request: network.Request): boolean {
-    // Favicons are aborted during interception and should never gate networkidle.
     if (request._isFavicon)
       return true;
-    // Server-sent events (EventSource) keep the response open indefinitely, so the
-    // request never "finishes" from the browser's perspective. Counting it as an
-    // inflight request would prevent networkidle from ever firing. WebSockets are
-    // already excluded since they are tracked separately and never enter the
-    // inflight set. See https://github.com/microsoft/playwright/issues/37226.
     if (request.resourceType() === 'eventsource')
       return true;
     return false;

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -211,9 +211,6 @@ it('should work after repeated navigations in the same page', async ({ page, ser
 it('should not wait for an open EventSource connection', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37226' });
 
-  // Server-sent events keep the response open indefinitely. Such a connection
-  // must not prevent networkidle from firing, otherwise navigation would hang
-  // until the timeout.
   server.setRoute('/sse', (req, res) => {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
@@ -221,7 +218,6 @@ it('should not wait for an open EventSource connection', async ({ page, server }
       'Cache-Control': 'no-cache',
     });
     res.write('data: hello\n\n');
-    // Intentionally never end the response.
   });
   server.setRoute('/sse-page.html', (req, res) => {
     res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -242,12 +238,9 @@ it('should not wait for an open EventSource connection in setContent', async ({ 
       'Cache-Control': 'no-cache',
     });
     res.write('data: hello\n\n');
-    // Intentionally never end the response.
   });
 
   await page.goto(server.EMPTY_PAGE);
-  // Open an EventSource and wait until it received the first message, so that the
-  // connection is established and inflight by the time we wait for networkidle.
   await page.setContent(`<script>
     window.__sseOpened = new Promise(resolve => {
       const es = new EventSource('/sse');

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -207,3 +207,52 @@ it('should work after repeated navigations in the same page', async ({ page, ser
   await page.goto(server.EMPTY_PAGE, { waitUntil: 'networkidle' });
   expect(requestCount).toBe(2);
 });
+
+it('should not wait for an open EventSource connection', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37226' });
+
+  // Server-sent events keep the response open indefinitely. Such a connection
+  // must not prevent networkidle from firing, otherwise navigation would hang
+  // until the timeout.
+  server.setRoute('/sse', (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Connection': 'keep-alive',
+      'Cache-Control': 'no-cache',
+    });
+    res.write('data: hello\n\n');
+    // Intentionally never end the response.
+  });
+  server.setRoute('/sse-page.html', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<script>new EventSource('/sse');</script>`);
+  });
+
+  const response = await page.goto(server.PREFIX + '/sse-page.html', { waitUntil: 'networkidle' });
+  expect(response.status()).toBe(200);
+});
+
+it('should not wait for an open EventSource connection in setContent', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37226' });
+
+  server.setRoute('/sse', (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Connection': 'keep-alive',
+      'Cache-Control': 'no-cache',
+    });
+    res.write('data: hello\n\n');
+    // Intentionally never end the response.
+  });
+
+  await page.goto(server.EMPTY_PAGE);
+  // Open an EventSource and wait until it received the first message, so that the
+  // connection is established and inflight by the time we wait for networkidle.
+  await page.setContent(`<script>
+    window.__sseOpened = new Promise(resolve => {
+      const es = new EventSource('/sse');
+      es.onmessage = () => resolve();
+    });
+  </script>`, { waitUntil: 'networkidle' });
+  await page.evaluate(() => window['__sseOpened']);
+});


### PR DESCRIPTION
Server-sent events (`EventSource`, `text/event-stream`) keep the HTTP response open indefinitely, so the browser never reports the request as finished. Because such a request stayed in the per-frame inflight set, the network idle timer never started and `waitUntil: 'networkidle'` / `waitForLoadState('networkidle')` would hang until the navigation timeout on any page that opens an `EventSource`.

This excludes `eventsource` requests from the network idle inflight set, the same way favicons are already excluded and WebSockets are tracked separately. The resource type is known at request-start time across all three backends, so the connection no longer gates `networkidle`.

Added regression tests in `page-network-idle.spec.ts` (`goto` and `setContent`) that hang without the fix and pass with it on Chromium, Firefox and WebKit.

Fixes #41513
