### PR TITLE
test(click): add coverage for click after a right click

### DIFF
--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1223,6 +1223,22 @@ it('should fire contextmenu event on right click in correct order', async ({ pag
     await expect.poll(() => entries).toEqual(['mousedown', 'contextmenu', 'mouseup']);
 });
 
+it('should click after a right click', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39246' } }, async ({ page, browserName }) => {
+  // On webkit the native context menu opened by the right click swallows the
+  // following left click, so the button never receives it.
+  it.fixme(browserName === 'webkit');
+  await page.setContent(`
+    <button>Click me</button>
+    <script>
+      const button = document.querySelector('button');
+      button.addEventListener('click', () => button.textContent = 'Clicked!');
+    </script>
+  `);
+  await page.getByRole('button').click({ button: 'right' });
+  await page.getByRole('button').click();
+  await expect(page.getByRole('button')).toHaveText('Clicked!');
+});
+
 it('should set PointerEvent.pressure on pointerdown', async ({ page, isLinux, headless }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/35844' });
   await page.setContent(`


### PR DESCRIPTION
## Summary
- Adds a test asserting that a left click works after a right click. It passes on Chromium and Firefox; on WebKit the native context menu opened by the right click swallows the following click, so the test is marked `fixme` pending the browser-side fix.

References https://github.com/microsoft/playwright/issues/39246