### PR TITLE
fix(screenshot): neutralize page ::backdrop styles on mask overlay

### DIFF
--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -65,6 +65,8 @@ export class Highlight {
   private _rafRequest: number | undefined;
   private _language: Language = 'javascript';
   private _elementHighlightSelectors = new Map<string, { selector: ParsedSelector, cssStyle?: string }>();
+  private _backdropResetSheet?: CSSStyleSheet;
+  private _backdropResetStyle?: HTMLStyleElement;
 
   constructor(injectedScript: InjectedScript) {
     this._injectedScript = injectedScript;
@@ -117,7 +119,26 @@ export class Highlight {
       return;
     if (!this._injectedScript.document.documentElement.contains(this._glassPaneElement) || this._glassPaneElement.nextElementSibling)
       this._injectedScript.document.documentElement.appendChild(this._glassPaneElement);
+    this._installBackdropReset();
     this._bringToFront();
+  }
+
+  private _installBackdropReset() {
+    const css = 'x-pw-glass::backdrop { background: transparent !important; }';
+    if (typeof this._injectedScript.document.adoptedStyleSheets.push !== 'function') {
+      if (!this._backdropResetStyle?.isConnected) {
+        this._backdropResetStyle = this._injectedScript.document.createElement('style');
+        this._backdropResetStyle.textContent = css;
+        this._injectedScript.document.documentElement!.appendChild(this._backdropResetStyle);
+      }
+      return;
+    }
+    if (!this._backdropResetSheet) {
+      this._backdropResetSheet = new this._injectedScript.window.CSSStyleSheet();
+      this._backdropResetSheet.replaceSync(css);
+    }
+    if (!this._injectedScript.document.adoptedStyleSheets.includes(this._backdropResetSheet))
+      this._injectedScript.document.adoptedStyleSheets.push(this._backdropResetSheet);
   }
 
   private _bringToFront() {
@@ -174,6 +195,13 @@ export class Highlight {
       this._rafRequest = undefined;
     }
     this._elementHighlightSelectors.clear();
+    if (this._backdropResetSheet) {
+      const adoptedStyleSheets = this._injectedScript.document.adoptedStyleSheets;
+      const index = adoptedStyleSheets.indexOf(this._backdropResetSheet);
+      if (index !== -1)
+        adoptedStyleSheets.splice(index, 1);
+    }
+    this._backdropResetStyle?.remove();
     this._glassPaneElement.remove();
   }
 

--- a/tests/page/page-screenshot.spec.ts
+++ b/tests/page/page-screenshot.spec.ts
@@ -574,6 +574,29 @@ it.describe('page screenshot', () => {
       })).toMatchSnapshot('mask-color-should-work.png');
     });
 
+    it('should not be affected by page backdrop styles', {
+      annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41504' },
+    }, async ({ page }) => {
+      await page.setViewportSize({ width: 200, height: 200 });
+      await page.setContent(`
+        <style>
+          html, body { margin: 0; padding: 0; }
+          body { background: #fff; }
+          #probe  { position: absolute; top: 0;    left: 0;    width: 100px; height: 100px; background: rgb(0, 128, 255); }
+          #secret { position: absolute; top: 120px; left: 120px; width: 50px;  height: 50px;  background: #000; }
+          ::backdrop, ::-webkit-backdrop { background: rgba(0, 0, 0, 0.5); }
+        </style>
+        <div id="probe"></div>
+        <div id="secret"></div>
+      `);
+      const probe = page.locator('#probe');
+      const noMask = await probe.screenshot();
+      const withMask = await probe.screenshot({ mask: [page.locator('#secret')] });
+      expect(withMask.equals(noMask)).toBe(true);
+      const masked = await probe.screenshot({ mask: [probe] });
+      expect(masked.equals(noMask)).toBe(false);
+    });
+
     it('should hide elements based on attr', async ({ page, server }) => {
       await page.setViewportSize({ width: 500, height: 500 });
       await page.goto(server.PREFIX + '/grid.html');


### PR DESCRIPTION
## Summary
- The mask overlay (`x-pw-glass`) is shown via the popover API, putting it in the top layer with a `::backdrop` pseudo-element. A broad page rule targeting `::backdrop` bled onto it and tinted masked screenshots (regression since 1.59).
- Neutralize the glass pane `::backdrop` from a document-level stylesheet (the host `::backdrop` is unreachable from the shadow root), installed in `install()` and removed in `uninstall()`. Falls back to a `<style>` element for Firefox during screenshots.

Alternative to #41505.

Fixes https://github.com/microsoft/playwright/issues/41504
