### PR TITLE
chore: remove __testHookBeforeQuery

### DIFF
--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -257,8 +257,8 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return result.elements.map(e => ElementHandle.from(e) as ElementHandle<SVGElement | HTMLElement>);
   }
 
-  async _queryCount(selector: string, options?: {}): Promise<number> {
-    return (await this._channel.queryCount({ selector, ...options }, undefined)).value;
+  async _queryCount(selector: string): Promise<number> {
+    return (await this._channel.queryCount({ selector }, undefined)).value;
   }
 
   async content(): Promise<string> {

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -264,9 +264,8 @@ export class Locator implements api.Locator {
     await this._frame._channel.blur({ selector: this._selector, strict: true, ...options, timeout: this._frame._timeout(options) }, options?.signal);
   }
 
-  // options are only here for testing
-  async count(_options?: {}): Promise<number> {
-    return await this._frame._queryCount(this._selector, _options);
+  async count(): Promise<number> {
+    return await this._frame._queryCount(this._selector);
   }
 
   async normalize(): Promise<Locator> {

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -115,7 +115,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async queryCount(params: channels.FrameQueryCountParams, progress: Progress): Promise<channels.FrameQueryCountResult> {
-    return { value: await this._frame.queryCount(progress, params.selector, params) };
+    return { value: await this._frame.queryCount(progress, params.selector) };
   }
 
   async content(params: channels.FrameContentParams, progress: Progress): Promise<channels.FrameContentResult> {

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -77,12 +77,11 @@ export class FrameSelectors {
     }, { info: resolved.info, scope: resolved.scope });
   }
 
-  async queryCount(selector: string, options: any): Promise<number> {
+  async queryCount(selector: string): Promise<number> {
     const resolved = await this.resolveInjectedForSelector(selector);
     // Be careful, |this.frame| can be different from |resolved.frame|.
     if (!resolved)
       throw new Error(`Failed to find frame for selector "${selector}"`);
-    await options.__testHookBeforeQuery?.();
     return await resolved.injected.evaluate((injected, { info }) => {
       const elements = injected.querySelectorAll(info.parsed, document);
       injected.checkDeprecatedSelectorUsage(info.parsed, elements);

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -940,9 +940,9 @@ export class Frame extends SdkObject<FrameEventMap> {
     return progress.race(this.selectors.queryAll(selector));
   }
 
-  async queryCount(progress: Progress, selector: string, options: any): Promise<number> {
+  async queryCount(progress: Progress, selector: string): Promise<number> {
     try {
-      return await progress.race(this.selectors.queryCount(selector, options));
+      return await progress.race(this.selectors.queryCount(selector));
     } catch (e) {
       if (this.isNonRetriableError(e))
         throw e;

--- a/tests/page/locator-query.spec.ts
+++ b/tests/page/locator-query.spec.ts
@@ -273,10 +273,19 @@ it('alias methods coverage', async ({ page }) => {
   await expect(page.mainFrame().locator('button')).toHaveCount(1);
 });
 
-it('count() should not throw during navigation', async ({ page, mode }) => {
-  it.skip(mode !== 'default', 'No test hooks');
-  await page.setContent(`<div>A</div>`);
-  const __testHookBeforeQuery = () => page.goto('data:text/html,<div>A</div><div>B</div>');
-  // @ts-expect-error
-  expect(await page.locator('div').count({ __testHookBeforeQuery })).toBe(0);
+it('count() should not throw during navigation', async ({ playwright, page, server }) => {
+  const createDummySelector = () => ({
+    query(root, selector) {
+      window.location.href = './frames/one-frame.html';
+      return document.querySelector(selector);
+    },
+    queryAll(root: HTMLElement, selector: string) {
+      window.location.href = './frames/one-frame.html';
+      return Array.from(document.querySelectorAll(selector));
+    }
+  });
+  await playwright.selectors.register('locatorCountHelper', createDummySelector);
+  await page.goto(server.PREFIX + '/frames/one-frame.html');
+  await page.frames()[1].setContent(`<div>A</div>`);
+  expect(await page.frameLocator('locatorCountHelper=iframe').locator('locatorCountHelper=div').count()).toBe(0);
 });


### PR DESCRIPTION
This hook is not very convenient to preserve in future refactorings.