### PR TITLE
fix(mcp): enable the chromium sandbox for the default browser

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -212,7 +212,7 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
       browser.launchOptions.channel = 'chrome';
   }
 
-  if (browser.browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
+  if (browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
     if (process.platform === 'linux')
       browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
     else

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -107,6 +107,11 @@ test.describe('browserName and channel', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('sandbox', () => {
+  test('chromium sandbox enabled by default', async () => {
+    const config = await resolveCLIConfigForMCP({}, emptyEnv);
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
   test('chromium sandbox enabled for chrome channel', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chrome' }, emptyEnv);
     expect(config.browser.launchOptions.chromiumSandbox).toBe(true);


### PR DESCRIPTION
`validateBrowserConfig` defaults `chromiumSandbox` to `true`, but it gated that on `browser.browserName` instead of the resolved local `browserName`:

`browser.browserName` is `undefined` with no `--browser` while the local `browserName` is defaulted to `chromium`, so the block was skipped and `chromiumSandbox` stayed `undefined`

launching then adds `--no-sandbox` whenever `chromiumSandbox !== true`, so the default MCP session ran Chrome with the sandbox disabled, unlike an identical `--browser=chrome` session

use the resolved `browserName`, matching the sibling chromium block a few lines below