### PR TITLE
fix(hit target): release hit-target interceptor closure to allow GC of detached elements

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -1124,7 +1124,7 @@ export class InjectedScript {
     }[action];
     let result: 'done' | { hitTargetDescription: string } | undefined;
 
-    const listener = (event: PointerEvent | MouseEvent | TouchEvent) => {
+    let listener: ((event: PointerEvent | MouseEvent | TouchEvent) => void) | undefined = (event: PointerEvent | MouseEvent | TouchEvent) => {
       // Ignore events that we do not expect to intercept.
       if (!events.has(event.type))
         return;
@@ -1153,6 +1153,7 @@ export class InjectedScript {
     const stop = () => {
       if (this._hitTargetInterceptor === listener)
         this._hitTargetInterceptor = undefined;
+      listener = undefined;
       // If we did not get any events, consider things working. Possible causes:
       // - JavaScript is disabled (webkit-only).
       // - Some <iframe> overlays the element from another frame.

--- a/tests/page/page-request-gc.spec.ts
+++ b/tests/page/page-request-gc.spec.ts
@@ -32,3 +32,14 @@ test('should work', async ({ page }) => {
   await page.requestGC();
   expect(await page.evaluate(() => globalThis.weakRef.deref())).toBe(undefined);
 });
+
+test('should collect element retained by locator hit-target interceptor after detach', async ({ page }) => {
+  await page.setContent('<button id="btn">click me</button>');
+  await page.locator('#btn').click();
+  await page.evaluate(() => {
+    globalThis.weakRef = new WeakRef(document.getElementById('btn')!);
+    document.getElementById('btn')!.remove();
+  });
+  await page.requestGC();
+  expect(await page.evaluate(() => globalThis.weakRef.deref())).toBe(undefined);
+});


### PR DESCRIPTION
## Summary
- After a locator pointer action, `setupHitTargetInterceptor` returns a `{ stop }` CDP remote object whose closure chain (`stop` → `listener` → target element) prevents V8 from collecting the element even after it is detached and `requestGC()` is called.
- Null out `listener` inside `stop()` after clearing `_hitTargetInterceptor`, so the element is immediately unreachable from JS after the action completes.

Fixes https://github.com/microsoft/playwright/issues/41462