### PR TITLE
Fix storageState IndexedDB falsy primitive round-tripping

### DIFF
--- a/packages/injected/src/storageScript.ts
+++ b/packages/injected/src/storageScript.ts
@@ -88,19 +88,19 @@ export class StorageScript {
         const record: IndexedDBDatabase['stores'][0]['records'][0] = {};
 
         if (objectStore.keyPath === null) {
-          const { encoded, trivial } = this._trySerialize(key);
-          if (trivial)
-            record.key = trivial;
+          const serializedKey = this._trySerialize(key);
+          if ('trivial' in serializedKey)
+            record.key = serializedKey.trivial;
           else
-            record.keyEncoded = encoded;
+            record.keyEncoded = serializedKey.encoded;
         }
 
         const value = await this._idbRequestToPromise(objectStore.get(key));
-        const { encoded, trivial } = this._trySerialize(value);
-        if (trivial)
-          record.value = trivial;
+        const serializedValue = this._trySerialize(value);
+        if ('trivial' in serializedValue)
+          record.value = serializedValue.trivial;
         else
-          record.valueEncoded = encoded;
+          record.valueEncoded = serializedValue.encoded;
 
         return record;
       }));
@@ -166,10 +166,12 @@ export class StorageScript {
     await Promise.all(dbInfo.stores.map(async store => {
       const objectStore = transaction.objectStore(store.name);
       await Promise.all(store.records.map(async record => {
+        const value = Object.prototype.hasOwnProperty.call(record, 'value') ? record.value : parseEvaluationResultValue(record.valueEncoded);
+        const key = Object.prototype.hasOwnProperty.call(record, 'key') ? record.key : parseEvaluationResultValue(record.keyEncoded);
         await this._idbRequestToPromise(
             objectStore.add(
-                record.value ?? parseEvaluationResultValue(record.valueEncoded),
-                record.key ?? parseEvaluationResultValue(record.keyEncoded),
+                value,
+                key,
             )
         );
       }));

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -200,6 +200,111 @@ it('should round-trip through the file', async ({ contextFactory, channel }, tes
   await context3.close();
 });
 
+it('should round-trip top-level falsy IndexedDB primitives', async ({ contextFactory }) => {
+  const context = await contextFactory();
+  const page = await context.newPage();
+  await page.route('**/*', route => {
+    route.fulfill({ body: '<html></html>' }).catch(() => {});
+  });
+  await page.goto('https://www.example.com');
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve, reject) => {
+      const openRequest = indexedDB.open('db', 1);
+      openRequest.onupgradeneeded = () => {
+        const db = openRequest.result;
+        db.createObjectStore('values');
+        db.createObjectStore('keys');
+      };
+      openRequest.onsuccess = () => {
+        const transaction = openRequest.result.transaction(['values', 'keys'], 'readwrite');
+        const valuesStore = transaction.objectStore('values');
+        valuesStore.put(0, 'zero');
+        valuesStore.put(false, 'false');
+        valuesStore.put('', 'empty-string');
+        valuesStore.put(null, 'null');
+
+        const keysStore = transaction.objectStore('keys');
+        keysStore.put('zero-key', 0);
+        keysStore.put('empty-key', '');
+
+        transaction.addEventListener('complete', resolve);
+        transaction.addEventListener('error', reject);
+      };
+      openRequest.onerror = () => reject(openRequest.error);
+    });
+  });
+
+  const storageState = await context.storageState({ indexedDB: true });
+  expect(storageState.origins).toEqual([{
+    origin: 'https://www.example.com',
+    localStorage: [],
+    indexedDB: [{
+      name: 'db',
+      version: 1,
+      stores: expect.arrayContaining([
+        expect.objectContaining({
+          name: 'values',
+          records: expect.arrayContaining([
+            { key: 'zero', value: 0 },
+            { key: 'false', value: false },
+            { key: 'empty-string', value: '' },
+            { key: 'null', value: null },
+          ]),
+        }),
+        expect.objectContaining({
+          name: 'keys',
+          records: expect.arrayContaining([
+            { key: 0, value: 'zero-key' },
+            { key: '', value: 'empty-key' },
+          ]),
+        }),
+      ]),
+    }],
+  }]);
+
+  const restoredContext = await contextFactory({ storageState });
+  const restoredPage = await restoredContext.newPage();
+  await restoredPage.route('**/*', route => {
+    route.fulfill({ body: '<html></html>' }).catch(() => {});
+  });
+  await restoredPage.goto('https://www.example.com');
+  const idbValues = await restoredPage.evaluate(() => new Promise((resolve, reject) => {
+    const openRequest = indexedDB.open('db', 1);
+    openRequest.addEventListener('success', async () => {
+      const db = openRequest.result;
+      const transaction = db.transaction(['values', 'keys'], 'readonly');
+      const valuesStore = transaction.objectStore('values');
+      const keysStore = transaction.objectStore('keys');
+      const read = (store: IDBObjectStore, key: IDBValidKey) => new Promise((resolve, reject) => {
+        const request = store.get(key);
+        request.addEventListener('success', () => resolve(request.result));
+        request.addEventListener('error', () => reject(request.error));
+      });
+
+      resolve({
+        values: await Promise.all([
+          read(valuesStore, 'zero'),
+          read(valuesStore, 'false'),
+          read(valuesStore, 'empty-string'),
+          read(valuesStore, 'null'),
+        ]),
+        keys: await Promise.all([
+          read(keysStore, 0),
+          read(keysStore, ''),
+        ]),
+      });
+    });
+    openRequest.addEventListener('error', () => reject(openRequest.error));
+  }));
+  expect(idbValues).toEqual({
+    values: [0, false, '', null],
+    keys: ['zero-key', 'empty-key'],
+  });
+
+  await restoredContext.close();
+  await context.close();
+});
+
 it('should capture cookies', async ({ server, context, page, contextFactory }) => {
   server.setRoute('/setcookie.html', (req, res) => {
     res.setHeader('Set-Cookie', ['a=b', 'empty=']);


### PR DESCRIPTION
## Summary
- preserve falsy primitive IndexedDB keys and values when collecting `storageState`
- restore IndexedDB records by checking field presence instead of truthiness or nullish fallbacks
- add regression coverage for top-level falsy primitive values and out-of-line falsy keys

## Why
`storageState({ indexedDB: true })` treated serialized "trivial" values as truthy in both the collect and restore paths. That dropped valid values like `0`, `false`, `''`, and `null`, and could also lose valid out-of-line keys like `0` and `''`.

## Impact
IndexedDB-backed auth and app state now round-trip correctly when records contain falsy primitive values or falsy out-of-line keys.

## Testing
- `npm test -- tests/library/browsercontext-storage-state.spec.ts --project=chromium-library --grep "should round-trip through the file|should round-trip top-level falsy IndexedDB primitives"`
- `npx eslint packages/injected/src/storageScript.ts tests/library/browsercontext-storage-state.spec.ts`
