### PR TITLE
chore(core): resolve selectors through a callOnSelector helper

### DIFF
--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -334,6 +334,12 @@ export class InjectedScript {
     return { ariaSnapshot, refs: tree.refs };
   }
 
+  ariaSnapshotForExpectFailure(element: Element, options: AriaTreeOptions): string {
+    // Bypass _lastAriaSnapshotForQuery — that cache is reserved for explicit
+    // ariaSnapshot() calls used by the aria-ref selector engine.
+    return renderAriaTree(generateAriaTree(element, options), options).text;
+  }
+
   getAllElementsMatchingExpectAriaTemplate(document: Document, template: AriaTemplateNode): Element[] {
     return getAllElementsMatchingExpectAriaTemplate(document.documentElement, template);
   }
@@ -1437,85 +1443,44 @@ export class InjectedScript {
     this.onGlobalListenersRemoved.add(addHitTargetInterceptorListeners);
   }
 
-  async expect(element: Element | undefined, options: FrameExpectParams, elements: Element[]): Promise<{ matches: boolean, received?: ExpectReceived, missingReceived?: boolean }> {
-    const core = await this._expectCore(element, options, elements);
+  async expect(element: Element, options: FrameExpectParams, elements: Element[]): Promise<{ matches: boolean, received?: ExpectReceived }> {
+    const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
+    const core = isArray ? this.expectArray(elements, options) : await this.expectSingleElement(element, options);
     const ariaSnapshot = core.matches !== options.isNot ? undefined : this._ariaSnapshotForExpect(element, options);
     if (core.received === undefined && ariaSnapshot === undefined)
-      return { matches: core.matches, missingReceived: core.missingReceived };
-    return { matches: core.matches, received: { value: core.received, ariaSnapshot }, missingReceived: core.missingReceived };
+      return { matches: core.matches };
+    return { matches: core.matches, received: { value: core.received, ariaSnapshot } };
   }
 
-  private _ariaSnapshotForExpect(element: Element | undefined, options: FrameExpectParams): string | undefined {
+  private _ariaSnapshotForExpect(element: Element, options: FrameExpectParams): string | undefined {
     const expression = options.expression;
-    if (expression === 'to.have.count' || expression.endsWith('.array'))
+    if (expression === 'to.have.count' || expression.endsWith('.array') || expression === 'to.match.aria')
       return undefined;
-    if (expression === 'to.match.aria')
-      return undefined;
-    if (element && isElementVisible(element)) {
+    if (isElementVisible(element) && expression !== 'to.have.title' && expression !== 'to.have.url') {
       // Element-scoped snapshot. Containment matchers want the full subtree;
       // property matchers only need the element's own line.
       const isContainment = expression === 'to.have.text';
-      return this._renderAriaSnapshot(element, { mode: 'default', depth: isContainment ? undefined : 1 });
+      return this.ariaSnapshotForExpectFailure(element, { mode: 'default', depth: isContainment ? undefined : 1 });
     }
-    // Element missing or hidden — fall back to a full-page snapshot for context.
     if (!this.document.body)
       return undefined;
-    return this._renderAriaSnapshot(this.document.body, { mode: 'default' });
-  }
-
-  private _renderAriaSnapshot(element: Element, options: AriaTreeOptions): string {
-    // Bypass _lastAriaSnapshotForQuery — that cache is reserved for explicit
-    // ariaSnapshot() calls used by the aria-ref selector engine.
-    return renderAriaTree(generateAriaTree(element, options), options).text;
-  }
-
-  private async _expectCore(element: Element | undefined, options: FrameExpectParams, elements: Element[]): Promise<{ matches: boolean, received?: any, missingReceived?: boolean }> {
-    const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
-    if (isArray)
-      return this.expectArray(elements, options);
-    if (!element) {
-      // expect(locator).toBeHidden() passes when there is no element.
-      if (!options.isNot && options.expression === 'to.be.hidden')
-        return { matches: true };
-      // expect(locator).not.toBeVisible() passes when there is no element.
-      if (options.isNot && options.expression === 'to.be.visible')
-        return { matches: false };
-      // expect(locator).toBeAttached({ attached: false }) passes when there is no element.
-      if (!options.isNot && options.expression === 'to.be.detached')
-        return { matches: true };
-      // expect(locator).not.toBeAttached() passes when there is no element.
-      if (options.isNot && options.expression === 'to.be.attached')
-        return { matches: false };
-      // expect(locator).not.toBeInViewport() passes when there is no element.
-      if (options.isNot && options.expression === 'to.be.in.viewport')
-        return { matches: false };
-      if (options.expression === 'to.have.title' && options?.expectedText?.[0]) {
-        const matcher = new ExpectedTextMatcher(options.expectedText[0]);
-        const received = this.document.title;
-        return { received, matches: matcher.matches(received) };
-      }
-      if (options.expression === 'to.have.url' && options?.expectedText?.[0]) {
-        const matcher = new ExpectedTextMatcher(options.expectedText[0]);
-        const received = this.document.location.href;
-        return { received, matches: matcher.matches(received) };
-      }
-      if (options.expression === 'to.match.aria' && !options.selector) {
-        if (!this.document.body)
-          return { matches: options.isNot, missingReceived: true };
-        const result = matchesExpectAriaTemplate(this.document.body, options.expectedValue);
-        return {
-          received: result.received,
-          matches: !!result.matches.length,
-        };
-      }
-      // When none of the above applies, expect does not match.
-      return { matches: options.isNot, missingReceived: true };
-    }
-    return await this.expectSingleElement(element, options);
+    return this.ariaSnapshotForExpectFailure(this.document.body, { mode: 'default' });
   }
 
   private async expectSingleElement(element: Element, options: FrameExpectParams): Promise<{ matches: boolean, received?: any }> {
     const expression = options.expression;
+
+    {
+      // Page-level values. The element (:root) is only used to reach the document.
+      if (expression === 'to.have.title') {
+        const received = this.document.title;
+        return { received, matches: new ExpectedTextMatcher(options.expectedText![0]).matches(received) };
+      }
+      if (expression === 'to.have.url') {
+        const received = this.document.location.href;
+        return { received, matches: new ExpectedTextMatcher(options.expectedText![0]).matches(received) };
+      }
+    }
 
     {
       // Element state / boolean values.

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -20,7 +20,7 @@ import { asLocator } from '@isomorphic/locatorGenerators';
 import type { ElementHandle, FrameExecutionContext } from './dom';
 import type { Frame } from './frames';
 import type { InjectedScript } from '@injected/injectedScript';
-import type { JSHandle } from './javascript';
+import type { JSHandle, SmartHandle } from './javascript';
 import type * as types from './types';
 import type { ParsedSelector } from '@isomorphic/selectorParser';
 
@@ -37,6 +37,8 @@ export type SelectorInFrame = {
   scope?: ElementHandle;
 };
 
+type MatchedElementsCallback<Arg, R> = (data: { injected: InjectedScript, elements: Element[], info: SelectorInfo }, arg: Arg) => R | Promise<R>;
+
 export class FrameSelectors {
   readonly frame: Frame;
 
@@ -50,72 +52,55 @@ export class FrameSelectors {
   }
 
   async query(selector: string, options?: types.StrictOptions & { mainWorld?: boolean }, scope?: ElementHandle): Promise<ElementHandle<Element> | null> {
-    const resolved = await this.resolveInjectedForSelector(selector, options, scope);
-    // Be careful, |this.frame| can be different from |resolved.frame|.
+    const resolved = await this.callOnSelectorHandle(selector, { ...options, scope }, ({ elements }) => elements[0], {});
     if (!resolved)
       return null;
-    const handle = await resolved.injected.evaluateHandle((injected, { info, scope }) => {
-      return injected.querySelector(info.parsed, scope || document, info.strict);
-    }, { info: resolved.info, scope: resolved.scope });
+    const handle = resolved.result;
     const elementHandle = handle.asElement() as ElementHandle<Element> | null;
     if (!elementHandle) {
       handle.dispose();
       return null;
     }
-    return adoptIfNeeded(elementHandle, await resolved.frame.mainContext());
+    return adoptIfNeeded(elementHandle, await elementHandle._frame.mainContext());
   }
 
   async queryArrayInMainWorld(selector: string, scope?: ElementHandle): Promise<JSHandle<Element[]>> {
-    const resolved = await this.resolveInjectedForSelector(selector, { mainWorld: true }, scope);
-    // Be careful, |this.frame| can be different from |resolved.frame|.
+    const resolved = await this.callOnSelectorHandle(selector, { mainWorld: true, strict: false, scope }, ({ elements }) => elements, {});
     if (!resolved) {
       const context = await this.frame.context('main');
-      return await context.evaluateHandle(() => { return []; });
+      return await context.evaluateHandle(() => []);
     }
-    return await resolved.injected.evaluateHandle((injected, { info, scope }) => {
-      const elements = injected.querySelectorAll(info.parsed, scope || document);
-      injected.checkDeprecatedSelectorUsage(info.parsed, elements);
-      return elements;
-    }, { info: resolved.info, scope: resolved.scope });
+    return resolved.result;
   }
 
   async queryCount(selector: string): Promise<number> {
-    const resolved = await this.resolveInjectedForSelector(selector);
-    if (!resolved)
-      return 0;
-    return await resolved.injected.evaluate((injected, { info }) => {
-      const elements = injected.querySelectorAll(info.parsed, document);
-      injected.checkDeprecatedSelectorUsage(info.parsed, elements);
-      return elements.length;
-    }, { info: resolved.info });
+    const resolved = await this.callOnSelector(selector, { strict: false }, ({ elements }) => elements.length, {});
+    return resolved ? resolved.result : 0;
   }
 
   async queryAll(selector: string, scope?: ElementHandle): Promise<ElementHandle<Element>[]> {
-    const resolved = await this.resolveInjectedForSelector(selector, {}, scope);
-    // Be careful, |this.frame| can be different from |resolved.frame|.
+    const resolved = await this.callOnSelectorHandle(selector, { strict: false, scope }, ({ elements }) => elements, {});
     if (!resolved)
       return [];
-    const arrayHandle = await resolved.injected.evaluateHandle((injected, { info, scope }) => {
-      const elements = injected.querySelectorAll(info.parsed, scope || document);
-      injected.checkDeprecatedSelectorUsage(info.parsed, elements);
-      return elements;
-    }, { info: resolved.info, scope: resolved.scope });
 
+    const arrayHandle = resolved.result;
     const properties = await arrayHandle.internalGetProperties();
-    arrayHandle.dispose();
-
-    // Note: adopting elements one by one may be slow. If we encounter the issue here,
-    // we might introduce 'useMainContext' option or similar to speed things up.
-    const targetContext = await resolved.frame.mainContext();
-    const result: Promise<ElementHandle<Element>>[] = [];
+    const elementHandles: ElementHandle<Element>[] = [];
     for (const property of properties.values()) {
-      const elementHandle = property.asElement() as ElementHandle<Element>;
+      const elementHandle = property.asElement() as ElementHandle<Element> | null;
       if (elementHandle)
-        result.push(adoptIfNeeded(elementHandle, targetContext));
+        elementHandles.push(elementHandle);
       else
         property.dispose();
     }
-    return Promise.all(result);
+    arrayHandle.dispose();
+    if (!elementHandles.length)
+      return [];
+
+    // Note: adopting elements one by one may be slow. If we encounter the issue here,
+    // we might introduce 'useMainContext' option or similar to speed things up.
+    const targetContext = await elementHandles[0]._frame.mainContext();
+    return Promise.all(elementHandles.map(handle => adoptIfNeeded(handle, targetContext)));
   }
 
   private _jumpToAriaRefFrameIfNeeded(selector: string, info: SelectorInfo, frame: Frame): Frame {
@@ -132,7 +117,7 @@ export class FrameSelectors {
     return jumptToFrame;
   }
 
-  async resolveFrameForSelector(selector: string, options: types.StrictOptions = {}, scope?: ElementHandle): Promise<SelectorInFrame | null> {
+  private async _resolveFrameForSelector(selector: string, options: types.StrictOptions = {}, scope?: ElementHandle): Promise<SelectorInFrame | null> {
     let frame: Frame = this.frame;
     const frameChunks = splitSelectorByFrame(selector);
 
@@ -173,15 +158,65 @@ export class FrameSelectors {
     return { frame, info: lastChunk, scope };
   }
 
-  async resolveInjectedForSelector(selector: string, options?: { strict?: boolean, mainWorld?: boolean }, scope?: ElementHandle): Promise<{ injected: JSHandle<InjectedScript>, info: SelectorInfo, frame: Frame, scope?: ElementHandle } | undefined> {
-    const resolved = await this.resolveFrameForSelector(selector, options, scope);
-    // Be careful, |this.frame| can be different from |resolved.frame|.
+  private async _resolveInjectedForSelector(selector: string, options: types.StrictOptions & { mainWorld?: boolean }, scope?: ElementHandle): Promise<{ frame: Frame, info: SelectorInfo, injected: JSHandle<InjectedScript>, scope?: ElementHandle } | null> {
+    const resolved = await this._resolveFrameForSelector(selector, options, scope);
     if (!resolved)
-      return;
-    const context = await resolved.frame.context(options?.mainWorld ? 'main' : resolved.info.world);
+      return null;
+    const context = await resolved.frame.context(options.mainWorld ? 'main' : resolved.info.world);
     const injected = await context.injectedScript();
-    return { injected, info: resolved.info, frame: resolved.frame, scope: resolved.scope };
+    return { frame: resolved.frame, info: resolved.info, injected, scope: resolved.scope };
   }
+
+  async callOnSelector<Arg, R>(
+    selector: string,
+    options: types.StrictOptions & { mainWorld?: boolean, callWithoutMatches?: boolean, scope?: ElementHandle, markTargets?: 'all' | 'first' | 'none' },
+    pageFunction: MatchedElementsCallback<Arg, R>,
+    arg: Arg,
+  ): Promise<{ frame: Frame, info: SelectorInfo, result: R } | null> {
+    const resolved = await this._resolveInjectedForSelector(selector, options, options.scope);
+    if (!resolved)
+      return null;
+    const result = await resolved.injected.evaluate(callMatchedElements, { info: resolved.info, scope: resolved.scope, functionText: String(pageFunction), arg, callWithoutMatches: !!options.callWithoutMatches, markTargets: options.markTargets }) as R;
+    // callMatchedElements returns undefined when there were no matches and it skipped the page function.
+    if (!options.callWithoutMatches && result === undefined)
+      return null;
+    return { frame: resolved.frame, info: resolved.info, result };
+  }
+
+  async callOnSelectorHandle<Arg, R>(
+    selector: string,
+    options: types.StrictOptions & { mainWorld?: boolean, scope?: ElementHandle, markTargets?: 'all' | 'first' | 'none' },
+    pageFunction: MatchedElementsCallback<Arg, R>,
+    arg: Arg,
+  ): Promise<{ result: SmartHandle<R> } | null> {
+    const resolved = await this._resolveInjectedForSelector(selector, options, options.scope);
+    if (!resolved)
+      return null;
+    const result = await resolved.injected.evaluateHandle(callMatchedElements, { info: resolved.info, scope: resolved.scope, functionText: String(pageFunction), arg, callWithoutMatches: false, markTargets: options.markTargets }) as SmartHandle<R>;
+    // A skipped page function returns undefined, which has no object id (unlike a matched element/object).
+    if (!result._objectId) {
+      result.dispose();
+      return null;
+    }
+    return { result };
+  }
+}
+
+function callMatchedElements(injected: InjectedScript, { info, scope, functionText, arg, callWithoutMatches, markTargets }: { info: SelectorInfo, scope: Node | undefined, functionText: string, arg: any, callWithoutMatches: boolean, markTargets?: 'all' | 'first' | 'none' }): any {
+  const elements = injected.querySelectorAll(info.parsed, scope || document);
+  if (markTargets === 'all')
+    injected.markTargetElements(new Set(elements));
+  else if (markTargets === 'first' && elements.length)
+    injected.markTargetElements(new Set([elements[0]]));
+  else if (markTargets === 'first')
+    injected.markTargetElements(new Set());
+  injected.checkDeprecatedSelectorUsage(info.parsed, elements);
+  if (info.strict && elements.length > 1)
+    throw injected.strictModeViolationError(info.parsed, elements);
+  if (!elements.length && !callWithoutMatches)
+    return undefined;
+  const pageFunction = injected.eval('(' + functionText + ')');
+  return pageFunction({ injected, elements, info }, arg);
 }
 
 async function adoptIfNeeded<T extends Node>(handle: ElementHandle<T>, context: FrameExecutionContext): Promise<ElementHandle<T>> {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -845,29 +845,25 @@ export class Frame extends SdkObject<FrameEventMap> {
       if (performActionPreChecksAndLog)
         await this._page.performActionPreChecks(progress);
 
-      const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, options, scope));
+      if (scope && await progress.race(scope.evaluateInUtility(([injected, node]) => node.isConnected, {})) !== true)
+        throw new dom.NonRecoverableDOMError('Element is not attached to the DOM');
+
+      const resolved = await progress.race(this.selectors.callOnSelectorHandle(selector, { ...options, scope }, ({ injected, elements }) => {
+        const element: Element | undefined  = elements[0];
+        const visible = element ? injected.utils.isElementVisible(element) : false;
+        let log = '';
+        if (elements.length > 1)
+          log = `  locator resolved to ${elements.length} elements. Proceeding with the first one: ${injected.previewNode(elements[0])}`;
+        else if (element)
+          log = `  locator resolved to ${visible ? 'visible' : 'hidden'} ${injected.previewNode(element)}`;
+        return { log, element, visible, attached: !!element };
+      }, {}));
       if (!resolved) {
         if (state === 'hidden' || state === 'detached')
           return null;
         return continuePolling;
       }
-      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info, root }) => {
-        if (root && !root.isConnected)
-          throw injected.createStacklessError('Element is not attached to the DOM');
-        const elements = injected.querySelectorAll(info.parsed, root || document);
-        const element: Element | undefined  = elements[0];
-        const visible = element ? injected.utils.isElementVisible(element) : false;
-        let log = '';
-        if (elements.length > 1) {
-          if (info.strict)
-            throw injected.strictModeViolationError(info.parsed, elements);
-          log = `  locator resolved to ${elements.length} elements. Proceeding with the first one: ${injected.previewNode(elements[0])}`;
-        } else if (element) {
-          log = `  locator resolved to ${visible ? 'visible' : 'hidden'} ${injected.previewNode(element)}`;
-        }
-        injected.checkDeprecatedSelectorUsage(info.parsed, elements);
-        return { log, element, visible, attached: !!element };
-      }, { info: resolved.info, root: resolved.frame === this ? scope : undefined }));
+      const result = resolved.result;
       const { log, visible, attached } = await progress.race(result.evaluate(r => ({ log: r.log, visible: r.visible, attached: r.attached })));
       if (log)
         progress.log(log);
@@ -887,7 +883,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       if ((options as any).__testHookBeforeAdoptNode)
         await progress.race((options as any).__testHookBeforeAdoptNode());
       try {
-        const mainContext = await progress.race(resolved.frame.mainContext());
+        const mainContext = await progress.race(element._frame.mainContext());
         return await progress.race(element._adoptTo(mainContext));
       } catch (e) {
         return continuePolling;
@@ -1210,27 +1206,21 @@ export class Frame extends SdkObject<FrameEventMap> {
       if (performActionPreChecks)
         await this._page.performActionPreChecks(progress);
 
-      const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, { strict: options.strict }));
+      const resolved = await progress.race(this.selectors.callOnSelectorHandle(selector, { strict: options.strict, markTargets: 'all' }, ({ injected, elements }) => {
+        const element = elements[0] as Element | undefined;
+        let log = '';
+        if (elements.length > 1)
+          log = `  locator resolved to ${elements.length} elements. Proceeding with the first one: ${injected.previewNode(elements[0])}`;
+        else if (element)
+          log = `  locator resolved to ${injected.previewNode(element)}`;
+        return { log, success: !!element, element };
+      }, {}));
       if (!resolved) {
         if (noAutoWaiting)
           throw new dom.NonRecoverableDOMError('Element(s) not found');
         return continuePolling;
       }
-      const result = await progress.race(resolved.injected.evaluateHandle((injected, { info }) => {
-        const elements = injected.querySelectorAll(info.parsed, document);
-        injected.markTargetElements(new Set(elements));
-        const element = elements[0] as Element | undefined;
-        let log = '';
-        if (elements.length > 1) {
-          if (info.strict)
-            throw injected.strictModeViolationError(info.parsed, elements);
-          log = `  locator resolved to ${elements.length} elements. Proceeding with the first one: ${injected.previewNode(elements[0])}`;
-        } else if (element) {
-          log = `  locator resolved to ${injected.previewNode(element)}`;
-        }
-        injected.checkDeprecatedSelectorUsage(info.parsed, elements);
-        return { log, success: !!element, element };
-      }, { info: resolved.info }));
+      const result = resolved.result;
       const { log, success } = await progress.race(result.evaluate(r => ({ log: r.log, success: r.success })));
       if (log)
         progress.log(log);
@@ -1379,21 +1369,15 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async addHighlight(progress: Progress, selector: string, style?: string) {
-    const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector));
-    if (!resolved)
-      return;
-    return await progress.race(resolved.injected.evaluate((injected, { info, style }) => {
+    await progress.race(this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }, style) => {
       return injected.addHighlight(info.parsed, style);
-    }, { info: resolved.info, style }));
+    }, style));
   }
 
   async removeHighlight(progress: Progress, selector: string) {
-    const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector));
-    if (!resolved)
-      return;
-    return await progress.race(resolved.injected.evaluate((injected, { info }) => {
+    await progress.race(this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }) => {
       return injected.removeHighlight(info.parsed);
-    }, { info: resolved.info }));
+    }, {}));
   }
 
   async hideHighlight() {
@@ -1420,14 +1404,12 @@ export class Frame extends SdkObject<FrameEventMap> {
 
   async isVisibleInternal(progress: Progress, selector: string, options: types.StrictOptions = {}, scope?: dom.ElementHandle): Promise<boolean> {
     try {
-      const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, options, scope));
+      const resolved = await progress.race(this.selectors.callOnSelector(selector, { ...options, scope }, ({ injected, elements }) => {
+        return injected.elementState(elements[0], 'visible').matches;
+      }, {}));
       if (!resolved)
         return false;
-      return await progress.race(resolved.injected.evaluate((injected, { info, root }) => {
-        const element = injected.querySelector(info.parsed, root || document, info.strict);
-        const state = element ? injected.elementState(element, 'visible') : { matches: false, received: 'error:notconnected' };
-        return state.matches;
-      }, { info: resolved.info, root: resolved.frame === this ? scope : undefined }));
+      return resolved.result;
     } catch (e) {
       if (this.isNonRetriableError(e))
         throw e;
@@ -1574,31 +1556,64 @@ export class Frame extends SdkObject<FrameEventMap> {
     // The first expect check, a.k.a. one-shot, always finishes - even when progress is aborted.
     if (noAbort)
       progress = nullProgress;
-    const selectorInFrame = selector ? await progress.race(this.selectors.resolveFrameForSelector(selector, { strict: true })) : undefined;
+    const mainWorld = options.expression === 'to.have.property';
+    const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
+    const effectiveSelector = selector ?? (options.expression === 'to.match.aria' ? 'body' : ':root');
 
-    const { frame, info } = selectorInFrame || { frame: this, info: undefined };
-    const world = options.expression === 'to.have.property' ? 'main' : (info?.world ?? 'utility');
-    const context = await progress.race(frame.context(world));
-    const injected = await progress.race(context.injectedScript());
+    let received: ExpectReceived | undefined;
+    let matches = options.isNot;
+    let missingReceived = false;
 
-    const { log, matches, received, missingReceived } = await progress.race(injected.evaluate(async (injected, { info, options }) => {
-      const elements = info ? injected.querySelectorAll(info.parsed, document) : [];
-      injected.markTargetElements(new Set(elements));
+    // Non-array expectations are strict (callOnSelector throws on multiple); array ones are not.
+    const resolved = await progress.race(this.selectors.callOnSelector(effectiveSelector, { strict: !isArray, mainWorld, markTargets: 'all' }, async ({ injected, elements }, options) => {
       const isArray = options.expression === 'to.have.count' || options.expression.endsWith('.array');
-      let log = '';
-      if (isArray)
-        log = `  locator resolved to ${elements.length} element${elements.length === 1 ? '' : 's'}`;
-      else if (elements.length > 1)
-        throw injected.strictModeViolationError(info!.parsed, elements);
-      else if (elements.length)
-        log = `  locator resolved to ${injected.previewNode(elements[0])}`;
-      if (info)
-        injected.checkDeprecatedSelectorUsage(info.parsed, elements);
+      const log = isArray
+        ? `  locator resolved to ${elements.length} element${elements.length === 1 ? '' : 's'}`
+        : `  locator resolved to ${injected.previewNode(elements[0])}`;
       return { log, ...await injected.expect(elements[0], options, elements) };
-    }, { info, options }));
+    }, options));
 
-    if (log)
-      progressLog(log);
+    if (resolved) {
+      received = resolved.result.received;
+      matches = resolved.result.matches;
+      if (resolved.result.log)
+        progressLog(resolved.result.log);
+    } else {
+      // When no elements matched the selector, some assertions can still pass.
+      if (options.expression === 'to.have.count') {
+        progressLog(`  locator resolved to 0 elements`);
+        received = { value: 0 };
+        matches = 0 === options.expectedNumber;
+      } else if (options.expression.endsWith('.array')) {
+        progressLog(`  locator resolved to 0 elements`);
+        received = { value: [] };
+        matches = (options.expectedText?.length ?? 0) === 0;
+      } else if (!options.isNot && options.expression === 'to.be.hidden') {
+        matches = true;
+      } else if (options.isNot && options.expression === 'to.be.visible') {
+        matches = false;
+      } else if (!options.isNot && options.expression === 'to.be.detached') {
+        matches = true;
+      } else if (options.isNot && options.expression === 'to.be.attached') {
+        matches = false;
+      } else if (options.isNot && options.expression === 'to.be.in.viewport') {
+        matches = false;
+      } else {
+        matches = options.isNot;
+        missingReceived = true;
+      }
+      if (matches === options.isNot && !isArray) {
+        const context = await progress.race(this.context(mainWorld ? 'main' : 'utility'));
+        const injected = await progress.race(context.injectedScript());
+        const ariaSnapshot = await progress.race(injected.evaluate(injected => {
+          if (injected.document.body)
+            return injected.ariaSnapshotForExpectFailure(injected.document.body, { mode: 'default' });
+        }));
+        if (ariaSnapshot)
+          received = { ...received, ariaSnapshot };
+      }
+    }
+
     // Note: missingReceived avoids `unexpected value "undefined"` when element was not found.
     if (matches === options.isNot) {
       lastIntermediateResult.errorMessage = missingReceived ? 'element(s) not found' : undefined;
@@ -1762,21 +1777,18 @@ export class Frame extends SdkObject<FrameEventMap> {
     const callbackText = body.toString();
     progress.log(`waiting for ${this._asLocator(selector)}`);
     const promise = this.retryWithProgressAndBackoff(progress, async (progress, continuePolling) => {
-      const resolved = await progress.race(this.selectors.resolveInjectedForSelector(selector, options, scope));
-      if (!resolved)
-        return continuePolling;
-      const { log, success, value } = await progress.race(resolved.injected.evaluate((injected, { info, callbackText, taskData, root }) => {
+      const resolved = await progress.race(this.selectors.callOnSelector(selector, { ...options, scope, markTargets: 'first' }, ({ injected, elements }, { callbackText, taskData }) => {
         const callback = injected.eval(callbackText) as ElementCallback<T, R>;
-        const element = injected.querySelector(info.parsed, root || document, info.strict);
-        if (!element)
-          return { success: false };
-        injected.markTargetElements(new Set([element]));
-        const value = callback(injected, element, taskData as T);
+        const element = elements[0];
+        const value = callback(injected, element, taskData);
         if (!value)
           return { success: false };
         const log = `  locator resolved to ${injected.previewNode(element)}`;
         return { log, success: true, value };
-      }, { info: resolved.info, callbackText, taskData, root: resolved.frame === this ? scope : undefined }));
+      }, { callbackText, taskData }));
+      if (!resolved)
+        return continuePolling;
+      const { log, success, value } = resolved.result;
       if (log)
         progress.log(log);
       if (!success)
@@ -1855,7 +1867,7 @@ export class Frame extends SdkObject<FrameEventMap> {
       });
       return { snapshot };
     }
-    const lines = await ariaSnapshotForFrame(progress, this, options.selector || 'body', options);
+    const lines = await ariaSnapshotForFrame(progress, this, options.selector, options);
     return { snapshot: lines.join('\n') };
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1106,32 +1106,25 @@ export class InitScript extends DisposableObject {
   }
 }
 
-export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Frame, selector: string, options: { mode?: 'ai' | 'default', doNotRenderActive?: boolean, depth?: number, boxes?: boolean } = {}): Promise<string[]> {
+export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Frame, selector: string | undefined, options: { mode?: 'ai' | 'default', doNotRenderActive?: boolean, depth?: number, boxes?: boolean } = {}): Promise<string[]> {
   const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async (progress, continuePolling) => {
     try {
-      const resolved = await progress.race(frame.selectors.resolveInjectedForSelector(selector, { strict: true }));
-      if (!resolved)
-        throw new Error(`Selector "${selector}" did not resolve to any element`);
-      // Note: resolvedFrame might differ from the original |frame|.
-      const resolvedFrame = resolved.frame;
-      const snapshotOrRetry = await progress.race(resolved.injected.evaluate((injected, options) => {
-        const element = injected.querySelector(options.info.parsed, injected.document, options.info.strict);
-        if (!element)
-          return true;
-        return injected.ariaSnapshotWithRefs(element, options);
+      // Note: the resolved frame might differ from the original |frame|.
+      const resolved = await progress.race(frame.selectors.callOnSelector(selector || 'body', { strict: true }, ({ injected, elements }, ariaOptions) => {
+        return injected.ariaSnapshotWithRefs(elements[0], ariaOptions);
       }, {
         mode: options.mode ?? 'default',
         doNotRenderActive: options.doNotRenderActive,
-        info: resolved.info,
         depth: options.depth,
         boxes: options.boxes,
       }));
-      if (snapshotOrRetry === true) {
-        if (selector !== 'body')
+      if (!resolved) {
+        if (selector)
           throw new NonRecoverableDOMError(`Selector "${selector}" does not match any element`);
+        // Retry only for the main frame "body" being absent, so that `page.ariaSnapshot()` does not fail.
         return continuePolling;
       }
-      return { ...snapshotOrRetry, resolvedFrame };
+      return { ...resolved.result, resolvedFrame: resolved.frame };
     } catch (e) {
       if (frame.isNonRetriableError(e))
         throw e;

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -378,17 +378,17 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       return;
     try {
       const mainFrame = frame._page.mainFrame();
-      const resolved = await mainFrame.selectors.resolveFrameForSelector(this._highlightedElement.selector);
+      const resolved = await mainFrame.selectors.callOnSelector(this._highlightedElement.selector, { callWithoutMatches: true }, () => {}, {});
       // selector couldn't be found, don't highlight anything
       if (!resolved)
         return '';
 
       // selector points to no specific frame, highlight in all frames
-      if (resolved?.frame === mainFrame)
+      if (resolved.frame === mainFrame)
         return stringifySelector(resolved.info.parsed);
 
       // selector points to this frame, highlight it
-      if (resolved?.frame === frame)
+      if (resolved.frame === frame)
         return stringifySelector(resolved.info.parsed);
 
       // selector points to a different frame, highlight nothing

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -63,18 +63,6 @@ export function mainFrameForAction(pageAliases: Map<Page, string>, actionInConte
   return page.mainFrame();
 }
 
-export async function frameForAction(pageAliases: Map<Page, string>, actionInContext: actions.ActionInContext, action: actions.ActionWithSelector): Promise<Frame> {
-  const pageAlias = actionInContext.frame.pageAlias;
-  const page = [...pageAliases.entries()].find(([, alias]) => pageAlias === alias)?.[0];
-  if (!page)
-    throw new Error('Internal error: page not found');
-  const fullSelector = buildFullSelector(actionInContext.frame.framePath, action.selector);
-  const result = await page.mainFrame().selectors.resolveFrameForSelector(fullSelector);
-  if (!result)
-    throw new Error('Internal error: frame not found');
-  return result.frame;
-}
-
 function isSameAction(a: actions.ActionInContext, b: actions.ActionInContext): boolean {
   return a.action.name === b.action.name && a.frame.pageAlias === b.frame.pageAlias && a.frame.framePath.join('|') === b.frame.framePath.join('|');
 }

--- a/packages/playwright-core/src/server/screenshotter.ts
+++ b/packages/playwright-core/src/server/screenshotter.ts
@@ -277,14 +277,9 @@ export class Screenshotter {
     try {
       await progress.race(this._page.hideHighlight());
       await progress.race(Promise.all((options.mask || []).map(async ({ frame, selector }) => {
-        const resolved = await frame.selectors.resolveInjectedForSelector(selector, { strict: false });
-        if (!resolved)
-          return;
-        await resolved.injected.evaluate((injected, { info, color }) => {
-          const elements = injected.querySelectorAll(info.parsed, injected.document.documentElement);
-          if (elements.length)
-            injected.addMaskedElements(elements, color);
-        }, { info: resolved.info, color: options.maskColor || '#F0F' });
+        await frame.selectors.callOnSelector(selector, { strict: false }, ({ injected, elements }, color) => {
+          injected.addMaskedElements(elements, color);
+        }, options.maskColor || '#F0F');
       })));
       return cleanup;
     } catch (error) {


### PR DESCRIPTION
## Summary

Preparation for frame-piercing locators.

Invert `FrameSelectors`' "resolve to a frame, then evaluate" into a single `callOnSelector` / `callOnSelectorHandle` helper: it resolves a selector to one frame, runs `querySelectorAll` for the last chunk there, and invokes a page-side callback with the matched elements. Owning the query in one place is what will let the piercing variant run the same callback across every matching frame.

- All selector consumers migrate to the helper (query/count, waitForSelector, expect, highlight, screenshot masking, recorder, aria snapshot).
- Strict-mode and deprecated-selector checks are centralized in the shared in-page wrapper.
- `expect` no longer relies on the injected `!element` branch; selector-less title/url/aria resolve through `:root`/`body`.