### PR TITLE
fix(routing): normalize literal glob components through new URL()

### DIFF
--- a/packages/isomorphic/urlMatch.ts
+++ b/packages/isomorphic/urlMatch.ts
@@ -239,6 +239,11 @@ function resolveGlobBase(baseURL: string | undefined, match: string): string {
         // Preserve explicit schema as is as it may affect trailing slashes after domain.
         return token;
       }
+      // Components without glob metacharacters are literal, so let them round-trip
+      // through new URL() to preserve normalization (default ports such as :80/:443,
+      // percent-encoding, IDN hosts). Only opaque tokens defeat that normalization.
+      if (!/[*?{}\\]/.test(token))
+        return token;
       const questionIndex = token.indexOf('?');
       if (questionIndex === -1)
         return mapToken(token, `$_${index}_$`);

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -134,6 +134,15 @@ it('should work with glob', async () => {
   expect(urlMatches(undefined, 'https://playwright.dev/foobar', 'https://playwright.dev/fooBAR')).toBeFalsy();
   expect(urlMatches(undefined, 'https://playwright.dev/foobar?a=b', 'https://playwright.dev/foobar?A=B')).toBeFalsy();
 
+  // Literal globs are normalized through new URL(), so explicit default ports,
+  // percent-encoding and IDN hosts match request.url() which is already normalized.
+  expect(urlMatches(undefined, 'http://example.com/path', 'http://example.com:80/path')).toBeTruthy();
+  expect(urlMatches(undefined, 'https://example.com/path', 'https://example.com:443/path')).toBeTruthy();
+  expect(urlMatches(undefined, 'http://example.com:8080/path', 'http://example.com:8080/path')).toBeTruthy();
+  expect(urlMatches(undefined, 'http://localhost/', 'http://localhost:80/**')).toBeTruthy();
+  expect(urlMatches(undefined, 'http://example.com/foo%20bar', 'http://example.com/foo bar')).toBeTruthy();
+  expect(urlMatches(undefined, 'http://xn--mnchen-3ya.de/', 'http://münchen.de/')).toBeTruthy();
+
   expect(urlMatches(undefined, 'https://localhost:3000/?a=b', '**/?a=b')).toBeTruthy();
   expect(urlMatches(undefined, 'https://localhost:3000/?a=b', '**?a=b')).toBeTruthy();
   expect(urlMatches(undefined, 'https://localhost:3000/?a=b', '**=b')).toBeTruthy();


### PR DESCRIPTION
## Summary
- Since 1.51 (#34923), `resolveGlobBase` tokenizes every URL path component before `new URL()` resolution, so URL normalization no longer applies to the glob. A glob with an explicit default port (`http://localhost:80/**`) can never match `request.url()`, which the browser normalizes to `http://localhost/`. Same regression for percent-encoded literals and IDN hosts.
- Fix: only tokenize components that contain glob metacharacters (`*`, `?`, `{`, `}`, `\`); let literal components round-trip through `new URL()` as before 1.51. Preserves the #34915 `?`-mangling fix.

**Open question:** whether we actually want globs to normalize this way (e.g. `:80` silently dropped) or whether the pre-1.51 behavior was itself accidental. Flagging for discussion before merge.

Fixes https://github.com/microsoft/playwright/issues/41678