### PR TITLE
fix(mcp): await init page before screenshot

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -190,6 +190,7 @@ export class Context {
       await this.newTab();
     if (crashed)
       this._currentTab!.logErrorMessage('Page crashed and was reset to about:blank.');
+    await this._currentTab!.waitForInitialized();
     return this._currentTab!;
   }
 

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -57,6 +57,8 @@ const screenshot = defineTabTool({
 
     const screenshotTargetLabel = params.target ? params.element || 'element' : (params.fullPage ? 'full page' : 'viewport');
     const target = params.target ? await tab.targetLocator({ element: params.element, target: params.target }) : null;
+    if (!target)
+      await tab.waitForInitialized();
     const data = target ? await target.locator.screenshot(options) : await tab.page.screenshot(options);
 
     const resolvedFile = await response.resolveClientFile({ prefix: target ? 'element' : 'page', ext: fileType, suggestedFilename: params.filename }, `Screenshot of ${screenshotTargetLabel}`);

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -57,8 +57,6 @@ const screenshot = defineTabTool({
 
     const screenshotTargetLabel = params.target ? params.element || 'element' : (params.fullPage ? 'full page' : 'viewport');
     const target = params.target ? await tab.targetLocator({ element: params.element, target: params.target }) : null;
-    if (!target)
-      await tab.waitForInitialized();
     const data = target ? await target.locator.screenshot(options) : await tab.page.screenshot(options);
 
     const resolvedFile = await response.resolveClientFile({ prefix: target ? 'element' : 'page', ext: fileType, suggestedFilename: params.filename }, `Screenshot of ${screenshotTargetLabel}`);

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -148,6 +148,10 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._consoleLog.stop();
   }
 
+  async waitForInitialized() {
+    await this._initializedPromise;
+  }
+
   static forPage(page: playwright.Page): Tab | undefined {
     // eslint-disable-next-line no-restricted-syntax
     return (page as any)[tabSymbol];

--- a/tests/mcp/init-page.spec.ts
+++ b/tests/mcp/init-page.spec.ts
@@ -94,6 +94,27 @@ test('init-page surfaces load errors instead of silently dropping them', async (
   expect(JSON.stringify(response.content)).toContain('boom from initPage');
 });
 
+test('init-page is applied before the first page screenshot', async ({ startClient }) => {
+  const initPagePath = test.info().outputPath('screenshotInitPage.ts');
+  await fs.promises.writeFile(initPagePath, `
+    export default async ({ page }) => {
+      page.screenshot = async () => {
+        throw new Error('initPage screenshot hook applied');
+      };
+    };
+  `);
+
+  const { client } = await startClient({
+    args: [`--init-page=${initPagePath}`],
+  });
+  const response: any = await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: {},
+  });
+  expect(response.isError).toBe(true);
+  expect(JSON.stringify(response.content)).toContain('initPage screenshot hook applied');
+});
+
 test('--init-page w/ --init-script', async ({ startClient, server }) => {
   server.setContent('/', `
     <div>Hello world</div>


### PR DESCRIPTION
## Summary
- wait for MCP tab initialization before taking page screenshots
- add a regression test for first-call `browser_take_screenshot` with `--init-page`

Fixes https://github.com/microsoft/playwright/issues/41650
