### PR TITLE
feat(page): return recorded code from page.pause()

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2889,6 +2889,9 @@ Returns the opener for popup pages and `null` for others. If the opener has been
 
 ## async method: Page.pause
 * since: v1.9
+- returns: <[Object]>
+  - alias-csharp: PagePauseResult
+  - `output` ?<[string]> The code recorded during the pause.
 
 Pauses script execution. Playwright will stop executing the script and wait for the user to either press the 'Resume'
 button in the page overlay or to call `playwright.resume()` in the DevTools console.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -3932,7 +3932,12 @@ export interface Page {
    * [`headless`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-headless) option.
    *
    */
-  pause(): Promise<void>;
+  pause(): Promise<{
+    /**
+     * The code recorded during the pause.
+     */
+    output?: string;
+  }>;
 
   /**
    * Returns the PDF buffer.

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -1588,7 +1588,9 @@ export type BrowserContextSetStorageStateOptions = {
 export type BrowserContextSetStorageStateResult = void;
 export type BrowserContextPauseParams = {};
 export type BrowserContextPauseOptions = {};
-export type BrowserContextPauseResult = void;
+export type BrowserContextPauseResult = {
+  output?: string,
+};
 export type BrowserContextEnableRecorderParams = {
   language?: string,
   mode?: 'inspecting' | 'recording',

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -852,18 +852,19 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return [...this._workers];
   }
 
-  async pause(_options?: { __testHookKeepTestTimeout: boolean }) {
+  async pause(_options?: { __testHookKeepTestTimeout: boolean }): Promise<{ output?: string }> {
     const isJSDebuggerAttached = !!inspector.url();
     if (isJSDebuggerAttached)
-      return;
+      return {};
     const defaultNavigationTimeout = this._browserContext._timeoutSettings.defaultNavigationTimeout();
     const defaultTimeout = this._browserContext._timeoutSettings.defaultTimeout();
     this._browserContext.setDefaultNavigationTimeout(0);
     this._browserContext.setDefaultTimeout(0);
     this._instrumentation?.onWillPause({ keepTestTimeout: !!_options?.__testHookKeepTestTimeout });
-    await this._closedOrCrashedScope.safeRace(this.context()._channel.pause({}, undefined));
+    const result = await this._closedOrCrashedScope.safeRace(this.context()._channel.pause({}, undefined));
     this._browserContext.setDefaultNavigationTimeout(defaultNavigationTimeout);
     this._browserContext.setDefaultTimeout(defaultTimeout);
+    return { output: result?.output };
   }
 
   async pdf(options: PDFOptions = {}): Promise<Buffer> {

--- a/packages/playwright-core/src/protocol/validator.ts
+++ b/packages/playwright-core/src/protocol/validator.ts
@@ -877,7 +877,9 @@ scheme.BrowserContextSetStorageStateParams = tObject({
 });
 scheme.BrowserContextSetStorageStateResult = tOptional(tObject({}));
 scheme.BrowserContextPauseParams = tOptional(tObject({}));
-scheme.BrowserContextPauseResult = tOptional(tObject({}));
+scheme.BrowserContextPauseResult = tObject({
+  output: tOptional(tString),
+});
 scheme.BrowserContextEnableRecorderParams = tObject({
   language: tOptional(tString),
   mode: tOptional(tEnum(['inspecting', 'recording'])),

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -116,6 +116,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
   private _routesInFlight = new Set<network.Route>();
   private _debugger!: Debugger;
   _closeReason: string | undefined;
+  _recorderApp: RecorderApp | undefined;
   readonly clock: Clock;
   readonly credentials: Credentials;
   _clientCertificatesProxy: ClientCertificatesProxy | undefined;

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -1591,7 +1591,9 @@ export type BrowserContextSetStorageStateOptions = {
 export type BrowserContextSetStorageStateResult = void;
 export type BrowserContextPauseParams = {};
 export type BrowserContextPauseOptions = {};
-export type BrowserContextPauseResult = void;
+export type BrowserContextPauseResult = {
+  output?: string,
+};
 export type BrowserContextEnableRecorderParams = {
   language?: string,
   mode?: 'inspecting' | 'recording',

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -396,8 +396,9 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
     await this._context.exposeConsoleApi(progress);
   }
 
-  async pause(params: channels.BrowserContextPauseParams, progress: Progress) {
-    // Debugger will take care of this.
+  async pause(params: channels.BrowserContextPauseParams, progress: Progress): Promise<channels.BrowserContextPauseResult> {
+    // The Debugger blocks in onBeforeCall until Resume, so recording is done by the time we get here.
+    return { output: this._context._recorderApp?.generatedCode() };
   }
 
   async newCDPSession(params: channels.BrowserContextNewCDPSessionParams, progress: Progress): Promise<channels.BrowserContextNewCDPSessionResult> {

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -192,6 +192,10 @@ export class RecorderApp {
     await this._page.close(nullProgress);
   }
 
+  generatedCode(): string | undefined {
+    return this._recorderSources.find(s => s.id === this._primaryGeneratorId)?.text;
+  }
+
   static showInspectorNoReply(context: BrowserContext) {
     if (process.env.PW_CODEGEN_NO_INSPECTOR)
       return;
@@ -238,7 +242,7 @@ export class RecorderApp {
 
     const recorderApp = new RecorderApp(recorder, appParams, page, appContext._browser.options.wsEndpoint);
     await recorderApp._init(inspectedContext);
-    (inspectedContext as any).recorderAppForTest = recorderApp;
+    inspectedContext._recorderApp = recorderApp;
   }
 
   private _wireListeners(recorder: Recorder) {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3932,7 +3932,12 @@ export interface Page {
    * [`headless`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-headless) option.
    *
    */
-  pause(): Promise<void>;
+  pause(): Promise<{
+    /**
+     * The code recorded during the pause.
+     */
+    output?: string;
+  }>;
 
   /**
    * Returns the PDF buffer.

--- a/packages/protocol/spec/browserContext.yml
+++ b/packages/protocol/spec/browserContext.yml
@@ -230,6 +230,8 @@ BrowserContext:
 
     pause:
       title: Pause
+      returns:
+        output: string?
 
     enableRecorder:
       internal: true

--- a/tests/library/inspector/inspectorTest.ts
+++ b/tests/library/inspector/inspectorTest.ts
@@ -57,9 +57,9 @@ export const test = contextTest.extend<CLITestArgs>({
     testInfo.skip(mode !== 'default');
     testInfo.skip(!headless, 'real mouse moves mess up with recording');
     await run(async () => {
-      while (!toImpl(context).recorderAppForTest)
+      while (!toImpl(context)._recorderApp)
         await new Promise(f => setTimeout(f, 100));
-      const wsEndpoint = toImpl(context).recorderAppForTest.wsEndpointForTest;
+      const wsEndpoint = toImpl(context)._recorderApp!.wsEndpointForTest;
       const browser = await playwrightToAutomateInspector.chromium.connectOverCDP({ wsEndpoint });
       const c = browser.contexts()[0];
       return c.pages()[0] || await c.waitForEvent('page');
@@ -68,7 +68,7 @@ export const test = contextTest.extend<CLITestArgs>({
 
   closeRecorder: async ({ context, toImpl }, run) => {
     await run(async () => {
-      await toImpl(context).recorderAppForTest.close();
+      await toImpl(context)._recorderApp!.close();
     });
   },
 

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -595,6 +595,23 @@ it.describe('pause', () => {
     await recorderPage.getByRole('button', { name: 'Resume' }).click();
     await scriptPromise;
   });
+
+  it('should return the recorded code on resume', async ({ page, recorderPageGetter }) => {
+    await page.setContent('<body style="width: 100%; height: 100%"></body>');
+    // @ts-ignore
+    const resultPromise = page.pause({ __testHookKeepTestTimeout: true });
+    const recorderPage = await recorderPageGetter();
+    await recorderPage.getByRole('button', { name: 'Record' }).click();
+
+    const recorder = new Recorder(page, recorderPage);
+    await recorder.hoverOverElement('body', { omitTooltip: true });
+    await recorder.trustedClick();
+
+    await expect(recorderPage.locator('.cm-wrapper')).toContainText(`await page.locator('body').click();`);
+    await recorderPage.getByRole('button', { name: 'Resume' }).click();
+    const result = await resultPromise;
+    expect(result.output).toContain(`await page.locator('body').click();`);
+  });
 });
 
 async function sanitizeLog(recorderPage: Page): Promise<string[]> {


### PR DESCRIPTION
## Summary
- `page.pause()` now returns `{ output?: string }` with the code recorded during the Recorder pause, so tooling can retrieve it programmatically instead of copying from the Inspector.

Fixes https://github.com/microsoft/playwright/issues/41564