### PR TITLE
fix(transform): strip TypeScript declare class fields before class-features plugins run

### DIFF
--- a/packages/playwright/src/transform/babelBundle.ts
+++ b/packages/playwright/src/transform/babelBundle.ts
@@ -41,12 +41,10 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (isTypeScript) {
     plugins.push(
-        // Babel merges plugins and presets into a single traversal, running plain
-        // plugins before presets regardless of list order. Since TypeScript
-        // stripping is applied via `@babel/preset-typescript` (a preset), the
-        // class-features plugins below (decorators/class-properties/private-methods)
-        // otherwise see not-yet-stripped TS-only syntax, such as `declare` class
-        // fields, and throw. Strip those fields ourselves, before those plugins run.
+        // Strip "declare" class fields before these plugins run:
+        // - plugin-proposal-decorators
+        // - plugin-transform-class-properties
+        // - plugin-transform-private-methods
         // See https://github.com/microsoft/playwright/issues/38586
         [
           (): PluginObj => ({

--- a/packages/playwright/src/transform/babelBundle.ts
+++ b/packages/playwright/src/transform/babelBundle.ts
@@ -41,6 +41,26 @@ function babelTransformOptions(isTypeScript: boolean, isModule: boolean, plugins
 
   if (isTypeScript) {
     plugins.push(
+        // Babel merges plugins and presets into a single traversal, running plain
+        // plugins before presets regardless of list order. Since TypeScript
+        // stripping is applied via `@babel/preset-typescript` (a preset), the
+        // class-features plugins below (decorators/class-properties/private-methods)
+        // otherwise see not-yet-stripped TS-only syntax, such as `declare` class
+        // fields, and throw. Strip those fields ourselves, before those plugins run.
+        // See https://github.com/microsoft/playwright/issues/38586
+        [
+          (): PluginObj => ({
+            name: 'strip-declare-class-fields',
+            visitor: {
+              Class(path) {
+                for (const member of path.get('body.body')) {
+                  if (member.isClassProperty() && member.node.declare)
+                    member.remove();
+                }
+              }
+            }
+          })
+        ],
         [require('@babel/plugin-proposal-decorators'), { version: '2023-05' }],
         [require('@babel/plugin-transform-class-properties')],
         [require('@babel/plugin-transform-class-static-block')],

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -37,22 +37,30 @@ test('should succeed', async ({ runInlineTest }) => {
   expect(result.failed).toBe(0);
 });
 
-test('should support declare class fields', async ({ runInlineTest }) => {
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38586' });
+test('should support declare class fields', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38586' },
+}, async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'one-success.spec.ts': `
       import { test, expect } from '@playwright/test';
 
-      class Foo {
-        declare field: number;
-        constructor() {
-          this.field = 42;
+      class Base {
+        constructor(p1, p2) {
+          this.p1 = p1;
+          this.p2 = p2;
         }
       }
 
-      test('succeeds', () => {
-        expect(new Foo().field).toBe(42);
-      });
+      class Derived extends Base {
+        p1: string;
+        declare p2: string;
+      }
+
+      test('works', () => {
+        const d = new Derived('value1', 'value2');
+        expect(d.p1).toBe(undefined);
+        expect(d.p2).toBe('value2');
+      })
     `
   });
   expect(result.exitCode).toBe(0);

--- a/tests/playwright-test/babel.spec.ts
+++ b/tests/playwright-test/babel.spec.ts
@@ -37,6 +37,29 @@ test('should succeed', async ({ runInlineTest }) => {
   expect(result.failed).toBe(0);
 });
 
+test('should support declare class fields', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/38586' });
+  const result = await runInlineTest({
+    'one-success.spec.ts': `
+      import { test, expect } from '@playwright/test';
+
+      class Foo {
+        declare field: number;
+        constructor() {
+          this.field = 42;
+        }
+      }
+
+      test('succeeds', () => {
+        expect(new Foo().field).toBe(42);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.failed).toBe(0);
+});
+
 test('should treat enums equally', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'component.tsx': `


### PR DESCRIPTION
Fixes #38586

- babelBundle applies TypeScript stripping via a preset, and Babel always runs plain plugins before presets regardless of list order, so class-features plugins (decorators, class-properties) saw declare class fields before TypeScript stripping removed them, throwing a SyntaxError
- Reordering the preset directly would fix this but breaks constructor-parameter-property vs class-field-initializer injection ordering (issue #21794), so instead added a small dedicated pre-pass plugin that strips declare-flagged class fields before the class-features plugins run
