### PR TITLE
feat(expect): support AbortSignal on web-first assertions

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -533,6 +533,9 @@ await Expect(Page.GetByText("Hidden text")).ToBeAttachedAsync();
 ### option: LocatorAssertions.toBeAttached.timeout = %%-js-assertions-timeout-%%
 * since: v1.33
 
+### option: LocatorAssertions.toBeAttached.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toBeAttached.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.33
 
@@ -591,6 +594,9 @@ This option can't be true when [`option: LocatorAssertions.toBeChecked.checked`]
 ### option: LocatorAssertions.toBeChecked.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeChecked.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toBeChecked.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -637,6 +643,9 @@ await Expect(locator).ToBeDisabledAsync();
 
 ### option: LocatorAssertions.toBeDisabled.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeDisabled.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toBeDisabled.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -685,6 +694,9 @@ await Expect(locator).ToBeEditableAsync();
 ### option: LocatorAssertions.toBeEditable.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeEditable.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toBeEditable.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -727,6 +739,9 @@ await Expect(locator).ToBeEmptyAsync();
 
 ### option: LocatorAssertions.toBeEmpty.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeEmpty.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toBeEmpty.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -775,6 +790,9 @@ await Expect(locator).ToBeEnabledAsync();
 ### option: LocatorAssertions.toBeEnabled.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeEnabled.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toBeEnabled.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -818,6 +836,9 @@ await Expect(locator).ToBeFocusedAsync();
 ### option: LocatorAssertions.toBeFocused.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toBeFocused.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toBeFocused.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -860,6 +881,9 @@ await Expect(locator).ToBeHiddenAsync();
 
 ### option: LocatorAssertions.toBeHidden.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeHidden.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toBeHidden.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -937,6 +961,9 @@ element should intersect viewport at any positive ratio. Defaults to `0`.
 
 ### option: LocatorAssertions.toBeInViewport.timeout = %%-js-assertions-timeout-%%
 * since: v1.31
