### PR TITLE
test(webkit): unskip right-click tests fixed by browser roll

### DIFF
--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1215,18 +1215,13 @@ it('should fire contextmenu event on right click in correct order', async ({ pag
   const entries = [];
   page.on('console', message => entries.push(message.text()));
   await page.getByRole('button', { name: 'Click me' }).click({ button: 'right' });
-  if (browserName === 'webkit')
-    await expect.poll(() => entries).toEqual(['mousedown', 'contextmenu']);
-  else if (browserName === 'chromium' && isWindows)
+  if (browserName === 'chromium' && isWindows)
     await expect.poll(() => entries).toEqual(['mousedown', 'mouseup', 'contextmenu']);
   else
     await expect.poll(() => entries).toEqual(['mousedown', 'contextmenu', 'mouseup']);
 });
 
-it('should click after a right click', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39246' } }, async ({ page, browserName }) => {
-  // On webkit the native context menu opened by the right click swallows the
-  // following left click, so the button never receives it.
-  it.fixme(browserName === 'webkit');
+it('should click after a right click', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/39246' } }, async ({ page }) => {
   await page.setContent(`
     <button>Click me</button>
     <script>


### PR DESCRIPTION
## Summary
- The recent WebKit roll makes right click fire `mouseup` after `contextmenu`, matching other browsers.
- Drop the now-redundant WebKit branch in the contextmenu-order test.
- Unskip `should click after a right click` (the native context menu no longer swallows the following left click).

Fixes https://github.com/microsoft/playwright/issues/39246