### PR TITLE
chore: make $$eval work when no frame was found

### DIFF
--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -68,8 +68,10 @@ export class FrameSelectors {
   async queryArrayInMainWorld(selector: string, scope?: ElementHandle): Promise<JSHandle<Element[]>> {
     const resolved = await this.resolveInjectedForSelector(selector, { mainWorld: true }, scope);
     // Be careful, |this.frame| can be different from |resolved.frame|.
-    if (!resolved)
-      throw new Error(`Failed to find frame for selector "${selector}"`);
+    if (!resolved) {
+      const context = await this.frame.context('main');
+      return await context.evaluateHandle(() => { return []; });
+    }
     return await resolved.injected.evaluateHandle((injected, { info, scope }) => {
       const elements = injected.querySelectorAll(info.parsed, scope || document);
       injected.checkDeprecatedSelectorUsage(info.parsed, elements);
@@ -79,9 +81,8 @@ export class FrameSelectors {
 
   async queryCount(selector: string): Promise<number> {
     const resolved = await this.resolveInjectedForSelector(selector);
-    // Be careful, |this.frame| can be different from |resolved.frame|.
     if (!resolved)
-      throw new Error(`Failed to find frame for selector "${selector}"`);
+      return 0;
     return await resolved.injected.evaluate((injected, { info }) => {
       const elements = injected.querySelectorAll(info.parsed, document);
       injected.checkDeprecatedSelectorUsage(info.parsed, elements);

--- a/tests/page/selectors-frame.spec.ts
+++ b/tests/page/selectors-frame.spec.ts
@@ -122,17 +122,11 @@ it('$eval should throw for missing frame', async ({ page, server }) => {
   }
 });
 
-it('$$eval should throw for missing frame', async ({ page, server }) => {
+it('$$eval should not throw for missing frame', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);
-  {
-    const error = await page.$$eval('iframe >> internal:control=enter-frame >> canvas', e => 1).catch(e => e);
-    expect(error.message).toContain('page.$$eval: Failed to find frame for selector');
-  }
-  {
-    const body = await page.$('body');
-    const error = await body.$$eval('iframe >> internal:control=enter-frame >> canvas', e => 1).catch(e => e);
-    expect(error.message).toContain('Failed to find frame for selector');
-  }
+  expect(await page.$$eval('iframe >> internal:control=enter-frame >> canvas', e => e.length)).toBe(0);
+  const body = await page.$('body');
+  expect(await body.$$eval('iframe >> internal:control=enter-frame >> canvas', e => e.length)).toBe(0);
 });
 
 it('should work for $ and $$ (handle)', async ({ page, server }) => {


### PR DESCRIPTION
Previously, we were throwing `Failed to find frame for selector` error. However, this will not be compatible with frame-piercing locators, so just default to an empty array.