+
+### option: LocatorAssertions.toBeInViewport.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toBeInViewport.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.31
@@ -1033,6 +1060,9 @@ await Expect(
 
 ### option: LocatorAssertions.toBeVisible.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toBeVisible.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toBeVisible.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1134,6 +1164,9 @@ A string containing expected class names, separated by spaces, or a list of such
 
 ### option: LocatorAssertions.toContainClass.timeout = %%-js-assertions-timeout-%%
 * since: v1.52
+
+### option: LocatorAssertions.toContainClass.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toContainClass.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.52
@@ -1311,6 +1344,9 @@ Whether to use `element.innerText` instead of `element.textContent` when retriev
 ### option: LocatorAssertions.toContainText.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toContainText.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toContainText.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1357,6 +1393,9 @@ Expected accessible description.
 
 ### option: LocatorAssertions.toHaveAccessibleDescription.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveAccessibleDescription.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveAccessibleDescription.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -1408,6 +1447,9 @@ Expected accessible error message.
 ### option: LocatorAssertions.toHaveAccessibleErrorMessage.timeout = %%-js-assertions-timeout-%%
 * since: v1.50
 
+### option: LocatorAssertions.toHaveAccessibleErrorMessage.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveAccessibleErrorMessage.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.50
 
@@ -1457,6 +1499,9 @@ Expected accessible name.
 
 ### option: LocatorAssertions.toHaveAccessibleName.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveAccessibleName.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveAccessibleName.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -1517,6 +1562,9 @@ Expected attribute value.
 ### option: LocatorAssertions.toHaveAttribute.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveAttribute.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveAttribute.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1545,6 +1593,9 @@ Attribute name.
 
 ### option: LocatorAssertions.toHaveAttribute#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.39
+
+### option: LocatorAssertions.toHaveAttribute#2.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ## async method: LocatorAssertions.toHaveClass
 * since: v1.20
@@ -1646,6 +1697,9 @@ Expected class or RegExp or a list of those.
 ### option: LocatorAssertions.toHaveClass.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveClass.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveClass.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1694,6 +1748,9 @@ Expected count.
 
 ### option: LocatorAssertions.toHaveCount.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveCount.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveCount.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1756,6 +1813,9 @@ Pseudo-element to read computed styles from.
 ### option: LocatorAssertions.toHaveCSS.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveCSS.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveCSS.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1804,6 +1864,9 @@ Element id.
 
 ### option: LocatorAssertions.toHaveId.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveId.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveId.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -1861,6 +1924,9 @@ Property value.
 ### option: LocatorAssertions.toHaveJSProperty.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveJSProperty.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveJSProperty.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -1906,6 +1972,9 @@ await Expect(locator).ToHaveRoleAsync(AriaRole.Button);
 
 ### option: LocatorAssertions.toHaveRole.timeout = %%-js-assertions-timeout-%%
 * since: v1.44
+
+### option: LocatorAssertions.toHaveRole.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveRole.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.44
@@ -2188,6 +2257,9 @@ Whether to use `element.innerText` instead of `element.textContent` when retriev
 ### option: LocatorAssertions.toHaveText.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: LocatorAssertions.toHaveText.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveText.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -2238,6 +2310,9 @@ Expected value.
 
 ### option: LocatorAssertions.toHaveValue.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: LocatorAssertions.toHaveValue.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toHaveValue.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
@@ -2320,6 +2395,9 @@ Expected options currently selected.
 ### option: LocatorAssertions.toHaveValues.timeout = %%-js-assertions-timeout-%%
 * since: v1.23
 
+### option: LocatorAssertions.toHaveValues.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toHaveValues.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.23
 
@@ -2380,6 +2458,9 @@ assertThat(page.locator("body")).matchesAriaSnapshot("""
 ### option: LocatorAssertions.toMatchAriaSnapshot.timeout = %%-js-assertions-timeout-%%
 * since: v1.49
 
+### option: LocatorAssertions.toMatchAriaSnapshot.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: LocatorAssertions.toMatchAriaSnapshot.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.49
 
@@ -2408,6 +2489,9 @@ Generates sequential names if not specified.
 
 ### option: LocatorAssertions.toMatchAriaSnapshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.50
+
+### option: LocatorAssertions.toMatchAriaSnapshot#2.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: LocatorAssertions.toMatchAriaSnapshot#2.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.50

--- a/docs/src/api/class-pageassertions.md
+++ b/docs/src/api/class-pageassertions.md
@@ -183,6 +183,9 @@ assertThat(page).matchesAriaSnapshot("""
 ### option: PageAssertions.toMatchAriaSnapshot.timeout = %%-js-assertions-timeout-%%
 * since: v1.60
 
+### option: PageAssertions.toMatchAriaSnapshot.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: PageAssertions.toMatchAriaSnapshot.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.60
 
@@ -224,6 +227,9 @@ Generates sequential names if not specified.
 
 ### option: PageAssertions.toMatchAriaSnapshot#2.timeout = %%-js-assertions-timeout-%%
 * since: v1.60
+
+### option: PageAssertions.toMatchAriaSnapshot#2.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ## async method: PageAssertions.toHaveScreenshot#1
 * since: v1.23
@@ -385,6 +391,9 @@ Expected title or RegExp.
 ### option: PageAssertions.toHaveTitle.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
 
+### option: PageAssertions.toHaveTitle.signal = %%-js-assertions-signal-%%
+* since: v1.62
+
 ### option: PageAssertions.toHaveTitle.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18
 
@@ -462,6 +471,9 @@ Whether to perform case-insensitive match. [`option: ignoreCase`] option takes p
 
 ### option: PageAssertions.toHaveURL.timeout = %%-js-assertions-timeout-%%
 * since: v1.18
+
+### option: PageAssertions.toHaveURL.signal = %%-js-assertions-signal-%%
+* since: v1.62
 
 ### option: PageAssertions.toHaveURL.timeout = %%-csharp-java-python-assertions-timeout-%%
 * since: v1.18

--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1028,6 +1028,16 @@ using the [`method: AndroidDevice.setDefaultTimeout`] method.
 
 Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
 
+## js-assertions-signal
+* langs: js
+* since: v1.62
+- `signal` <[AbortSignal]>
+
+An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that
+can cancel the assertion. Aborting the signal fails the assertion like a timeout: if the signal
+is aborted while the assertion is retrying, or is already aborted before the assertion starts,
+the assertion fails without retrying further.
+
 ## csharp-java-python-assertions-timeout
 * langs: java, python, csharp
 - `timeout` <[float]>

--- a/packages/isomorphic/abortSignal.ts
+++ b/packages/isomorphic/abortSignal.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function assertionAbortedMessage(reason: unknown): string {
+  const detail = reason instanceof Error ? reason.message : reason === undefined || reason === null ? '' : String(reason);
+  return 'The assertion was aborted' + (detail ? `: ${detail}` : '');
+}

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -24,7 +24,7 @@ import { EventEmitter } from './eventEmitter';
 import { ChannelOwner } from './channelOwner';
 import { addSourceUrlToScript } from './clientHelper';
 import { ElementHandle, convertInputFiles, convertSelectOptionValues } from './elementHandle';
-import { PlaywrightError } from './errors';
+import { AbortError, PlaywrightError } from './errors';
 import { Events } from './events';
 import { JSHandle, assertMaxArguments, parseResult, serializeArgument } from './jsHandle';
 import { FrameLocator, Locator, testIdAttributeName } from './locator';
@@ -41,6 +41,8 @@ import type * as api from '../../types/types';
 import type { ByRoleOptions } from '@isomorphic/locatorUtils';
 import type { URLMatch } from '@isomorphic/urlMatch';
 import type * as channels from './channels';
+
+const kAbortErrorMessage = 'Error: The assertion was aborted';
 
 export type WaitForNavigationOptions = {
   timeout?: number,
@@ -500,6 +502,8 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
       await this._channel.expect(params, signal);
       return { matches: !params.isNot };
     } catch (e) {
+      if (e instanceof AbortError)
+        return { matches: !!params.isNot, errorMessage: kAbortErrorMessage };
       if (!(e instanceof PlaywrightError))
         throw e;
       const details = e.details as channels.FrameExpectErrorDetails;

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -17,6 +17,7 @@
 
 import fs from 'fs';
 
+import { assertionAbortedMessage } from '@isomorphic/abortSignal';
 import { assert } from '@isomorphic/assert';
 import { getByAltTextSelector, getByLabelSelector, getByPlaceholderSelector, getByRoleSelector, getByTestIdSelector, getByTextSelector, getByTitleSelector } from '@isomorphic/locatorUtils';
 import { urlMatches } from '@isomorphic/urlMatch';
@@ -41,8 +42,6 @@ import type * as api from '../../types/types';
 import type { ByRoleOptions } from '@isomorphic/locatorUtils';
 import type { URLMatch } from '@isomorphic/urlMatch';
 import type * as channels from './channels';
-
-const kAbortErrorMessage = 'Error: The assertion was aborted';
 
 export type WaitForNavigationOptions = {
   timeout?: number,
@@ -175,15 +174,19 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     state = verifyLoadState('state', state);
     return await this._page!._wrapApiCall(async () => {
       const waiter = this._setupNavigationWaiter(options ?? {});
-      if (this._loadStates.has(state)) {
-        waiter.log(`  not waiting, "${state}" event already fired`);
-      } else {
-        await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
-          waiter.log(`  "${s}" event fired`);
-          return s === state;
-        });
+      try {
+        if (this._loadStates.has(state)) {
+          waiter.log(`  not waiting, "${state}" event already fired`);
+          waiter.throwIfImmediatelyRejected();
+        } else {
+          await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
+            waiter.log(`  "${s}" event fired`);
+            return s === state;
+          });
+        }
+      } finally {
+        waiter.dispose();
       }
-      waiter.dispose();
     }, { title: `Wait for load state "${state}"` });
   }
 
