### PR TITLE
feat(mcp): surface non-2xx navigation status

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -302,6 +302,9 @@ export function renderTabMarkdown(tab: TabHeader): string[] {
     lines.push(`- Page Title: ${tab.title}`);
   if (tab.crashed)
     lines.push(`- Page status: crashed`);
+  const status = tab.mainDocumentStatus;
+  if (status && (status.status < 200 || status.status >= 300))
+    lines.push(`- Page status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
   if (tab.console.errors || tab.console.warnings)
     lines.push(`- Console: ${tab.console.errors} errors, ${tab.console.warnings} warnings`);
   return lines;

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -304,7 +304,7 @@ export function renderTabMarkdown(tab: TabHeader): string[] {
     lines.push(`- Page status: crashed`);
   const status = tab.mainDocumentStatus;
   if (status && (status.status < 200 || status.status >= 300))
-    lines.push(`- Page status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
+    lines.push(`- HTTP status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
   if (tab.console.errors || tab.console.warnings)
     lines.push(`- Console: ${tab.console.errors} errors, ${tab.console.warnings} warnings`);
   return lines;

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -77,6 +77,7 @@ export type TabHeader = {
   url: string;
   current: boolean;
   crashed: boolean;
+  mainDocumentStatus?: { status: number, statusText: string };
   console: { total: number, warnings: number, errors: number };
 };
 
@@ -93,6 +94,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _lastHeader: TabHeader = { title: 'about:blank', url: 'about:blank', current: false, crashed: false, console: { total: 0, warnings: 0, errors: 0 } };
   private _downloads: Download[] = [];
   private _requests: playwright.Request[] = [];
+  private _mainDocumentStatus: { status: number, statusText: string } | undefined;
   private _onPageClose: (tab: Tab) => void;
   crashed = false;
   private _modalStates: ModalState[] = [];
@@ -219,6 +221,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   private _clearCollectedArtifacts() {
     this._downloads.length = 0;
     this._requests.length = 0;
+    this._mainDocumentStatus = undefined;
     this._recentEventEntries.length = 0;
     this._resetLogs();
   }
@@ -238,9 +241,12 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _handleResponse(response: playwright.Response) {
-    const timing = response.request().timing();
+    const request = response.request();
+    if (request.isNavigationRequest() && response.frame() === this.page.mainFrame())
+      this._mainDocumentStatus = { status: response.status(), statusText: response.statusText() };
+    const timing = request.timing();
     const wallTime = timing.responseStart + timing.startTime;
-    this._addLogEntry({ type: 'request', wallTime, request: response.request() });
+    this._addLogEntry({ type: 'request', wallTime, request });
   }
 
   private _handleRequestFailed(request: playwright.Request) {
@@ -284,6 +290,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       url: this.page.url(),
       current: this.isCurrentTab(),
       crashed: this.crashed,
+      mainDocumentStatus: this._mainDocumentStatus,
       console: consoleCounts,
     };
 
@@ -583,6 +590,8 @@ function tabHeaderEquals(a: TabHeader, b: TabHeader): boolean {
       a.url === b.url &&
       a.current === b.current &&
       a.crashed === b.crashed &&
+      a.mainDocumentStatus?.status === b.mainDocumentStatus?.status &&
+      a.mainDocumentStatus?.statusText === b.mainDocumentStatus?.statusText &&
       a.console.errors === b.console.errors &&
       a.console.warnings === b.console.warnings &&
       a.console.total === b.console.total;

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -242,7 +242,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
   private _handleResponse(response: playwright.Response) {
     const request = response.request();
-    if (request.isNavigationRequest() && response.frame() === this.page.mainFrame())
+    if (request.isNavigationRequest() && response.frame() === this.page.mainFrame() && !request.redirectedTo())
       this._mainDocumentStatus = { status: response.status(), statusText: response.statusText() };
     const timing = request.timing();
     const wallTime = timing.responseStart + timing.startTime;

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -30,6 +30,28 @@ test('browser_navigate', async ({ client, server }) => {
   });
 });
 
+test('browser_navigate surfaces non-2xx HTTP status', async ({ client, server }) => {
+  server.setRoute('/locked', (req, res) => {
+    res.writeHead(402, { 'Content-Type': 'text/html' });
+    res.end('<title>Payment Required</title><body>Pay up</body>');
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX + '/locked' },
+  })).toHaveResponse({
+    page: expect.stringContaining(`- Page status: 402 Payment Required`),
+  });
+
+  // A subsequent 2xx navigation must not carry a status line.
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).not.toHaveResponse({
+    page: expect.stringContaining('Page status'),
+  });
+});
+
 test('browser_navigate blocks file:// URLs by default', async ({ client }) => {
   expect(await client.callTool({
     name: 'browser_navigate',

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -40,15 +40,20 @@ test('browser_navigate surfaces non-2xx HTTP status', async ({ client, server })
     name: 'browser_navigate',
     arguments: { url: server.PREFIX + '/locked' },
   })).toHaveResponse({
-    page: expect.stringContaining(`- Page status: 402 Payment Required`),
+    page: expect.stringContaining(`- HTTP status: 402 Payment Required`),
   });
 
-  // A subsequent 2xx navigation must not carry a status line.
+  // A redirect to a 2xx page must not carry a status line: the intermediate
+  // 302 hop must not leak, and the final 2xx landing renders nothing.
+  server.setRoute('/redirect', (req, res) => {
+    res.writeHead(302, { location: server.HELLO_WORLD });
+    res.end();
+  });
   expect(await client.callTool({
     name: 'browser_navigate',
-    arguments: { url: server.HELLO_WORLD },
+    arguments: { url: server.PREFIX + '/redirect' },
   })).not.toHaveResponse({
-    page: expect.stringContaining('Page status'),
+    page: expect.stringContaining('HTTP status'),
   });
 });
 


### PR DESCRIPTION
`browser_navigate` reports URL, title and a console-error count, but not the HTTP status. So a page that comes back 4xx/5xx looks like a successful navigation - the only hint is the error count, which is noisy (a favicon 404 bumps it just the same) and means the agent has to go read `browser_console_messages` or enumerate `browser_network_requests` to find out what actually happened.

This adds a `Page status` line to the page header, but only when the main document is non-2xx:

```
- Page URL: http://localhost:8402/locked
- Page Title: Payment Required
- Page status: 402 Payment Required   👈
- Console: 2 errors, 0 warnings
```

A normal 200 shows nothing extra, so the common case stays quiet. It mirrors the existing `Page status: crashed` line, and the status is captured from the main-frame navigation response, so it also covers reload and back/forward and clears again once you land on a 2xx.

Nothing new is *exposed* here - the status was always reachable via the console text or the network list. It's a discoverability fix: promote "the document came back non-2xx" to a first-class fact on the result an agent already reads, instead of something it has to go digging for.

This came out of looking at how HTTP 402 paywalls surface to a browser agent. One related gap I hit but left out of here: `browser_route` can't scope a route to a single request (no `times`/`once`), which matters when you want to attach a one-shot header to exactly the next navigation. That's a separate, generic change - I'll do it in its own PR.
