### PR TITLE
feat(mcp): forward noDefaults to connectOverCDP for --cdp-endpoint connections

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -109,6 +109,7 @@ async function createCDPBrowser(config: FullConfig, clientInfo: ClientInfo): Pro
     headers: config.browser.cdpHeaders,
     timeout: config.browser.cdpTimeout,
     artifactsDir,
+    noDefaults: config.browser.cdpNoDefaults,
   });
   return browser;
 }

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -82,6 +82,18 @@ export type Config = {
     cdpTimeout?: number;
 
     /**
+     * When true, forwarded as `noDefaults` to
+     * @see https://playwright.dev/docs/api/class-browsertype#browser-type-connect-over-cdp
+     * Skips Playwright's default overrides (download behavior, focus emulation, media emulation)
+     * on the pre-existing default browser context. Useful when connecting to CDP endpoints that
+     * don't implement Chromium's full browser-context-management surface (e.g. some non-Chromium
+     * remote debugging targets). Note this only affects the default context; it has no effect
+     * when combined with `isolated`, since that creates a new context via `browser.newContext()`.
+     * Defaults to false.
+     */
+    cdpNoDefaults?: boolean;
+
+    /**
      * Remote endpoint to connect to an existing Playwright server. May be a
      * WebSocket URL string, or a [ConnectOptions] object that mirrors the
      * `connectOptions` shape used by the test runner. When passed as an object,

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -42,6 +42,7 @@ export type CLIOptions = {
   caps?: string[];
   cdpEndpoint?: string;
   cdpHeader?: Record<string, string>;
+  cdpNoDefaults?: boolean;
   cdpTimeout?: number;
   codegen?: 'typescript' | 'none';
   config?: string;
@@ -346,6 +347,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
       contextOptions,
       cdpEndpoint: cliOptions.cdpEndpoint,
       cdpHeaders: cliOptions.cdpHeader,
+      cdpNoDefaults: cliOptions.cdpNoDefaults,
       cdpTimeout: cliOptions.cdpTimeout,
       initPage: cliOptions.initPage,
       initScript: cliOptions.initScript,
@@ -401,6 +403,7 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   options.caps = commaSeparatedList(e.PLAYWRIGHT_MCP_CAPS);
   options.cdpEndpoint = envToString(e.PLAYWRIGHT_MCP_CDP_ENDPOINT);
   options.cdpHeader = headerParser(envToString(e.PLAYWRIGHT_MCP_CDP_HEADERS));
+  options.cdpNoDefaults = envToBoolean(e.PLAYWRIGHT_MCP_CDP_NO_DEFAULTS);
   options.cdpTimeout = numberParser(e.PLAYWRIGHT_MCP_CDP_TIMEOUT);
   options.config = envToString(e.PLAYWRIGHT_MCP_CONFIG);
   if (e.PLAYWRIGHT_MCP_CONSOLE_LEVEL)

--- a/packages/playwright-core/src/tools/mcp/configIni.ts
+++ b/packages/playwright-core/src/tools/mcp/configIni.ts
@@ -106,6 +106,7 @@ const longhandTypes: Record<string, LonghandType> = {
   'browser.isolated': 'boolean',
   'browser.userDataDir': 'string',
   'browser.cdpEndpoint': 'string',
+  'browser.cdpNoDefaults': 'boolean',
   'browser.cdpTimeout': 'number',
   'browser.remoteEndpoint': 'string',
   'browser.initPage': 'string[]',

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -41,6 +41,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf, devtools.', commaSeparatedList)
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
+      .option('--cdp-no-defaults', 'skip Playwright\'s default overrides (download behavior, focus/media emulation) on the existing default context when connecting via --cdp-endpoint. Useful for CDP targets that don\'t implement Chromium\'s full browser-context-management surface.')
       .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
       .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript']))
       .option('--config <path>', 'path to the configuration file.')

--- a/tests/mcp/cdp.spec.ts
+++ b/tests/mcp/cdp.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { test, expect, mcpServerPath } from './fixtures';
+import { test, expect, mcpServerPath, parseResponse } from './fixtures';
 
 test.describe.configure({
   retries: 1,
@@ -167,4 +167,40 @@ test('cdp server with empty and complex headers', async ({ startClient, server }
   });
   expect(customHeader).toBe('value:with:colons');
   expect(emptyHeader).toBe('');
+});
+
+test('cdp server with --cdp-no-defaults skips download override', async ({ cdpServer, startClient, server }, testInfo) => {
+  await cdpServer.start();
+  const { client } = await startClient({
+    args: [`--cdp-endpoint=${cdpServer.endpoint}`, '--cdp-no-defaults'],
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  server.setContent('/', `<a href="/download" download="test.txt">Download</a>`, 'text/html');
+  server.setContent('/download', 'Data', 'text/plain');
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`- link "Download" [ref=e2]`),
+  });
+
+  const response = await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'Download link',
+      target: 'e2',
+    },
+  });
+  const parsed = parseResponse(response);
+
+  // With --cdp-no-defaults, Playwright never calls Browser.setDownloadBehavior on the
+  // default context on connect, so downloads are not routed through the page's
+  // 'download' event and the MCP server has nothing to report.
+  await new Promise(resolve => setTimeout(resolve, 500));
+  const snapshotAfter = parseResponse(await client.callTool({ name: 'browser_snapshot' }));
+  const events = [parsed.events, snapshotAfter.events].filter(Boolean).join('\n');
+  expect(events).not.toContain('Downloading file test.txt');
+  expect(events).not.toContain('Downloaded file test.txt');
 });


### PR DESCRIPTION
Fixes #41661

## Summary

`--cdp-endpoint` connections (used by both `@playwright/mcp` and `@playwright/cli`) go through `createCDPBrowser()` in `packages/playwright-core/src/tools/mcp/browserFactory.ts`, which calls `chromium.connectOverCDP()` but never forwards the `noDefaults` option added in #40185. It also isn't exposed in `config.d.ts`'s `browser` section, nor as a CLI flag.

This makes it impossible to attach to CDP targets that reject Playwright's default context-management overrides (e.g. `Browser.setDownloadBehavior`) sent on connect — the same class of problem `noDefaults` was introduced to solve (#40158), also reported for other non-Chromium CDP targets (#36961, #15370).

This PR exposes `noDefaults` as a `browser.cdpNoDefaults` config field / `--cdp-no-defaults` CLI flag, mirroring the existing `cdpEndpoint` / `cdpHeaders` / `cdpTimeout` options. Since `browserFactory.ts` is shared, this fixes both `@playwright/mcp` and `@playwright/cli` in one change.

## Changes

- `packages/playwright-core/src/tools/mcp/config.d.ts`: add `browser.cdpNoDefaults?: boolean` field with JSDoc, documenting that it only affects the pre-existing default context (not `newContext()`/`--isolated`), per `noDefaults`'s own design.
- `packages/playwright-core/src/tools/mcp/config.ts`: add `cdpNoDefaults` to `CLIOptions`, forward it in `configFromCLIOptions()`, and read `PLAYWRIGHT_MCP_CDP_NO_DEFAULTS` in `configFromEnv()`.
- `packages/playwright-core/src/tools/mcp/program.ts`: register `--cdp-no-defaults` CLI flag.
- `packages/playwright-core/src/tools/mcp/configIni.ts`: register `browser.cdpNoDefaults` as `boolean` in `longhandTypes` for INI config support.
- `packages/playwright-core/src/tools/mcp/browserFactory.ts`: forward `noDefaults: config.browser.cdpNoDefaults` into the `connectOverCDP` call in `createCDPBrowser`.
- `tests/mcp/cdp.spec.ts`: add a test that connects with `--cdp-no-defaults` and asserts that clicking a download link does **not** produce the usual "Downloading file .../Downloaded file ..." events, mirroring the existing `should skip default overrides with noDefaults` assertion style from `tests/library/chromium/connect-over-cdp.spec.ts` (no `page.on('download')` firing implies `Browser.setDownloadBehavior` was skipped on connect).

## Notes

- `noDefaults` only ever applies to the pre-existing default context (`browser.contexts()[0]`), never to contexts created via `browser.newContext()`. So `--isolated` combined with `--cdp-no-defaults` will still fail against targets that reject `Target.createBrowserContext` — that's expected, not a regression, and matches #40185's original design.
- Naming: I went with `cdpNoDefaults` / `--cdp-no-defaults` to match the existing `cdp*` prefix convention used by `cdpEndpoint`/`cdpHeaders`/`cdpTimeout`. Happy to rename to plain `noDefaults` if maintainers prefer matching the underlying Playwright API name exactly.
- Verified manually against a real non-Chromium CDP target (a WebKit-based embedded remote debugging endpoint) that previously failed immediately with `Protocol error (Browser.setDownloadBehavior): Browser context management is not supported.` — with this change and `--cdp-no-defaults`, the connection succeeds and MCP tools work end-to-end (non-isolated mode). Full write-up is linked from #41661.

Versions tested locally: `@playwright/mcp@0.0.77`, `@playwright/cli@0.1.15`, `playwright-core@1.62.0-alpha-2026-06-29` (this PR is against current `main`, tip-of-tree).
