### PR TITLE
chore(bidi): fix Enter key

### DIFF
--- a/packages/playwright-core/src/server/bidi/third_party/bidiKeyboard.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiKeyboard.ts
@@ -32,6 +32,8 @@ export const getBidiKeyValue = (keyName: string) => {
     case 'Clear':
       return '\uE005';
     case 'Enter':
+      return '\uE006';
+    case 'NumpadEnter':
       return '\uE007';
     case 'Shift':
     case 'ShiftLeft':

--- a/tests/bidi/expectations/moz-firefox-nightly-page.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-page.txt
@@ -102,7 +102,6 @@ page/page-history.spec.ts › goBack/goForward should work with bfcache-able pag
 page/page-history.spec.ts › page.goBack should work for file urls [timeout]
 page/page-history.spec.ts › regression test for issue 20791 [flaky]
 page/page-keyboard.spec.ts › insertText should only emit input event [fail]
-page/page-keyboard.spec.ts › should press Enter [fail]
 page/page-keyboard.spec.ts › should press audio and media control keys [fail]
 page/page-keyboard.spec.ts › should send a character with insertText [fail]
 page/page-mouse.spec.ts › should always round down [fail]


### PR DESCRIPTION
Fixes "should press Enter" in `page/page-keyboard.spec.ts`.