### PR TITLE
fix(firefox): guard undefined pageError.location in dispatcher

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -117,9 +117,9 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
         error: serializeError(pageError.error),
         page: PageDispatcher.from(this, page),
         location: {
-          url: pageError.location.url,
-          line: pageError.location.lineNumber,
-          column: pageError.location.columnNumber,
+          url: pageError.location?.url ?? '',
+          line: pageError.location?.lineNumber ?? 0,
+          column: pageError.location?.columnNumber ?? 0,
         },
       });
     });


### PR DESCRIPTION
### What / why

A page emitting an uncaught JS error whose `location` is `undefined` crashes the entire Node driver process with an unhandled `TypeError: Cannot read properties of undefined (reading 'url')`, rather than surfacing the error to the client. Because the crash happens upstream of event dispatch, `page.on('pageerror')` cannot intercept it. Regression from #39767 (shipped 1.60.0).

Fixes #41628.

### The fix

`BrowserContextDispatcher`'s `PageError` listener dereferenced `pageError.location.url` unconditionally. Firefox can deliver an uncaught error with no `location` (reproducible with Firefox builds that omit it, e.g. Camoufox), so guard the access:

```ts
location: {
  url: pageError.location?.url ?? '',
  line: pageError.location?.lineNumber ?? 0,
  column: pageError.location?.columnNumber ?? 0,
},
```

A driver-process crash on absent protocol data is never desirable regardless of the Firefox build.

### Notes

- Minimal, defensive one-liner; no behavior change when `location` is present.
- Happy to add a regression test if you can point me at the right fixture/harness — the trigger is a locationless uncaught page error, which needs a crafted Firefox fixture to reproduce deterministically.