### PR TITLE
chore(tsconfig): drop misleading extends fallback comment

### DIFF
--- a/packages/playwright/src/transform/tsconfig-loader.ts
+++ b/packages/playwright/src/transform/tsconfig-loader.ts
@@ -67,7 +67,6 @@ function resolveConfigFile(baseConfigFile: string, referencedConfigFile: string,
     referencedConfigFile += '.json';
   const currentDir = path.dirname(baseConfigFile);
   let resolvedConfigFile = path.resolve(currentDir, referencedConfigFile);
-  // TODO: I don't see how this makes sense, delete in the next minor release.
   if (referencedConfigFile.includes('/') && referencedConfigFile.includes('.') && !fs.existsSync(resolvedConfigFile))
     resolvedConfigFile = path.join(currentDir, 'node_modules', referencedConfigFile);
   if (!fs.existsSync(resolvedConfigFile))

--- a/tests/playwright-test/resolver.spec.ts
+++ b/tests/playwright-test/resolver.spec.ts
@@ -587,6 +587,41 @@ test('should resolve paths relative to the originating config when extending and
   expect(result.exitCode).toBe(0);
 });
 
+test('should resolve extends from an explicit node_modules subpath', async ({ runInlineTest }) => {
+  // The @tsconfig/* base packages are commonly referenced by an explicit subpath,
+  // e.g. "extends": "@tsconfig/node18/tsconfig.json". Playwright resolves such a
+  // value through the config's node_modules when it is not found relative to the
+  // config directory. Removing that fallback would break these configs.
+  const result = await runInlineTest({
+    'node_modules/@my/tsconfig-base/tsconfig.json': `{
+      "compilerOptions": {
+        "paths": {
+          "util/*": ["./mapped/*"],
+        },
+      },
+    }`,
+    'tsconfig.json': `{
+      "extends": "@my/tsconfig-base/tsconfig.json",
+      "compilerOptions": {
+        "baseUrl": ".",
+      },
+    }`,
+    'a.test.ts': `
+      import { foo } from 'util/file';
+      import { test, expect } from '@playwright/test';
+      test('test', () => {
+        expect(foo).toBe('foo');
+      });
+    `,
+    'mapped/file.ts': `
+      export const foo = 'foo';
+    `,
+  });
+
+  expect(result.passed).toBe(1);
+  expect(result.exitCode).toBe(0);
+});
+
 test('should fail loudly when extends path cannot be resolved', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41543' });
 


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/playwright/pull/41571, which left a `TODO: I don't see how this makes sense, delete in the next minor release` on the node_modules fallback in `resolveConfigFile`.

Turns out it does make sense: it's what resolves `"extends": "@tsconfig/<name>/tsconfig.json"`, the canonical way to use `@tsconfig/*` base packages by explicit subpath. There are ~25k of these on GitHub. Deleting the fallback would turn all of them into hard errors now that #41571 fails loudly on unresolved extends.

So rather than delete the code, this drops the misleading comment and adds a regression test that fails without the fallback.
