### PR TITLE
fix(utils): hide spawned process console on Windows

### DIFF
--- a/packages/utils/processLauncher.ts
+++ b/packages/utils/processLauncher.ts
@@ -136,6 +136,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
     // process group, making it possible to kill child process tree with `.kill(-pid)` command.
     // @see https://nodejs.org/api/child_process.html#child_process_options_detached
     detached: process.platform !== 'win32',
+    windowsHide: true,
     env: options.env,
     cwd: options.cwd,
     shell: options.shell,


### PR DESCRIPTION
## Summary
- Add `windowsHide: true` to shared `launchProcess` spawn options in `packages/utils/processLauncher.ts`.
- This prevents `chrome-headless-shell` and other spawned Playwright processes from opening a console window on Windows.

## Validation
- Manual review against issue repro and targeted code path confirms this is a one-line platform-safe fix.
- No behavior change for non-Windows spawn paths.

Fixes #41630.
