### PR TITLE
chore(client): stub "crypto" for the browser build

### DIFF
--- a/packages/playwright-client/src/nodeStubs/crypto.ts
+++ b/packages/playwright-client/src/nodeStubs/crypto.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function randomBytes(size: number): { toString(encoding?: string): string } {
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(size));
+  return {
+    toString: () => Array.from(bytes, b => b.toString(16).padStart(2, '0')).join(''),
+  };
+}
+
+export default { randomBytes };

--- a/packages/playwright-core/src/client/DEPS.list
+++ b/packages/playwright-core/src/client/DEPS.list
@@ -1,6 +1,7 @@
 [*]
 ../protocol/
 @isomorphic/**
+@utils/crypto.ts
 @utils/debug.ts
 @utils/debugLogger.ts
 @utils/zones.ts

--- a/packages/playwright-core/src/client/waiter.ts
+++ b/packages/playwright-core/src/client/waiter.ts
@@ -15,6 +15,7 @@
  */
 
 import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { createGuid } from '@utils/crypto';
 import { currentZone } from '@utils/zones';
 import { TimeoutError } from './errors';
 
@@ -34,7 +35,7 @@ export class Waiter {
   private _savedZone: Zone;
 
   constructor(channelOwner: ChannelOwner, event: string) {
-    this._waitId = createGuidWithWebCrypto();
+    this._waitId = createGuid();
     this._channelOwner = channelOwner;
     this._savedZone = currentZone().without('apiZone');
 
@@ -184,10 +185,4 @@ function formatLogRecording(log: string[]): string {
   const leftLength = (headerLength - header.length) / 2;
   const rightLength = headerLength - header.length - leftLength;
   return `\n${'='.repeat(leftLength)}${header}${'='.repeat(rightLength)}\n${log.join('\n')}\n${'='.repeat(headerLength)}`;
-}
-
-function createGuidWithWebCrypto() {
-  // This avoids stubbing "crypto" for browser build.
-  // TODO: consider replacing the main createGuid() helper with this.
-  return Array.from(globalThis.crypto.getRandomValues(new Uint8Array(16)), b => b.toString(16).padStart(2, '0')).join('');
 }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -579,6 +579,7 @@ for (const pkg of workspace.packages()) {
       'inspector': clientNodeStub('inspector'),
       'async_hooks': clientNodeStub('async_hooks'),
       'events': clientNodeStub('events'),
+      'crypto': clientNodeStub('crypto'),
       // Vendored npm dep used for terminal colors; no-op in the browser.
       'colors/safe': clientNodeStub('colors'),
     },


### PR DESCRIPTION
## Summary
- Route `Waiter` through the shared `createGuid()` and stub the Node `crypto` module for the `@playwright/client` browser bundle (minimal `randomBytes`, backed by WebCrypto).
- Removes the bespoke `createGuidWithWebCrypto()` helper that only existed to avoid stubbing `crypto`.