### PR TITLE
devops: use node 26 for publishing packages

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -24,9 +24,7 @@ jobs:
       with:
         node-version: 26
         registry-url: 'https://registry.npmjs.org'
-    # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
-    - name: Update npm
-      run: npm install -g npm@latest
+    # node 26 bundles npm >= 11.5.1, which is required for OIDC npm publishing.
     - run: npm ci
     - run: npm run build
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 26
         registry-url: 'https://registry.npmjs.org'
     # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
     - name: Update npm
@@ -57,7 +57,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 26
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -24,7 +24,6 @@ jobs:
       with:
         node-version: 26
         registry-url: 'https://registry.npmjs.org'
-    # node 26 bundles npm >= 11.5.1, which is required for OIDC npm publishing.
     - run: npm ci
     - run: npm run build
 


### PR DESCRIPTION
## Summary
- The publish workflow ran `npm install -g npm@latest`, which now installs npm@12.0.0. npm 12 dropped node 20 support, so the `publish NPM` job failed on the pinned node 20:

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

- Bump the publish workflow to node 26. This does not affect published package compatibility (node 20 support comes from the `engines` field and build target, not the publisher's runtime).
- Drop the now-redundant `npm install -g npm@latest` step: node 26 bundles npm 11.17.0, which already satisfies the >= 11.5.1 requirement for OIDC publishing (and this step was the source of the failure).

Failed run: https://github.com/microsoft/playwright/actions/runs/28998710908/job/86054021758