### PR TITLE
chore: fix stack traces in development builds

### DIFF
--- a/packages/playwright/src/isomorphic/testServerConnection.ts
+++ b/packages/playwright/src/isomorphic/testServerConnection.ts
@@ -16,7 +16,7 @@
 
 import * as events from './events';
 
-import type { TestServerInterface, TestServerInterfaceEvents } from '@testIsomorphic/testServerInterface';
+import type { TestServerInterface, TestServerInterfaceEvents } from './testServerInterface';
 import type * as reporterTypes from '../../types/testReporter';
 
 // -- Reuse boundary -- Everything below this line is reused in the vscode extension.

--- a/packages/playwright/src/transform/compilationCache.ts
+++ b/packages/playwright/src/transform/compilationCache.ts
@@ -20,7 +20,6 @@ import path from 'path';
 
 import sourceMapSupport from 'source-map-support';
 import { calculateSha1 } from '@utils/crypto';
-import { isUnderTest } from '@utils/debug';
 
 import { isWorkerProcess } from '../globals';
 import { packageRoot } from '../package';
@@ -69,8 +68,6 @@ const fileDependencies = new Map<string, Set<string>>();
 // Dependencies resolved by the external bundler.
 const externalDependencies = new Map<string, Set<string>>();
 
-const devSourceInfix = path.sep + 'playwright' + path.sep + 'packages' + path.sep;
-
 export function installSourceMapSupport() {
   Error.stackTraceLimit = 200;
 
@@ -78,8 +75,6 @@ export function installSourceMapSupport() {
     environment: 'node',
     handleUncaughtExceptions: false,
     retrieveSourceMap(source) {
-      if (!process.env.PWDEBUGIMPL && isUnderTest() && source.includes(devSourceInfix))
-        return { map: identitySourceMap(source), url: source };
       if (!sourceMaps.has(source))
         return null;
       const sourceMapPath = sourceMaps.get(source)!;
@@ -93,15 +88,6 @@ export function installSourceMapSupport() {
       }
     }
   });
-}
-
-function identitySourceMap(source: string) {
-  const lineCount = fs.readFileSync(source, 'utf8').split('\n').length;
-  return {
-    version: 3,
-    sources: [source],
-    mappings: lineCount ? 'AAAA' + ';AACA'.repeat(lineCount - 1) : '',
-  };
 }
 
 function _innerAddToCompilationCacheAndSerialize(filename: string, entry: MemoryCache) {

--- a/packages/utils/stackTrace.ts
+++ b/packages/utils/stackTrace.ts
@@ -22,6 +22,7 @@
 import path from 'path';
 
 import { getAsBooleanFromENV } from './env';
+import { isUnderTest } from './debug';
 
 export type RawStack = string[];
 
@@ -172,6 +173,10 @@ export function filterStackFile(file: string) {
   if (!!_coreDir && file.startsWith(_coreDir))
     return false;
   if (_boxedStackPrefixes.some(prefix => file.startsWith(prefix)))
+    return false;
+  if (isUnderTest() && file.match(/[/\\]packages[/\\](playwright|playwright-core|utils|isomorphic|injected)[/\\]/))
+    return false;
+  if (isUnderTest() && file.match(/[/\\]playwright[^/\\]*[/\\]node_modules[/\\]/))
     return false;
   return true;
 }

--- a/tests/playwright-test/basic.spec.ts
+++ b/tests/playwright-test/basic.spec.ts
@@ -63,7 +63,7 @@ test('should succeed', async ({ runInlineTest }) => {
 test('should report suite errors', async ({ runInlineTest }) => {
   const { exitCode, failed, output } = await runInlineTest({
     'suite-error.spec.ts': `
-      if (new Error().stack.includes('workerProcess'))
+      if (process.env.TEST_WORKER_INDEX)
         throw new Error('Suite error');
 
       import { test, expect } from '@playwright/test';

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -626,6 +626,7 @@ steps.push(new EsbuildStep({
 }, [filePath('packages/playwright-core/src/*')]));
 
 const playwrightCoreSrc = filePath('packages/playwright-core/src');
+const commonUtilsSrc = [filePath('packages/protocol/src'), filePath('packages/utils'), filePath('packages/isomorphic')];
 
 // playwright-core/lib/utilsBundle.js — bundled npm utilities barrel.
 steps.push(new EsbuildStep({
@@ -665,7 +666,7 @@ steps.push(new EsbuildStep({
     setup: build => build.onResolve({ filter: /utilsBundle/ },
         () => ({ path: './utilsBundle', external: true })),
   }, dynamicImportToRequirePlugin],
-}, [playwrightCoreSrc, filePath('packages/protocol/src')]));
+}, [playwrightCoreSrc, ...commonUtilsSrc, filePath('packages/injected')]));
 
 function assertCoreBundleHasNoNodeModules() {
   const bundlePath = filePath('packages/playwright-core/lib/coreBundle.js');
@@ -710,7 +711,7 @@ steps.push(new CustomCallbackStep(assertCoreBundleHasNoNodeModules));
       '../transform/esmLoader.js',
     ],
     plugins: [],
-  }, [playwrightSrc]));
+  }, [playwrightSrc, ...commonUtilsSrc]));
 }
 
 // Build playwright entry points (per-file), excluding matchers/* and
@@ -737,7 +738,7 @@ steps.push(new EsbuildStep({
     '../package',
   ],
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // playwright/lib/matchers/expect.js — bundled jest expect facade.
 steps.push(new EsbuildStep({
@@ -752,7 +753,7 @@ steps.push(new EsbuildStep({
     '../babelBundle',
   ],
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // playwright/lib/common/index.js — bundled common barrel.
 steps.push(new EsbuildStep({
@@ -770,7 +771,7 @@ steps.push(new EsbuildStep({
     '../transform/esmLoader.js',
   ],
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // playwright/lib/runner/index.js — bundled runner barrel.
 steps.push(new EsbuildStep({
@@ -796,7 +797,7 @@ steps.push(new EsbuildStep({
     __PW_HMR__: String(!!watchMode),
   },
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // playwright/lib/isomorphic/index.js — bundled isomorphic barrel.
 steps.push(new EsbuildStep({
@@ -825,7 +826,7 @@ steps.push(new EsbuildStep({
     '../transform/esmLoader',
   ],
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // playwright/lib/worker/workerProcessEntry.js — bundled worker process
 // entry. Output sits at the same depth as the source so '../X' externals
@@ -845,7 +846,7 @@ steps.push(new EsbuildStep({
     '../transform/esmLoader',
   ],
   plugins: [dynamicImportToRequirePlugin],
-}, [filePath('packages/playwright/src')]));
+}, [filePath('packages/playwright/src'), ...commonUtilsSrc]));
 
 // Build the Electron preload loader as a standalone CJS file. It runs inside
 // the Electron process (via `electron -r loader.js`) and must not depend on


### PR DESCRIPTION
Filter out workspace-specific stack lines when `isUnderTest()`. Fix build scripts to rebuild upon utils/isomorphic changes.