### PR TITLE
fix(tracing): only mark target elements while snapshots are recording

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -519,7 +519,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   }
 
   private async _markAsTargetElement(progress: Progress) {
-    if (!progress.metadata.id)
+    if (!this._frame.shouldMarkTargetElements(progress))
       return;
     await progress.race(this.evaluateInUtility(([injected, node, callId]) => {
       if (node.nodeType === 1 /* Node.ELEMENT_NODE */)

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1172,9 +1172,9 @@ export class Frame extends SdkObject<FrameEventMap> {
           throw new dom.NonRecoverableDOMError('Element(s) not found');
         return continuePolling;
       }
-      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, callId }) => {
+      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, callId, markTargetElements }) => {
         const elements = injected.querySelectorAll(info.parsed, document);
-        if (callId)
+        if (markTargetElements)
           injected.markTargetElements(new Set(elements), callId);
         const element = elements[0] as Element | undefined;
         let log = '';
@@ -1187,7 +1187,7 @@ export class Frame extends SdkObject<FrameEventMap> {
         }
         injected.checkDeprecatedSelectorUsage(info.parsed, elements);
         return { log, success: !!element, element };
-      }, { info: resolved.info, callId: progress.metadata.id }));
+      }, { info: resolved.info, callId: progress.metadata.id, markTargetElements: this.shouldMarkTargetElements(progress) }));
       const { log, success } = await progress.race(result.evaluate(r => ({ log: r.log, success: r.success })));
       if (log)
         progress.log(log);
@@ -1517,6 +1517,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   private async _expectInternal(progress: Progress, selector: string | undefined, options: FrameExpectParams, lastIntermediateResult: { received?: ExpectReceived, isSet: boolean, errorMessage?: string }, noAbort: boolean) {
     const progressLog = (text: string) => progress.log(text);
     const callId = progress.metadata.id;
+    const markTargetElements = this.shouldMarkTargetElements(progress);
     // The first expect check, a.k.a. one-shot, always finishes - even when progress is aborted.
     if (noAbort)
       progress = nullProgress;
@@ -1527,9 +1528,9 @@ export class Frame extends SdkObject<FrameEventMap> {
     const context = await progress.race(frame.context(world));
     const injected = await progress.race(context.injectedScript());
 
-    const { log, matches, received, missingReceived } = await progress.race(injected.evaluate(async (injected, { info, options, callId }) => {
+    const { log, matches, received, missingReceived } = await progress.race(injected.evaluate(async (injected, { info, options, callId, markTargetElements }) => {
       const elements = info ? injected.querySelectorAll(info.parsed, document) : [];
-      if (callId)
+      if (markTargetElements)
         injected.markTargetElements(new Set(elements), callId);
       const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
       let log = '';
@@ -1542,7 +1543,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       if (info)
         injected.checkDeprecatedSelectorUsage(info.parsed, elements);
       return { log, ...await injected.expect(elements[0], options, elements) };
-    }, { info, options, callId }));
+    }, { info, options, callId, markTargetElements }));
 
     if (log)
       progressLog(log);
@@ -1692,16 +1693,16 @@ export class Frame extends SdkObject<FrameEventMap> {
       const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, options, scope));
       if (!resolved)
         return continuePolling;
-      const { log, success, value } = await progress.race(resolved.injected.evaluate((injected, { info, callbackText, taskData, callId, root }) => {
+      const { log, success, value } = await progress.race(resolved.injected.evaluate((injected, { info, callbackText, taskData, callId, markTargetElements, root }) => {
         const callback = injected.eval(callbackText) as ElementCallback<T, R>;
         const element = injected.querySelector(info.parsed, root || document, info.strict);
         if (!element)
           return { success: false };
         const log = `  locator resolved to ${injected.previewNode(element)}`;
-        if (callId)
+        if (markTargetElements)
           injected.markTargetElements(new Set([element]), callId);
         return { log, success: true, value: callback(injected, element, taskData as T) };
-      }, { info: resolved.info, callbackText, taskData, callId: progress.metadata.id, root: resolved.frame === this ? scope : undefined }));
+      }, { info: resolved.info, callbackText, taskData, callId: progress.metadata.id, markTargetElements: this.shouldMarkTargetElements(progress), root: resolved.frame === this ? scope : undefined }));
       if (log)
         progress.log(log);
       if (!success)
@@ -1803,6 +1804,10 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   private _asLocator(selector: string) {
     return asLocator(this._page.browserContext._browser.sdkLanguage(), selector);
+  }
+
+  shouldMarkTargetElements(progress: Progress): boolean {
+    return !!progress.metadata.id && this._page.browserContext.tracing.snapshotStarted();
   }
 }
 

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -458,6 +458,10 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     return { artifact };
   }
 
+  snapshotStarted(): boolean {
+    return !!this._snapshotter?.started();
+  }
+
   private async _captureSnapshot(snapshotName: string | undefined, sdkObject: SdkObject, metadata: CallMetadata): Promise<void> {
     if (!snapshotName || !sdkObject.attribution.page)
       return;

--- a/tests/page/page-leaks.spec.ts
+++ b/tests/page/page-leaks.spec.ts
@@ -107,6 +107,24 @@ test('click should not leak', async ({ page, toImpl }) => {
   await checkWeakRefs(toImpl(page), 2, 25);
 });
 
+test('should not retain the last target element after an action', async ({ page, toImpl }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41462' });
+
+  // Without tracing/snapshots, actions must not keep the last targeted element
+  // alive via the target-highlight bookkeeping, otherwise a detached element
+  // stays in memory and pollutes leak detection.
+  await page.setContent(`<div id="container"><button>target</button></div>`);
+  await page.locator('#container > button').textContent();
+
+  await weakRefObjects(toImpl(page), '#container > button');
+  await page.evaluate(() => {
+    document.getElementById('container').textContent = '';
+  });
+
+  expect(leakedJSHandles()).toBeFalsy();
+  await checkWeakRefs(toImpl(page), 0, 1);
+});
+
 test('fill should not leak', async ({ page, mode, toImpl }) => {
   test.skip(mode !== 'default');
 


### PR DESCRIPTION
We marked the last target element on every action, tracing on or not. That marking pins the element in the injected script's `_markedElements`, keeping detached DOM alive - so a page that never turned on tracing still retains its last acted-on element, which breaks user-side leak detection. That's #41462.

Two more reasons to gate it that fell out while digging:

- Marking dispatches a `bubbles: true, composed: true` event into the live page, so any user listener on an ancestor (or across a shadow boundary) sees `__playwright_mark_target__` fire during ordinary automation. We shouldn't poke the page when we're not recording.
- For input actions (`dom.ts`) marking is its own `evaluate`, so every `click` / `fill` / `hover` paid a browser roundtrip for it - now skipped server-side when snapshots aren't recording.

Highlight behaviour is unchanged: the trace viewer highlights strictly by per-action `callId`, so this only affects *whether* we mark, never *which* element renders. Tracing can still hold one element between a chunk stop and the next action, which is fine - highlighting is best-effort and tracing-only anyway.

Fixes https://github.com/microsoft/playwright/issues/41462
