### PR TITLE
chore: update github actions script to v9

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -56,7 +56,7 @@ jobs:
         AZCOPY_AUTO_LOGIN_TYPE: AZCLI
 
     - name: Publish Report URL as Commit Status
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           await github.rest.repos.createCommitStatus({

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -58,7 +58,7 @@ jobs:
         app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
         private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
     - name: Create Pull Request
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       if: ${{ steps.prepare-branch.outputs.exists == '0' }}
       with:
         github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/roll_nodejs.yml
+++ b/.github/workflows/roll_nodejs.yml
@@ -40,7 +40,7 @@ jobs:
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -45,7 +45,7 @@ jobs:
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@actions/core": "^3.0.0",
-        "@actions/github": "^8.0.0",
+        "@actions/github": "^9.0.0",
         "@babel/code-frame": "^7.27.1",
         "@babel/core": "^7.28.0",
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-8.0.1.tgz",
-      "integrity": "sha512-cue7mS+kx1/2Dnc/094pitRUm+0uPXVXYVaqOdZwD15BsXATWYHW3idJDYOlyBc5gJlzAQ/w5YLU4LR8D7hjVg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   ],
   "devDependencies": {
     "@actions/core": "^3.0.0",
-    "@actions/github": "^8.0.0",
+    "@actions/github": "^9.0.0",
     "@babel/code-frame": "^7.27.1",
     "@babel/core": "^7.28.0",
     "@babel/helper-plugin-utils": "^7.27.1",


### PR DESCRIPTION
Avoids using Node.js 20 that is removed from GHA.