@@ -503,7 +506,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
       return { matches: !params.isNot };
     } catch (e) {
       if (e instanceof AbortError)
-        return { matches: !!params.isNot, errorMessage: kAbortErrorMessage };
+        return { matches: !!params.isNot, errorMessage: 'Error: ' + assertionAbortedMessage(e.cause) };
       if (!(e instanceof PlaywrightError))
         throw e;
       const details = e.details as channels.FrameExpectErrorDetails;

--- a/packages/playwright-core/src/client/waiter.ts
+++ b/packages/playwright-core/src/client/waiter.ts
@@ -16,7 +16,7 @@
 
 import { rewriteErrorMessage } from '@isomorphic/stackTrace';
 import { currentZone } from '@utils/zones';
-import { TimeoutError } from './errors';
+import { AbortError, TimeoutError } from './errors';
 
 import type { ChannelOwner } from './channelOwner';
 import type * as channels from './channels';
@@ -90,18 +90,23 @@ export class Waiter {
     if (!signal)
       return;
     if (signal.aborted) {
-      this.rejectImmediately(signalToError(signal));
+      this.rejectImmediately(new AbortError(undefined, { cause: signal.reason }));
       return;
     }
     let rejectPromise: (e: any) => void;
     const promise = new Promise<void>((_, reject) => { rejectPromise = reject; });
-    const listener = () => rejectPromise!(signalToError(signal));
+    const listener = () => rejectPromise!(new AbortError(undefined, { cause: signal.reason }));
     signal.addEventListener('abort', listener, { once: true });
     this._rejectOn(promise, () => signal.removeEventListener('abort', listener));
   }
 
   rejectImmediately(error: Error) {
     this._immediateError = error;
+  }
+
+  throwIfImmediatelyRejected() {
+    if (this._immediateError)
+      throw this._immediateError;
   }
 
   dispose() {
@@ -159,14 +164,6 @@ function waitForEvent<T = void>(emitter: EventEmitter, event: string, savedZone:
   });
   const dispose = () => emitter.removeListener(event, listener);
   return { promise, dispose };
-}
-
-function signalToError(signal: AbortSignal): Error {
-  const reason = signal.reason;
-  if (reason instanceof Error)
-    return reason;
-  const message = typeof reason?.message === 'string' ? reason.message : reason;
-  return new Error(String(message ?? 'The operation was aborted'));
 }
 
 function waitForTimeout(timeout: number): { promise: Promise<void>, dispose: () => void } {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -28,7 +28,7 @@ import { makeWaitForNextTask } from '@utils/task';
 import { createGuid } from '@utils/crypto';
 import { BrowserContext } from './browserContext';
 import * as dom from './dom';
-import { TimeoutError, isTargetClosedError } from './errors';
+import { TimeoutError, AbortError, isTargetClosedError } from './errors';
 import { prepareFilesForUpload } from './fileUploadUtils';
 import { FrameSelectors } from './frameSelectors';
 import { helper } from './helper';
@@ -1560,6 +1560,8 @@ export class Frame extends SdkObject<FrameEventMap> {
         progress.log(e.message);
       if (e instanceof TimeoutError)
         details.timedOut = true;
+      if (e instanceof AbortError)
+        details.customErrorMessage = 'The assertion was aborted';
       throw new ExpectError(details);
     }
   }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -16,6 +16,7 @@
  */
 
 import yaml from 'yaml';
+import { assertionAbortedMessage } from '@isomorphic/abortSignal';
 import { parseAriaSnapshotUnsafe } from '@isomorphic/ariaSnapshot';
 import { isInvalidSelectorError } from '@isomorphic/selectorParser';
 import { ManualPromise } from '@isomorphic/manualPromise';
@@ -1561,7 +1562,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       if (e instanceof TimeoutError)
         details.timedOut = true;
       if (e instanceof AbortError)
-        details.customErrorMessage = 'The assertion was aborted';
+        details.customErrorMessage = assertionAbortedMessage(e.cause);
       throw new ExpectError(details);
     }
   }

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -80,20 +80,20 @@ interface APIResponseEx extends APIResponse {
 export function toBeAttached(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { attached?: boolean, timeout?: number },
+  options?: { attached?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const attached = !options || options.attached === undefined || options.attached;
   const expected = attached ? 'attached' : 'detached';
   const arg = attached ? '' : '{ attached: false }';
-  return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeChecked(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { checked?: boolean, indeterminate?: boolean, timeout?: number },
+  options?: { checked?: boolean, indeterminate?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const checked = options?.checked;
   const indeterminate = options?.indeterminate;
@@ -110,97 +110,97 @@ export function toBeChecked(
     expected = options?.checked === false ? 'unchecked' : 'checked';
     arg = options?.checked === false ? `{ checked: false }` : '';
   }
-  return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue }, undefined);
+  return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue }, signal);
   }, options);
 }
 
 export function toBeDisabled(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.disabled', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.disabled', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeEditable(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { editable?: boolean, timeout?: number },
+  options?: { editable?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const editable = !options || options.editable === undefined || options.editable;
   const expected = editable ? 'editable' : 'readOnly';
   const arg = editable ? '' : '{ editable: false }';
-  return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeEmpty(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.empty', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.empty', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeEnabled(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { enabled?: boolean, timeout?: number },
+  options?: { enabled?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const enabled = !options || options.enabled === undefined || options.enabled;
   const expected = enabled ? 'enabled' : 'disabled';
   const arg = enabled ? '' : '{ enabled: false }';
-  return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeFocused(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.focused', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.focused', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeHidden(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.hidden', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.hidden', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeVisible(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { visible?: boolean, timeout?: number },
+  options?: { visible?: boolean, timeout?: number, signal?: AbortSignal },
 ) {
   const visible = !options || options.visible === undefined || options.visible;
   const expected = visible ? 'visible' : 'hidden';
   const arg = visible ? '' : '{ visible: false }';
-  return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout) => {
-    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
+    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout }, signal);
   }, options);
 }
 
 export function toBeInViewport(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
-  options?: { timeout?: number, ratio?: number },
+  options?: { timeout?: number, ratio?: number, signal?: AbortSignal },
 ) {
-  return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout) => {
-    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout }, undefined);
+  return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout, signal) => {
+    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout }, signal);
   }, options);
 }
 
