### PR TITLE
fix(mcp): close isolated HTTP client context on disconnect

### DIFF
--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -132,12 +132,18 @@ export function decorateMCPCommand(command: Command) {
           },
           disposed: async backend => {
             clientCount--;
-            if (sharedBrowserPromise && clientCount > 0)
+            const browserContext = (backend as BrowserBackend).browserContext;
+
+            if (sharedBrowserPromise && clientCount > 0) {
+              if (config.browser.isolated) {
+                testDebug('close context');
+                await browserContext.close().catch(() => { });
+              }
               return;
+            }
 
             testDebug('close browser');
             sharedBrowserPromise = undefined;
-            const browserContext = (backend as BrowserBackend).browserContext;
             await browserContext.close().catch(() => { });
             await browserContext.browser()?.close().catch(() => { });
           }

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -161,7 +161,7 @@ test('http transport browser sigint', async ({ serverEndpoint, server }) => {
   });
 });
 
-test('http transport browser lifecycle (isolated, multiclient)', async ({ serverEndpoint, server }) => {
+test('http transport browser lifecycle (isolated, multiclient)', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41539' } }, async ({ serverEndpoint, server }) => {
   const { url, stderr } = await serverEndpoint({ args: ['--isolated'] });
 
   const transport1 = new StreamableHTTPClientTransport(new URL('/mcp', url));
@@ -200,6 +200,7 @@ test('http transport browser lifecycle (isolated, multiclient)', async ({ server
     'delete http session': 3,
     'create context': 3,
     'create browser (isolated)': 1,
+    'close context': 2,
     'close browser': 1,
   });
 });
@@ -229,6 +230,7 @@ test('http transport browser lifecycle (isolated, concurrent clients)', { annota
     'delete http session': 3,
     'create context': 3,
     'create browser (isolated)': 1,
+    'close context': 2,
     'close browser': 1,
   });
 });

--- a/tests/mcp/sse.spec.ts
+++ b/tests/mcp/sse.spec.ts
@@ -161,6 +161,9 @@ test('sse transport browser lifecycle (isolated, multiclient)', async ({ serverE
     'delete SSE session': 3,
     'create context': 3,
     'create browser (isolated)': 1,
+    // A disconnecting client's isolated context is closed immediately, not leaked
+    // until the last client leaves.
+    'close context': 2,
     'close browser': 1,
   });
 });

--- a/tests/mcp/sse.spec.ts
+++ b/tests/mcp/sse.spec.ts
@@ -161,8 +161,6 @@ test('sse transport browser lifecycle (isolated, multiclient)', async ({ serverE
     'delete SSE session': 3,
     'create context': 3,
     'create browser (isolated)': 1,
-    // A disconnecting client's isolated context is closed immediately, not leaked
-    // until the last client leaves.
     'close context': 2,
     'close browser': 1,
   });


### PR DESCRIPTION
## Summary
- In `--isolated` mode each HTTP client owns its own browser context, but the `disposed` callback returned early while other clients were still connected, leaking the disconnected client's context until the last client left.
- Now the per-client isolated context is closed immediately on disconnect; a genuinely shared context (`--shared-browser-context`) still stays open for remaining clients, and the browser is closed only when the last client leaves.

Fixes https://github.com/microsoft/playwright/issues/41539