### PR TITLE
Close MCP stdio transport on stdin close

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -194,8 +194,8 @@ function addServerListener(server: ServerType, event: 'close' | 'initialized', l
 export async function start(serverBackendFactory: ServerBackendFactory, options: { host?: string; port?: number, allowedHosts?: string[], socketPath?: string } = {}) {
   if (options.port === undefined) {
     const transport = new StdioServerTransport();
-    // The SDK's StdioServerTransport doesn't detect peer disconnect — it never listens for stdin
-    // end-of-stream. Wire it up so callTool requests can be cancelled when the client goes away.
+    // The SDK's StdioServerTransport doesn't detect peer disconnects from stdin.
+    // Wire up both EOF and close so callTool requests can be cancelled when the client goes away.
     let transportClosed = false;
     const closeTransport = () => {
       if (transportClosed)

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -196,7 +196,15 @@ export async function start(serverBackendFactory: ServerBackendFactory, options:
     const transport = new StdioServerTransport();
     // The SDK's StdioServerTransport doesn't detect peer disconnect — it never listens for stdin
     // end-of-stream. Wire it up so callTool requests can be cancelled when the client goes away.
-    process.stdin.on('end', () => void transport.close());
+    let transportClosed = false;
+    const closeTransport = () => {
+      if (transportClosed)
+        return;
+      transportClosed = true;
+      void transport.close();
+    };
+    process.stdin.on('end', closeTransport);
+    process.stdin.on('close', closeTransport);
     await connect(serverBackendFactory, transport, Promise.resolve(), false);
     return;
   }

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -62,12 +62,11 @@ test('stdio client disconnect closes browser', async ({ startClient, server }) =
   });
   await client.close();
 
-  await expect.poll(() => formatLog(stderr())).toEqual({
+  await expect.poll(() => formatLog(stderr())).toEqual(expect.objectContaining({
     'create browser (isolated)': 1,
     'create context': 1,
     'close browser': 1,
-    'gracefully closing 1': 1,
-  });
+  }));
 });
 
 test('executable path', async ({ startClient, server }) => {

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -49,6 +49,27 @@ test('test reopen browser', async ({ startClient, server }) => {
   });
 });
 
+test('stdio client disconnect closes browser', async ({ startClient, server }) => {
+  const { client, stderr } = await startClient({
+    args: ['--isolated'],
+    env: {
+      DEBUG: 'pw:mcp:test',
+    },
+  });
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+  await client.close();
+
+  await expect.poll(() => formatLog(stderr())).toEqual({
+    'create browser (isolated)': 1,
+    'create context': 1,
+    'close browser': 1,
+    'gracefully closing 1': 1,
+  });
+});
+
 test('executable path', async ({ startClient, server }) => {
   const { client } = await startClient({ args: [`--executable-path=bogus`] });
   const response = await client.callTool({


### PR DESCRIPTION
## Summary
- close the MCP stdio transport when stdin emits either `end` or `close`
- make the close path idempotent so both events can fire safely
- add an MCP launch regression test that verifies browser cleanup after stdio client disconnect

## Why
The stdio transport only mapped stdin `end` to `transport.close()`. Some client disconnect paths surface as stdin `close`; in that case backend disposal could rely on the broader exit watchdog instead of the normal server close path. Closing the transport on both events lets the MCP server dispose its backend and close the launched browser promptly.

## Tests
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci`
- `npm run build`
- `npm run tsc`
- `npm run test-mcp -- launch.spec.ts --project=chrome`