### PR TITLE
fix(test-runner): validate NaN and non-positive worker percentages

### DIFF
--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -221,8 +221,13 @@ function resolveReporters(reporters: Config['reporter'], rootDir: string): Repor
 function resolveWorkers(workers: string | number): number {
   if (typeof workers === 'string') {
     if (workers.endsWith('%')) {
+      const percent = parseInt(workers, 10);
+      if (isNaN(percent))
+        throw new Error(`Workers ${workers} must be a number or percentage.`);
+      if (percent < 1)
+        throw new Error(`Workers must be a positive number, received ${percent}.`);
       const cpus = os.cpus().length;
-      return Math.max(1, Math.floor(cpus * (parseInt(workers, 10) / 100)));
+      return Math.max(1, Math.floor(cpus * (percent / 100)));
     }
     const parsedWorkers = parseInt(workers, 10);
     if (isNaN(parsedWorkers))

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -585,18 +585,6 @@ test('should throw when workers is an invalid percentage via CLI (regression for
   expect(result.output).toContain('Workers abc% must be a number or percentage.');
 });
 
-test('should throw when workers is a non-positive percentage via CLI', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'playwright.config.ts': `module.exports = {};`,
-    'a.test.ts': `
-      import { test } from '@playwright/test';
-      test('pass', () => {});
-    `,
-  }, { workers: '0%' });
-  expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('Workers must be a positive number');
-});
-
 test('should work with undefined values and base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `

--- a/tests/playwright-test/config.spec.ts
+++ b/tests/playwright-test/config.spec.ts
@@ -573,6 +573,30 @@ test('should throw when workers is negative via CLI (regression for #39938)', as
   expect(result.output).toContain('Workers must be a positive number');
 });
 
+test('should throw when workers is an invalid percentage via CLI (regression for #41679)', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `module.exports = {};`,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('fails', () => { expect(1).toBe(2); });
+    `,
+  }, { workers: 'abc%' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers abc% must be a number or percentage.');
+});
+
+test('should throw when workers is a non-positive percentage via CLI', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `module.exports = {};`,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('pass', () => {});
+    `,
+  }, { workers: '0%' });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Workers must be a positive number');
+});
+
 test('should work with undefined values and base', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `


### PR DESCRIPTION
## Summary
- The `%` branch of `resolveWorkers` skipped the NaN validation the numeric branch performs, so `--workers=abc%` (or an unset env var expanding to `--workers=%`) resolved to `NaN` workers. The dispatcher then allocated zero worker slots, ran no tests, and exited 0 — silent success while nothing ran.
- Apply the same validation to the percentage branch and add a regression test.

Fixes https://github.com/microsoft/playwright/issues/41679