### PR TITLE
chore(devops): don't pick already-fixed flakes in fix-flakes

### DIFF
--- a/.github/workflows/fix-flakes-prompt.md
+++ b/.github/workflows/fix-flakes-prompt.md
@@ -17,13 +17,20 @@ bots/PRs it disrupts — **not** by "has a tidy error message".
 Pick a candidate whose failing `bot_name` OS matches yours so you can reproduce it.
 Keep the ranked list — you fall back down it in step 2. Say why you picked the top one.
 
-## 2. Check nobody's already on it
+## 2. Check nobody's on it — and that it isn't already fixed
 
-Search open PRs/issues for the test title words and file path before touching anything.
-Also check any issue linked in the
-test's `annotation`.
-If an open PR already touches the test, **it's taken — drop it and go down your step-1 ranking**, re-checking each.
-Only stop and report if the whole shortlist is covered.
+Two dead ends to rule out before touching a candidate. If either fires, drop it and go
+down your step-1 ranking, re-checking each; only stop once the whole shortlist is covered.
+
+- **Already being worked on** — search PRs/issues (open *and* recently merged/closed) for
+  the test title words and file path, plus any issue linked in the test's `annotation`.
+- **Already fixed** — the DB is a rolling window that still holds the failing runs from
+  before a fix landed, so a test fixed mid-window looks maximally bimodal (old fails + new
+  passes), which is exactly what floats it up step 1. Check whether a fix has landed since it
+  last flaked: find the commit its most recent failing run ran on, and look at what's changed
+  in that test's file since. A commit that plausibly targets the test or its feature — a
+  browser roll, or a fix to the test or the code it exercises — means the remaining DB fails
+  are from before the fix, so move on.
 
 ## 3. Reproduce on this OS
 

--- a/.github/workflows/fix-flakes.yml
+++ b/.github/workflows/fix-flakes.yml
@@ -36,10 +36,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download test-results DB
+      - name: Download and refresh test-results DB
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node utils/test-results-db/cli.ts download
+        run: |
+          node utils/test-results-db/cli.ts download
+          node utils/test-results-db/cli.ts update --lookback-days 3
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
@@ -57,9 +59,12 @@ jobs:
           off only that runner label. Do NOT fix anything.
 
           Optimise for the OS with the highest-impact actionable flakiness/reds that isn't
-          already being worked on (its top candidates aren't covered by an open fix PR — check
-          with the GitHub MCP tools). All else equal, favour variety so Linux, Windows and macOS
-          each get attention over time.
+          already being worked on OR already fixed. A candidate is dead if a fix PR touches it
+          (open, or recently merged/closed) — the DB window still holds the failing runs from
+          before a fix landed, so a just-fixed test keeps showing old fails and looks bimodal.
+          For a top candidate, check open and merged/closed PRs plus any linked annotation
+          issue (GitHub MCP tools) for a plausible fix before betting an OS on it. All else
+          equal, favour variety so Linux, Windows and macOS each get attention over time.
 
           The DB is already downloaded at utils/test-results-db/test-results.duckdb — query it
           via the playwright-test-results skill. \`bot_name\` encodes the OS.
@@ -148,10 +153,12 @@ jobs:
             npx playwright install
           fi
 
-      - name: Download test-results DB
+      - name: Download and refresh test-results DB
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node utils/test-results-db/cli.ts download
+        run: |
+          node utils/test-results-db/cli.ts download
+          node utils/test-results-db/cli.ts update --lookback-days 3
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot


### PR DESCRIPTION
In [run 29005203265](https://github.com/microsoft/playwright/actions/runs/29005203265) the triage agent picked a test that had already been fixed. The DB is a rolling window that still holds the failing runs from before a fix lands, so a just-fixed test looks maximally bimodal - which is exactly what floats it to the top of the ranking. The agent then only checked *open* PRs, so it missed the roll that had already fixed it.

Two changes:

- **Refresh the DB after download** (`update --lookback-days 3`) in both jobs, so triage and fix see the last few hours of runs instead of just the snapshot.
- **Teach the picker to drop already-fixed candidates.** The fix step (full clone) checks whether a fix has landed since the test last flaked. Triage (shallow clone, only picks an OS) leans on merged/closed PRs instead of git history.
