### PR TITLE
feat(test runner): cancel operations on test end via default abort signal

### DIFF
--- a/packages/isomorphic/abortSignal.ts
+++ b/packages/isomorphic/abortSignal.ts
@@ -19,27 +19,31 @@ export function assertionAbortedMessage(reason: unknown): string {
   return 'The assertion was aborted' + (detail ? `: ${detail}` : '');
 }
 
-export function combineSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {
+export function combineSignals(a?: AbortSignal, b?: AbortSignal): { signal: AbortSignal | undefined, cleanup: () => void } {
+  const noop = () => {};
   if (!a)
-    return b;
+    return { signal: b, cleanup: noop };
   if (!b)
-    return a;
+    return { signal: a, cleanup: noop };
   if (a.aborted)
-    return a;
+    return { signal: a, cleanup: noop };
   if (b.aborted)
-    return b;
+    return { signal: b, cleanup: noop };
 
   const controller = new AbortController();
   const onA = () => onAbort(a);
   const onB = () => onAbort(b);
-  const onAbort = (source: AbortSignal) => {
-    controller.abort(source.reason);
+  const cleanup = () => {
     a.removeEventListener('abort', onA);
     b.removeEventListener('abort', onB);
   };
+  const onAbort = (source: AbortSignal) => {
+    controller.abort(source.reason);
+    cleanup();
+  };
   a.addEventListener('abort', onA, { once: true });
   b.addEventListener('abort', onB, { once: true });
-  return controller.signal;
+  return { signal: controller.signal, cleanup };
 }
 
 export class TestEndedError extends Error {}

--- a/packages/isomorphic/abortSignal.ts
+++ b/packages/isomorphic/abortSignal.ts
@@ -18,3 +18,28 @@ export function assertionAbortedMessage(reason: unknown): string {
   const detail = reason instanceof Error ? reason.message : reason === undefined || reason === null ? '' : String(reason);
   return 'The assertion was aborted' + (detail ? `: ${detail}` : '');
 }
+
+export function combineSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {
+  if (!a)
+    return b;
+  if (!b)
+    return a;
+  if (a.aborted)
+    return a;
+  if (b.aborted)
+    return b;
+
+  const controller = new AbortController();
+  const onA = () => onAbort(a);
+  const onB = () => onAbort(b);
+  const onAbort = (source: AbortSignal) => {
+    controller.abort(source.reason);
+    a.removeEventListener('abort', onA);
+    b.removeEventListener('abort', onB);
+  };
+  a.addEventListener('abort', onA, { once: true });
+  b.addEventListener('abort', onB, { once: true });
+  return controller.signal;
+}
+
+export class TestEndedError extends Error {}

--- a/packages/isomorphic/index.ts
+++ b/packages/isomorphic/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './abortSignal';
 export * from './ariaSnapshot';
 export * from './assert';
 export * from './base64';

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -156,17 +156,21 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
               return await this._wrapApiCall(async apiZone => {
                 const validatedParams = validator(params, '', this._validatorToWireContext());
                 const def = this._connection._defaultOperationSignal;
-                const effectiveSignal = combineSignals(signal, def?.aborted ? undefined : def);
-                if (!apiZone.internal && !apiZone.reported) {
-                  // Reporting/tracing/logging this api call for the first time.
-                  apiZone.reported = true;
-                  this._instrumentation.onApiCallBegin(apiZone, { type: this._type, method: prop, params });
-                  logApiCall(this._logger, `=> ${apiZone.apiName} started`);
-                  return await this._connection.sendMessageToServer(this, prop, validatedParams, { ...apiZone, signal: effectiveSignal });
+                const { signal: effectiveSignal, cleanup } = combineSignals(signal, def?.aborted ? undefined : def);
+                try {
+                  if (!apiZone.internal && !apiZone.reported) {
+                    // Reporting/tracing/logging this api call for the first time.
+                    apiZone.reported = true;
+                    this._instrumentation.onApiCallBegin(apiZone, { type: this._type, method: prop, params });
+                    logApiCall(this._logger, `=> ${apiZone.apiName} started`);
+                    return await this._connection.sendMessageToServer(this, prop, validatedParams, { ...apiZone, signal: effectiveSignal });
+                  }
+                  // Since this api call is either internal, or has already been reported/traced once,
+                  // passing as internal.
+                  return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true, signal: effectiveSignal });
+                } finally {
+                  cleanup();
                 }
-                // Since this api call is either internal, or has already been reported/traced once,
-                // passing as internal.
-                return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true, signal: effectiveSignal });
               }, { internal });
             };
           }

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -15,6 +15,7 @@
  */
 
 import { getMetainfo } from '@isomorphic/protocolMetainfo';
