### PR TITLE
fix(locators): reverse-engineer regexes with all valid flags

### DIFF
--- a/packages/isomorphic/locatorGenerators.ts
+++ b/packages/isomorphic/locatorGenerators.ts
@@ -284,7 +284,7 @@ function combineTokens(factory: LocatorFactory, tokens: string[][], maxOutputSiz
 
 function detectExact(text: string): { exact?: boolean, text: string | RegExp } {
   let exact = false;
-  const match = text.match(/^\/(.*)\/([igm]*)$/);
+  const match = text.match(/^\/(.*)\/([dgimsuvy]*)$/);
   if (match)
     return { text: new RegExp(match[1], match[2]) };
   if (text.endsWith('"')) {

--- a/tests/library/locator-generator.spec.ts
+++ b/tests/library/locator-generator.spec.ts
@@ -330,6 +330,17 @@ it('reverse engineer locators with regex', async ({ page }) => {
   });
 });
 
+it('reverse engineer regexes with all flags', async () => {
+  // Only javascript is checked here. python, java and csharp locators do not
+  // encode the s, u, v, y and d flags, so a regex carrying one of them cannot
+  // round-trip through those languages the way generate() asserts. The value of
+  // the change is the javascript rendering in error messages and the trace
+  // viewer, where these selectors were shown as string literals.
+  expect.soft(asLocator('javascript', 'internal:text=/abc/s')).toBe('getByText(/abc/s)');
+  expect.soft(asLocator('javascript', 'internal:text=/abc/u')).toBe('getByText(/abc/u)');
+  expect.soft(asLocator('javascript', 'internal:text=/abc/y')).toBe('getByText(/abc/y)');
+});
+
 it('reverse engineer hasText', async ({ page }) => {
   expect.soft(generate(page.getByText('Hello').filter({ hasText: 'wo"rld\n' }))).toEqual({
     csharp: `GetByText("Hello").Filter(new() { HasText = "wo\\"rld\\n" })`,


### PR DESCRIPTION
## Summary

- Follow-up to #41592. `asLocator` matched regex text and label selectors with only the flags `i`, `g`, `m` (`/^\/(.*)\/([igm]*)$/`), so a regex using any other JavaScript flag (`d`, `s`, `u`, `v`, `y`) was reverse-engineered to a string literal instead of a regex, for example `getByText('/abc/s')`. This shows up in error messages and the trace viewer. The selector parser already uses `[dgimsuvy]`.
- The test in #41592 used `generate()`, which asserts a round-trip across all four languages. python, java and csharp locators do not encode these flags, so that round-trip cannot hold for a flag-carrying regex, which is why it failed. This version asserts only the javascript rendering with `asLocator`, which does round-trip.
