### PR TITLE
devops(ci): flag preexisting failures in PR test reports

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Shell to use'
     required: false
     default: 'bash'
+  rerun-failures-on-base:
+    description: 'On a failing pull request, re-run the failures against the base commit to identify pre-existing failures'
+    required: false
+    default: 'true'
   flakiness-client-id:
     description: 'Azure Flakiness Dashboard Client ID'
     required: false
@@ -99,3 +103,23 @@ runs:
       with:
         report_dir: blob-report
         job_name: ${{ inputs.bot-name }}-${{ inputs.shard-index }}
+    - name: Re-run failures against base
+      if: ${{ failure() && github.event_name == 'pull_request' && inputs.rerun-failures-on-base == 'true' }}
+      shell: bash
+      continue-on-error: true
+      env:
+        COMMAND: ${{ inputs.command }}
+        SETUP_COMMAND: ${{ inputs.setup-command }}
+        BROWSERS_TO_INSTALL: ${{ inputs.browsers-to-install }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BOT_NAME: ${{ inputs.bot-name }}
+        SHARD_INDEX: ${{ inputs.shard-index }}
+      run: node utils/rerun_failures_on_base.js
+    - name: Upload base failures
+      if: ${{ failure() && github.event_name == 'pull_request' && inputs.rerun-failures-on-base == 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: base-failures-${{ inputs.bot-name }}-${{ inputs.shard-index }}
+        path: ${{ runner.temp }}/base-failures-*.json
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MARKDOWN_OUTPUT_FILE: ${{ github.workspace }}/report.md
+      PRE_EXISTING_FAILURES_FILE: ${{ github.workspace }}/pre-existing-failures.json
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
@@ -28,6 +29,16 @@ jobs:
       with:
         namePrefix: 'blob-report'
         path: 'all-blob-reports'
+
+    - name: Download base failures artifact
+      uses: ./.github/actions/download-artifact
+      with:
+        namePrefix: 'base-failures'
+        path: 'all-base-failures'
+
+    - name: Collect pre-existing failures
+      shell: bash
+      run: node utils/collect_pre_existing_failures.js all-base-failures "$PRE_EXISTING_FAILURES_FILE"
 
     - name: Merge reports
       run: |

--- a/tests/config/markdownReporter.ts
+++ b/tests/config/markdownReporter.ts
@@ -31,6 +31,7 @@ class MarkdownReporter implements Reporter {
   private _fatalErrors: TestError[] = [];
   private _config!: FullConfig;
   private _suite!: Suite;
+  private _preExistingFailureKeys = new Set<string>();
 
   constructor(options: MarkdownReporterOptions) {
     this._options = options;
@@ -43,6 +44,25 @@ class MarkdownReporter implements Reporter {
   onBegin(config: FullConfig, suite: Suite) {
     this._config = config;
     this._suite = suite;
+    this._loadPreExistingFailures();
+  }
+
+  private _loadPreExistingFailures() {
+    const file = process.env.PRE_EXISTING_FAILURES_FILE;
+    if (!file)
+      return;
+    try {
+      const keys = JSON.parse(fs.readFileSync(file, 'utf8')) as string[];
+      this._preExistingFailureKeys = new Set(keys);
+    } catch {
+    }
+  }
+
+  // Must match canonicalKey() in utils/rerun_failures_on_base.js.
+  private _canonicalTestKey(test: TestCase): string {
+    const [, projectName, , ...titles] = test.titlePath();
+    const relativeFile = path.relative(this._config.rootDir, test.location.file).split(path.sep).join('/');
+    return [projectName, relativeFile, ...titles].join('\x1e');
   }
 
   onError(error: TestError) {
@@ -59,9 +79,17 @@ class MarkdownReporter implements Reporter {
     }
     if (this._fatalErrors.length)
       lines.push(`**${this._fatalErrors.length} fatal errors, not part of any test**`);
-    if (summary.unexpected.length) {
-      lines.push(`**${summary.unexpected.length} failed**`);
+    const failedCount = summary.unexpected.length + summary.preExisting.length;
+    if (failedCount) {
+      lines.push(`**${failedCount} failed**`);
       this._printTestList(':x:', summary.unexpected, lines);
+    }
+    if (summary.preExisting.length) {
+      lines.push(`<details>`);
+      lines.push(`<summary>:x: <b>${summary.preExisting.length} preexisting</b> (also failing on base, not caused by this change)</summary>`);
+      this._printTestList(':x:', summary.preExisting, lines, ' <br/>');
+      lines.push(`</details>`);
+      lines.push(``);
     }
     if (summary.flaky.length) {
       lines.push(`<details>`);
@@ -106,6 +134,7 @@ class MarkdownReporter implements Reporter {
     const interrupted: TestCase[] = [];
     const interruptedToPrint: TestCase[] = [];
     const unexpected: TestCase[] = [];
+    const preExisting: TestCase[] = [];
     const flaky: TestCase[] = [];
 
     this._suite.allTests().forEach(test => {
@@ -123,7 +152,12 @@ class MarkdownReporter implements Reporter {
           break;
         }
         case 'expected': ++expected; break;
-        case 'unexpected': unexpected.push(test); break;
+        case 'unexpected':
+          if (this._preExistingFailureKeys.has(this._canonicalTestKey(test)))
+            preExisting.push(test);
+          else
+            unexpected.push(test);
+          break;
         case 'flaky': flaky.push(test); break;
       }
     });
@@ -134,6 +168,7 @@ class MarkdownReporter implements Reporter {
       expected,
       interrupted,
       unexpected,
+      preExisting,
       flaky,
     };
   }

--- a/utils/collect_pre_existing_failures.js
+++ b/utils/collect_pre_existing_failures.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+const fs = require('fs');
+const path = require('path');
+
+function collect(dir) {
+  const keys = new Set();
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return keys;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      for (const key of collect(entryPath))
+        keys.add(key);
+    } else if (entry.name.endsWith('.json')) {
+      try {
+        for (const key of JSON.parse(fs.readFileSync(entryPath, 'utf8')))
+          keys.add(key);
+      } catch {
+      }
+    }
+  }
+  return keys;
+}
+
+function main() {
+  const [, , inputDir, outputFile] = process.argv;
+  if (!inputDir || !outputFile) {
+    console.error('Usage: collect_pre_existing_failures.js <input-dir> <output-file>');
+    process.exit(1);
+  }
+  const keys = collect(inputDir);
+  fs.writeFileSync(outputFile, JSON.stringify([...keys]));
+  console.log(`Collected ${keys.size} pre-existing failure key(s).`);
+}
+
+module.exports = { collect };
+
+if (require.main === module)
+  main();

--- a/utils/rerun_failures_on_base.js
+++ b/utils/rerun_failures_on_base.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const MAX_RERUN_FAILURES = 50;
+const RUNNER_TEMP = process.env.RUNNER_TEMP || os.tmpdir();
+
+function group(title, fn) {
+  console.log(`::group::${title}`);
+  try {
+    return fn();
+  } finally {
+    console.log('::endgroup::');
+  }
+}
+
+function sh(command, { allowFailure = false } = {}) {
+  try {
+    execSync(command, { stdio: 'inherit' });
+  } catch (error) {
+    if (!allowFailure)
+      throw error;
+  }
+}
+
+function run(file, args, { allowFailure = false } = {}) {
+  const result = spawnSync(file, args, { stdio: 'inherit' });
+  if (result.error) {
+    if (!allowFailure)
+      throw result.error;
+    console.log(`${file} could not start: ${result.error.message}`);
+  } else if (result.status !== 0 && !allowFailure) {
+    throw new Error(`${file} exited with code ${result.status}`);
+  }
+}
+
+function rerunCommand(command, lastRunFile) {
+  let rerun = command.replace(/--shard[ =]\d+\/\d+/g, '').trim();
+  // npm scripts need `--` to forward the flags appended below.
+  if (rerun.startsWith('npm run') && !rerun.includes(' -- '))
+    rerun += ' --';
+  return `${rerun} --last-failed --last-failed-file=${lastRunFile}`;
+}
+
+const KEY_SEPARATOR = '\x1e';
+
+// Must match _canonicalTestKey() in tests/config/markdownReporter.ts.
+function canonicalKey(projectName, file, titles) {
+  return [projectName, file.split(path.sep).join('/'), ...titles].join(KEY_SEPARATOR);
+}
+
+function visitSuite(suite, file, titles, keys) {
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      if (test.status === 'unexpected')
+        keys.add(canonicalKey(test.projectName, file, [...titles, spec.title]));
+    }
+  }
+  for (const child of suite.suites ?? [])
+    visitSuite(child, file, [...titles, child.title], keys);
+}
+
+function extractBaseFailures(report) {
+  const keys = new Set();
+  for (const fileSuite of report.suites ?? [])
+    visitSuite(fileSuite, fileSuite.file, [], keys);
+  return [...keys].sort();
+}
+
+function main() {
+  const lastRun = 'test-results/.last-run.json';
+  if (!fs.existsSync(lastRun)) {
+    console.log(`No ${lastRun} found; nothing to re-run on base.`);
+    return;
+  }
+
+  let failedCount = 0;
+  try {
+    failedCount = (JSON.parse(fs.readFileSync(lastRun, 'utf8')).failedTests || []).length;
+  } catch {
+  }
+  console.log(`Genuine failures recorded on head: ${failedCount}`);
+  if (failedCount === 0) {
+    console.log('No genuine failures recorded; skipping base re-run.');
+    return;
+  }
+  if (failedCount > MAX_RERUN_FAILURES) {
+    console.log(`Too many failures (${failedCount} > ${MAX_RERUN_FAILURES}); likely systemic, skipping base re-run.`);
+    return;
+  }
+
+  const { COMMAND = '', SETUP_COMMAND = '', BROWSERS_TO_INSTALL = '', BASE_SHA = '', BOT_NAME = '', SHARD_INDEX = '0' } = process.env;
+  const savedLastRun = path.join(RUNNER_TEMP, '.last-run.json');
+  fs.copyFileSync(lastRun, savedLastRun);
+  const headSha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+
+  group(`Checkout base (${BASE_SHA})`, () => {
+    sh(`git fetch --no-tags --depth=1 origin ${BASE_SHA}`);
+    sh(`git checkout --force --detach ${BASE_SHA}`);
+    sh('git clean -ffdx -e node_modules');
+  });
+  group('Build base', () => {
+    sh('npm ci');
+    sh('npm run build');
+    sh(`npx playwright install --with-deps ${BROWSERS_TO_INSTALL}`);
+  });
+  if (SETUP_COMMAND)
+    group('Base setup command', () => run('bash', ['-c', SETUP_COMMAND]));
+
+  group('Re-run failing tests on base', () => {
+    const command = rerunCommand(COMMAND, savedLastRun);
+    console.log(`Base re-run command: ${command}`);
+    if (process.platform === 'linux')
+      run('xvfb-run', ['--auto-servernum', '--server-args=-screen 0 1280x960x24', '--', 'bash', '-c', command], { allowFailure: true });
+    else
+      run('bash', ['-c', command], { allowFailure: true });
+  });
+
+  const baseFailures = path.join(RUNNER_TEMP, `base-failures-${BOT_NAME}-${SHARD_INDEX}.json`);
+  let keys = [];
+  try {
+    keys = extractBaseFailures(JSON.parse(fs.readFileSync('test-results/report.json', 'utf8')));
+  } catch (error) {
+    console.log(`No base report parsed: ${error instanceof Error ? error.message : error}`);
+  }
+  fs.writeFileSync(baseFailures, JSON.stringify(keys, null, 2) + '\n');
+
+  group(`Restore head (${headSha})`, () => sh(`git checkout --force --detach ${headSha}`, { allowFailure: true }));
+
+  console.log('Tests failing on base too:');
+  try {
+    console.log(fs.readFileSync(baseFailures, 'utf8'));
+  } catch {
+    console.log('(none)');
+  }
+}
+
+module.exports = { rerunCommand, extractBaseFailures };
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
When a PR's CI shard fails, it is often unclear whether the failures are new or were already broken on the base branch. This re-runs the shard's failing tests against the PR's base commit and labels the ones that fail there too as "preexisting". Tests that also fail on base are recorded per shard, unioned centrally, and bucketed separately by the markdown reporter. Reviewers can then focus on the failures the PR actually introduced.

For example, a shard with 5 failures where 3 already fail on base still reports "5 failed". It lists the 2 new failures and collapses the other 3 under a `<details>`. A shard with only new failures will have the same message as before this change. A shard where all failures also fail on base lists none inline and collapses them all under the `<details>`. The base re-run is skipped when there are no failures or more than 50 (i.e. likely a systemic issue).