+import { combineSignals } from '@isomorphic/abortSignal';
 import { showInternalStackFrames, stringifyStackFrames } from '@utils/stackTrace';
 import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
@@ -154,16 +155,18 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
             return async (params: any, signal: AbortSignal | undefined) => {
               return await this._wrapApiCall(async apiZone => {
                 const validatedParams = validator(params, '', this._validatorToWireContext());
+                const def = this._connection._defaultOperationSignal;
+                const effectiveSignal = combineSignals(signal, def?.aborted ? undefined : def);
                 if (!apiZone.internal && !apiZone.reported) {
                   // Reporting/tracing/logging this api call for the first time.
                   apiZone.reported = true;
                   this._instrumentation.onApiCallBegin(apiZone, { type: this._type, method: prop, params });
                   logApiCall(this._logger, `=> ${apiZone.apiName} started`);
-                  return await this._connection.sendMessageToServer(this, prop, validatedParams, { ...apiZone, signal });
+                  return await this._connection.sendMessageToServer(this, prop, validatedParams, { ...apiZone, signal: effectiveSignal });
                 }
                 // Since this api call is either internal, or has already been reported/traced once,
                 // passing as internal.
-                return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true, signal });
+                return await this._connection.sendMessageToServer(this, prop, validatedParams, { internal: true, signal: effectiveSignal });
               }, { internal });
             };
           }

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -15,6 +15,7 @@
  */
 
 import colors from 'colors/safe';
+import { TestEndedError } from '@isomorphic/abortSignal';
 import { rewriteErrorMessage } from '@utils/stackTrace';
 import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
