### PR TITLE
fix(firefox): report missing object ids correctly

### DIFF
--- a/browser_patches/firefox/juggler/content/Runtime.js
+++ b/browser_patches/firefox/juggler/content/Runtime.js
@@ -547,7 +547,7 @@ class ExecutionContext {
 
   getObjectProperties(objectId) {
     if (!this._remoteObjects.has(objectId))
-      throw new Error('Cannot find object with id = ' + arg.objectId);
+      throw new Error('Cannot find object with id = ' + objectId);
     const result = [];
     for (let obj = this._remoteObjects.get(objectId); obj; obj = obj.proto) {
       for (const propertyName of obj.getOwnPropertyNames()) {


### PR DESCRIPTION
- fix Firefox Juggler's missing-object error path to use the actual `objectId`
- avoid turning a normal missing-object protocol error into a misleading `ReferenceError`
- verified the bad message on the stock rolled Firefox build, then reran the same direct `Runtime.getObjectProperties` probe against a locally patched Firefox copy and got the expected missing-object error
