### PR TITLE
test(firefox): unskip concurrent hover test

### DIFF
--- a/tests/library/emulation-focus.spec.ts
+++ b/tests/library/emulation-focus.spec.ts
@@ -198,10 +198,9 @@ browserTest('should not fire blur events when interacting with more than one pag
   expect(await page2.evaluate(() => !!window['gotBlur'])).toBe(false);
 });
 
-browserTest('should trigger hover state concurrently', async ({ browserType, browserName, headless, isBidi }) => {
+browserTest('should trigger hover state concurrently', async ({ browserType, headless }) => {
   browserTest.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27969' });
   browserTest.skip(!headless, 'headed messes up with hover');
-  browserTest.fixme(browserName === 'firefox' && !isBidi);
 
   const browser1 = await browserType.launch();
   const context1 = await browser1.newContext();


### PR DESCRIPTION
Fixme'd since #28042 as a repro for #27969. #37751 later unskipped it for Firefox-BiDi but left the legacy Juggler path off via `!isBidi`. Turns out the Juggler bug got fixed too, nobody just re-checked - passes 190/190 on non-BiDi Firefox now.

See #27969
