### PR TITLE
fix(mcp): skip ARIA snapshot serialization when snapshot-mode=none

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -270,7 +270,7 @@ export class Response {
       addSection('Ran Playwright code', this._code, 'js');
 
     // Render tab titles upon changes or when more than one tab.
-    const tabSnapshot = this._context.currentTab() ? await this._context.currentTabOrDie().captureSnapshot(this._includeSnapshotRoot, this._includeSnapshotDepth, this._includeSnapshotBoxes, this._clientWorkspace) : undefined;
+    const tabSnapshot = this._context.currentTab() ? await this._context.currentTabOrDie().captureSnapshot(this._includeSnapshotRoot, this._includeSnapshotDepth, this._includeSnapshotBoxes, this._clientWorkspace, this._includeSnapshot !== 'none') : undefined;
     const tabHeaders = await Promise.all(this._context.tabs().map(tab => tab.headerSnapshot()));
     if (this._includeSnapshot !== 'none' || tabHeaders.some(header => header.changed)) {
       if (tabHeaders.length !== 1)

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -410,9 +410,6 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     await this._initializedPromise;
     let tabSnapshot: TabSnapshot | undefined;
     const modalStates = await this._raceAgainstModalStates(async () => {
-      // Serializing the ARIA snapshot is expensive, so skip it when the caller
-      // does not need it (e.g. snapshot mode 'none'). All other response state
-      // (modal states, console link, events) is still collected below.
       const ariaSnapshot = !includeAria
         ? ''
         : root

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -406,13 +406,18 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     this._requests.length = 0;
   }
 
-  async captureSnapshot(root: playwright.Locator | undefined, depth: number | undefined, boxes: boolean | undefined, relativeTo: string | undefined): Promise<TabSnapshot> {
+  async captureSnapshot(root: playwright.Locator | undefined, depth: number | undefined, boxes: boolean | undefined, relativeTo: string | undefined, includeAria: boolean): Promise<TabSnapshot> {
     await this._initializedPromise;
     let tabSnapshot: TabSnapshot | undefined;
     const modalStates = await this._raceAgainstModalStates(async () => {
-      const ariaSnapshot = root
-        ? await root.ariaSnapshot({ mode: 'ai', depth, boxes })
-        : await this.page.ariaSnapshot({ mode: 'ai', depth, boxes });
+      // Serializing the ARIA snapshot is expensive, so skip it when the caller
+      // does not need it (e.g. snapshot mode 'none'). All other response state
+      // (modal states, console link, events) is still collected below.
+      const ariaSnapshot = !includeAria
+        ? ''
+        : root
+          ? await root.ariaSnapshot({ mode: 'ai', depth, boxes })
+          : await this.page.ariaSnapshot({ mode: 'ai', depth, boxes });
       tabSnapshot = {
         ariaSnapshot,
         modalStates: [],

--- a/tests/mcp/snapshot-mode.spec.ts
+++ b/tests/mcp/snapshot-mode.spec.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { test, expect } from './fixtures';
+import { test, expect, parseResponse } from './fixtures';
 
 test('should respect --snapshot-mode=full', async ({ startClient, server }) => {
   server.setContent('/', `<button>Button 1</button>`, 'text/html');
@@ -94,6 +94,40 @@ test('should not inline console messages with --snapshot-mode=none', async ({ st
   expect(response).not.toHaveResponse({
     events: expect.stringContaining('error message'),
   });
+});
+
+test('should still emit download events with --snapshot-mode=none', async ({ startClient, server }, testInfo) => {
+  server.setContent('/', `<a href="/download" download="test.txt">Download</a>`, 'text/html');
+  server.setContent('/download', 'Data', 'text/plain');
+
+  const { client } = await startClient({
+    args: ['--snapshot-mode=none'],
+    config: { outputDir: testInfo.outputPath('output') },
+  });
+
+  const navigate = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+  // ARIA snapshot is skipped, but other state (page header) is still present.
+  expect(navigate).toHaveResponse({ page: `- Page URL: ${server.PREFIX}/` });
+  expect(navigate).not.toHaveResponse({ snapshot: expect.anything() });
+
+  // No ARIA refs exist in 'none' mode, so target by selector instead.
+  const click = await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Download link', target: 'a' },
+  });
+
+  // The download finishes asynchronously; accumulate events across polls.
+  let events = parseResponse(click).events ?? '';
+  await expect.poll(async () => {
+    const r = await client.callTool({ name: 'browser_evaluate', arguments: { function: '() => 1' } });
+    const p = parseResponse(r);
+    if (p.events)
+      events += '\n' + p.events;
+    return events;
+  }).toContain(`- Downloaded file test.txt to`);
 });
 
 test('should respect snapshot[filename]', async ({ client, server }, testInfo) => {

--- a/tests/mcp/snapshot-mode.spec.ts
+++ b/tests/mcp/snapshot-mode.spec.ts
@@ -109,7 +109,6 @@ test('should still emit download events with --snapshot-mode=none', async ({ sta
     name: 'browser_navigate',
     arguments: { url: server.PREFIX },
   });
-  // ARIA snapshot is skipped, but other state (page header) is still present.
   expect(navigate).toHaveResponse({ page: `- Page URL: ${server.PREFIX}/` });
   expect(navigate).not.toHaveResponse({ snapshot: expect.anything() });
 
@@ -119,7 +118,6 @@ test('should still emit download events with --snapshot-mode=none', async ({ sta
     arguments: { element: 'Download link', target: 'a' },
   });
 
-  // The download finishes asynchronously; accumulate events across polls.
   let events = parseResponse(click).events ?? '';
   await expect.poll(async () => {
     const r = await client.callTool({ name: 'browser_evaluate', arguments: { function: '() => 1' } });


### PR DESCRIPTION
## Summary
- When `snapshot-mode=none`, `Tab.captureSnapshot()` still ran the expensive `page.ariaSnapshot()` even though the snapshot is never emitted (~166ms → ~5ms on a large page in the reported repro).
- Pass an `includeAria` flag to `captureSnapshot()` so the ARIA serialization is skipped when unused, while still collecting modal state, console links, and events.

Fixes https://github.com/microsoft/playwright/issues/41717