### PR TITLE
fix(locators): reverse-engineer regexes with all valid flags

### DIFF
--- a/packages/isomorphic/locatorGenerators.ts
+++ b/packages/isomorphic/locatorGenerators.ts
@@ -284,7 +284,7 @@ function combineTokens(factory: LocatorFactory, tokens: string[][], maxOutputSiz
 
 function detectExact(text: string): { exact?: boolean, text: string | RegExp } {
   let exact = false;
-  const match = text.match(/^\/(.*)\/([igm]*)$/);
+  const match = text.match(/^\/(.*)\/([dgimsuvy]*)$/);
   if (match)
     return { text: new RegExp(match[1], match[2]) };
   if (text.endsWith('"')) {

--- a/tests/library/locator-generator.spec.ts
+++ b/tests/library/locator-generator.spec.ts
@@ -322,6 +322,13 @@ it('reverse engineer locators with regex', async ({ page }) => {
     python: `get_by_text(re.compile(r"hel\\"lo"))`,
   });
 
+  expect.soft(generate(page.getByText(/hello/s))).toEqual({
+    csharp: `GetByText(new Regex("hello"))`,
+    java: `getByText(Pattern.compile("hello"))`,
+    javascript: `getByText(/hello/s)`,
+    python: `get_by_text(re.compile(r"hello"))`,
+  });
+
   expect.soft(generate(page.getByPlaceholder(/hel"lo/))).toEqual({
     csharp: `GetByPlaceholder(new Regex("hel\\"lo"))`,
     java: `getByPlaceholder(Pattern.compile("hel\\"lo"))`,


### PR DESCRIPTION
## Summary

- `asLocator` turns a regex text or label selector back into a locator by matching `/^\/(.*)\/([igm]*)$/`. That only accepts the `i`, `g` and `m` flags, so a regex using any other JavaScript flag (`d`, `s`, `u`, `v`, `y`) fails the match and is emitted as a string literal instead of a regex.
- For example `page.getByText(/abc/s)` reverse-engineers to `getByText('/abc/s')`, which matches the literal text `/abc/s` rather than running the regex. This affects codegen output, the trace viewer and assertion error messages, in all four languages.
- The selector parser already uses the full flag set `[dgimsuvy]` (`packages/isomorphic/selectorParser.ts`). This aligns `detectExact` with it, and adds a `getByText(/hello/s)` case to the regex reverse-engineer test.
