### PR TITLE
fix(page): collect DOM elements retained by locator after detach

### DIFF
--- a/browser_patches/firefox/juggler/content/PageAgent.js
+++ b/browser_patches/firefox/juggler/content/PageAgent.js
@@ -158,6 +158,8 @@ export class PageAgent {
         callFunction: this._runtime.callFunction.bind(this._runtime),
         getObjectProperties: this._runtime.getObjectProperties.bind(this._runtime),
         disposeObject: this._runtime.disposeObject.bind(this._runtime),
+        // Alternating GC+CC passes needed: each round may unroot objects or cycle members that the next round then collects.
+        collectGarbage: () => { Cu.forceGC(); Cu.forceCC(); Cu.forceGC(); Cu.forceCC(); Cu.forceGC(); },
       }),
     ];
   }

--- a/browser_patches/firefox/juggler/protocol/PageHandler.js
+++ b/browser_patches/firefox/juggler/protocol/PageHandler.js
@@ -252,10 +252,7 @@ export class PageHandler {
   }
 
   async ['Heap.collectGarbage']() {
-    Services.obs.notifyObservers(null, "child-gc-request");
-    Cu.forceGC();
-    Services.obs.notifyObservers(null, "child-cc-request");
-    Cu.forceCC();
+    await this._contentPage.send('collectGarbage');
   }
 
   async ['Network.getResponseBody']({requestId}) {

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -1124,7 +1124,7 @@ export class InjectedScript {
     }[action];
     let result: 'done' | { hitTargetDescription: string } | undefined;
 
-    const listener = (event: PointerEvent | MouseEvent | TouchEvent) => {
+    let listener: ((event: PointerEvent | MouseEvent | TouchEvent) => void) | undefined = (event: PointerEvent | MouseEvent | TouchEvent) => {
       // Ignore events that we do not expect to intercept.
       if (!events.has(event.type))
         return;
@@ -1153,6 +1153,7 @@ export class InjectedScript {
     const stop = () => {
       if (this._hitTargetInterceptor === listener)
         this._hitTargetInterceptor = undefined;
+      listener = undefined;
       // If we did not get any events, consider things working. Possible causes:
       // - JavaScript is disabled (webkit-only).
       // - Some <iframe> overlays the element from another frame.

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -221,6 +221,8 @@ export class CRPage implements PageDelegate {
   }
 
   async requestGC(): Promise<void> {
+    // A no-op mouse move off-viewport clears Blink's native hit-target state, which retains the last-targeted element as a GC root invisible to V8.
+    await this._mainFrameSession._client.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: -1, y: -1 });
     await this._mainFrameSession._client.send('HeapProfiler.collectGarbage');
   }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -432,8 +432,10 @@ export class FFPage implements PageDelegate {
   }
 
   async requestGC(): Promise<void> {
-    // An in-viewport mousemove enters the renderer via sendEvents(), moving Gecko's C++ event-target pointer off the previously-clicked element so the cycle collector can release it. An out-of-viewport move (x < 0) takes a different Juggler path that never reaches the renderer and leaves the pointer intact.
+    // A synthetic mousemove flushes Gecko's EventStateManager event-target pointer off the previously-clicked element. The 30 ms sleep is a heuristic that creates a no-IPC idle window so pending 0 ms C++ timers in the content process (e.g. AccHide accessibility cleanup) can fire before the first GC. Two collectGarbage IPC calls are needed: Gecko dispatches cleanup callbacks in the content process event loop between the two round-trips, and those callbacks unroot the element so the second call can collect it.
     await this._session.send('Page.dispatchMouseEvent', { type: 'mousemove', x: 0, y: 0, button: 0, modifiers: 0, buttons: 0 });
+    await new Promise<void>(r => setTimeout(r, 30));
+    await this._session.send('Heap.collectGarbage');
     await this._session.send('Heap.collectGarbage');
   }
 

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -432,6 +432,8 @@ export class FFPage implements PageDelegate {
   }
 
   async requestGC(): Promise<void> {
+    // An in-viewport mousemove enters the renderer via sendEvents(), moving Gecko's C++ event-target pointer off the previously-clicked element so the cycle collector can release it. An out-of-viewport move (x < 0) takes a different Juggler path that never reaches the renderer and leaves the pointer intact.
+    await this._session.send('Page.dispatchMouseEvent', { type: 'mousemove', x: 0, y: 0, button: 0, modifiers: 0, buttons: 0 });
     await this._session.send('Heap.collectGarbage');
   }
 

--- a/tests/page/page-request-gc.spec.ts
+++ b/tests/page/page-request-gc.spec.ts
@@ -32,3 +32,14 @@ test('should work', async ({ page }) => {
   await page.requestGC();
   expect(await page.evaluate(() => globalThis.weakRef.deref())).toBe(undefined);
 });
+
+test('should collect element retained by locator hit-target interceptor after detach', async ({ page }) => {
+  await page.setContent('<button id="btn">click me</button>');
+  await page.locator('#btn').click();
+  await page.evaluate(() => {
+    globalThis.weakRef = new WeakRef(document.getElementById('btn')!);
+    document.getElementById('btn')!.remove();
+  });
+  await page.requestGC();
+  expect(await page.evaluate(() => globalThis.weakRef.deref())).toBe(undefined);
+});


### PR DESCRIPTION
## Summary
- Locator's hit-target interceptor was holding a closure reference to the clicked element, preventing GC after detach; `injectedScript.ts` now releases it
- Chromium: dispatch a no-op off-viewport mousemove before GC to clear Blink's C++ hit-target pointer
- Firefox: re-route `Heap.collectGarbage` to the content process via Juggler IPC (the old implementation ran in the parent/chrome process where DOM elements don't live); add a synthetic mousemove + 30ms sleep to flush Gecko's EventStateManager pointer and give accessibility cleanup timers an idle window before GC runs

Fixes https://github.com/microsoft/playwright/issues/41462

Thanks to @apocalyp0sz for the report.