### PR TITLE
test(network): skip response.body() navigation race test under tracing

### DIFF
--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -451,8 +451,9 @@ it('Response.formData() should parse multipart/form-data in page context', async
   expect(result.fileContent).toBe('hello');
 });
 
-it('should give a readable error when response.body() races with navigation', async ({ page, server, browserName }) => {
+it('should give a readable error when response.body() races with navigation', async ({ page, server, browserName, trace }) => {
   it.skip(browserName === 'firefox', 'Firefox keeps the response body available after navigating away, so it never throws');
+  it.skip(trace === 'on', 'Tracing fetches response bodies eagerly, so the body is already cached before navigation');
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41512' });
   const [response] = await Promise.all([
     page.waitForResponse(server.PREFIX + '/title.html'),


### PR DESCRIPTION
This test was 40%+ flaky on the tracing bots (webkit-page and chromium-page).

The HAR tracer calls response.internalBody() eagerly to capture response bodies, so the body is already cached before the test navigates away from title.html. In that case response.body() returns the cached buffer instead of the "navigated away" error the test is looking for. Skip the test when tracing is enabled - the eviction error message is still covered by the non-tracing runs.

Fixes https://github.com/microsoft/playwright/issues/41512