### PR TITLE
docs(api): add Python expect_download usage

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4648,6 +4648,24 @@ Will throw an error if the page is closed before the download event is fired.
 * langs: python
 - returns: <[EventContextManager]<[Download]>>
 
+**Usage**
+
+```python async
+async with page.expect_download() as download_info:
+    await page.get_by_text("Download").click()
+
+download = await download_info.value
+print(download.url)
+```
+
+```python sync
+with page.expect_download() as download_info:
+    page.get_by_text("Download").click()
+
+download = download_info.value
+print(download.url)
+```
+
 ### param: Page.waitForDownload.action = %%-csharp-wait-for-event-action-%%
 * since: v1.12
 


### PR DESCRIPTION
## Summary

Adds Python sync and async usage examples for `page.expect_download()` in the `Page.waitForDownload` API docs.

## Why

The Python API exposes `expect_download()` as a context manager, but the API reference does not clearly show how to access the final `Download` object through `download_info.value`.

## Change

Adds examples for both Python APIs:

* `async with page.expect_download() as download_info`
* `download = await download_info.value`
* `with page.expect_download() as download_info`
* `download = download_info.value`

## Notes

I did not edit the generated Python files in `microsoft/playwright-python`, since those docstrings are generated from the upstream API markdown.

References microsoft/playwright-python#3110.
