### PR TITLE
fix(routing): match ws(s) baseURL rewrite case-insensitively

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -202,9 +202,10 @@ export function resolveGlobToRegexPattern(baseURL: string | undefined, glob: str
 }
 
 function toWebSocketBaseUrl(baseURL: string | undefined) {
-  // Allow http(s) baseURL to match ws(s) urls.
-  if (baseURL && /^https?:\/\//.test(baseURL))
-    baseURL = baseURL.replace(/^http/, 'ws');
+  // Allow http(s) baseURL to match ws(s) urls. Schemes are case-insensitive,
+  // same as elsewhere in this file, so 'HTTP://...' should be rewritten too.
+  if (baseURL && /^https?:\/\//i.test(baseURL))
+    baseURL = baseURL.replace(/^https?/i, scheme => scheme.toLowerCase() === 'https' ? 'wss' : 'ws');
   return baseURL;
 }
 

--- a/tests/library/route-web-socket.spec.ts
+++ b/tests/library/route-web-socket.spec.ts
@@ -646,6 +646,30 @@ test('should work with baseURL', async ({ contextFactory, server }) => {
   ]);
 });
 
+test('should work with baseURL regardless of scheme casing', async ({ contextFactory, server }) => {
+  // baseURL schemes are case-insensitive, same as everywhere else in URL matching.
+  const context = await contextFactory({ baseURL: 'HTTP://' + server.HOST });
+  const page = await context.newPage();
+
+  await page.routeWebSocket('/ws', ws => {
+    ws.onMessage(message => {
+      ws.send(message);
+    });
+  });
+
+  await setupWS(page, server, 'blob');
+
+  await page.evaluate(async () => {
+    await window.wsOpened;
+    window.ws.send('echo');
+  });
+
+  await expect.poll(() => page.evaluate(() => window.log)).toEqual([
+    'open',
+    `message: data=echo origin=ws://${server.HOST} lastEventId=`,
+  ]);
+});
+
 test('should expose protocols to the route handler', async ({ page, server }) => {
   const routes: WebSocketRoute[] = [];
   await page.routeWebSocket(/.*/, ws => {


### PR DESCRIPTION
`toWebSocketBaseUrl` only rewrote an http(s) `baseURL` to ws(s) when the scheme happened to be lowercase, so something like `baseURL: 'HTTP://x.com'` was left as-is and `routeWebSocket()` / `waitForEvent('websocket')` would just never match. URI schemes are case-insensitive per RFC 3986, and the rest of `urlMatch.ts` already treats them that way (see the origin handling a few lines down), so this just brings the ws(s) rewrite in line with that. Added a test with an uppercase `HTTP://` baseURL that fails on main and passes with the fix.