### PR TITLE
chore: move stackTrace helpers from isomorphic to utils

### DIFF
--- a/packages/isomorphic/index.ts
+++ b/packages/isomorphic/index.ts
@@ -29,7 +29,6 @@ export * from './protocolFormatter';
 export * from './protocolMetainfo';
 export * from './rtti';
 export * from './semaphore';
-export * from './stackTrace';
 export * from './stringUtils';
 export * from './formatUtils';
 export * from './time';

--- a/packages/isomorphic/manualPromise.ts
+++ b/packages/isomorphic/manualPromise.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { captureRawStack } from './stackTrace';
-
 export class ManualPromise<T = void> extends Promise<T> {
   private _resolve!: (t: T) => void;
   private _reject!: (e: Error) => void;
@@ -96,7 +94,7 @@ export class LongStandingScope {
 
   private async _race(promises: Promise<any>[], safe: boolean, defaultValue?: any): Promise<any> {
     const terminatePromise = new ManualPromise<Error>();
-    const frames = captureRawStack();
+    const frames = (new Error().stack || '').split('\n');
     if (this._terminateError)
       terminatePromise.resolve(this._terminateError);
     if (this._closeError)

--- a/packages/isomorphic/trace/traceModel.ts
+++ b/packages/isomorphic/trace/traceModel.ts
@@ -16,7 +16,6 @@
 
 import { getActionGroup, renderTitleForCall } from '../protocolFormatter';
 
-import type { StackFrame } from '../stackTrace';
 import type { Language } from '../locatorGenerators';
 import type { ResourceSnapshot } from '@trace/snapshot';
 import type * as trace from '@trace/trace';
@@ -57,7 +56,7 @@ export type ActionTreeItem = {
 
 export type ErrorDescription = {
   action?: ActionTraceEventInContext;
-  stack?: StackFrame[];
+  stack?: trace.StackFrame[];
   message: string;
 };
 

--- a/packages/isomorphic/trace/traceUtils.ts
+++ b/packages/isomorphic/trace/traceUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { StackFrame } from '../stackTrace';
+import type { StackFrame } from '@trace/trace';
 import type { ClientSideCallMetadata } from '@protocol/structs';
 
 export type SerializedStackFrame = [number, number, number, string];

--- a/packages/playwright-core/src/browserServerImpl.ts
+++ b/packages/playwright-core/src/browserServerImpl.ts
@@ -18,7 +18,7 @@ import EventEmitter from 'events';
 
 import { createGuid } from '@utils/crypto';
 import { isUnderTest } from '@utils/debug';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT } from '@isomorphic/time';
 import { PlaywrightServer } from './remote/playwrightServer';
 import { helper } from './server/helper';

--- a/packages/playwright-core/src/client/DEPS.list
+++ b/packages/playwright-core/src/client/DEPS.list
@@ -4,5 +4,6 @@
 @utils/crypto.ts
 @utils/debug.ts
 @utils/debugLogger.ts
+@utils/stackTrace.ts
 @utils/zones.ts
 node_modules/colors/safe

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import { headersObjectToArray } from '@isomorphic/headers';
 import { urlMatchesEqual } from '@isomorphic/urlMatch';
 import { isRegExp, isString } from '@isomorphic/rtti';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { Browser } from './browser';
 import { CDPSession } from './cdpSession';
 import { ChannelOwner } from './channelOwner';

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -15,7 +15,7 @@
  */
 
 import { getMetainfo } from '@isomorphic/protocolMetainfo';
-import { showInternalStackFrames, stringifyStackFrames } from '@isomorphic/stackTrace';
+import { showInternalStackFrames, stringifyStackFrames } from '@utils/stackTrace';
 import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
 import { currentZone } from '@utils/zones';

--- a/packages/playwright-core/src/client/clientStackTrace.ts
+++ b/packages/playwright-core/src/client/clientStackTrace.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-import path from 'path';
+import { captureRawStack, coreDir, filterStackFile, parseStackFrame } from '@utils/stackTrace';
 
-import { captureRawStack, coreDir, filterStackFile, parseStackFrame } from '@isomorphic/stackTrace';
-
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@utils/stackTrace';
 
 export function captureLibraryStackTrace(): { frames: StackFrame[], apiName: string } {
   const stack = captureRawStack();
@@ -30,7 +28,7 @@ export function captureLibraryStackTrace(): { frames: StackFrame[], apiName: str
     isPlaywrightLibrary: boolean;
   };
   let parsedFrames = stack.map(line => {
-    const frame = parseStackFrame(line, path.sep);
+    const frame = parseStackFrame(line);
     if (!frame || !frame.file)
       return null;
     const isPlaywrightLibrary = !!playwrightCoreDir && frame.file.startsWith(playwrightCoreDir);

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -15,7 +15,7 @@
  */
 
 import colors from 'colors/safe';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
 import { emptyZone } from '@utils/zones';

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -22,7 +22,7 @@ import { resolveGlobToRegexPattern, serializeURLMatch, urlMatches } from '@isomo
 import { LongStandingScope, ManualPromise } from '@isomorphic/manualPromise';
 import { MultiMap } from '@isomorphic/multimap';
 import { isString } from '@isomorphic/rtti';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { getMimeTypeForPath } from '@isomorphic/mimeType';
 import { currentZone } from '@utils/zones';
 import { Worker } from './worker';

--- a/packages/playwright-core/src/client/waiter.ts
+++ b/packages/playwright-core/src/client/waiter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { createGuid } from '@utils/crypto';
 import { currentZone } from '@utils/zones';
 import { AbortError, TimeoutError } from './errors';

--- a/packages/playwright-core/src/inprocess.ts
+++ b/packages/playwright-core/src/inprocess.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { setCoreDir, setShowInternalStackFrames } from '@isomorphic/stackTrace';
+import { setCoreDir } from '@utils/stackTrace';
 import { AndroidServerLauncherImpl } from './androidServerImpl';
 import { BrowserServerLauncherImpl } from './browserServerImpl';
 import { DispatcherConnection, PlaywrightDispatcher, RootDispatcher, createPlaywright } from './server';
@@ -27,7 +27,6 @@ import type { Language } from '@isomorphic/locatorGenerators';
 export function createInProcessPlaywright(): PlaywrightAPI {
   const playwright = createPlaywright({ sdkLanguage: (process.env.PW_LANG_NAME as Language | undefined) || 'javascript', isClientCollocatedWithServer: true });
   setCoreDir(packageRoot);
-  setShowInternalStackFrames(!!process.env.PWDEBUGIMPL);
   const clientConnection = new Connection();
   clientConnection.useRawBuffers();
   const dispatcherConnection = new DispatcherConnection(true /* in process */);

--- a/packages/playwright-core/src/outofprocess.ts
+++ b/packages/playwright-core/src/outofprocess.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 import { PipeTransport } from '@utils/pipeTransport';
 import { ManualPromise } from '@isomorphic/manualPromise';
-import { setCoreDir, setShowInternalStackFrames } from '@isomorphic/stackTrace';
+import { setCoreDir } from '@utils/stackTrace';
 import { Connection } from './client/connection';
 import { packageRoot } from './package';
 
@@ -52,7 +52,6 @@ class PlaywrightClient {
     this._driverProcess.stderr!.on('data', data => process.stderr.write(data));
 
     setCoreDir(packageRoot);
-    setShowInternalStackFrames(!!process.env.PWDEBUGIMPL);
     const connection = new Connection();
     const transport = new PipeTransport(this._driverProcess.stdin!, this._driverProcess.stdout!);
     connection.onmessage = message => transport.send(JSON.stringify(message));

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs';
 
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { debugMode, isUnderTest } from '@utils/debug';
 import { Clock } from './clock';
 import { Credentials } from './credentials';

--- a/packages/playwright-core/src/server/chromium/crExecutionContext.ts
+++ b/packages/playwright-core/src/server/chromium/crExecutionContext.ts
@@ -16,7 +16,7 @@
  */
 
 import { assert } from '@isomorphic/assert';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { parseEvaluationResultValue } from '@isomorphic/utilityScriptSerializers';
 import { getExceptionMessage, releaseObject } from './crProtocolHelper';
 import * as js from '../javascript';

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -16,7 +16,7 @@
  */
 
 import { assert } from '@isomorphic/assert';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { eventsHelper } from '@utils/eventsHelper';
 import * as dialog from '../dialog';
 import * as dom from '../dom';

--- a/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
+++ b/packages/playwright-core/src/server/chromium/crProtocolHelper.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs';
 
-import { splitErrorMessage } from '@isomorphic/stackTrace';
+import { splitErrorMessage } from '@utils/stackTrace';
 import { mkdirIfNeeded } from '@utils/fileUtils';
 
 import type { CRSession } from './crConnection';

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -21,7 +21,7 @@ import { eventsHelper } from '@utils/eventsHelper';
 import { isUnderTest } from '@utils/debug';
 import { assert } from '@isomorphic/assert';
 import { monotonicTime } from '@isomorphic/time';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { ValidationError, createMetadataValidator, createWaitInfoValidator, findValidator, maybeFindValidator } from '../../protocol/validator';
 import { AbortError, TargetClosedError, isTargetClosedError, serializeError } from '../errors';
 import { createRootSdkObject, SdkObject } from '../instrumentation';

--- a/packages/playwright-core/src/server/firefox/ffExecutionContext.ts
+++ b/packages/playwright-core/src/server/firefox/ffExecutionContext.ts
@@ -16,7 +16,7 @@
  */
 
 import { assert } from '@isomorphic/assert';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { parseEvaluationResultValue } from '@isomorphic/utilityScriptSerializers';
 import * as js from '../javascript';
 import * as dom from '../dom';

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -16,7 +16,7 @@
  */
 
 import { assert } from '@isomorphic/assert';
-import { splitErrorMessage } from '@isomorphic/stackTrace';
+import { splitErrorMessage } from '@utils/stackTrace';
 import { eventsHelper } from '@utils/eventsHelper';
 import * as dialog from '../dialog';
 import * as dom from '../dom';

--- a/packages/playwright-core/src/server/launchApp.ts
+++ b/packages/playwright-core/src/server/launchApp.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { isUnderTest } from '@utils/debug';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { wrapInASCIIBox } from '@utils/ascii';
 import { libPath } from '../package';
 import { buildPlaywrightCLICommand, findChromiumChannelBestEffort } from './registry';

--- a/packages/playwright-core/src/server/network.ts
+++ b/packages/playwright-core/src/server/network.ts
@@ -16,7 +16,7 @@
 
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { assert } from '@isomorphic/assert';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { isProtocolError } from './protocolError';
 import { BrowserContext } from './browserContext';
 import { APIRequestContext } from './fetch';

--- a/packages/playwright-core/src/server/protocolError.ts
+++ b/packages/playwright-core/src/server/protocolError.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 
 export class ProtocolError extends Error {
   type: 'error' | 'closed' | 'crashed';

--- a/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
+++ b/packages/playwright-core/src/server/socksClientCertificatesInterceptor.ts
@@ -26,7 +26,7 @@ import { debugLogger } from '@utils/debugLogger';
 import { createSocket } from '@utils/happyEyeballs';
 import { escapeHTML } from '@isomorphic/stringUtils';
 import { generateSelfSignedCertificate } from '@utils/crypto';
-import { rewriteErrorMessage } from '@isomorphic/stackTrace';
+import { rewriteErrorMessage } from '@utils/stackTrace';
 import { createProxyAgent } from '@utils/network';
 import { verifyClientCertificates } from './browserContext';
 import type * as types from './types';

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -20,7 +20,7 @@ import jpegjs from 'jpeg-js';
 import { assert } from '@isomorphic/assert';
 import { headersArrayToObject, headersObjectToArray } from '@isomorphic/headers';
 import { ManualPromise } from '@isomorphic/manualPromise';
-import { splitErrorMessage } from '@isomorphic/stackTrace';
+import { splitErrorMessage } from '@utils/stackTrace';
 import { debugLogger } from '@utils/debugLogger';
 import { eventsHelper } from '@utils/eventsHelper';
 import * as dialog from '../../dialog';

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -16,7 +16,7 @@
  */
 
 import { headersArrayToObject, headersObjectToArray } from '@isomorphic/headers';
-import { splitErrorMessage } from '@isomorphic/stackTrace';
+import { splitErrorMessage } from '@utils/stackTrace';
 import { eventsHelper } from '@utils/eventsHelper';
 import { hostPlatform } from '@utils/hostPlatform';
 import { assert } from '@isomorphic/assert';

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -15,7 +15,7 @@
  */
 
 import crypto from 'crypto';
-import { filterStackFile } from '@isomorphic/stackTrace';
+import { filterStackFile } from '@utils/stackTrace';
 
 import { formatLocation } from '../util';
 

--- a/packages/playwright/src/common/process.ts
+++ b/packages/playwright/src/common/process.ts
@@ -19,7 +19,7 @@ import 'playwright-core/lib/bootstrap';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { setTimeOrigin } from '@isomorphic/time';
 import { startProfiling, stopProfiling } from '@utils/profiler';
-import { setBoxedStackPrefixes } from '@isomorphic/stackTrace';
+import { setBoxedStackPrefixes } from '@utils/stackTrace';
 
 import { packageRoot } from '../package';
 import { serializeError } from '../util';

--- a/packages/playwright/src/errorContext.ts
+++ b/packages/playwright/src/errorContext.ts
@@ -15,9 +15,8 @@
  */
 
 import fs from 'fs';
-import path from 'path';
 
-import { parseErrorStack } from '@isomorphic/stackTrace';
+import { parseErrorStack } from '@utils/stackTrace';
 import { stripAnsiEscapes } from '@isomorphic/stringUtils';
 
 import { relativeFilePath } from './util';
@@ -105,7 +104,7 @@ function buildCodeFrame(error: TestInfoError, testLocation: { file: string; line
   if (!stack)
     return undefined;
 
-  const parsed = parseErrorStack(stack, path.sep);
+  const parsed = parseErrorStack(stack);
   const errorLocation = parsed.location;
   if (!errorLocation)
     return undefined;

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import path from 'path';
-
-import { parseStackFrame, captureRawStack } from '@isomorphic/stackTrace';
+import { parseStackFrame, captureRawStack } from '@utils/stackTrace';
 import { escapeWithQuotes, isString } from '@isomorphic/stringUtils';
 import { pollAgainstDeadline } from '@isomorphic/timeoutRunner';
 import { currentZone } from '@utils/zones';
@@ -88,7 +86,7 @@ import type { MatcherContext, MatchersObject, RawMatcherFn } from './expectLibra
 import type { MatcherAttachment, MatcherResult } from './matcherHint';
 import type { ExpectMatcherStateInternal } from './matchers';
 import type { Expect } from '../../types/test';
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@utils/stackTrace';
 
 interface ExpectStep {
   complete(result: {
@@ -115,7 +113,7 @@ export interface ExpectTestInfo {
 
 export type ExpectConfig = {
   testInfo: ExpectTestInfo | null;
-  filteredStackTrace: (rawStack: string[], pathSeparator: string) => StackFrame[];
+  filteredStackTrace: (rawStack: string[]) => StackFrame[];
   ignoreSnapshots: boolean;
   updateSnapshots: 'all' | 'changed' | 'missing' | 'none';
   timeout?: number;
@@ -143,8 +141,8 @@ export type ExpectConfig = {
   toPass?: { timeout?: number; intervals?: number[] };
 };
 
-function unfilteredStackTrace(rawStack: string[], pathSeparator: string): StackFrame[] {
-  return rawStack.map(frame => parseStackFrame(frame, pathSeparator)).filter(f => !!f);
+function unfilteredStackTrace(rawStack: string[]): StackFrame[] {
+  return rawStack.map(frame => parseStackFrame(frame)).filter(f => !!f);
 }
 
 let _expectConfig: ExpectConfig = { testInfo: null, filteredStackTrace: unfilteredStackTrace, ignoreSnapshots: false, updateSnapshots: 'missing' };
@@ -339,7 +337,7 @@ function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: un
 
   // This looks like it is unnecessary, but it isn't - we need to filter
   // out all the frames that belong to the test runner from caught runtime errors.
-  const stackFrames = expectConfig().filteredStackTrace(captureRawStack(), path.sep);
+  const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
   const stepData = {
     category: 'expect' as const,
     apiName,

--- a/packages/playwright/src/matchers/matcherHint.ts
+++ b/packages/playwright/src/matchers/matcherHint.ts
@@ -16,9 +16,9 @@
 
 import util from 'util';
 
-import { stringifyStackFrames } from '@isomorphic/stackTrace';
+import { stringifyStackFrames } from '@utils/stackTrace';
 
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@utils/stackTrace';
 
 export type MatcherAttachment = { name: string; contentType: string; path?: string; body?: string | Buffer };
 

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -20,7 +20,7 @@ import 'playwright-core/lib/bootstrap';
 
 import { libCli, tools } from 'playwright-core/lib/coreBundle';
 import { program } from 'commander';
-import { setBoxedStackPrefixes } from '@isomorphic/stackTrace';
+import { setBoxedStackPrefixes } from '@utils/stackTrace';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { builtInReporters, config, configLoader } from './common';
 import { runTests, clearCache, runTestServerAction } from './cli/testActions';

--- a/packages/playwright/src/reporters/base.ts
+++ b/packages/playwright/src/reporters/base.ts
@@ -20,7 +20,7 @@ import { Writable } from 'stream';
 import realColors from 'colors/safe';
 import { noColors } from '@isomorphic/colors';
 import { msToString } from '@isomorphic/formatUtils';
-import { parseErrorStack } from '@isomorphic/stackTrace';
+import { parseErrorStack } from '@utils/stackTrace';
 import { getPackageManagerExecCommand } from '@utils/env';
 import { fitToWidth } from '@utils/stringWidth';
 
@@ -631,7 +631,7 @@ export function prepareErrorStack(stack: string): {
   stackLines: string[];
   location?: Location;
 } {
-  return parseErrorStack(stack, path.sep);
+  return parseErrorStack(stack);
 }
 
 function resolveFromEnv(name: string): string | undefined {

--- a/packages/playwright/src/util.ts
+++ b/packages/playwright/src/util.ts
@@ -24,7 +24,7 @@ import { minimatch } from 'minimatch';
 import { calculateSha1 } from '@utils/crypto';
 import { sanitizeForFilePath } from '@utils/fileUtils';
 import { isRegExp } from '@isomorphic/rtti';
-import { stringifyStackFrames, filteredStackTrace } from '@isomorphic/stackTrace';
+import { stringifyStackFrames, filteredStackTrace } from '@utils/stackTrace';
 import { ansiRegex, isString, stripAnsiEscapes } from '@isomorphic/stringUtils';
 
 import type { Location } from './../types/testReporter';
@@ -37,7 +37,7 @@ export function filterStackTrace(e: Error): TestInfoError {
   if (process.env.PWDEBUGIMPL)
     return { message: name + e.message, stack: e.stack || '', cause };
 
-  const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || [], path.sep));
+  const stackLines = stringifyStackFrames(filteredStackTrace(e.stack?.split('\n') || []));
   return {
     message: name + e.message,
     stack: `${name}${e.message}${stackLines.map(line => '\n' + line).join('')}`,

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -16,7 +16,7 @@
 
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
-import { filterStackFile } from '@isomorphic/stackTrace';
+import { filterStackFile } from '@utils/stackTrace';
 
 import { fixtures } from '../common';
 import { formatLocation } from '../util';

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { ManualPromise } from '@isomorphic/manualPromise';
-import { captureRawStack, stringifyStackFrames, filteredStackTrace } from '@isomorphic/stackTrace';
+import { captureRawStack, stringifyStackFrames, filteredStackTrace } from '@utils/stackTrace';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { monotonicTime } from '@isomorphic/time';
 import { createGuid } from '@utils/crypto';
@@ -35,7 +35,7 @@ import type { RunnableDescription } from './timeoutManager';
 import type { FullProject, TestInfo, TestInfoError, TestStatus, TestStepInfo, TestAnnotation } from '../../types/test';
 import type { FullConfig, Location } from '../../types/testReporter';
 import type { config as commonConfig, FullConfigInternal, test as testNs } from '../common';
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@utils/stackTrace';
 
 export type TestStepCategory = 'expect' | 'fixture' | 'hook' | 'pw:api' | 'test.step' | 'test.attach';
 
@@ -295,7 +295,7 @@ export class TestInfoImpl implements TestInfo {
         parentStep = this._parentStep();
     }
 
-    const filteredStack = filteredStackTrace(captureRawStack(), path.sep);
+    const filteredStack = filteredStackTrace(captureRawStack());
     let boxedStack = parentStep?.boxedStack;
     let location = data.location;
     if (!boxedStack && data.box) {

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -24,11 +24,11 @@ import { monotonicTime } from '@isomorphic/time';
 import { calculateSha1, createGuid } from '@utils/crypto';
 import { SerializedFS } from '@utils/serializedFS';
 import { getPlaywrightVersion } from 'playwright-core/lib/coreBundle';
-import { filteredStackTrace } from '@isomorphic/stackTrace';
+import { filteredStackTrace } from '@utils/stackTrace';
 
 import type { TestStepCategory, TestInfoImpl } from './testInfo';
 import type { PlaywrightWorkerOptions, TestInfo, TestInfoError, TraceMode } from '../../types/test';
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@utils/stackTrace';
 import type * as trace from '@trace/trace';
 import type EventEmitter from 'events';
 
@@ -250,7 +250,7 @@ export class TestTracing {
 
   appendForError(error: TestInfoError) {
     const rawStack = error.stack?.split('\n') || [];
-    const stack = rawStack ? filteredStackTrace(rawStack, path.sep) : [];
+    const stack = rawStack ? filteredStackTrace(rawStack) : [];
     this._appendTraceEvent({
       type: 'error',
       message: this._formatError(error),

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -18,7 +18,7 @@ import colors from 'colors/safe';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { removeFolders } from '@utils/fileUtils';
 import { gracefullyCloseAll } from '@utils/processLauncher';
-import { filteredStackTrace } from '@isomorphic/stackTrace';
+import { filteredStackTrace } from '@utils/stackTrace';
 
 import { configLoader, fixtures, ipc, poolBuilder, ProcessRunner, suiteUtils, testLoader } from '../common';
 import * as globals from '../globals';

--- a/packages/trace-viewer/src/ui/sourceTab.tsx
+++ b/packages/trace-viewer/src/ui/sourceTab.tsx
@@ -22,7 +22,7 @@ import { StackTraceView } from './stackTrace';
 import { CodeMirrorWrapper } from '@web/components/codeMirrorWrapper';
 import type { SourceHighlight } from '@web/components/codeMirrorWrapper';
 import type { SourceLocation, SourceModel } from '@isomorphic/trace/traceModel';
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@trace/trace';
 import { CopyToClipboard } from './copyToClipboard';
 import { ToolbarButton } from '@web/components/toolbarButton';
 import { Toolbar } from '@web/components/toolbar';

--- a/packages/trace-viewer/src/ui/stackTrace.tsx
+++ b/packages/trace-viewer/src/ui/stackTrace.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import './stackTrace.css';
 import { ListView } from '@web/components/listView';
-import type { StackFrame } from '@isomorphic/stackTrace';
+import type { StackFrame } from '@trace/trace';
 
 const StackFrameListView = ListView<StackFrame>;
 

--- a/packages/trace/src/trace.ts
+++ b/packages/trace/src/trace.ts
@@ -16,10 +16,16 @@
 
 import type { FrameSnapshot, ResourceSnapshot } from './snapshot';
 import type { Language } from '@isomorphic/locatorGenerators';
-import type { StackFrame } from '@isomorphic/stackTrace';
 import type { Point } from '@isomorphic/types';
 
 export type Size = { width: number, height: number };
+
+export type StackFrame = {
+  file: string,
+  line: number,
+  column: number,
+  function?: string,
+};
 
 export type SerializedValue = {
   n?: number,

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -31,6 +31,7 @@ export * from './profiler';
 export * from './serializedFS';
 export * from './socksProxy';
 export * from './spawnAsync';
+export * from './stackTrace';
 export * from './stringWidth';
 export * from './task';
 export * from './wsServer';

--- a/packages/utils/stackTrace.ts
+++ b/packages/utils/stackTrace.ts
@@ -19,6 +19,10 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import path from 'path';
+
+import { getAsBooleanFromENV } from './env';
+
 export type RawStack = string[];
 
 export type StackFrame = {
@@ -37,7 +41,7 @@ export function captureRawStack(): RawStack {
   return stack.split('\n');
 }
 
-export function parseStackFrame(text: string, pathSeparator: string): StackFrame | null {
+export function parseStackFrame(text: string): StackFrame | null {
   const match = text && text.match(re);
   if (!match)
     return null;
@@ -46,7 +50,7 @@ export function parseStackFrame(text: string, pathSeparator: string): StackFrame
   let file = match[7];
   if (!file)
     return null;
-  if (!_showInternalStackFrames && (file.startsWith('internal') || file.startsWith('node:')))
+  if (!showInternalStackFrames() && (file.startsWith('internal') || file.startsWith('node:')))
     return null;
 
   const line = match[8];
@@ -96,7 +100,7 @@ export function parseStackFrame(text: string, pathSeparator: string): StackFrame
 
   if (file) {
     if (file.startsWith('file://'))
-      file = fileURLToPath(file, pathSeparator);
+      file = fileURLToPath(file);
     frame.file = file;
   }
 
@@ -134,7 +138,7 @@ export function splitErrorMessage(message: string): { name: string, message: str
   };
 }
 
-export function parseErrorStack(stack: string, pathSeparator: string): {
+export function parseErrorStack(stack: string): {
   message: string;
   stackLines: string[];
   location?: StackFrame;
@@ -147,10 +151,10 @@ export function parseErrorStack(stack: string, pathSeparator: string): {
   const stackLines = lines.slice(firstStackLine);
   let location: StackFrame | undefined;
   for (const line of stackLines) {
-    const frame = parseStackFrame(line, pathSeparator);
+    const frame = parseStackFrame(line);
     if (!frame || !frame.file)
       continue;
-    if (belongsToNodeModules(frame.file, pathSeparator))
+    if (belongsToNodeModules(frame.file))
       continue;
     location = { file: frame.file, column: frame.column || 0, line: frame.line || 0 };
     break;
@@ -158,8 +162,8 @@ export function parseErrorStack(stack: string, pathSeparator: string): {
   return { message, stackLines, location };
 }
 
-function belongsToNodeModules(file: string, pathSeparator: string) {
-  return file.includes(`${pathSeparator}node_modules${pathSeparator}`);
+function belongsToNodeModules(file: string) {
+  return file.includes(`${path.sep}node_modules${path.sep}`);
 }
 
 export function filterStackFile(file: string) {
@@ -172,10 +176,10 @@ export function filterStackFile(file: string) {
   return true;
 }
 
-export function filteredStackTrace(rawStack: RawStack, pathSeparator: string): StackFrame[] {
+export function filteredStackTrace(rawStack: RawStack): StackFrame[] {
   const frames: StackFrame[] = [];
   for (const line of rawStack) {
-    const frame = parseStackFrame(line, pathSeparator);
+    const frame = parseStackFrame(line);
     if (!frame || !frame.file)
       continue;
     if (!filterStackFile(frame.file))
@@ -212,20 +216,19 @@ const re = new RegExp('^' +
 
 const methodRe = /^(.*?) \[as (.*?)\]$/;
 
-function fileURLToPath(fileUrl: string, pathSeparator: string): string {
+function fileURLToPath(fileUrl: string): string {
   if (!fileUrl.startsWith('file://'))
     return fileUrl;
 
-  let path = decodeURIComponent(fileUrl.slice(7));
-  if (path.startsWith('/') && /^[a-zA-Z]:/.test(path.slice(1)))
-    path = path.slice(1);
+  let filePath = decodeURIComponent(fileUrl.slice(7));
+  if (filePath.startsWith('/') && /^[a-zA-Z]:/.test(filePath.slice(1)))
+    filePath = filePath.slice(1);
 
-  return path.replace(/\//g, pathSeparator);
+  return filePath.replace(/\//g, path.sep);
 }
 
 let _coreDir: string | undefined;
 let _boxedStackPrefixes: string[] = [];
-let _showInternalStackFrames = false;
 
 export function setCoreDir(dir: string | undefined) {
   _coreDir = dir;
@@ -239,10 +242,7 @@ export function setBoxedStackPrefixes(prefixes: string[]) {
   _boxedStackPrefixes = prefixes;
 }
 
-export function setShowInternalStackFrames(value: boolean) {
-  _showInternalStackFrames = value;
-}
-
+const _showInternalStackFrames = getAsBooleanFromENV('PWDEBUGIMPL');
 export function showInternalStackFrames(): boolean {
   return _showInternalStackFrames;
 }

--- a/tests/config/utils.ts
+++ b/tests/config/utils.ts
@@ -19,8 +19,7 @@ import { utils, iso } from '../../packages/playwright-core/lib/coreBundle';
 
 import type { iso as isoType } from '../../packages/playwright-core/lib/coreBundle';
 import type { Locator, Frame, Page } from 'playwright-core';
-import type { StackFrame } from '../../packages/isomorphic/stackTrace';
-import type { ActionTraceEvent, TraceEvent } from '@trace/trace';
+import type { StackFrame, ActionTraceEvent, TraceEvent } from '@trace/trace';
 
 const { TraceLoader, TraceModel } = iso;
 type TraceModel = InstanceType<typeof TraceModel>;

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -19,8 +19,7 @@ import { jpegjs } from 'playwright-core/lib/utilsBundle';
 import path from 'path';
 import { browserTest, contextTest as test, expect } from '../config/browserTest';
 import { parseTraceRaw } from '../config/utils';
-import type { StackFrame } from '../../packages/isomorphic/stackTrace';
-import type { ActionTraceEvent } from '../../packages/trace/src/trace';
+import type { StackFrame, ActionTraceEvent } from '../../packages/trace/src/trace';
 import { artifactsFolderName } from '../../packages/playwright/src/isomorphic/folders';
 import { rafraf } from '../page/pageTest';
 


### PR DESCRIPTION
## Summary
- Move `packages/isomorphic/stackTrace.ts` to `packages/utils` and use `path.sep` directly instead of threading a `pathSeparator` argument through the API.
- Compute `PWDEBUGIMPL` lazily inside `stackTrace.ts` instead of pushing it in via `setShowInternalStackFrames()`.
- Source the `StackFrame` type from `@trace/trace` so browser/isomorphic code no longer depends on the node-only utils module.