### PR TITLE
test(clock): unflake "while running" page-clock tests

### DIFF
--- a/tests/library/page-clock.spec.ts
+++ b/tests/library/page-clock.spec.ts
@@ -399,66 +399,62 @@ it.describe('setFixedTime', () => {
 it.describe('while running', () => {
   it('should progress time', async ({ page }) => {
     await page.clock.install({ time: 0 });
+    const startRealTime = Date.now();
     await page.goto('data:text/html,');
     await page.waitForTimeout(1000);
     const now = await page.evaluate(() => Date.now());
+    const realElapsed = Date.now() - startRealTime;
     expect(now).toBeGreaterThanOrEqual(1000);
-    expect(now).toBeLessThanOrEqual(2000);
+    expect(now).toBeLessThanOrEqual(realElapsed + 1000);
   });
 
   it('should runFor', async ({ page }) => {
     await page.clock.install({ time: 0 });
+    const startRealTime = Date.now();
     await page.goto('data:text/html,');
     await page.clock.runFor(10000);
     const now = await page.evaluate(() => Date.now());
+    const realElapsed = Date.now() - startRealTime;
     expect(now).toBeGreaterThanOrEqual(10000);
-    expect(now).toBeLessThanOrEqual(11000);
+    expect(now).toBeLessThanOrEqual(10000 + realElapsed + 1000);
   });
 
   it('should fastForward', async ({ page }) => {
     await page.clock.install({ time: 0 });
+    const startRealTime = Date.now();
     await page.goto('data:text/html,');
     await page.clock.fastForward(10000);
     const now = await page.evaluate(() => Date.now());
+    const realElapsed = Date.now() - startRealTime;
     expect(now).toBeGreaterThanOrEqual(10000);
-    expect(now).toBeLessThanOrEqual(11000);
-  });
-
-  it('should fastForwardTo', async ({ page }) => {
-    await page.clock.install({ time: 0 });
-    await page.goto('data:text/html,');
-    await page.clock.fastForward(10000);
-    const now = await page.evaluate(() => Date.now());
-    expect(now).toBeGreaterThanOrEqual(10000);
-    expect(now).toBeLessThanOrEqual(11000);
+    expect(now).toBeLessThanOrEqual(10000 + realElapsed + 1000);
   });
 
   it('should pause', async ({ page }) => {
     await page.clock.install({ time: 0 });
     await page.goto('data:text/html,');
-    await page.clock.pauseAt(1000);
+    await page.clock.pauseAt(60000);
     // Internally wait to make sure the clock is paused and not running.
     await page.waitForTimeout(1111);
     const now = await page.evaluate(() => Date.now());
-    expect(now).toBeGreaterThanOrEqual(0);
-    expect(now).toBeLessThanOrEqual(1000);
+    expect(now).toBe(60000);
   });
 
   it('should pause and fastForward', async ({ page }) => {
     await page.clock.install({ time: 0 });
     await page.goto('data:text/html,');
-    await page.clock.pauseAt(1000);
+    await page.clock.pauseAt(60000);
     await page.clock.fastForward(1000);
     const now = await page.evaluate(() => Date.now());
-    expect(now).toBe(2000);
+    expect(now).toBe(61000);
   });
 
   it('should set system time on pause', async ({ page }) => {
     await page.clock.install({ time: 0 });
     await page.goto('data:text/html,');
-    await page.clock.pauseAt(1000);
+    await page.clock.pauseAt(60000);
     const now = await page.evaluate(() => Date.now());
-    expect(now).toBe(1000);
+    expect(now).toBe(60000);
   });
 });
 


### PR DESCRIPTION
The `while running` clock tests run a fake clock that ticks with real wall-clock time, but assert against hard-coded bounds that assume real drift stays under 1000ms. On a loaded CI box it doesn't, so `runFor`/`fastForward` overshoot the `<= 11000` bound and the `pauseAt(1000)` cases fail with "Cannot fast-forward to the past".

- `progress time`, `runFor`, `fastForward` now bound the result by *measured* real elapsed time instead of a constant. The lower bound is unchanged, so a real advance bug is still caught.
- The `pauseAt` tests pause at 60000 instead of 1000, well beyond any drift in the `install`→`pauseAt` window, so the pause can't land in the past.
- Dropped `should fastForwardTo` - a byte-for-byte copy of `should fastForward` (there's no `fastForwardTo` API).