### PR TITLE
fix(transform): skip explicit-resource-management lowering on Node 24+

### DIFF
--- a/packages/playwright/src/transform/babelBundle.ts
+++ b/packages/playwright/src/transform/babelBundle.ts
@@ -32,6 +32,8 @@ export type { BabelAPI } from '@babel/helper-plugin-utils';
 export type BabelPlugin = [string, any?];
 export type BabelTransformFunction = (code: string, filename: string, isModule: boolean, pluginsPrefix: BabelPlugin[], pluginsSuffix: BabelPlugin[], jsxImportSource?: string) => BabelFileResult | null;
 
+const nodeMajorVersion = +process.versions.node.split('.')[0];
+
 function babelTransformOptions(isTypeScript: boolean, isModule: boolean, pluginsPrologue: [string, any?][], pluginsEpilogue: [string, any?][], jsxImportSource?: string): TransformOptions {
   const plugins = [
     [require('@babel/plugin-syntax-import-attributes'), { deprecatedAssertSyntax: true }],
@@ -40,7 +42,6 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
   if (isTypeScript) {
     plugins.push(
         [require('@babel/plugin-proposal-decorators'), { version: '2023-05' }],
-        [require('@babel/plugin-transform-explicit-resource-management')],
         [require('@babel/plugin-transform-class-properties')],
         [require('@babel/plugin-transform-class-static-block')],
         [require('@babel/plugin-transform-numeric-separator')],
@@ -69,6 +70,9 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
           })
         ]
     );
+
+    if (nodeMajorVersion < 24)
+      plugins.push([require('@babel/plugin-transform-explicit-resource-management')]);
   }
 
   // Support JSX/TSX at all times, regardless of the file extension.

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -40,7 +40,6 @@ export type BrowserTestWorkerFixtures = PageWorkerFixtures & {
   isElectron: boolean;
   isHeadlessShell: boolean;
   isFrozenWebkit: boolean;
-  nodeVersion: { major: number, minor: number, patch: number };
   isBidi: boolean;
   bidiTestSkipPredicate: (info: TestInfo) => boolean;
 };
@@ -92,11 +91,6 @@ const test = baseTest.extend<BrowserTestTestFixtures & { _contextFactory: Contex
 
   browserMajorVersion: [async ({ browserVersion }, run) => {
     await run(Number(browserVersion.split('.')[0]));
-  }, { scope: 'worker' }],
-
-  nodeVersion: [async ({}, use) => {
-    const [major, minor, patch] = process.versions.node.split('.');
-    await use({ major: +major, minor: +minor, patch: +patch });
   }, { scope: 'worker' }],
 
   isBidi: [async ({ channel }, use) => {

--- a/tests/config/platformFixtures.ts
+++ b/tests/config/platformFixtures.ts
@@ -23,6 +23,7 @@ export type PlatformWorkerFixtures = {
   isMac: boolean;
   isLinux: boolean;
   macVersion: number; // major only, 11 or later, zero if not mac
+  nodeVersion: { major: number, minor: number, patch: number };
 };
 
 function platform(): 'win32' | 'darwin' | 'linux' {
@@ -51,4 +52,8 @@ export const platformTest = test.extend<{}, PlatformWorkerFixtures>({
   isMac: [platform() === 'darwin', { scope: 'worker' }],
   isLinux: [platform() === 'linux', { scope: 'worker' }],
   macVersion: [macVersion(), { scope: 'worker' }],
+  nodeVersion: [async ({}, use) => {
+    const [major, minor, patch] = process.versions.node.split('.');
+    await use({ major: +major, minor: +minor, patch: +patch });
+  }, { scope: 'worker' }],
 });

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -867,6 +867,20 @@ it('should work with Array.from/map', async ({ page }) => {
   })).toBe('([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})');
 });
 
+it('should work with a using declaration', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41511' });
+  it.skip(+process.versions.node.split('.')[0] < 24, 'using is lowered to a module-scope helper that does not survive evaluate serialization on Node < 24');
+  const disposed = await page.evaluate(() => {
+    let disposed = false;
+    {
+      using r = { [Symbol.dispose]: () => { disposed = true; } };
+      void r;
+    }
+    return disposed;
+  });
+  expect(disposed).toBe(true);
+});
+
 it('should ignore dangerous object keys', async ({ page }) => {
   const input = {
     __proto__: { polluted: true },

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -867,9 +867,9 @@ it('should work with Array.from/map', async ({ page }) => {
   })).toBe('([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})');
 });
 
-it('should work with a using declaration', async ({ page }) => {
+it('should work with a using declaration', async ({ page, nodeVersion }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41511' });
-  it.skip(+process.versions.node.split('.')[0] < 24, 'using is lowered to a module-scope helper that does not survive evaluate serialization on Node < 24');
+  it.skip(nodeVersion.major < 24, 'using is lowered to a module-scope helper that does not survive evaluate serialization on Node < 24');
   const disposed = await page.evaluate(() => {
     let disposed = false;
     {


### PR DESCRIPTION
`using` inside `page.evaluate()` throws `Cannot read properties of undefined`, because we lower it to a `_usingCtx` helper hoisted to module scope, and `page.evaluate` ships the callback via `fn.toString()` which drops everything but the function body. So the helper is undefined in the page.

Node 24+ parses `using` natively, so there's no need to lower it there - and the browser supports it too. This skips the explicit-resource-management transform on Node 24+ and keeps it for older Node, where specs would otherwise fail to parse.

Fixes https://github.com/microsoft/playwright/issues/41511
