### PR TITLE
fix(chromium): do not modify Origin header across a redirect

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -348,6 +348,16 @@ export class CRNetworkManager {
           const originalHeaders = Object.entries(requestPausedEvent.request.headers).map(([name, value]) => ({ name, value }));
           headersOverride = removeCookieHeader(network.applyHeadersOverrides(originalHeaders, headersOverride));
         }
+        if (redirectedFrom) {
+          // Chromium 149+ rejects a request whose Origin header is modified across a redirect
+          // (BlockOriginHeaderModificationOnRedirect). Continuing the redirected request resends
+          // the pre-redirect Origin, which the browser treats as a modification and fails with
+          // net::ERR_INVALID_ARGUMENT. Drop the Origin from the continued request so the browser
+          // keeps the Origin it computed for the redirected request.
+          // https://github.com/microsoft/playwright/issues/41690
+          const originalHeaders = headersOverride ?? Object.entries(requestPausedEvent.request.headers).map(([name, value]) => ({ name, value }));
+          headersOverride = removeOriginHeader(originalHeaders);
+        }
         requestPausedSessionInfo!.session._sendMayFail('Fetch.continueRequest', { requestId: requestPausedEvent.requestId, headers: headersOverride });
       } else {
         route = new RouteImpl(requestPausedSessionInfo!.session, requestPausedEvent.requestId);
@@ -719,6 +729,10 @@ async function catchDisallowedErrors(callback: () => Promise<void>) {
 // network stack source the cookie from the store. https://github.com/microsoft/playwright/issues/41428
 function removeCookieHeader(headers: types.HeadersArray): types.HeadersArray {
   return headers.filter(header => header.name.toLowerCase() !== 'cookie');
+}
+
+function removeOriginHeader(headers: types.HeadersArray): types.HeadersArray {
+  return headers.filter(header => header.name.toLowerCase() !== 'origin');
 }
 
 function splitSetCookieHeader(headers: types.HeadersArray): types.HeadersArray {

--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -125,6 +125,35 @@ it('should work when header manipulation headers with redirect', async ({ page, 
   await page.goto(server.PREFIX + '/rrredirect');
 });
 
+it('should continue a request across a cross-origin redirect that changes the Origin', async ({ page, server, browserName }) => {
+  it.skip(browserName !== 'chromium', 'The Origin-modification-on-redirect restriction is Chromium-specific.');
+  // Regression test for https://github.com/microsoft/playwright/issues/41690
+  // Chromium 149+ rejects a request whose Origin header is modified across a redirect.
+  // When re-applying header overrides after a cross-origin redirect, Playwright must not
+  // touch the Origin computed by the browser, otherwise the request fails with
+  // net::ERR_INVALID_ARGUMENT.
+  server.setRoute('/cross-origin-redirect', (req, res) => {
+    res.writeHead(307, { location: server.PREFIX + '/redirect-target.html' });
+    res.end();
+  });
+  server.setRoute('/redirect-target.html', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<!doctype html><title>final</title><p>ok</p>');
+  });
+  server.setRoute('/origin-page.html', (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(`<!doctype html><form id="f" method="POST" action="${server.CROSS_PROCESS_PREFIX}/cross-origin-redirect"><input type="submit"></form>`);
+  });
+
+  await page.route('**/*', route => route.continue());
+  await page.goto(server.PREFIX + '/origin-page.html');
+  await Promise.all([
+    page.waitForURL(server.PREFIX + '/redirect-target.html'),
+    page.locator('input').click(),
+  ]);
+  await expect(page.locator('p')).toHaveText('ok');
+});
+
 // @see https://github.com/GoogleChrome/puppeteer/issues/4743
 it('should be able to remove headers', async ({ page, server }) => {
   await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
## Summary
- Continuing a redirected request re-sent the pre-redirect `Origin` header. Chromium 149+ (`BlockOriginHeaderModificationOnRedirect`) treats that as a modification and fails the request with `net::ERR_INVALID_ARGUMENT`, so `route.continue()` across a cross-origin redirect broke.
- Drop the `Origin` from the continued request on the redirect path so the browser keeps the Origin it computed for the redirected request.

Fixes https://github.com/microsoft/playwright/issues/41690