### PR TITLE
fix(mcp): preserve directory for additional tab videos

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -236,8 +236,9 @@ export class Context {
     const suffix = this._video.fileNames.length ? `-${this._video.fileNames.length}` : '';
     let fileName = this._video.fileName;
     if (fileName && suffix) {
+      const dir = path.dirname(fileName);
       const ext = path.extname(fileName);
-      fileName = path.basename(fileName, ext) + suffix + ext;
+      fileName = path.join(dir, path.basename(fileName, ext) + suffix + ext);
     }
     this._video.fileNames.push(fileName);
     await page.screencast.start({ path: fileName, ...this._video.params });

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -216,7 +216,7 @@ test('tracing-start-stop', async ({ cli, server }, testInfo) => {
 
 test('video-start-stop', async ({ cli, server }) => {
   await cli('open', server.HELLO_WORLD);
-  const { output: videoStartOutput } = await cli('video-start', 'video.webm', '--size=400x300');
+  const { output: videoStartOutput } = await cli('video-start', 'recordings/video.webm', '--size=400x300');
   expect(videoStartOutput).toContain('Video recording started.');
   const { output: tabNewOutput } = await cli('tab-new');
   expect(tabNewOutput).toContain('1: (current) [](about:blank)');
@@ -225,7 +225,7 @@ test('video-start-stop', async ({ cli, server }) => {
   const { output: tabCloseOutput } = await cli('tab-close');
   expect(tabCloseOutput).toContain(`0: (current) [](${server.EMPTY_PAGE})`);
   const { output: videoStopOutput } = await cli('video-stop');
-  expect(videoStopOutput).toContain(`### Result\n- [Video](./video.webm)\n- [Video](./video-1.webm)`);
+  expect(videoStopOutput).toContain(`### Result\n- [Video](recordings/video.webm)\n- [Video](recordings/video-1.webm)`);
 });
 
 test('video-chapter', async ({ cli, server }) => {

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -225,7 +225,7 @@ test('video-start-stop', async ({ cli, server }) => {
   const { output: tabCloseOutput } = await cli('tab-close');
   expect(tabCloseOutput).toContain(`0: (current) [](${server.EMPTY_PAGE})`);
   const { output: videoStopOutput } = await cli('video-stop');
-  expect(videoStopOutput).toContain(`### Result\n- [Video](recordings/video.webm)\n- [Video](recordings/video-1.webm)`);
+  expect(videoStopOutput).toContain(`### Result\n- [Video](recordings${path.sep}video.webm)\n- [Video](recordings${path.sep}video-1.webm)`);
 });
 
 test('video-chapter', async ({ cli, server }) => {


### PR DESCRIPTION
## Summary
- `browser_start_video` dropped the directory part of the filename for videos recorded from additional tabs (`recordings/video.webm` → `video-1.webm`) because the numeric suffix was applied with `path.basename`.
- Preserve `path.dirname` so additional tab videos land next to the first (`recordings/video-1.webm`).

Fixes https://github.com/microsoft/playwright/issues/41659