### PR TITLE
fix(reporter): surface JSON.stringify failures in json reporter instead of silently succeeding

### DIFF
--- a/packages/playwright/src/reporters/json.ts
+++ b/packages/playwright/src/reporters/json.ts
@@ -239,7 +239,16 @@ class JSONReporter implements ReporterV2 {
 }
 
 async function outputReport(report: JSONReport, resolvedOutputFile: string | undefined) {
-  const reportString = JSON.stringify(report, undefined, 2);
+  let reportString: string;
+  try {
+    reportString = JSON.stringify(report, undefined, 2);
+  } catch (e) {
+    // JSON.stringify() throws RangeError('Invalid string length') when the resulting
+    // string would exceed the JS engine's max string length (e.g. for very large merged
+    // reports). Surface this as a real, actionable error instead of silently producing
+    // a missing/empty report file - the caller (reporter/merge command) will fail the run.
+    throw new Error(`Failed to generate JSON report: the report is too large to serialize (${e instanceof Error ? e.message : String(e)}). Consider splitting the run into smaller shards or using a different reporter.`);
+  }
   if (resolvedOutputFile) {
     await fs.promises.mkdir(path.dirname(resolvedOutputFile), { recursive: true });
     await fs.promises.writeFile(resolvedOutputFile, reportString);

--- a/tests/playwright-test/reporter-json.spec.ts
+++ b/tests/playwright-test/reporter-json.spec.ts
@@ -355,3 +355,31 @@ test('should report parallelIndex', async ({ runInlineTest }, testInfo) => {
   expect(result.report.suites[0].specs[1].tests[0].results[0].parallelIndex).toBe(1);
   expect(result.report.suites[0].specs[2].tests[0].results[0].parallelIndex).toBe(1);
 });
+
+test('should fail the run when JSON.stringify fails to serialize the report', async ({ runInlineTest }) => {
+  // Regression test for https://github.com/microsoft/playwright/issues/40983:
+  // a report that is too large for JSON.stringify() (RangeError: Invalid string
+  // length) used to be silently swallowed, exiting 0 with a missing/empty file.
+  const result = await runInlineTest({
+    'patch-reporter.js': `
+      class PatchReporter {
+        onEnd() {
+          const original = JSON.stringify;
+          JSON.stringify = (...args) => {
+            JSON.stringify = original;
+            throw new RangeError('Invalid string length');
+          };
+        }
+      }
+      module.exports = PatchReporter;
+    `,
+    'playwright.config.ts': `module.exports = { reporter: [['dot'], ['./patch-reporter.js'], ['json', { outputFile: 'report.json' }]] };`,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('passing', async () => {});
+    `,
+  }, { reporter: '' });
+  expect(result.exitCode).toBe(1);
+  expect(result.passed).toBe(1);
+  expect(result.output).toContain('Failed to generate JSON report');
+});


### PR DESCRIPTION
Fixes #40983

- Wrap the JSON.stringify call in the JSON reporter's outputReport with a try/catch that rethrows a clear, actionable error (e.g. when hitting V8's max string length on very large merged reports) instead of letting a raw RangeError surface with no context
- The error still propagates through the existing reporter-error mechanism, so the run/merge command now correctly exits non-zero instead of silently succeeding with a 0-byte report
