### PR TITLE
Defer evaluation of defaultCacheDirectory until it is needed

### DIFF
--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -495,7 +495,7 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
   },
 };
 
-export const defaultCacheDirectory = (() => {
+export function defaultCacheDirectory(): string {
   if (process.platform === 'linux')
     return process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
   if (process.platform === 'darwin')
@@ -503,9 +503,7 @@ export const defaultCacheDirectory = (() => {
   if (process.platform === 'win32')
     return process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
   throw new Error('Unsupported platform: ' + process.platform);
-})();
-
-export const defaultRegistryDirectory = path.join(defaultCacheDirectory, 'ms-playwright');
+}
 
 export const registryDirectory = (() => {
   let result: string;
@@ -516,7 +514,7 @@ export const registryDirectory = (() => {
   else if (envDefined)
     result = envDefined;
   else
-    result = defaultRegistryDirectory;
+    result = path.join(defaultCacheDirectory(), 'ms-playwright');
 
   if (!path.isAbsolute(result)) {
     // It is important to resolve to the absolute path:

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -194,7 +194,7 @@ async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInf
 }
 
 async function createUserDataDir(config: FullConfig, clientInfo: ClientInfo) {
-  const dir = process.env.PWMCP_PROFILES_DIR_FOR_TEST ?? path.join(defaultCacheDirectory, 'ms-playwright-mcp');
+  const dir = process.env.PWMCP_PROFILES_DIR_FOR_TEST ?? path.join(defaultCacheDirectory(), 'ms-playwright-mcp');
   const browserToken = config.browser.launchOptions?.channel ?? config.browser?.browserName;
   // Hesitant putting hundreds of files into the user's workspace, so using it for hashing instead.
   const rootPathToken = createHash(clientInfo.cwd);


### PR DESCRIPTION
Summary

This PR defers evaluation of "defaultCacheDirectory" by converting it from an eagerly evaluated value to a function and updating its call sites.

Motivation

"defaultCacheDirectory" was previously evaluated during module initialization. This meant that its platform checks were performed before callers had a chance to provide an explicit override, even when the default cache directory was never needed.

By evaluating the default cache directory only when it is actually required, the existing behavior is preserved while avoiding unnecessary initialization.

Changes

- Convert "defaultCacheDirectory" to a lazily evaluated function.
- Update callers to invoke "defaultCacheDirectory()" when constructing default paths.
- No functional changes are intended for supported platforms; only the evaluation timing has changed.