### PR TITLE
fix(tests): wait for click action to start before aborting in signal test

### DIFF
--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1381,6 +1381,8 @@ it('should throw an Error when aborted in-flight with a string reason', async ({
   await page.setContent(`<button style="display:none">click me</button>`);
   const controller = new AbortController();
   const promise = page.locator('button').click({ signal: controller.signal, timeout: 0 });
+  // Give the action time to start and emit call log entries before aborting.
+  await page.waitForTimeout(500);
   controller.abort('aborted by user');
   const error = await promise.catch(e => e);
   expect(error).toBeInstanceOf(Error);


### PR DESCRIPTION
The "should throw an Error when aborted in-flight with a string reason" test was aborting the signal immediately after starting the click, before the server-side ProgressController was registered. On tracing bots the __abort__ message arrived first and was silently ignored, so the test timed out.

This adds the same 500ms wait that the adjacent "should abort via signal" test already uses, giving the action time to start before aborting.