### PR TITLE
test: fix stale extension snapshot refs (e1 -> f1e1)

### DIFF
--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -37,7 +37,7 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
 });
 
@@ -210,7 +210,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
 });
 
@@ -342,7 +342,7 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   });
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
 });
 

--- a/tests/extension/tab-management.spec.ts
+++ b/tests/extension/tab-management.spec.ts
@@ -24,7 +24,7 @@ test(`browser_tabs new creates a new tab`, async ({ startExtensionClient, server
 
   const navigateResponse = await connectAndNavigate(browserContext, client, server.HELLO_WORLD);
   expect(navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
 
   const newTabResponse = await client.callTool({
@@ -117,7 +117,7 @@ test(`cmd+click opens new tab visible in tab list`, async ({ startExtensionClien
 
   await client.callTool({
     name: 'browser_click',
-    arguments: { element: 'click me', target: 'e2', modifiers: ['ControlOrMeta'] },
+    arguments: { element: 'click me', target: 'f1e2', modifiers: ['ControlOrMeta'] },
   });
 
   await expect.poll(async () => {
@@ -149,7 +149,7 @@ test(`window.open from tracked tab auto-attaches new tab`, async ({ startExtensi
 
   await client.callTool({
     name: 'browser_click',
-    arguments: { element: 'open', target: 'e2' },
+    arguments: { element: 'open', target: 'f1e2' },
   });
 
   await expect.poll(async () => {


### PR DESCRIPTION
## Summary
- In extension mode the connected tab already holds a real document, so the first MCP navigation renumbers the main frame and its aria refs gain an `f1` prefix (`f1e1`).
- Update the connect+navigate snapshot expectations in the extension tests to `f1e1`.
- Snapshot-only (existing page) and fresh new-tab cases legitimately keep `e1` and are unchanged.