@@ -208,17 +208,17 @@ export function toContainText(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, signal?: AbortSignal } = {},
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, undefined);
+      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, signal);
     }, expected, { ...options, contains: true });
   } else {
-    return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, undefined);
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, signal);
     }, expected, { ...options, matchSubstring: true });
   }
 }
@@ -227,11 +227,11 @@ export function toHaveAccessibleDescription(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -239,11 +239,11 @@ export function toHaveAccessibleName(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -251,11 +251,11 @@ export function toHaveAccessibleErrorMessage(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number; ignoreCase?: boolean },
+  options?: { timeout?: number; ignoreCase?: boolean, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -264,7 +264,7 @@ export function toHaveAttribute(
   locator: LocatorEx,
   name: string,
   expected: string | RegExp | undefined | { timeout?: number },
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
   if (!options) {
     // Update params for the case toHaveAttribute(name, options);
@@ -274,13 +274,13 @@ export function toHaveAttribute(
     }
   }
   if (expected === undefined) {
-    return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout) => {
-      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout }, undefined);
+    return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout, signal) => {
+      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout }, signal);
     }, options);
   }
-  return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected as (string | RegExp)], { ignoreCase: options?.ignoreCase });
-    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout }, signal);
   }, expected as (string | RegExp), options);
 }
 
@@ -288,17 +288,17 @@ export function toHaveClass(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout }, undefined);
+      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout }, signal);
     }, expected, options);
   } else {
-    return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.have.class', { expectedText, isNot, timeout }, undefined);
+      return await locator._expect('to.have.class', { expectedText, isNot, timeout }, signal);
     }, expected, options);
   }
 }
@@ -307,21 +307,21 @@ export function toContainClass(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | string[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
   if (Array.isArray(expected)) {
     if (expected.some(e => isRegExp(e)))
       throw new Error(`"expected" argument in toContainClass cannot contain RegExp values`);
-    return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout }, undefined);
+      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout }, signal);
     }, expected, options);
   } else {
     if (isRegExp(expected))
       throw new Error(`"expected" argument in toContainClass cannot be a RegExp value`);
-    return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.contain.class', { expectedText, isNot, timeout }, undefined);
+      return await locator._expect('to.contain.class', { expectedText, isNot, timeout }, signal);
     }, expected, options);
   }
 }
@@ -330,24 +330,24 @@ export function toHaveCount(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: number,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout) => {
-    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout }, undefined);
+  return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout, signal) => {
+    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout }, signal);
   }, expected, options);
 }
 
-export function toHaveCSS(this: ExpectMatcherStateInternal, locator: LocatorEx, name: string, expected: string | RegExp, options?: { timeout?: number, pseudo?: 'before' | 'after' }): Promise<MatcherResult<any, any>>;
+export function toHaveCSS(this: ExpectMatcherStateInternal, locator: LocatorEx, name: string, expected: string | RegExp, options?: { timeout?: number, pseudo?: 'before' | 'after', signal?: AbortSignal }): Promise<MatcherResult<any, any>>;
 export function toHaveCSS(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   name: string,
   expected: string | RegExp,
-  options?: { timeout?: number, pseudo?: 'before' | 'after' },
+  options?: { timeout?: number, pseudo?: 'before' | 'after', signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout }, undefined);
+    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout }, signal);
   }, expected, options);
 }
 
@@ -355,11 +355,11 @@ export function toHaveId(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.id', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.id', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -368,10 +368,10 @@ export function toHaveJSProperty(
   locator: LocatorEx,
   name: string,
   expected: any,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout) => {
-    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout }, undefined);
+  return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout, signal) => {
+    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -379,13 +379,13 @@ export function toHaveRole(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string,
-  options?: { timeout?: number, ignoreCase?: boolean },
+  options?: { timeout?: number, ignoreCase?: boolean, signal?: AbortSignal },
 ) {
   if (!isString(expected))
     throw new Error(`"role" argument in toHaveRole must be a string`);
-  return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.role', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.role', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -393,17 +393,17 @@ export function toHaveText(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean } = {},
+  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, signal?: AbortSignal } = {},
 ) {
   if (Array.isArray(expected)) {
-    return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout) => {
+    return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, undefined);
+      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, signal);
     }, expected, options);
   } else {
-    return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout) => {
+    return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, undefined);
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, signal);
     }, expected, options);
   }
 }
@@ -412,11 +412,11 @@ export function toHaveValue(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp,
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.value', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.value', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -424,11 +424,11 @@ export function toHaveValues(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: (string | RegExp)[],
-  options?: { timeout?: number },
+  options?: { timeout?: number, signal?: AbortSignal },
 ) {
-  return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout) => {
+  return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues(expected);
-    return await locator._expect('to.have.values', { expectedText, isNot, timeout }, undefined);
+    return await locator._expect('to.have.values', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -436,11 +436,11 @@ export function toHaveTitle(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: string | RegExp,
-  options: { timeout?: number } = {},
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ) {
-  return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout }, undefined);
+    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 
@@ -448,7 +448,7 @@ export function toHaveURL(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: string | RegExp | URLPattern | ((url: URL) => boolean),
-  options?: { ignoreCase?: boolean; timeout?: number },
+  options?: { ignoreCase?: boolean; timeout?: number, signal?: AbortSignal },
 ) {
   if (isURLPattern(expected))
     return toHaveURLWithPredicate.call(this, page, url => (expected as URLPattern).test(url.href), options);
@@ -459,9 +459,9 @@ export function toHaveURL(
 
   const baseURL = (page.context() as any)._options.baseURL;
   expected = typeof expected === 'string' ? constructURLBasedOnBaseURL(baseURL, expected) : expected;
-  return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout) => {
+  return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout }, undefined);
+    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout }, signal);
   }, expected, options);
 }
 

