### PR TITLE
feat(elementhandle): add timeout and signal to inputValue

### DIFF
--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -656,6 +656,8 @@ Throws for non-input elements. However, if the element is inside the `<label>` e
 ### option: ElementHandle.inputValue.timeout = %%-input-timeout-js-%%
 * since: v1.13
 
+### option: ElementHandle.inputValue.signal = %%-input-signal-%%
+
 ## async method: ElementHandle.isChecked
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.isChecked`] instead. Read more about [locators](../locators.md).

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -12980,6 +12980,17 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    */
   inputValue(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout,
+     * which can be changed using
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout); pass
+     * `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -3238,8 +3238,12 @@ export type ElementHandleInnerTextOptions = {};
 export type ElementHandleInnerTextResult = {
   value: string,
 };
-export type ElementHandleInputValueParams = {};
-export type ElementHandleInputValueOptions = {};
+export type ElementHandleInputValueParams = {
+  timeout: number,
+};
+export type ElementHandleInputValueOptions = {
+
+};
 export type ElementHandleInputValueResult = {
   value: string,
 };

--- a/packages/playwright-core/src/client/elementHandle.ts
+++ b/packages/playwright-core/src/client/elementHandle.ts
@@ -69,8 +69,8 @@ export class ElementHandle<T extends Node = Node> extends JSHandle<T> implements
     return value === undefined ? null : value;
   }
 
-  async inputValue(): Promise<string> {
-    return (await this._elementChannel.inputValue({}, undefined)).value;
+  async inputValue(options: channels.ElementHandleInputValueOptions & TimeoutOptions = {}): Promise<string> {
+    return (await this._elementChannel.inputValue({ ...options, timeout: this._frame._timeout(options) }, options.signal)).value;
   }
 
   async textContent(): Promise<string | null> {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -1830,7 +1830,9 @@ scheme.ElementHandleInnerTextParams = tOptional(tObject({}));
 scheme.ElementHandleInnerTextResult = tObject({
   value: tString,
 });
-scheme.ElementHandleInputValueParams = tOptional(tObject({}));
+scheme.ElementHandleInputValueParams = tObject({
+  timeout: tFloat,
+});
 scheme.ElementHandleInputValueResult = tObject({
   value: tString,
 });

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -3241,8 +3241,12 @@ export type ElementHandleInnerTextOptions = {};
 export type ElementHandleInnerTextResult = {
   value: string,
 };
-export type ElementHandleInputValueParams = {};
-export type ElementHandleInputValueOptions = {};
+export type ElementHandleInputValueParams = {
+  timeout: number,
+};
+export type ElementHandleInputValueOptions = {
+
+};
 export type ElementHandleInputValueResult = {
   value: string,
 };

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -12980,6 +12980,17 @@ export interface ElementHandle<T=Node> extends JSHandle<T> {
    */
   inputValue(options?: {
     /**
+     * Allows to cancel the operation using an
+     * [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted, the
+     * operation will be aborted and throw an error. Note that providing a signal does not disable the default timeout,
+     * which can be changed using
+     * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+     * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout); pass
+     * `timeout: 0` to disable the timeout entirely.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Maximum time in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout`
      * option in the config, or by using the
      * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)

--- a/packages/protocol/spec/handles.yml
+++ b/packages/protocol/spec/handles.yml
@@ -313,6 +313,8 @@ ElementHandle:
     inputValue:
       title: Get input value
       group: getter
+      parameters:
+        timeout: float
       returns:
         value: string
       flags:


### PR DESCRIPTION
Adds `timeout` and `signal` to `ElementHandle.inputValue`, following on from #41141.

## ⚠️ Breaking change

`inputValue` will start timing out again.

The history is worth spelling out, because I got it wrong at first. `inputValue` has advertised a `timeout` option since v1.13, and until v1.53 it was honoured: the server ran it through the usual path and applied the context's default action timeout (30s). Then #35988 ("move timeout handling to the client") pinned all the ElementHandle getters - `inputValue`, `textContent`, `getAttribute`, `isChecked` and friends - to `{ timeout: 0 }`, and the client `inputValue()` was never taught to send a timeout. So since v1.53 it's had no timeout at all, and the documented option has been a silent no-op.

This PR wires `timeout` back through the protocol properly and adds `signal` next to it. Because the client sends the default timeout again, `inputValue` will once more time out (30s by default) where for the last several releases it would wait forever. That restores the pre-1.53 behaviour, but it's a real change for anyone who came to rely on it never timing out - hence the loud warning.

The alternative would be to go the other way: accept that `inputValue` doesn't really need a timeout (it runs against an already-resolved element) and just deprecate the `timeout` option instead of reviving it. That keeps today's behaviour and quietly retires a dead option. I've gone with reviving it here because it lines `inputValue` back up with how it worked pre-1.53 and lets us add `signal` alongside, but I'm happy to flip to the deprecation route if you'd prefer it.

Why just `inputValue`? The same v1.53 regression hit every ElementHandle getter - they're all still pinned to `timeout: 0` - but `inputValue` is the only one that ever advertised a `timeout` option in the docs and types, so it's the only one where the public API and the runtime actually disagree. The other getters (`textContent`, `getAttribute`, `isChecked`, ...) never promised a timeout, so I've left them alone.

Refs https://github.com/microsoft/playwright/issues/40578
