### PR TITLE
feat(protocol): add `outputFile` parameter to `browserContext.pause`

### DIFF
--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -1286,7 +1286,7 @@ export interface BrowserContextChannel extends BrowserContextEventTarget, Channe
   setOffline(params: BrowserContextSetOfflineParams): Promise<BrowserContextSetOfflineResult>;
   storageState(params: BrowserContextStorageStateParams): Promise<BrowserContextStorageStateResult>;
   setStorageState(params: BrowserContextSetStorageStateParams): Promise<BrowserContextSetStorageStateResult>;
-  pause(params?: BrowserContextPauseParams): Promise<BrowserContextPauseResult>;
+  pause(params: BrowserContextPauseParams): Promise<BrowserContextPauseResult>;
   enableRecorder(params: BrowserContextEnableRecorderParams): Promise<BrowserContextEnableRecorderResult>;
   disableRecorder(params?: BrowserContextDisableRecorderParams): Promise<BrowserContextDisableRecorderResult>;
   exposeConsoleApi(params?: BrowserContextExposeConsoleApiParams): Promise<BrowserContextExposeConsoleApiResult>;
@@ -1562,8 +1562,12 @@ export type BrowserContextSetStorageStateOptions = {
   },
 };
 export type BrowserContextSetStorageStateResult = void;
-export type BrowserContextPauseParams = {};
-export type BrowserContextPauseOptions = {};
+export type BrowserContextPauseParams = {
+  outputFile?: string,
+};
+export type BrowserContextPauseOptions = {
+  outputFile?: string,
+};
 export type BrowserContextPauseResult = void;
 export type BrowserContextEnableRecorderParams = {
   language?: string,

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -862,9 +862,9 @@ scheme.BrowserContextSetStorageStateParams = tObject({
   })),
 });
 scheme.BrowserContextSetStorageStateResult = tOptional(tObject({}));
-scheme.BrowserContextPauseParams = tObject({
+scheme.BrowserContextPauseParams = tOptional(tObject({
   outputFile: tOptional(tString),
-});
+}));
 scheme.BrowserContextPauseResult = tOptional(tObject({}));
 scheme.BrowserContextEnableRecorderParams = tObject({
   language: tOptional(tString),

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -862,7 +862,9 @@ scheme.BrowserContextSetStorageStateParams = tObject({
   })),
 });
 scheme.BrowserContextSetStorageStateResult = tOptional(tObject({}));
-scheme.BrowserContextPauseParams = tOptional(tObject({}));
+scheme.BrowserContextPauseParams = tObject({
+  outputFile: tOptional(tString),
+});
 scheme.BrowserContextPauseResult = tOptional(tObject({}));
 scheme.BrowserContextEnableRecorderParams = tObject({
   language: tOptional(tString),

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -157,8 +157,11 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
     if (shouldEnableDebugger) {
       this._debugger.setPauseAt();
       this._debugger.on(Debugger.Events.PausedStateChanged, () => {
-        if (this._debugger.isPaused())
-          RecorderApp.showInspectorNoReply(this);
+        if (this._debugger.isPaused()) {
+          const details = this._debugger.pausedDetails();
+          const outputFile = details?.metadata?.params?.outputFile as string | undefined;
+          RecorderApp.showInspectorNoReply(this, { outputFile });
+        }
       });
     }
 

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -1565,8 +1565,12 @@ export type BrowserContextSetStorageStateOptions = {
   },
 };
 export type BrowserContextSetStorageStateResult = void;
-export type BrowserContextPauseParams = {};
-export type BrowserContextPauseOptions = {};
+export type BrowserContextPauseParams = {
+  outputFile?: string,
+};
+export type BrowserContextPauseOptions = {
+  outputFile?: string,
+};
 export type BrowserContextPauseResult = void;
 export type BrowserContextEnableRecorderParams = {
   language?: string,

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -192,10 +192,10 @@ export class RecorderApp {
     await this._page.close(nullProgress);
   }
 
-  static showInspectorNoReply(context: BrowserContext) {
+  static showInspectorNoReply(context: BrowserContext, params: channels.BrowserContextEnableRecorderParams = {}) {
     if (process.env.PW_CODEGEN_NO_INSPECTOR)
       return;
-    void Recorder.forContext(context, {}).then(recorder => RecorderApp._show(recorder, context, {})).catch(() => {});
+    void Recorder.forContext(context, params).then(recorder => RecorderApp._show(recorder, context, params)).catch(() => {});
   }
 
   private static async _show(recorder: Recorder, inspectedContext: BrowserContext, params: channels.BrowserContextEnableRecorderParams) {

--- a/packages/protocol/spec/browserContext.yml
+++ b/packages/protocol/spec/browserContext.yml
@@ -210,6 +210,8 @@ BrowserContext:
 
     pause:
       title: Pause
+      parameters:
+        outputFile: string?
 
     enableRecorder:
       internal: true


### PR DESCRIPTION
Feature Issue Raised - https://github.com/microsoft/playwright/issues/41564

- Allows specifying a file path to save the inspector or recorder output when the browser context is paused.
- Part of a Joint change with playwright-dotnet to allow Page.PauseAsync to pass an output file path.