### PR TITLE
fix(cli): don't crash the response when navigating closes the last tab

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -275,7 +275,8 @@ export class Response {
     if (this._includeSnapshot !== 'none' || tabHeaders.some(header => header.changed)) {
       if (tabHeaders.length !== 1)
         addSection('Open tabs', renderTabsMarkdown(tabHeaders));
-      addSection('Page', renderTabMarkdown(tabHeaders.find(h => h.current) ?? tabHeaders[0]));
+      if (tabHeaders.length)
+        addSection('Page', renderTabMarkdown(tabHeaders.find(h => h.current) ?? tabHeaders[0]));
     }
 
     // Handle modal states.

--- a/tests/mcp/cli-navigation.spec.ts
+++ b/tests/mcp/cli-navigation.spec.ts
@@ -52,3 +52,10 @@ test('run-code', async ({ cli, server }) => {
   const { output } = await cli('run-code', '() => page.title()');
   expect(output).toContain('"Title"');
 });
+
+test('goto chrome:// page that closes the tab does not crash the response', async ({ cli, server, mcpBrowser }) => {
+  test.skip(mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'chrome:// pages are chromium-specific');
+  await cli('open', server.HELLO_WORLD);
+  const { output } = await cli('goto', 'chrome://extensions/');
+  expect(output).toContain('No open tabs. Navigate to a URL to create one.');
+});


### PR DESCRIPTION
Navigating the only tab to a `chrome://` page like `chrome://extensions/` closes that tab, leaving zero open tabs. The response builder then rendered the `Page` section unconditionally and crashed with `TypeError: Cannot read properties of undefined (reading 'url')`, leaving the session unusable.

The "no open tabs" state already exists (`browser_close` renders it), so the fix just guards the `Page` section on `tabHeaders.length`. You now get `No open tabs. Navigate to a URL to create one.` instead of a crash.

Fixes https://github.com/microsoft/playwright-cli/issues/433
