### PR TITLE
fix(cli): don't garbage-collect browsers during CLI daemon install

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -1101,7 +1101,7 @@ export class Registry {
       return await installDependenciesLinux(targets, dryRun);
   }
 
-  async install(executablesToInstall: Executable[], options?: { force?: boolean }) {
+  async install(executablesToInstall: Executable[], options?: { force?: boolean, gc?: boolean }) {
     const executables = this._dedupe(executablesToInstall);
     await fs.promises.mkdir(registryDirectory, { recursive: true });
     const lockfilePath = path.join(registryDirectory, '__dirlock');
@@ -1127,7 +1127,7 @@ export class Registry {
       await fs.promises.writeFile(path.join(linksDir, calculateSha1(PACKAGE_PATH)), PACKAGE_PATH);
 
       // Remove stale browsers.
-      if (!getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_GC'))
+      if (options?.gc !== false && !getAsBooleanFromENV('PLAYWRIGHT_SKIP_BROWSER_GC'))
         await this._validateInstallationCache(linksDir);
 
       // Install browsers for this package.

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -139,7 +139,7 @@ async function findOrInstallDefaultBrowser() {
 
 async function resolveAndInstall(nameOrChannel: string) {
   const executables = browserRegistry.resolveBrowsers([nameOrChannel], { shell: 'no' });
-  await browserRegistry.install(executables);
+  await browserRegistry.install(executables, { gc: false });
 }
 
 async function createDefaultConfig(channel: string) {


### PR DESCRIPTION
## Summary
- The CLI daemon's `install --skills` flow ensures its own browser/ffmpeg are present, but `Registry.install()` ran browser GC and removed cached browsers owned by other Playwright packages.
- Add a `gc` option to `Registry.install()` and pass `gc: false` from the CLI daemon so it no longer deletes browsers it didn't install.