### PR TITLE
test(webview): tolerate a hung `simctl terminate` when resetting MobileSafari

### DIFF
--- a/tests/webview/webviewTest.ts
+++ b/tests/webview/webviewTest.ts
@@ -105,7 +105,11 @@ function clearMobileSafariState(udid: string): void {
 }
 
 async function resetMobileSafari(udid: string): Promise<void> {
-  runSimctl(['terminate', udid, 'com.apple.mobilesafari']);
+  try {
+    runSimctl(['terminate', udid, 'com.apple.mobilesafari']);
+  } catch (error) {
+    console.error(`[webview] failed to \`simctl terminate\`: ${(error as Error).message}`);
+  }
   // Let the proxy drop the dead tabs before wiping state and relaunching.
   const drained = Date.now() + 30000;
   while (Date.now() < drained && (await listTabs()).length > 0)


### PR DESCRIPTION
`resetMobileSafari` terminates Mobile Safari at the start of each worker, but an intermittent CoreSimulator hang makes `runSimctl` throw on its 60s timeout, failing the worker and cascading across the shard.

Make the `terminate` call best effort so a hung terminate is logged and ignored, since the relaunch and endpoint discovery still bring up a fresh Safari.