### PR TITLE
devops: use node lts/* for non-test workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: lts/*
       - run: npm ci
       - run: npm run build
       - run: npx playwright install --with-deps

--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: lts/*
     - run: npm ci
     - run: npm run build
 

--- a/.github/workflows/fix-flakes.yml
+++ b/.github/workflows/fix-flakes.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: lts/*
 
       - name: Install dependencies
         run: npm ci
@@ -136,7 +136,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: lts/*
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: lts/*
     - run: npm ci
     - run: npm run build
     - run: npx playwright install --with-deps
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: lts/*
     - uses: actions/setup-python@v6
       with:
         python-version: '3.11'

--- a/.github/workflows/publish_extension.yml
+++ b/.github/workflows/publish_extension.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 26
+        node-version: lts/*
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
     - run: npm run build
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 26
+        node-version: lts/*
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:

--- a/.github/workflows/publish_release_docker.yml
+++ b/.github/workflows/publish_release_docker.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: lts/*
         registry-url: 'https://registry.npmjs.org'
     - name: Set up Docker QEMU for arm64 docker builds
       uses: docker/setup-qemu-action@v4

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: lts/*
     - run: npm ci
     - run: npm run build
     - name: Install dependencies

--- a/.github/workflows/roll_nodejs.yml
+++ b/.github/workflows/roll_nodejs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
       - run: node utils/build/update-playwright-node.mjs
       - name: Prepare branch
         id: prepare-branch

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
       - run: |
           npm install @playwright/test@next
           VERSION=$(node -e "console.log(require('./package.json').dependencies['@playwright/test'].replace('^', ''))")

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          # Pin to a specific node major: this job commits package-lock.json,
+          # and a newer npm can churn the lockfile against contributors' npm.
+          node-version: 22
       - run: |
           npm install @playwright/test@next
           VERSION=$(node -e "console.log(require('./package.json').dependencies['@playwright/test'].replace('^', ''))")

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -15,9 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          # Pin to a specific node major: this job commits package-lock.json,
-          # and a newer npm can churn the lockfile against contributors' npm.
-          node-version: 22
+          node-version: lts/*
       - run: |
           npm install @playwright/test@next
           VERSION=$(node -e "console.log(require('./package.json').dependencies['@playwright/test'].replace('^', ''))")

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: lts/*
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot

--- a/.github/workflows/update_test_results_db.yml
+++ b/.github/workflows/update_test_results_db.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: lts/*
       - run: npm ci
       - name: Download current database
         env:


### PR DESCRIPTION
## Summary
- Switch non-test workflows to `node-version: lts/*` so they track the current LTS instead of pinning specific node majors: publish (release, extension, docker), roll (browser, nodejs, stable test runner), fix-flakes, triage, report, infra and copilot setup.
- Test workflows (`tests_*.yml`) are left untouched since they deliberately pin node versions to exercise compatibility across majors.
- The current LTS (node 24) bundles npm >= 11.5.1, so OIDC publishing keeps working with no separate npm upgrade step.