### PR TITLE
test(webkit-wsl): fix security detail and connect-from-page expectations

### DIFF
--- a/tests/library/client-certificates.spec.ts
+++ b/tests/library/client-certificates.spec.ts
@@ -344,7 +344,7 @@ test.describe('browser', () => {
 
   test('should not intercept TLS for origins without a client certificate', {
     annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41106' },
-  }, async ({ browser, asset, httpsServer, browserName, platform }) => {
+  }, async ({ browser, asset, httpsServer, browserName, platform, channel }) => {
     // If the proxy intercepted this origin, the browser would see its self-signed cert (CN=localhost)
     // instead of the real server cert (CN=playwright-test).
     const page = await browser.newPage({
@@ -357,7 +357,7 @@ test.describe('browser', () => {
     const response = await page.goto(httpsServer.EMPTY_PAGE);
     expect(response.ok()).toBe(true);
     const subjectName = (await response.securityDetails()).subjectName;
-    if (browserName === 'webkit' && platform === 'win32') {
+    if (browserName === 'webkit' && platform === 'win32' && channel !== 'webkit-wsl') {
       // Don't ask me why this is "true" on Windows WebKit.
       expect(subjectName).toContain('true');
     } else {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -704,7 +704,10 @@ it('should return security details directly from response', async ({ contextFact
   const page = await context.newPage();
   const response = await page.goto(httpsServer.EMPTY_PAGE);
   const securityDetails = await response!.securityDetails();
-  if (browserName === 'webkit' && platform === 'win32')
+  if (channel === 'webkit-wsl')
+    // The Linux WebKit build reports the real subject name, but (like the Windows port) does not surface the TLS protocol.
+    expect({ ...securityDetails, protocol: undefined }).toEqual({ subjectName: 'playwright-test', validFrom: 1691708270, validTo: 2007068270 });
+  else if (browserName === 'webkit' && platform === 'win32')
     expect({ ...securityDetails, protocol: undefined }).toEqual({ subjectName: 'true', validFrom: 1691708270, validTo: 2007068270 });
   else if (browserName === 'webkit')
     expect(securityDetails).toEqual({ protocol: 'TLS 1.3', subjectName: 'playwright-test', validFrom: 1691708270, validTo: 2007068270 });

--- a/tests/library/playwright-client.spec.ts
+++ b/tests/library/playwright-client.spec.ts
@@ -23,9 +23,11 @@ it.skip(({ mode }) => mode !== 'default');
 
 const kBundlePath = path.join(__dirname, '..', '..', 'packages', 'playwright-client', 'lib', 'index.mjs');
 
-it('should connect from a page and drive the same browser', async ({ browser, browserName, server }) => {
-  // Expose this very browser over a WebSocket endpoint.
-  const { endpoint } = await browser.bind('playwright-client-test', { port: 0 });
+it('should connect from a page and drive the same browser', async ({ browser, browserName, channel, server }) => {
+  // Expose this very browser over a WebSocket endpoint. In WSL the browser runs in the
+  // guest and reaches the host over mirrored networking, which mirrors the IPv4 loopback
+  // but not the host's IPv6 `::1`; bind to 127.0.0.1 so the in-page client can connect back.
+  const { endpoint } = await browser.bind('playwright-client-test', { port: 0, host: channel === 'webkit-wsl' ? '127.0.0.1' : undefined });
 
   // Serve the built browser client bundle.
   server.setRoute('/playwright-client.mjs', (req, res) => {


### PR DESCRIPTION
## Summary
- webkit-wsl runs the Linux WebKit build on a Windows host, so three tests that branch on `platform === 'win32'` (or assume a locally-reachable bind endpoint) failed:
  - `client-certificates.spec.ts` / `har.spec.ts`: Linux WebKit reports `subjectName: "playwright-test"` (not the Windows-port `"true"`), and does not surface the TLS protocol — added `webkit-wsl`-aware expectations.
  - `playwright-client.spec.ts`: `browser.bind` advertised an IPv6 `ws://[::1]` endpoint that the in-WSL browser cannot reach (mirrored networking mirrors the IPv4 loopback but not `::1`) — bind to `127.0.0.1` for webkit-wsl.

Fixes https://github.com/microsoft/playwright/issues/37036