### PR TITLE
feat(cli): add init-skills command to install the Playwright CLI skill

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
+++ b/packages/playwright-core/src/tools/cli-client/skill/SKILL.md
@@ -326,13 +326,13 @@ playwright-cli kill-all
 
 ## Installation
 
-If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+If global `playwright-cli` command is not available, try a local version via `npx playwright cli`:
 
 ```bash
-npx --no-install playwright-cli --version
+npx --no-install playwright --version
 ```
 
-When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+When local version is available, use `npx playwright cli` in all commands. Otherwise, install `playwright-cli` as a global command:
 
 ```bash
 npm install -g @playwright/cli@latest

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -83,7 +83,7 @@ function globalConfigFile(): string {
   return path.join(process.env['PWTEST_CLI_GLOBAL_CONFIG'] ?? os.homedir(), '.playwright', 'cli.config.json');
 }
 
-async function initWorkspace(initSkills: string | undefined) {
+export async function initWorkspace(initSkills: string | undefined) {
   const cwd = process.cwd();
   const playwrightDir = path.join(cwd, '.playwright');
   await fs.promises.mkdir(playwrightDir, { recursive: true });

--- a/packages/playwright-core/src/tools/index.ts
+++ b/packages/playwright-core/src/tools/index.ts
@@ -31,7 +31,7 @@ export { extractTrace, DirTraceLoaderBackend } from './trace/traceParser';
 export { decorateMCPCommand } from './mcp/program';
 export { program as cliProgram } from './cli-client/program';
 export { generateHelp, generateHelpJSON } from './cli-daemon/helpGenerator';
-export { decorateProgram as decorateCliDaemonProgram } from './cli-daemon/program';
+export { decorateProgram as decorateCliDaemonProgram, initWorkspace } from './cli-daemon/program';
 export { openDashboardApp, openDashboardForContext } from './dashboard/dashboardApp';
 
 export type { ContextConfig } from './backend/context';

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -185,6 +185,20 @@ function addInitAgentsCommand(program: Command) {
   });
 }
 
+function addInitSkillsCommand(program: Command) {
+  const command = program.command('init-skills');
+  command.description('Initialize the workspace and install Playwright CLI skills');
+  const option = command.createOption('--loop <loop>', 'Agentic loop provider');
+  option.choices(['claude', 'generic']);
+  option.default('generic');
+  command.addOption(option);
+  command.action(async opts => {
+    // Claude Code only reads skills from `.claude/skills`, every other agent reads
+    // them from the universal `.agents/skills` folder.
+    await tools.initWorkspace(opts.loop === 'claude' ? 'claude' : 'agents');
+  });
+}
+
 const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure', 'retain-on-failure-and-retries'];
 
 // Note: update docs/src/test-cli-js.md when you update this, program is the source of truth.
@@ -237,3 +251,4 @@ addClearCacheCommand(program);
 addTestMCPServerCommand(program);
 addTestServerCommand(program);
 addInitAgentsCommand(program);
+addInitSkillsCommand(program);


### PR DESCRIPTION
## Summary
- Add `init-skills` command that installs the Playwright CLI skill (SKILL.md + references) into a coding agent's skills directory
- `--loop generic` targets the universal `.agents/skills` folder; `--loop claude` targets `.claude/skills` since Claude Code does not read from `.agents`
- Update the skill's install instructions to reference `npx playwright cli`