### PR TITLE
test(mcp): de-flake webkit dashboard CLI tests

### DIFF
--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -228,6 +228,7 @@ test('user-initiated annotate downloads zip with feedback.md', async ({ connectT
 });
 
 test('should capture annotations via show --annotate', async ({ connectToDashboard, cli, server }) => {
+  test.slow();
   await cli('open', server.EMPTY_PAGE);
   const bindTitle = `--playwright-internal--${crypto.randomUUID()}`;
   await cli('show', { bindTitle });

--- a/tests/mcp/cli-killall.spec.ts
+++ b/tests/mcp/cli-killall.spec.ts
@@ -44,11 +44,16 @@ test('kill-all kills filtered dashboard pid', async ({ cli }) => {
   expect(dashboardPid).toBeDefined();
   await expect.poll(() => isAlive(dashboardPid)).toBe(true);
 
-  const { output } = await cli('kill-all', {
-    env: { PWTEST_KILL_ALL_PID_FILTER_FOR_TEST: String(dashboardPid) },
-  });
-  expect(output).toContain(`Killed daemon process ${dashboardPid}`);
-  expect(output).toContain('Killed 1 daemon process.');
+  // kill-all discovers daemons via `execSync('ps auxww')` and treats any failure
+  // (including a swallowed spawn error under load) as "no processes found", so a
+  // single call can miss a live daemon. Retry until it observes and kills it.
+  await expect(async () => {
+    const { output } = await cli('kill-all', {
+      env: { PWTEST_KILL_ALL_PID_FILTER_FOR_TEST: String(dashboardPid) },
+    });
+    expect(output).toContain(`Killed daemon process ${dashboardPid}`);
+    expect(output).toContain('Killed 1 daemon process.');
+  }).toPass();
 
   await expect.poll(() => isAlive(dashboardPid)).toBe(false);
 });


### PR DESCRIPTION
## Summary
- `annotate.spec.ts` *"should capture annotations via show --annotate"* hit the 30s test timeout inside `connectToDashboard`'s unbounded `toPass` on slow webkit startup — mark it `test.slow()`, matching the sibling dashboard tests in the file.
- `cli-killall.spec.ts` *"kill-all kills filtered dashboard pid"* observed a live daemon 1ms before `kill-all`, yet `kill-all` reported *"No daemon processes found"*. Its discovery is best-effort (`ps auxww` via `execSync`, failures swallowed), so retry until it observes and kills the daemon.

Both surfaced as flakes on the `macos-latest - webkit` MCP shard.