@@ -86,6 +87,8 @@ export class Connection extends EventEmitter {
   // Used from @playwright/test fixtures -> TODO remove?
   readonly headers: HeadersArray;
   private _objectFactories = new Map<string, ChannelOwnerFactory>();
+
+  _defaultOperationSignal: AbortSignal | undefined;
 
   constructor(localUtils?: LocalUtils, instrumentation?: ClientInstrumentation, headers: HeadersArray = []) {
     super();
@@ -246,6 +249,9 @@ export class Connection extends EventEmitter {
         const parsedError = parseError(error);
         if (callback.signal?.aborted && parsedError instanceof AbortError)
           parsedError.cause = callback.signal.reason;
+        // hack to preserve error message strings from @playwright/test
+        if (parsedError.cause instanceof TestEndedError)
+          rewriteErrorMessage(parsedError, parsedError.cause.message);
         parsedError.log = log || [];
         rewriteErrorMessage(parsedError, parsedError.message + formatCallLog(log));
         const detailsValidator = maybeFindValidator(callback.type, callback.method, 'ErrorDetails');

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -247,10 +247,9 @@ export class Connection extends EventEmitter {
       this._callbacks.delete(id);
       if (error && !result) {
         const parsedError = parseError(error);
-        if (callback.signal?.aborted && parsedError instanceof AbortError)
+        if (callback.signal?.aborted)
           parsedError.cause = callback.signal.reason;
-        // hack to preserve error message strings from @playwright/test
-        if (parsedError.cause instanceof TestEndedError)
+        if (parsedError instanceof AbortError && parsedError.cause instanceof TestEndedError)
           rewriteErrorMessage(parsedError, parsedError.cause.message);
         parsedError.log = log || [];
         rewriteErrorMessage(parsedError, parsedError.message + formatCallLog(log));

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs';
 
-import { assertionAbortedMessage } from '@isomorphic/abortSignal';
+import { TestEndedError, assertionAbortedMessage } from '@isomorphic/abortSignal';
 import { assert } from '@isomorphic/assert';
 import { getByAltTextSelector, getByLabelSelector, getByPlaceholderSelector, getByRoleSelector, getByTestIdSelector, getByTextSelector, getByTitleSelector } from '@isomorphic/locatorUtils';
 import { urlMatches } from '@isomorphic/urlMatch';
@@ -514,12 +514,18 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
         value: details.received.value !== undefined ? parseResult(details.received.value) : undefined,
         ariaSnapshot: details.received.ariaSnapshot,
       } : undefined;
+      const abortedByUser = e.cause !== undefined && !(e.cause instanceof TestEndedError);
+      let errorMessage: string | undefined;
+      if (abortedByUser)
+        errorMessage = 'Error: ' + assertionAbortedMessage(e.cause);
+      else if (details.customErrorMessage)
+        errorMessage = 'Error: ' + details.customErrorMessage;
       return {
         matches: !!params.isNot,
         received,
         log: e.log,
         timedOut: details.timedOut,
-        errorMessage: details.customErrorMessage ? 'Error: ' + details.customErrorMessage : undefined,
+        errorMessage,
       };
     }
   }

--- a/packages/playwright-core/src/client/playwright.ts
+++ b/packages/playwright-core/src/client/playwright.ts
@@ -42,6 +42,14 @@ export class Playwright extends ChannelOwner<channels.PlaywrightChannel> {
   _defaultContextTimeout?: number;
   _defaultContextNavigationTimeout?: number;
 
+  get _defaultOperationSignal(): AbortSignal | undefined {
+    return this._connection._defaultOperationSignal;
+  }
+
+  set _defaultOperationSignal(signal: AbortSignal | undefined) {
+    this._connection._defaultOperationSignal = signal;
+  }
+
   constructor(parent: ChannelOwner, type: string, guid: string, initializer: channels.PlaywrightInitializer) {
     super(parent, type, guid, initializer);
     this.request = new APIRequest(this);

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -16,7 +16,6 @@
  */
 
 import yaml from 'yaml';
-import { assertionAbortedMessage } from '@isomorphic/abortSignal';
 import { parseAriaSnapshotUnsafe } from '@isomorphic/ariaSnapshot';
 import { isInvalidSelectorError } from '@isomorphic/selectorParser';
 import { ManualPromise } from '@isomorphic/manualPromise';
@@ -29,7 +28,7 @@ import { makeWaitForNextTask } from '@utils/task';
 import { createGuid } from '@utils/crypto';
 import { BrowserContext } from './browserContext';
 import * as dom from './dom';
-import { TimeoutError, AbortError, isTargetClosedError } from './errors';
+import { TimeoutError, isTargetClosedError } from './errors';
 import { prepareFilesForUpload } from './fileUploadUtils';
 import { FrameSelectors } from './frameSelectors';
 import { helper } from './helper';
@@ -1545,8 +1544,6 @@ export class Frame extends SdkObject<FrameEventMap> {
         progress.log(e.message);
       if (e instanceof TimeoutError)
         details.timedOut = true;
-      if (e instanceof AbortError)
-        details.customErrorMessage = assertionAbortedMessage(e.cause);
       throw new ExpectError(details);
     }
   }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -384,9 +384,11 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
 
     playwright._defaultContextTimeout = actionTimeout || 0;
     playwright._defaultContextNavigationTimeout = navigationTimeout || 0;
+    playwright._defaultOperationSignal = testInfo._operationAbortController.signal;
     await use();
     playwright._defaultContextTimeout = undefined;
     playwright._defaultContextNavigationTimeout = undefined;
+    playwright._defaultOperationSignal = undefined;
   }, { auto: 'all-hooks-included',  title: 'context configuration', box: true } as any],
 
   _contextFactory: [async ({ browser, video, _reuseContext, _combinedContextOptions /** mitigate dep-via-auto lack of traceability */ }, use, testInfo) => {
@@ -420,8 +422,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         if (closed)
           return;
         closed = true;
-        const closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
-        await context.close({ reason: closeReason });
+        await context.close();
         const preserveVideo = captureVideo && shouldPreserveVideo(videoMode, testInfo);
         if (preserveVideo) {
           const { pagesWithVideo: pagesForVideo } = contexts.get(context)!;

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { ManualPromise } from '@isomorphic/manualPromise';
+import { TestEndedError } from '@isomorphic/abortSignal';
 import { captureRawStack, stringifyStackFrames, filteredStackTrace } from '@utils/stackTrace';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { monotonicTime } from '@isomorphic/time';
@@ -94,6 +95,7 @@ export class TestInfoImpl implements TestInfo {
   readonly _uniqueSymbol;
 
   private _interruptedPromise = new ManualPromise<void>();
+  readonly _operationAbortController = new AbortController();
   _lastStepId = 0;
   private readonly _requireFile: string;
   readonly _projectInternal: commonConfig.FullProjectInternal;
@@ -402,6 +404,11 @@ export class TestInfoImpl implements TestInfo {
   _abort(location: Location, message: string | undefined) {
     this.annotations.push({ type: 'abort', description: message, location });
     throw new TestAbortError('Test aborted' + (message ? ': ' + message : ''));
+  }
+
+  _abortOperations(reason: string) {
+    if (!this._operationAbortController.signal.aborted)
+      this._operationAbortController.abort(new TestEndedError(reason));
   }
 
   _interrupt() {

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -452,6 +452,9 @@ export class WorkerMain extends ProcessRunner {
 
       testInfo._tracing.didFinishTestFunctionAndAfterEachHooks();
 
+      const abortReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
+      testInfo._abortOperations(abortReason);
+
       try {
         // Teardown test-scoped fixtures. Attribute to 'test' so that users understand
         // they should probably increase the test timeout to fix this issue.

--- a/tests/components/ct-react-vite/tests/route.spec.tsx
+++ b/tests/components/ct-react-vite/tests/route.spec.tsx
@@ -50,8 +50,10 @@ test.describe('request handlers', () => {
     respond();
     await expect(component.getByTestId('name')).toHaveText('John Doe');
 
+    const postResponse = page.waitForResponse('**/post');
     await component.getByRole('button', { name: 'Post it' }).click();
     expect(await postBody).toBe('hello from the page');
+    await postResponse;
   });
 
   test('should add dynamically', async ({ page, mount, router }) => {
@@ -179,4 +181,3 @@ test.describe('request handlers', () => {
   });
 
 });
-

--- a/tests/library/page-close.spec.ts
+++ b/tests/library/page-close.spec.ts
@@ -211,11 +211,15 @@ test('should not throw when continuing while page is closing', async ({ page, se
 
 test('should not throw when continuing after page is closed', async ({ page, server }) => {
   let done;
+  let routeHandledCallback = () => {};
+  const routeHandled = new Promise<void>(f => routeHandledCallback = f);
   await page.route('**/*', async route => {
     await page.close();
     done = route.continue();
+    routeHandledCallback();
   });
   const error = await page.goto(server.EMPTY_PAGE).catch(e => e);
+  await routeHandled;
   await done;
   expect(error).toBeInstanceOf(Error);
 });

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -23,12 +23,14 @@ const { globToRegexPattern, urlMatches } = iso;
 
 it('should work with navigation @smoke', async ({ page, server }) => {
   const requests = new Map();
+  const routeContinuations: Promise<unknown>[] = [];
   await page.route('**/*', route => {
     requests.set(route.request().url().split('/').pop(), route.request());
-    void route.continue();
+    routeContinuations.push(route.continue());
   });
   server.setRedirect('/rrredirect', '/frames/one-frame.html');
   await page.goto(server.PREFIX + '/rrredirect');
+  await Promise.all(routeContinuations);
   expect(requests.get('rrredirect').isNavigationRequest()).toBe(true);
   expect(requests.get('frame.html').isNavigationRequest()).toBe(true);
   expect(requests.get('script.js').isNavigationRequest()).toBe(false);

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -565,7 +565,7 @@ test('should print expected/received before timeout', async ({ runInlineTest }) 
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Test timeout of 2000ms exceeded.');
   expect(result.output).toContain('Expected: "Text 2"');
-  expect(result.output).toContain('Received: "Text content"');
+  expect(result.output).toContain('Error: The assertion was aborted: Test timeout of 2000ms exceeded.');
 });
 
 test('should print pending operations for toHaveText', async ({ runInlineTest }) => {
@@ -584,7 +584,7 @@ test('should print pending operations for toHaveText', async ({ runInlineTest })
   const output = result.output;
   expect(output).toContain(`expect(locator).toHaveText(expected)`);
   expect(output).toContain('Expected: "Text"');
-  expect(output).toContain('Error: element(s) not found');
+  expect(output).toContain('Error: The assertion was aborted: Test timeout of 2000ms exceeded.');
   expect(output).toContain('waiting for locator(\'no-such-thing\')');
 });
 
@@ -640,7 +640,7 @@ test('should print expected/received on Ctrl+C', async ({ interactWithTestRunner
   expect(result.passed).toBe(0);
   expect(result.interrupted).toBe(1);
   expect(result.output).toContain('Expected: "Text 2"');
-  expect(result.output).toContain('Received: "Text content"');
+  expect(result.output).toContain('Error: The assertion was aborted: Test ended.');
 });
 
 test('should not print timed out error message when test times out', async ({ runInlineTest }) => {

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -565,7 +565,7 @@ test('should print expected/received before timeout', async ({ runInlineTest }) 
   expect(result.failed).toBe(1);
   expect(result.output).toContain('Test timeout of 2000ms exceeded.');
   expect(result.output).toContain('Expected: "Text 2"');
-  expect(result.output).toContain('Error: The assertion was aborted: Test timeout of 2000ms exceeded.');
+  expect(result.output).toContain('Received: "Text content"');
 });
 
 test('should print pending operations for toHaveText', async ({ runInlineTest }) => {
@@ -584,7 +584,7 @@ test('should print pending operations for toHaveText', async ({ runInlineTest })
   const output = result.output;
   expect(output).toContain(`expect(locator).toHaveText(expected)`);
   expect(output).toContain('Expected: "Text"');
-  expect(output).toContain('Error: The assertion was aborted: Test timeout of 2000ms exceeded.');
+  expect(output).toContain('Error: element(s) not found');
   expect(output).toContain('waiting for locator(\'no-such-thing\')');
 });
 
@@ -640,7 +640,7 @@ test('should print expected/received on Ctrl+C', async ({ interactWithTestRunner
   expect(result.passed).toBe(0);
   expect(result.interrupted).toBe(1);
   expect(result.output).toContain('Expected: "Text 2"');
-  expect(result.output).toContain('Error: The assertion was aborted: Test ended.');
+  expect(result.output).toContain('Received: "Text content"');
 });
 
 test('should not print timed out error message when test times out', async ({ runInlineTest }) => {

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -630,14 +630,13 @@ pw:api    |      Launch browser
 pw:api    |    Create page @ a.test.ts:6
 pw:api    |Set content @ a.test.ts:15
 pw:api    |Click locator('div') @ a.test.ts:16
-pw:api    |↪ error: Error: page.click: Target page, context or browser has been closed
 hook      |After Hooks
 hook      |  afterAll hook @ a.test.ts:9
 pw:api    |    Close context @ a.test.ts:10
 hook      |Worker Cleanup
 fixture   |  Fixture "browser"
           |Test timeout of 2000ms exceeded.
-          |Error: page.click: Target page, context or browser has been closed
+          |AbortError: page.click: Test timeout of 2000ms exceeded.
 `);
 });
 


### PR DESCRIPTION
## Summary

Explores replacing the "close the context at test end to unblock in-flight operations" teardown with a **default `AbortSignal`** that fires on test end and flows into every client operation.

- The test runner sets `playwright._defaultOperationSignal` for the duration of the test; `workerMain` aborts it after `afterEach` with a `TestEndedError(reason)`.
- `channelOwner` merges this default signal into every operation via `combineSignals`.
- `connection` rewrites the aborted error message from the `TestEndedError` reason, preserving the existing "Test ended." / "Test timeout of Nms exceeded." wording.
- `context.close()` no longer needs an explicit reason — the signal drives cancellation.

Draft / exploration — opening for discussion.