### PR TITLE
test(screenshot): fix flaky "event loop is blocked" test

### DIFF
--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -213,13 +213,14 @@ browserTest.describe('page screenshot', () => {
   browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page, trace }) => {
     browserTest.skip(trace === 'on', 'taking a snapshot hangs when the page is blocked');
     browserTest.setTimeout(5000);
-    await page.evaluate(() => {
-      window.builtins.setTimeout(() => {
+    const __testHookBeforeScreenshot = async () => {
+      page.evaluate(() => {
+        console.log('blocked');
         while (true) {}
-      }, 10);
-    });
-    await new Promise(f => setTimeout(f, 500));
-    await expect(page.screenshot({ fullPage: true, timeout: 200 })).rejects.toThrow(/page.screenshot: Timeout 200ms exceeded/);
+      }).catch(() => {});
+      await page.waitForEvent('console', e => e.text() === 'blocked');
+    };
+    await expect(page.screenshot({ fullPage: true, timeout: 200, __testHookBeforeScreenshot } as any)).rejects.toThrow(/page.screenshot: Timeout 200ms exceeded/);
   });
 });
 

--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -218,6 +218,7 @@ browserTest.describe('page screenshot', () => {
         while (true) {}
       }, 10);
     });
+    await new Promise(f => setTimeout(f, 500));
     await expect(page.screenshot({ fullPage: true, timeout: 200 })).rejects.toThrow(/page.screenshot: Timeout 200ms exceeded/);
   });
 });


### PR DESCRIPTION
`should not hang when event loop is blocked` is flaky. It schedules an in-page busy-loop with `setTimeout(..., 10)`, then immediately expects `page.screenshot({ fullPage: true, timeout: 200 })` to reject with a timeout:

```js
await page.evaluate(() => {
  window.builtins.setTimeout(() => {
    while (true) {}
  }, 10);
});
await expect(page.screenshot({ fullPage: true, timeout: 200 })).rejects.toThrow(/Timeout 200ms exceeded/);
```

The problem: on a fast/unloaded machine the full-page screenshot finishes within that ~10ms window, before the busy-loop actually starts blocking the renderer. So it resolves with a PNG buffer instead of timing out, and the test fails with `Received promise resolved instead of rejected`. Under CI load the screenshot is slower, the block wins, and it passes - hence the flake.

Fix: wait 500ms after scheduling the block, so the renderer is genuinely frozen before we take the screenshot. Adds half a second to a test with a 5s budget.

See #36702.