### PR TITLE
test(webkit): CacheStorage entry should survive page.reload()

### DIFF
--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -283,6 +283,27 @@ it('dialog.accept should work', {
   await context.close();
 });
 
+it('CacheStorage entry should survive page.reload()', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41618' }
+}, async ({ launchPersistent, server }) => {
+  const { context, page } = await launchPersistent();
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(async () => {
+    const cache = await caches.open('repro-cache');
+    await cache.put('/meta', new Response('payload'));
+  });
+
+  await page.reload();
+
+  const after = await page.evaluate(async () => {
+    const cache = await caches.open('repro-cache');
+    const resp = await cache.match('/meta');
+    return resp ? await resp.text() : null;
+  });
+  expect(after).toBe('payload');
+  await context.close();
+});
+
 it('exposes browser', async ({ launchPersistent }) => {
   const { context } = await launchPersistent();
   const browser = context.browser();

--- a/tests/page/page-cache-storage.spec.ts
+++ b/tests/page/page-cache-storage.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './pageTest';
+
+test('CacheStorage entry should survive page.reload()', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41618' }
+}, async ({ page, server, browserName }) => {
+  test.fail(browserName === 'webkit', 'Ephemeral CacheStorage is not persisted across reload in WebKit, consistent with Safari');
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(async () => {
+    const cache = await caches.open('repro-cache');
+    await cache.put('/meta', new Response('payload'));
+  });
+
+  await page.reload();
+
+  const after = await page.evaluate(async () => {
+    const cache = await caches.open('repro-cache');
+    const resp = await cache.match('/meta');
+    return resp ? await resp.text() : null;
+  });
+  expect(after).toBe('payload');
+});


### PR DESCRIPTION
## Summary
- Roll WebKit to r2328, which fixes CacheStorage disk persistence in persistent contexts. The Playwright patch added `httpRequestHeaderFields` to `ResourceResponseData` but never to its persistence *encoder*, so persisted responses failed to decode and `cache.match()` returned `null` on disk-backed (persistent) contexts — even immediately after `cache.put()`. Browser fix: microsoft/playwright-browsers#2404.
- Add a persistent-context regression test (fixed by the roll).
- Add an ephemeral-context test, marked expected-fail on WebKit: an in-memory CacheStorage entry is not persisted across reload, consistent with Safari.

Fixes https://github.com/microsoft/playwright/issues/41618