### PR TITLE
chore: rework screenshot masking to be compatible with frame piercing

### DIFF
--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -318,8 +318,10 @@ export class Highlight {
     this._renderedEntries = [];
   }
 
-  maskElements(elements: Element[], color: string) {
-    this.updateHighlight(elements.map(element => ({ element, color })));
+  addMaskedElements(elements: Element[], color: string) {
+    const existingEntries = this._renderedEntries.map(e => ({ element: e.targetElement, color: e.color }));
+    const newEntries = elements.map(element => ({ element, color }));
+    this.updateHighlight([...existingEntries, ...newEntries]);
   }
 
   updateHighlight(entries: HighlightEntry[]) {

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -1303,20 +1303,9 @@ export class InjectedScript {
     return new Highlight(this);
   }
 
-  maskSelectors(selectors: ParsedSelector[], color: string) {
-    const highlight = this._createHighlight();
-    const elements = [];
-    for (const selector of selectors)
-      elements.push(this.querySelectorAll(selector, this.document.documentElement));
-    highlight.maskElements(elements.flat(), color);
-  }
-
-  private _createHighlight() {
-    if (this._highlight)
-      this.hideHighlight();
-    this._highlight = new Highlight(this);
-    this._highlight.install();
-    return this._highlight;
+  addMaskedElements(elements: Element[], color: string) {
+    const highlight = this._ensureHighlight();
+    highlight.addMaskedElements(elements, color);
   }
 
   private _ensureHighlight() {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -47,7 +47,6 @@ import type { ElementStateWithoutStable, FrameExpectParams, InjectedScript } fro
 import type { Progress } from './progress';
 import type { ScreenshotOptions } from './screenshotter';
 import type { RegisteredListener } from '@utils/eventsHelper';
-import type { ParsedSelector } from '@isomorphic/selectorParser';
 import type * as channels from './channels';
 
 type ContextData = {
@@ -928,14 +927,6 @@ export class Frame extends SdkObject<FrameEventMap> {
     return result;
   }
 
-  async maskSelectors(selectors: ParsedSelector[], color: string): Promise<void> {
-    const context = await this.utilityContext();
-    const injectedScript = await context.injectedScript();
-    await injectedScript.evaluate((injected, { parsed, color }) => {
-      injected.maskSelectors(parsed, color);
-    }, { parsed: selectors, color: color });
-  }
-
   async querySelectorAll(progress: Progress, selector: string): Promise<dom.ElementHandle<Element>[]> {
     return progress.race(this.selectors.queryAll(selector));
   }
@@ -1402,11 +1393,9 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   async hideHighlight() {
     return this.raceAgainstEvaluationStallingEvents(async () => {
-      const context = await this.utilityContext();
-      const injectedScript = await context.injectedScript();
-      return await injectedScript.evaluate(injected => {
-        return injected.hideHighlight();
-      });
+      const context = this._contextData.get('utility')?.context;
+      const injectedScript = await context?.injectedScript();
+      await injectedScript?.evaluate(injected => injected.hideHighlight());
     });
   }
 

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { MultiMap } from '@isomorphic/multimap';
 import { assert } from '@isomorphic/assert';
 import { helper } from './helper';
 
@@ -25,7 +24,6 @@ import type { Page } from './page';
 import type { Progress } from './progress';
 import type * as types from './types';
 import type { Rect } from '@isomorphic/types';
-import type { ParsedSelector } from '@isomorphic/selectorParser';
 
 
 declare global {
@@ -275,21 +273,19 @@ export class Screenshotter {
     if (!options.mask || !options.mask.length)
       return () => Promise.resolve();
 
-    const framesToParsedSelectors: MultiMap<Frame, ParsedSelector> = new MultiMap();
-    await progress.race(Promise.all((options.mask || []).map(async ({ frame, selector }) => {
-      const pair = await frame.selectors.resolveFrameForSelector(selector);
-      if (pair)
-        framesToParsedSelectors.set(pair.frame, pair.info.parsed);
-    })));
-
-    const frames = [...framesToParsedSelectors.keys()];
-    const cleanup = async () => {
-      await Promise.all(frames.map(frame => frame.hideHighlight()));
-    };
-
+    const cleanup = () => this._page.hideHighlight();
     try {
-      const promises = frames.map(frame => frame.maskSelectors(framesToParsedSelectors.get(frame), options.maskColor || '#F0F'));
-      await progress.race(Promise.all(promises));
+      await progress.race(this._page.hideHighlight());
+      await progress.race(Promise.all((options.mask || []).map(async ({ frame, selector }) => {
+        const resolved = await frame.selectors.resolveInjectedForSelector(selector, { strict: false });
+        if (!resolved)
+          return;
+        await resolved.injected.evaluate((injected, { info, color }) => {
+          const elements = injected.querySelectorAll(info.parsed, injected.document.documentElement);
+          if (elements.length)
+            injected.addMaskedElements(elements, color);
+        }, { info: resolved.info, color: options.maskColor || '#F0F' });
+      })));
       return cleanup;
     } catch (error) {
       cleanup().catch(() => {});


### PR DESCRIPTION
In the new world, there is no way to "resolve frame for selector". Instead, you can "evaluate on selector", so use that.