### PR TITLE
feat(mcp): always pass noDefaults for CDP connections

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -108,6 +108,7 @@ async function createCDPBrowser(config: FullConfig, clientInfo: ClientInfo): Pro
   const browser = await playwright.chromium.connectOverCDP(config.browser.cdpEndpoint!, {
     headers: config.browser.cdpHeaders,
     timeout: config.browser.cdpTimeout,
+    noDefaults: true,
     artifactsDir,
   });
   return browser;

--- a/tests/mcp/cdp.spec.ts
+++ b/tests/mcp/cdp.spec.ts
@@ -59,6 +59,19 @@ test('cdp server reuse tab', async ({ cdpServer, startClient, server }) => {
   });
 });
 
+test('cdp connection uses noDefaults', async ({ cdpServer, startClient }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41661' });
+  const browserContext = await cdpServer.start();
+  const [page] = browserContext.pages();
+  await page.emulateMedia({ media: 'print' });
+  expect(await page.evaluate(() => matchMedia('print').matches)).toBe(true);
+
+  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  await client.callTool({ name: 'browser_snapshot' });
+
+  expect(await page.evaluate(() => matchMedia('print').matches)).toBe(true);
+});
+
 test('should throw connection error and allow re-connecting', async ({ cdpServer, startClient, server }) => {
   const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
 


### PR DESCRIPTION
## Summary
- Always pass `noDefaults: true` to `connectOverCDP` when attaching over `--cdp-endpoint` (used by both `@playwright/mcp` and `@playwright/cli`).
- Attaching to an existing browser should not override its pre-existing default context, and this lets us connect to non-Chromium CDP targets (e.g. embedded web inspectors) that reject `Browser.setDownloadBehavior`.

Fixes https://github.com/microsoft/playwright/issues/41661