### PR TITLE
fix(chromium): disable BlockOriginHeaderModificationOnRedirect

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -36,6 +36,9 @@ const disabledFeatures = [
   'PaintHolding',
   // See https://github.com/microsoft/playwright/issues/32230
   'ThirdPartyStoragePartitioning',
+  // Chromium 149 rejects re-applying the `origin` header on a redirect (as request interception
+  // does) with net::ERR_INVALID_ARGUMENT. See https://github.com/microsoft/playwright/issues/41690
+  'BlockOriginHeaderModificationOnRedirect',
   // See https://github.com/microsoft/playwright/issues/16126
   'Translate',
   // See https://issues.chromium.org/u/1/issues/435410220

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -872,6 +872,35 @@ it('propagate headers cross origin redirect after interception', {
   expect.soft(serverRequest.headers['custom']).toBe('foo');
 });
 
+it('continue should pass on 307 cross-origin redirect', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41690' }
+}, async ({ page, server, isAndroid }) => {
+  it.skip(isAndroid, 'No cross-process on Android');
+
+  server.setRoute('/final', (request, response) => {
+    response.writeHead(200, { 'content-type': 'text/html' });
+    response.end('<!doctype html><title>final</title><p>ok</p>');
+  });
+  // Cross-origin 307 redirect that preserves the POST method.
+  server.setRoute('/redirect307', (request, response) => {
+    response.writeHead(307, { location: `${server.PREFIX}/final` });
+    response.end();
+  });
+
+  await page.goto(server.PREFIX + '/empty.html');
+  await page.setContent(`
+    <form id="f" method="POST" action="${server.CROSS_PROCESS_PREFIX}/redirect307">
+      <input type="submit">
+    </form>`);
+
+  await page.route('**/*', route => route.continue());
+  await Promise.all([
+    page.waitForURL(`${server.PREFIX}/final`),
+    page.locator('input').click(),
+  ]);
+  await expect(page.locator('p')).toHaveText('ok');
+});
+
 it('should intercept css variable with background url', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/19158' });
 


### PR DESCRIPTION
## Summary
- Chromium 149 rejects re-applying the `origin` header on a redirect (which request interception does) with `net::ERR_INVALID_ARGUMENT`, breaking cross-origin redirects when `page.route` is enabled.
- Disable the `BlockOriginHeaderModificationOnRedirect` feature via `--disable-features`, letting the network stack own the `origin` header across redirects.

Fixes https://github.com/microsoft/playwright/issues/41690