### PR TITLE
fix(electron): close pages from the main process to avoid Target.closeTarget hang

### DIFF
--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -143,20 +143,20 @@ export class ElectronApplication extends SdkObject {
       return;
     // Target.closeTarget can hang on Electron when the close races a committing
     // navigation. Close from the main process instead. We close the webContents
-    // rather than the BrowserWindow because BrowserWindow.close() runs the
-    // beforeunload handler (and can hang on it), while page.close() should not.
-    page.setCustomCloseHandler(async () => {
+    // rather than the BrowserWindow because BrowserWindow.close() always runs the
+    // beforeunload handler, while webContents.close() lets us opt in or out of it.
+    page.setCustomCloseHandler(async runBeforeUnload => {
       const electronHandle = await this._nodeElectronHandlePromise;
-      const closed = await electronHandle.evaluate(({ webContents }, targetId) => {
+      const closed = await electronHandle.evaluate(({ webContents }, { targetId, runBeforeUnload }) => {
         const wc = webContents.fromDevToolsTargetId(targetId);
         if (!wc || wc.isDestroyed())
           return false;
-        wc.close({ waitForBeforeUnload: false });
+        wc.close({ waitForBeforeUnload: runBeforeUnload });
         return true;
-      }, (page.delegate as CRPage)._targetId).catch(() => false);
+      }, { targetId: (page.delegate as CRPage)._targetId, runBeforeUnload }).catch(() => false);
       // Fall back to the default close if the webContents could not be found.
       if (!closed)
-        await page.delegate.closePage(false);
+        await page.delegate.closePage(runBeforeUnload);
     });
   }
 

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -25,7 +25,7 @@ import { eventsHelper } from '@utils/eventsHelper';
 import { envArrayToObject, launchProcess } from '@utils/processLauncher';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { libPath } from '../../package';
-import { validateBrowserContextOptions } from '../browserContext';
+import { BrowserContext, validateBrowserContextOptions } from '../browserContext';
 import { CRBrowser } from '../chromium/crBrowser';
 import { CRConnection } from '../chromium/crConnection';
 import { createHandle, CRExecutionContext } from '../chromium/crExecutionContext';
@@ -38,7 +38,6 @@ import { WebSocketTransport } from '../transport';
 import { nullProgress } from '../progress';
 
 import type { BrowserOptions, BrowserProcess } from '../browser';
-import type { BrowserContext } from '../browserContext';
 import type { CRBrowserContext } from '../chromium/crBrowser';
 import type { CRSession } from '../chromium/crConnection';
 import type { CRPage } from '../chromium/crPage';
@@ -86,6 +85,7 @@ export class ElectronApplication extends SdkObject {
       this._nodeElectronHandlePromise.resolve(new js.JSHandle(this._nodeExecutionContext!, 'object', 'ElectronModule', remoteObject.objectId!));
     });
     this._nodeSession.on('Runtime.consoleAPICalled', event => this._onConsoleAPI(event));
+    this._browserContext.on(BrowserContext.Events.Page, page => this._onPage(page));
     const appClosePromise = new Promise(f => this.once(ElectronApplication.Events.Close, f));
     this._browserContext.setCustomCloseHandler(async () => {
       const electronHandle = await this._nodeElectronHandlePromise;
@@ -136,6 +136,20 @@ export class ElectronApplication extends SdkObject {
   async close(progress: Progress) {
     // This will call BrowserContext.setCustomCloseHandler.
     await this._browserContext.close(progress, { reason: 'Application exited' });
+  }
+
+  private _onPage(page: Page) {
+    // Target.closeTarget can hang on Electron when the close races a committing
+    // navigation. Close from the main process instead; webContents.close() does
+    // not run beforeunload, matching page.close() semantics.
+    page.setCustomCloseHandler(async () => {
+      const electronHandle = await this._nodeElectronHandlePromise;
+      await electronHandle.evaluate(({ webContents }, targetId) => {
+        const wc = webContents.fromDevToolsTargetId(targetId);
+        if (wc && !wc.isDestroyed())
+          wc.close();
+      }, (page.delegate as CRPage)._targetId).catch(() => {});
+    });
   }
 
   async browserWindow(progress: Progress, page: Page): Promise<js.JSHandle<BrowserWindow>> {

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -151,7 +151,7 @@ export class ElectronApplication extends SdkObject {
         const wc = webContents.fromDevToolsTargetId(targetId);
         if (!wc || wc.isDestroyed())
           return false;
-        wc.close();
+        wc.close({ waitForBeforeUnload: false });
         return true;
       }, (page.delegate as CRPage)._targetId).catch(() => false);
       // Fall back to the default close if the webContents could not be found.

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -139,16 +139,24 @@ export class ElectronApplication extends SdkObject {
   }
 
   private _onPage(page: Page) {
+    if (process.env.PLAYWRIGHT_ELECTRON_LEGACY_PAGE_CLOSE)
+      return;
     // Target.closeTarget can hang on Electron when the close races a committing
-    // navigation. Close from the main process instead; webContents.close() does
-    // not run beforeunload, matching page.close() semantics.
+    // navigation. Close from the main process instead. We close the webContents
+    // rather than the BrowserWindow because BrowserWindow.close() runs the
+    // beforeunload handler (and can hang on it), while page.close() should not.
     page.setCustomCloseHandler(async () => {
       const electronHandle = await this._nodeElectronHandlePromise;
-      await electronHandle.evaluate(({ webContents }, targetId) => {
+      const closed = await electronHandle.evaluate(({ webContents }, targetId) => {
         const wc = webContents.fromDevToolsTargetId(targetId);
-        if (wc && !wc.isDestroyed())
-          wc.close();
-      }, (page.delegate as CRPage)._targetId).catch(() => {});
+        if (!wc || wc.isDestroyed())
+          return false;
+        wc.close();
+        return true;
+      }, (page.delegate as CRPage)._targetId).catch(() => false);
+      // Fall back to the default close if the webContents could not be found.
+      if (!closed)
+        await page.delegate.closePage(false);
     });
   }
 

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -202,7 +202,7 @@ export class Page extends SdkObject<PageEventMap> {
   readonly overlay: Overlay;
   readonly screencast: Screencast;
   _closeReason: string | undefined;
-  private _customCloseHandler?: () => Promise<void>;
+  private _customCloseHandler?: (runBeforeUnload: boolean) => Promise<void>;
 
   constructor(delegate: PageDelegate, browserContext: BrowserContext) {
     super(browserContext, 'page');
@@ -834,13 +834,13 @@ export class Page extends SdkObject<PageEventMap> {
       this._lifecycle = 'closing';
       // This might throw if the browser context containing the page closes
       // while we are trying to close the page.
-      const closePage = this._customCloseHandler ?? (() => this.delegate.closePage(false));
-      await closePage().catch(e => debugLogger.log('error', e));
+      const closePage = this._customCloseHandler ?? (runBeforeUnload => this.delegate.closePage(runBeforeUnload));
+      await closePage(false).catch(e => debugLogger.log('error', e));
     }
     await this.closedPromise;
   }
 
-  setCustomCloseHandler(handler: (() => Promise<void>) | undefined) {
+  setCustomCloseHandler(handler: ((runBeforeUnload: boolean) => Promise<void>) | undefined) {
     this._customCloseHandler = handler;
   }
 
@@ -851,7 +851,8 @@ export class Page extends SdkObject<PageEventMap> {
   private async _runBeforeUnload() {
     // This might throw if the browser context containing the page closes
     // while we are trying to close the page.
-    await this.delegate.closePage(true).catch(e => debugLogger.log('error', e));
+    const closePage = this._customCloseHandler ?? (runBeforeUnload => this.delegate.closePage(runBeforeUnload));
+    await closePage(true).catch(e => debugLogger.log('error', e));
   }
 
   isClosed(): boolean {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -202,6 +202,7 @@ export class Page extends SdkObject<PageEventMap> {
   readonly overlay: Overlay;
   readonly screencast: Screencast;
   _closeReason: string | undefined;
+  private _customCloseHandler?: () => Promise<void>;
 
   constructor(delegate: PageDelegate, browserContext: BrowserContext) {
     super(browserContext, 'page');
@@ -833,9 +834,14 @@ export class Page extends SdkObject<PageEventMap> {
       this._lifecycle = 'closing';
       // This might throw if the browser context containing the page closes
       // while we are trying to close the page.
-      await this.delegate.closePage(false).catch(e => debugLogger.log('error', e));
+      const closePage = this._customCloseHandler ?? (() => this.delegate.closePage(false));
+      await closePage().catch(e => debugLogger.log('error', e));
     }
     await this.closedPromise;
+  }
+
+  setCustomCloseHandler(handler: (() => Promise<void>) | undefined) {
+    this._customCloseHandler = handler;
   }
 
   async runBeforeUnload(progress: Progress) {


### PR DESCRIPTION
## Summary
- `page.close()` sends CDP `Target.closeTarget` and resolves only on the browser-level `Target.detachedFromTarget` event. On Electron, when the close races a navigation that is being committed, Electron acks `Target.closeTarget` with `success` but silently drops the actual close, so the target is never destroyed and `page.close()` hangs forever (Electron has no unload watchdog to recover, unlike Chrome). This surfaced as flaky Electron teardown timeouts in CI (e.g. `page-autowaiting-no-hang.spec.ts` "assigning location to about:blank").
- Fix in the Electron layer: a per-page custom close handler closes the page from the main process via `webContents.close()`, which is not subject to the CDP/navigation race. `webContents.close()` (without `waitForBeforeUnload`) closes without running `beforeunload`, matching `page.close(runBeforeUnload: false)` force-close semantics.
- Not an Electron version regression — reproduces equally on 42.4.1 / 42.5.0 / 42.6.1.