### PR TITLE
fix(windows): hide console window when launching headless browsers

### DIFF
--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -224,6 +224,7 @@ export abstract class BrowserType extends SdkObject {
       },
       stdio: 'pipe',
       tempDirectories: prepared.tempDirectories,
+      windowsHide: options.headless,
       attemptToGracefullyClose: async () => {
         if ((options as any).__testHookGracefullyClose)
           await (options as any).__testHookGracefullyClose();

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -172,6 +172,7 @@ class FfmpegVideoRecorder {
       stdio: 'stdin',
       log: (message: string) => debugLogger.log('browser', message),
       tempDirectories: [],
+      windowsHide: true,
       attemptToGracefullyClose: async () => {
         debugLogger.log('browser', 'Closing stdin...');
         launchedProcess.stdin!.end();

--- a/packages/utils/processLauncher.ts
+++ b/packages/utils/processLauncher.ts
@@ -27,6 +27,7 @@ export type LaunchProcessOptions = {
   args?: string[],
   env?: NodeJS.ProcessEnv,
   shell?: boolean,
+  windowsHide?: boolean,
 
   handleSIGINT?: boolean,
   handleSIGTERM?: boolean,
@@ -140,6 +141,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     cwd: options.cwd,
     shell: options.shell,
     stdio,
+    windowsHide: options.windowsHide,
   };
   const spawnedProcess = childProcess.spawn(options.command, options.args || [], spawnOptions);
 
@@ -233,7 +235,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
       // Force kill the browser.
       try {
         if (process.platform === 'win32') {
-          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true });
+          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true, windowsHide: true });
           const [stdout, stderr] = [taskkillProcess.stdout.toString(), taskkillProcess.stderr.toString()];
           if (stdout)
             options.log(`[pid=${spawnedProcess.pid}] taskkill stdout: ${stdout}`);


### PR DESCRIPTION
## Rationale

The tricky part here is that `launchProcess()` is shared by all browser launches, including headed ones like codegen and Inspector. Setting `windowsHide` unconditionally would hide those too, so it needs to be opt-in and only kick in for headless launches.

While at it, also applied it to the ffmpeg and taskkill spawns since neither of those should be showing a console window either.

Fixes #41630