### PR TITLE
fix(webkit): do not lose in-memory cache storage records on navigation

### DIFF
--- a/browser_patches/webkit/patches/bootstrap.diff
+++ b/browser_patches/webkit/patches/bootstrap.diff
@@ -6681,6 +6681,21 @@ index f7edb09dfd0bcee4b60f4bf8ce16f8cbeea937f8..1c10fb6ea21b897015a5c0092fc8f6cd
      dispatchDidReceiveResponse();
  }
  
+diff --git a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+index 209a2eb909e9c762f240fb4a10345937e14b444e..b26f56704e408116c25cceac4ec29e9a085360a9 100644
+--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
++++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+@@ -497,6 +497,10 @@ void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheId
+         m_registry->unregisterCache(cacheIdentifier);
+         return;
+     }
++
++    // Playwright: in-memory caches cannot restore their records after close(), so closing them would lose the data.
++    if (m_path.isEmpty())
++        return;
+ 
+     for (Ref cache : borrow(m_caches).get()) {
+         if (cache->identifier() == cacheIdentifier) {
 diff --git a/Source/WebKit/PlatformWPE.cmake b/Source/WebKit/PlatformWPE.cmake
 index f98ae19e9c5fa4b0601572de46b1e0a1c62e92d8..747157cb6b47441ed2c1ca89465c81a89acc7f2a 100644
 --- a/Source/WebKit/PlatformWPE.cmake

--- a/tests/page/page-cache-storage.spec.ts
+++ b/tests/page/page-cache-storage.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as it, expect } from './pageTest';
+
+it('cache storage entry should survive page.reload', async ({ page, server, browserName }) => {
+  it.fixme(browserName === 'webkit', 'https://github.com/microsoft/playwright/issues/41618');
+
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(async () => {
+    const cache = await caches.open('cache-v1');
+    await cache.put('/meta', new Response(JSON.stringify({ hello: 'world' })));
+  });
+
+  await page.reload();
+
+  expect(await page.evaluate(() => caches.keys())).toEqual(['cache-v1']);
+  expect(await page.evaluate(async () => {
+    const cache = await caches.open('cache-v1');
+    const response = await cache.match('/meta');
+    return response ? await response.text() : null;
+  })).toBe(JSON.stringify({ hello: 'world' }));
+});


### PR DESCRIPTION
## Summary
- WebKit's `CacheStorageManager` closes caches once no web process references them (e.g. on the process swap during reload); `close()` clears the records assuming they can be re-read from disk. Ephemeral contexts use the in-memory store, so records were silently lost while the cache name survived.
- Keep live in-memory caches open in `CacheStorageManager::removeUnusedCache()`.
- Add a regression test, marked fixme on WebKit until the next browser roll.

Fixes https://github.com/microsoft/playwright/issues/41618