### PR TITLE
docs(mcp): document heartbeat timeout

### DIFF
--- a/docs/src/getting-started-mcp.md
+++ b/docs/src/getting-started-mcp.md
@@ -195,6 +195,8 @@ When running a headed browser on a system without a display or from IDE worker p
 npx @playwright/mcp@latest --port 8931
 ```
 
+HTTP sessions use a five-second heartbeat timeout. If your MCP client or proxy does not answer server-initiated pings, set `PLAYWRIGHT_MCP_PING_TIMEOUT_MS` to a longer timeout in milliseconds. Set it to `0` to disable the heartbeat.
+
 Then point your MCP client to the HTTP endpoint:
 
 ```json


### PR DESCRIPTION
## Summary

- Document the default HTTP heartbeat timeout and how to adjust or disable it with `PLAYWRIGHT_MCP_PING_TIMEOUT_MS`.

Follow-up to #41391.