--- a/packages/playwright/src/matchers/toBeTruthy.ts
+++ b/packages/playwright/src/matchers/toBeTruthy.ts
@@ -28,14 +28,14 @@ export async function toBeTruthy(
   receiverType: 'Locator',
   expected: string,
   arg: string,
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
-  options: { timeout?: number } = {},
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<any, any>> {
   expectTypes(locator, [receiverType], matcherName);
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, log, timedOut, received, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, log, timedOut, received, errorMessage } = await query(!!this.isNot, timeout, options.signal);
   const receivedValue = received?.value;
 
   if (pass === !this.isNot) {

--- a/packages/playwright/src/matchers/toEqual.ts
+++ b/packages/playwright/src/matchers/toEqual.ts
@@ -32,15 +32,15 @@ export async function toEqual<T>(
   matcherName: string,
   locator: Locator,
   receiverType: 'Locator',
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
   expected: T,
-  options: { timeout?: number, contains?: boolean } = {},
+  options: { timeout?: number, contains?: boolean, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<any, any>> {
   expectTypes(locator, [receiverType], matcherName);
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout, options.signal);
   const receivedValue = received?.value;
 
   if (pass === !this.isNot) {

--- a/packages/playwright/src/matchers/toHaveURL.ts
+++ b/packages/playwright/src/matchers/toHaveURL.ts
@@ -22,47 +22,71 @@ import type { MatcherResult } from './matcherHint';
 import type { Page } from 'playwright-core';
 import type { ExpectMatcherStateInternal } from './matchers';
 
+// Mirrors kAbortErrorMessage in playwright-core's client/frame.ts (separate package, so duplicated).
+const kAbortErrorMessage = 'Error: The assertion was aborted';
+
 export async function toHaveURLWithPredicate(
   this: ExpectMatcherStateInternal,
   page: Page,
   expected: (url: URL) => boolean,
-  options?: { ignoreCase?: boolean; timeout?: number },
+  options?: { ignoreCase?: boolean; timeout?: number, signal?: AbortSignal },
 ): Promise<MatcherResult<string | RegExp, string>> {
   const matcherName = 'toHaveURL';
   const timeout = options?.timeout ?? this.timeout;
   const baseURL: string | undefined = (page.context() as any)._options.baseURL;
   let conditionSucceeded = false;
   let lastCheckedURLString: string | undefined = undefined;
-  try {
-    await page.mainFrame().waitForURL(
-        url => {
-          lastCheckedURLString = url.toString();
+  // An already-aborted signal fails the assertion (like a timeout) without attempting a check.
+  if (!options?.signal?.aborted) {
+    try {
+      await page.mainFrame().waitForURL(
+          url => {
+            lastCheckedURLString = url.toString();
 
-          if (options?.ignoreCase) {
+            if (options?.ignoreCase) {
+              return (
+                !this.isNot ===
+                urlMatches(
+                    baseURL?.toLocaleLowerCase(),
+                    lastCheckedURLString.toLocaleLowerCase(),
+                    expected,
+                )
+              );
+            }
+
             return (
-              !this.isNot ===
-              urlMatches(
-                  baseURL?.toLocaleLowerCase(),
-                  lastCheckedURLString.toLocaleLowerCase(),
-                  expected,
-              )
+              !this.isNot === urlMatches(baseURL, lastCheckedURLString, expected)
             );
-          }
+          },
+          { timeout, signal: options?.signal },
+      );
 
-          return (
-            !this.isNot === urlMatches(baseURL, lastCheckedURLString, expected)
-          );
-        },
-        { timeout },
-    );
-
-    conditionSucceeded = true;
-  } catch (e) {
-    conditionSucceeded = false;
+      conditionSucceeded = true;
+    } catch (e) {
+      conditionSucceeded = false;
+    }
   }
 
   if (conditionSucceeded)
     return { name: matcherName, pass: !this.isNot, message: () => '' };
+
+  if (options?.signal?.aborted) {
+    return {
+      name: matcherName,
+      pass: this.isNot,
+      message: () => formatMatcherMessage(this.utils, {
+        isNot: this.isNot,
+        promise: this.promise,
+        matcherName,
+        expectation: 'expected',
+        timeout,
+        printedExpected: `Expected: predicate to ${!this.isNot ? 'succeed' : 'fail'}`,
+        errorMessage: kAbortErrorMessage,
+      }),
+      actual: lastCheckedURLString,
+      timeout,
+    };
+  }
 
   return {
     name: matcherName,

--- a/packages/playwright/src/matchers/toHaveURL.ts
+++ b/packages/playwright/src/matchers/toHaveURL.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { assertionAbortedMessage } from '@isomorphic/abortSignal';
 import { urlMatches } from '@isomorphic/urlMatch';
 
 import { formatMatcherMessage, printReceivedStringContainExpectedResult } from './matcherHint';
@@ -21,9 +22,6 @@ import { formatMatcherMessage, printReceivedStringContainExpectedResult } from '
 import type { MatcherResult } from './matcherHint';
 import type { Page } from 'playwright-core';
 import type { ExpectMatcherStateInternal } from './matchers';
-
-// Mirrors kAbortErrorMessage in playwright-core's client/frame.ts (separate package, so duplicated).
-const kAbortErrorMessage = 'Error: The assertion was aborted';
 
 export async function toHaveURLWithPredicate(
   this: ExpectMatcherStateInternal,
@@ -34,76 +32,67 @@ export async function toHaveURLWithPredicate(
   const matcherName = 'toHaveURL';
   const timeout = options?.timeout ?? this.timeout;
   const baseURL: string | undefined = (page.context() as any)._options.baseURL;
-  let conditionSucceeded = false;
   let lastCheckedURLString: string | undefined = undefined;
-  // An already-aborted signal fails the assertion (like a timeout) without attempting a check.
-  if (!options?.signal?.aborted) {
-    try {
-      await page.mainFrame().waitForURL(
-          url => {
-            lastCheckedURLString = url.toString();
+  try {
+    await page.mainFrame().waitForURL(
+        url => {
+          lastCheckedURLString = url.toString();
 
-            if (options?.ignoreCase) {
-              return (
-                !this.isNot ===
-                urlMatches(
-                    baseURL?.toLocaleLowerCase(),
-                    lastCheckedURLString.toLocaleLowerCase(),
-                    expected,
-                )
-              );
-            }
-
+          if (options?.ignoreCase) {
             return (
-              !this.isNot === urlMatches(baseURL, lastCheckedURLString, expected)
+              !this.isNot ===
+              urlMatches(
+                  baseURL?.toLocaleLowerCase(),
+                  lastCheckedURLString.toLocaleLowerCase(),
+                  expected,
+              )
             );
-          },
-          { timeout, signal: options?.signal },
-      );
+          }
 
-      conditionSucceeded = true;
-    } catch (e) {
-      conditionSucceeded = false;
-    }
-  }
+          return (
+            !this.isNot === urlMatches(baseURL, lastCheckedURLString, expected)
+          );
+        },
+        { timeout, signal: options?.signal },
+    );
 
-  if (conditionSucceeded)
     return { name: matcherName, pass: !this.isNot, message: () => '' };
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      return {
+        name: matcherName,
+        pass: this.isNot,
+        message: () => formatMatcherMessage(this.utils, {
+          isNot: this.isNot,
+          promise: this.promise,
+          matcherName,
+          expectation: 'expected',
+          timeout,
+          printedExpected: `Expected: predicate to ${!this.isNot ? 'succeed' : 'fail'}`,
+          errorMessage: 'Error: ' + assertionAbortedMessage(e.cause),
+        }),
+        actual: lastCheckedURLString,
+        timeout,
+      };
+    }
 
-  if (options?.signal?.aborted) {
     return {
       name: matcherName,
       pass: this.isNot,
-      message: () => formatMatcherMessage(this.utils, {
-        isNot: this.isNot,
-        promise: this.promise,
-        matcherName,
-        expectation: 'expected',
-        timeout,
-        printedExpected: `Expected: predicate to ${!this.isNot ? 'succeed' : 'fail'}`,
-        errorMessage: kAbortErrorMessage,
-      }),
+      message: () =>
+        toHaveURLMessage(
+            this,
+            matcherName,
+            expected,
+            lastCheckedURLString,
+            this.isNot,
+            true,
+            timeout,
+        ),
       actual: lastCheckedURLString,
       timeout,
     };
   }
-
-  return {
-    name: matcherName,
-    pass: this.isNot,
-    message: () =>
-      toHaveURLMessage(
-          this,
-          matcherName,
-          expected,
-          lastCheckedURLString,
-          this.isNot,
-          true,
-          timeout,
-      ),
-    actual: lastCheckedURLString,
-    timeout,
-  };
 }
 
 function toHaveURLMessage(

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -42,7 +42,7 @@ export async function toMatchAriaSnapshot(
   this: ExpectMatcherStateInternal,
   receiver: LocatorEx | Page,
   expectedParam?: ToMatchAriaSnapshotExpected,
-  options: { timeout?: number } = {},
+  options: { timeout?: number, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<string | RegExp, string>> {
   const matcherName = 'toMatchAriaSnapshot';
   expectTypes(receiver, ['Page', 'Locator'], matcherName);
@@ -93,8 +93,8 @@ export async function toMatchAriaSnapshot(
 
   const expectParams = { expectedValue: expected, isNot: this.isNot, timeout };
   const { matches: pass, received, log, timedOut, errorMessage } = locator ?
-    await (locator as LocatorEx)._expect('to.match.aria', expectParams, undefined) :
-    await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams, undefined);
+    await (locator as LocatorEx)._expect('to.match.aria', expectParams, options.signal) :
+    await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams, options.signal);
   const typedReceived = received?.value as MatcherReceived;
 
   const message = () => {

--- a/packages/playwright/src/matchers/toMatchText.ts
+++ b/packages/playwright/src/matchers/toMatchText.ts
@@ -26,9 +26,9 @@ export async function toMatchText(
   matcherName: string,
   receiver: Locator | Page,
   receiverType: 'Locator' | 'Page',
-  query: (isNot: boolean, timeout: number) => Promise<ExpectResult>,
+  query: (isNot: boolean, timeout: number, signal?: AbortSignal) => Promise<ExpectResult>,
   expected: string | RegExp,
-  options: { timeout?: number, matchSubstring?: boolean } = {},
+  options: { timeout?: number, matchSubstring?: boolean, signal?: AbortSignal } = {},
 ): Promise<MatcherResult<string | RegExp, string>> {
   expectTypes(receiver, [receiverType], matcherName);
   const locator = receiverType === 'Locator' ? receiver as Locator : undefined;
@@ -43,7 +43,7 @@ export async function toMatchText(
 
   const timeout = options.timeout ?? this.timeout;
 
-  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout);
+  const { matches: pass, received, log, timedOut, errorMessage } = await query(!!this.isNot, timeout, options.signal);
 
   if (pass === !this.isNot) {
     return {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -8749,6 +8749,13 @@ interface LocatorAssertions {
     attached?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8783,6 +8790,13 @@ interface LocatorAssertions {
     indeterminate?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8806,6 +8820,13 @@ interface LocatorAssertions {
    */
   toBeDisabled(options?: {
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8825,6 +8846,13 @@ interface LocatorAssertions {
    */
   toBeEditable(options?: {
     editable?: boolean;
+
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -8847,6 +8875,13 @@ interface LocatorAssertions {
    */
   toBeEmpty(options?: {
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8868,6 +8903,13 @@ interface LocatorAssertions {
     enabled?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -8886,6 +8928,13 @@ interface LocatorAssertions {
    * @param options
    */
   toBeFocused(options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -8906,6 +8955,13 @@ interface LocatorAssertions {
    * @param options
    */
   toBeHidden(options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -8937,6 +8993,13 @@ interface LocatorAssertions {
      * any positive ratio. Defaults to `0`.
      */
     ratio?: number;
+
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -8971,6 +9034,13 @@ interface LocatorAssertions {
    * @param options
    */
   toBeVisible(options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9018,6 +9088,13 @@ interface LocatorAssertions {
    * @param options
    */
   toContainClass(expected: string|ReadonlyArray<string>, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9086,6 +9163,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9119,6 +9203,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9145,6 +9236,13 @@ interface LocatorAssertions {
      * option takes precedence over the corresponding regular expression flag if specified.
      */
     ignoreCase?: boolean;
+
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -9175,6 +9273,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9203,6 +9308,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9223,6 +9335,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveAttribute(name: string, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9260,6 +9379,13 @@ interface LocatorAssertions {
    */
   toHaveClass(expected: string|RegExp|ReadonlyArray<string|RegExp>, options?: {
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9279,6 +9405,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveCount(count: number, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9307,6 +9440,13 @@ interface LocatorAssertions {
     pseudo?: "before"|"after";
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9327,6 +9467,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveId(id: string|RegExp, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9349,6 +9496,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveJSProperty(name: string, value: any, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9373,6 +9527,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveRole(role: "alert"|"alertdialog"|"application"|"article"|"banner"|"blockquote"|"button"|"caption"|"cell"|"checkbox"|"code"|"columnheader"|"combobox"|"complementary"|"contentinfo"|"definition"|"deletion"|"dialog"|"directory"|"document"|"emphasis"|"feed"|"figure"|"form"|"generic"|"grid"|"gridcell"|"group"|"heading"|"img"|"insertion"|"link"|"list"|"listbox"|"listitem"|"log"|"main"|"marquee"|"math"|"meter"|"menu"|"menubar"|"menuitem"|"menuitemcheckbox"|"menuitemradio"|"navigation"|"none"|"note"|"option"|"paragraph"|"presentation"|"progressbar"|"radio"|"radiogroup"|"region"|"row"|"rowgroup"|"rowheader"|"scrollbar"|"search"|"searchbox"|"separator"|"slider"|"spinbutton"|"status"|"strong"|"subscript"|"superscript"|"switch"|"tab"|"table"|"tablist"|"tabpanel"|"term"|"textbox"|"time"|"timer"|"toolbar"|"tooltip"|"tree"|"treegrid"|"treeitem", options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9627,6 +9788,13 @@ interface LocatorAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9652,6 +9820,13 @@ interface LocatorAssertions {
    * @param options
    */
   toHaveValue(value: string|RegExp, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9685,6 +9860,13 @@ interface LocatorAssertions {
    */
   toHaveValues(values: ReadonlyArray<string|RegExp>, options?: {
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9707,6 +9889,13 @@ interface LocatorAssertions {
    * @param options
    */
   toMatchAriaSnapshot(expected: string, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9734,6 +9923,13 @@ interface LocatorAssertions {
      * specified.
      */
     name?: string;
+
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
@@ -9817,6 +10013,13 @@ interface PageAssertions {
    */
   toHaveTitle(titleOrRegExp: string|RegExp, options?: {
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9862,6 +10065,13 @@ interface PageAssertions {
     ignoreCase?: boolean;
 
     /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
+    /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
     timeout?: number;
@@ -9884,6 +10094,13 @@ interface PageAssertions {
    * @param options
    */
   toMatchAriaSnapshot(expected: string, options?: {
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
+
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.
      */
@@ -9911,6 +10128,13 @@ interface PageAssertions {
      * specified.
      */
     name?: string;
+
+    /**
+     * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the
+     * assertion. Aborting the signal fails the assertion like a timeout: if the signal is aborted while the assertion is
+     * retrying, or is already aborted before the assertion starts, the assertion fails without retrying further.
+     */
+    signal?: AbortSignal;
 
     /**
      * Time to retry the assertion for in milliseconds. Defaults to `timeout` in `TestConfig.expect`.

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -120,3 +120,91 @@ test('should not miss element that appears between retries before the deadline',
   });
   await expect(page.locator('#target')).toBeVisible({ timeout: 1800 });
 });
+
+test('should fail like a timeout when the signal is aborted mid-assertion', async ({ page }) => {
+  await page.setContent('<div>content</div>');
+  const controller = new AbortController();
+  const promise = expect(page.locator('span')).toBeVisible({ timeout: 5000, signal: controller.signal }).catch(e => e);
+  await page.waitForTimeout(500);
+  controller.abort(new Error('stop it'));
+  const error = await promise;
+  expect(error.name).not.toBe('AbortError');
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toBeVisible() failed
+
+Locator: locator('span')
+Expected: visible
+Error: The assertion was aborted
+
+Call log:
+  - Expect "toBeVisible" with timeout 5000ms
+  - waiting for locator('span')`);
+});
+
+test('should fail like a timeout when toHaveText is aborted mid-assertion', async ({ page }) => {
+  await page.setContent('<div>content</div>');
+  const controller = new AbortController();
+  const promise = expect(page.locator('span')).toHaveText('missing', { timeout: 5000, signal: controller.signal }).catch(e => e);
+  await page.waitForTimeout(300);
+  controller.abort(new Error('stop it'));
+  const error = await promise;
+  expect(error.name).not.toBe('AbortError');
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveText(expected) failed`);
+});
+
+test('should fail like a timeout when toHaveCount is aborted mid-assertion', async ({ page }) => {
+  await page.setContent('<div>content</div>');
+  const controller = new AbortController();
+  const promise = expect(page.locator('span')).toHaveCount(3, { timeout: 5000, signal: controller.signal }).catch(e => e);
+  await page.waitForTimeout(300);
+  controller.abort(new Error('stop it'));
+  const error = await promise;
+  expect(error.name).not.toBe('AbortError');
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toHaveCount(expected) failed`);
+});
+
+test('should fail like a timeout when toMatchAriaSnapshot is aborted mid-assertion', async ({ page }) => {
+  await page.setContent('<div>content</div>');
+  const controller = new AbortController();
+  const promise = expect(page.locator('body')).toMatchAriaSnapshot(`- list`, { timeout: 5000, signal: controller.signal }).catch(e => e);
+  await page.waitForTimeout(300);
+  controller.abort(new Error('stop it'));
+  const error = await promise;
+  expect(error.name).not.toBe('AbortError');
+  expect(stripAnsi(error.message)).toContain(`expect(locator).toMatchAriaSnapshot(expected) failed`);
+});
+
+test('should fail like a timeout when toHaveURL is aborted mid-assertion', async ({ page }) => {
+  await page.setContent('<div>content</div>');
+  const controller = new AbortController();
+  const promise = expect(page).toHaveURL('https://example.com/', { timeout: 5000, signal: controller.signal }).catch(e => e);
+  await page.waitForTimeout(500);
+  controller.abort(new Error('stop it'));
+  const error = await promise;
+  expect(error.name).not.toBe('AbortError');
+  expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed`);
+});
+
+test('should fail the assertion when the signal is already aborted', async ({ page, server }) => {
+  await page.setContent('<div>content</div>');
+  {
+    const controller = new AbortController();
+    controller.abort(new Error('already aborted'));
+    const error = await expect(page.locator('div')).toBeVisible({ timeout: 5000, signal: controller.signal }).catch(e => e);
+    expect(error.name).not.toBe('AbortError');
+    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeVisible() failed
+
+Locator: locator('div')
+Expected: visible
+Error: The assertion was aborted`);
+  }
+  {
+    const controller = new AbortController();
+    controller.abort('stop it');
+    const error = await expect(page).toHaveURL(server.EMPTY_PAGE, { timeout: 5000, signal: controller.signal }).catch(e => e);
+    expect(error.name).not.toBe('AbortError');
+    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed
+
+Expected: ${JSON.stringify(server.EMPTY_PAGE)}
+Error: The assertion was aborted`);
+  }
+});

--- a/tests/page/expect-timeout.spec.ts
+++ b/tests/page/expect-timeout.spec.ts
@@ -133,7 +133,7 @@ test('should fail like a timeout when the signal is aborted mid-assertion', asyn
 
 Locator: locator('span')
 Expected: visible
-Error: The assertion was aborted
+Error: The assertion was aborted: stop it
 
 Call log:
   - Expect "toBeVisible" with timeout 5000ms
@@ -191,20 +191,22 @@ test('should fail the assertion when the signal is already aborted', async ({ pa
     controller.abort(new Error('already aborted'));
     const error = await expect(page.locator('div')).toBeVisible({ timeout: 5000, signal: controller.signal }).catch(e => e);
     expect(error.name).not.toBe('AbortError');
-    expect(stripAnsi(error.message)).toContain(`expect(locator).toBeVisible() failed
+    expect(stripAnsi(error.message)).toBe(`expect(locator).toBeVisible() failed
 
 Locator: locator('div')
 Expected: visible
-Error: The assertion was aborted`);
+Error: The assertion was aborted: already aborted
+`);
   }
   {
     const controller = new AbortController();
     controller.abort('stop it');
     const error = await expect(page).toHaveURL(server.EMPTY_PAGE, { timeout: 5000, signal: controller.signal }).catch(e => e);
     expect(error.name).not.toBe('AbortError');
-    expect(stripAnsi(error.message)).toContain(`expect(page).toHaveURL(expected) failed
+    expect(stripAnsi(error.message)).toBe(`expect(page).toHaveURL(expected) failed
 
 Expected: ${JSON.stringify(server.EMPTY_PAGE)}
-Error: The assertion was aborted`);
+Error: The assertion was aborted: stop it
+`);
   }
 });

--- a/tests/page/page-filechooser.spec.ts
+++ b/tests/page/page-filechooser.spec.ts
@@ -221,7 +221,9 @@ test('should abort with signal', async ({ page }) => {
   const controller = new AbortController();
   const promise = page.waitForEvent('filechooser', { signal: controller.signal });
   controller.abort('Aborted by user');
-  await expect(promise).rejects.toThrow('Aborted by user');
+  const error = await promise.catch(e => e);
+  expect(error.name).toBe('AbortError');
+  expect(error.cause).toBe('Aborted by user');
 });
 
 test('should return the same file chooser when there are many watchdogs simultaneously', async ({ page, server }) => {

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -79,23 +79,3 @@ test('testInfo should contain all soft expect errors', async ({ runInlineTest })
   expect(result.output).toContain('Error: two times two');
   expect(result.output).not.toContain('Error: must be exactly two errors');
 });
-
-test('soft assertion accumulates an aborted matcher as a failure', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'a.spec.ts': `
-      import { test, expect } from '@playwright/test';
-      test('should work', async ({ page }) => {
-        await page.setContent('<div>content</div>');
-        const controller = new AbortController();
-        const promise = expect.soft(page.locator('span')).toBeVisible({ timeout: 5000, signal: controller.signal });
-        await page.waitForTimeout(500);
-        controller.abort(new Error('stop it'));
-        await promise;
-        console.log('%% reached-after-soft');
-      });
-    `
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.outputLines).toContain('reached-after-soft');
-  expect(result.output).toContain('expect(locator).toBeVisible() failed');
-});

--- a/tests/playwright-test/expect-soft.spec.ts
+++ b/tests/playwright-test/expect-soft.spec.ts
@@ -79,3 +79,23 @@ test('testInfo should contain all soft expect errors', async ({ runInlineTest })
   expect(result.output).toContain('Error: two times two');
   expect(result.output).not.toContain('Error: must be exactly two errors');
 });
+
+test('soft assertion accumulates an aborted matcher as a failure', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('should work', async ({ page }) => {
+        await page.setContent('<div>content</div>');
+        const controller = new AbortController();
+        const promise = expect.soft(page.locator('span')).toBeVisible({ timeout: 5000, signal: controller.signal });
+        await page.waitForTimeout(500);
+        controller.abort(new Error('stop it'));
+        await promise;
+        console.log('%% reached-after-soft');
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.outputLines).toContain('reached-after-soft');
+  expect(result.output).toContain('expect(locator).toBeVisible() failed');
+});


### PR DESCRIPTION
Adds a `signal` option to web-first assertions, so a retrying assertion can be aborted from an `AbortController`:

```ts
const controller = new AbortController();
await expect(locator).toBeVisible({ signal: controller.signal });
```

Aborting fails the assertion like a timeout - whether it's aborted mid-retry, or already aborted before the assertion starts, it stops retrying and fails. The failure message mentions the abort rather than pretending it timed out.

A mid-assertion abort is reported by the server through the error details. An already-aborted signal never reaches the server - it short-circuits on the client.

Closes #40578
