### PR TITLE
fix(firefox): restore toJSON after serialization errors

### DIFF
--- a/browser_patches/firefox/juggler/content/Runtime.js
+++ b/browser_patches/firefox/juggler/content/Runtime.js
@@ -335,18 +335,19 @@ class ExecutionContext {
         Array.prototype.toJSON = undefined;
 
       let hasSymbol = false;
-      const result = stringify(object, (key, value) => {
-        if (typeof value === 'symbol')
-          hasSymbol = true;
-        return value;
-      });
-
-      if (oldToJSON)
-        Date.prototype.toJSON = oldToJSON;
-      if (oldArrayHadToJSON)
-        Array.prototype.toJSON = oldArrayToJSON;
-
-      return hasSymbol ? undefined : result;
+      try {
+        const result = stringify(object, (key, value) => {
+          if (typeof value === 'symbol')
+            hasSymbol = true;
+          return value;
+        });
+        return hasSymbol ? undefined : result;
+      } finally {
+        if (oldToJSON)
+          Date.prototype.toJSON = oldToJSON;
+        if (oldArrayHadToJSON)
+          Array.prototype.toJSON = oldArrayToJSON;
+      }
     }).bind(null, JSON.stringify.bind(JSON))`).return;
   }
 

--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -742,6 +742,23 @@ it('should not use Array.prototype.toJSON when evaluating', async ({ page }) => 
   expect(result).toEqual([1, 2, 3]);
 });
 
+it('should restore toJSON after failed serialization', async ({ page, browserName, isBidi }) => {
+  it.skip(browserName !== 'firefox' || isBidi, 'Firefox Juggler specific');
+
+  await page.evaluate(() => {
+    (Array.prototype as any).toJSON = () => 'busted';
+  });
+  expect(await page.evaluate(() => JSON.stringify([1, 2, 3]))).toBe('"busted"');
+  expect(await page.evaluate(() => typeof Date.prototype.toJSON)).toBe('function');
+
+  await page.evaluate(() => {
+    throw 42n;
+  }).catch(() => {});
+
+  expect(await page.evaluate(() => JSON.stringify([1, 2, 3]))).toBe('"busted"');
+  expect(await page.evaluate(() => typeof Date.prototype.toJSON)).toBe('function');
+});
+
 it('should not add a toJSON property to newly created Arrays after evaluation', async ({ page, browserName }) => {
   await page.evaluate(() => []);
   const hasToJSONProperty = await page.evaluate(() => 'toJSON' in []);


### PR DESCRIPTION
- restore Date.prototype.toJSON and Array.prototype.toJSON in a finally block during Firefox Juggler serialization
- add a Firefox Juggler regression that throws a BigInt while serializing and verifies the page prototypes are still intact afterwards