### PR TITLE
fix(test-runner): consider dependency project tests when applying --last-failed

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -148,7 +148,20 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   }
 
   // Add post-filtered top-level projects to the root suite for sharding and 'only' processing.
-  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], project => filteredProjectSuites.get(project)!._hasTests());
+  // A project only counts as having tests (and therefore as a candidate root-level project) if it
+  // has tests that also survive the post-shard filters (e.g. --last-failed). Otherwise a project
+  // that is only reachable through another project's "dependencies" (and therefore classified as
+  // a "dependency" project below) could end up entirely excluded from consideration, even though
+  // it is the project that actually contains the tests we are looking for.
+  const projectHasMatchingTests = (project: commonConfig.FullProjectInternal) => {
+    const filteredProjectSuite = filteredProjectSuites.get(project)!;
+    if (!filteredProjectSuite._hasTests())
+      return false;
+    if (!testRun.postShardTestFilters.length)
+      return true;
+    return filteredProjectSuite.allTests().some(test => testRun.postShardTestFilters.every(filter => filter(test)));
+  };
+  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], projectHasMatchingTests);
   for (const [project, type] of projectClosure) {
     if (type === 'top-level') {
       project.project.repeatEach = project.fullConfig.configCLIOverrides.repeatEach ?? project.project.repeatEach;

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -847,6 +847,41 @@ test('should run last failed tests', async ({ runInlineTest }) => {
   expect(result2.failed).toBe(1);
 });
 
+test('should run last failed tests when the failing project is a dependency of another project', async ({ runInlineTest }) => {
+  const workspace = {
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'default', testIgnore: /setup/ },
+          { name: 'sequential', testMatch: /setup/, dependencies: ['default'] },
+        ],
+      });
+    `,
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+      test('fail', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+    'setup.spec.js': `
+      import { test } from '@playwright/test';
+      test('setup', async () => {});
+    `,
+  };
+  const result1 = await runInlineTest(workspace);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(1);
+  expect(result1.failed).toBe(1);
+
+  const result2 = await runInlineTest(workspace, {}, {}, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(1);
+  expect(result2.output).toContain('a.spec.js:4:11 › fail');
+});
+
 test('should run nothing with --last-failed when previous run had no failures', async ({ runInlineTest }) => {
   const workspace = {
     'a.spec.js': `


### PR DESCRIPTION
Fixes #39811

- When deciding which projects are top-level entry points for the run, also check whether a projects own tests match --last-faileds postShardTestFilters, not just the pre-shard filters
- Previously a project whose tests actually failed last run, but which is only reachable as a dependency of another project, was never added to the run before the last-failed filter executed, causing "No tests found" even though .last-run.json had valid failed test IDs
