### PR TITLE
chore(recorder): fold frame path into action selector

### DIFF
--- a/packages/isomorphic/codegen/actions.d.ts
+++ b/packages/isomorphic/codegen/actions.d.ts
@@ -161,12 +161,10 @@ export type Signal = NavigationSignal | PopupSignal | DownloadSignal | DialogSig
 export type FrameDescription = {
   pageGuid: string;
   pageAlias: string;
-  framePath: string[];
 };
 
 export type ActionInContext = {
   frame: FrameDescription;
-  description?: string;
   action: Action;
   startTime: number;
   endTime?: number;

--- a/packages/isomorphic/codegen/csharp.ts
+++ b/packages/isomorphic/codegen/csharp.ts
@@ -72,8 +72,7 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
       return formatter.format();
     }
 
-    const locators = actionInContext.frame.framePath.map(selector => `.${this._asLocator(selector)}.ContentFrame`);
-    const subject = `${pageAlias}${locators.join('')}`;
+    const subject = pageAlias;
     const signals = toSignalMap(action);
 
     if (signals.dialog) {

--- a/packages/isomorphic/codegen/java.ts
+++ b/packages/isomorphic/codegen/java.ts
@@ -63,8 +63,7 @@ export class JavaLanguageGenerator implements LanguageGenerator {
       return formatter.format();
     }
 
-    const locators = actionInContext.frame.framePath.map(selector => `.${this._asLocator(selector, false)}.contentFrame()`);
-    const subject = `${pageAlias}${locators.join('')}`;
+    const subject = pageAlias;
     const signals = toSignalMap(action);
 
     if (signals.dialog) {
@@ -74,7 +73,7 @@ export class JavaLanguageGenerator implements LanguageGenerator {
       });`);
     }
 
-    let code = this._generateActionCall(subject, actionInContext, !!actionInContext.frame.framePath.length);
+    let code = this._generateActionCall(subject, actionInContext);
 
     if (signals.popup) {
       code = `Page ${signals.popup.popupAlias} = ${pageAlias}.waitForPopup(() -> {
@@ -93,7 +92,7 @@ export class JavaLanguageGenerator implements LanguageGenerator {
     return formatter.format();
   }
 
-  private _generateActionCall(subject: string, actionInContext: actions.ActionInContext, inFrameLocator: boolean): string {
+  private _generateActionCall(subject: string, actionInContext: actions.ActionInContext): string {
     const action = actionInContext.action;
     switch (action.name) {
       case 'openPage':
@@ -106,46 +105,46 @@ export class JavaLanguageGenerator implements LanguageGenerator {
           method = 'dblclick';
         const options = toClickOptionsForSourceCode(action);
         const optionsText = formatClickOptions(options);
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.${method}(${optionsText});`;
+        return `${subject}.${this._asLocator(action.selector)}.${method}(${optionsText});`;
       }
       case 'hover': {
         const optionsText = action.position ? `new Locator.HoverOptions().setPosition(${action.position.x}, ${action.position.y})` : '';
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.hover(${optionsText});`;
+        return `${subject}.${this._asLocator(action.selector)}.hover(${optionsText});`;
       }
       case 'check':
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.check();`;
+        return `${subject}.${this._asLocator(action.selector)}.check();`;
       case 'uncheck':
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.uncheck();`;
+        return `${subject}.${this._asLocator(action.selector)}.uncheck();`;
       case 'fill':
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.fill(${quote(action.text)});`;
+        return `${subject}.${this._asLocator(action.selector)}.fill(${quote(action.text)});`;
       case 'setInputFiles':
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.setInputFiles(${formatPath(action.files.length === 1 ? action.files[0] : action.files)});`;
+        return `${subject}.${this._asLocator(action.selector)}.setInputFiles(${formatPath(action.files.length === 1 ? action.files[0] : action.files)});`;
       case 'press': {
         const modifiers = toKeyboardModifiers(action.modifiers);
         const shortcut = [...modifiers, action.key].join('+');
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.press(${quote(shortcut)});`;
+        return `${subject}.${this._asLocator(action.selector)}.press(${quote(shortcut)});`;
       }
       case 'navigate':
         return `${subject}.navigate(${quote(action.url)});`;
       case 'select':
-        return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.selectOption(${formatSelectOption(action.options.length === 1 ? action.options[0] : action.options)});`;
+        return `${subject}.${this._asLocator(action.selector)}.selectOption(${formatSelectOption(action.options.length === 1 ? action.options[0] : action.options)});`;
       case 'assertText':
-        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).${action.substring ? 'containsText' : 'hasText'}(${quote(action.text)});`;
+        return `assertThat(${subject}.${this._asLocator(action.selector)}).${action.substring ? 'containsText' : 'hasText'}(${quote(action.text)});`;
       case 'assertChecked':
-        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)})${action.checked ? '' : '.not()'}.isChecked();`;
+        return `assertThat(${subject}.${this._asLocator(action.selector)})${action.checked ? '' : '.not()'}.isChecked();`;
       case 'assertVisible':
-        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).isVisible();`;
+        return `assertThat(${subject}.${this._asLocator(action.selector)}).isVisible();`;
       case 'assertValue': {
         const assertion = action.value ? `hasValue(${quote(action.value)})` : `isEmpty()`;
-        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).${assertion};`;
+        return `assertThat(${subject}.${this._asLocator(action.selector)}).${assertion};`;
       }
       case 'assertSnapshot':
-        return `assertThat(${subject}.${this._asLocator(action.selector, inFrameLocator)}).matchesAriaSnapshot(${quote(action.ariaSnapshot)});`;
+        return `assertThat(${subject}.${this._asLocator(action.selector)}).matchesAriaSnapshot(${quote(action.ariaSnapshot)});`;
     }
   }
 
-  private _asLocator(selector: string, inFrameLocator: boolean) {
-    return asLocator('java', selector, inFrameLocator);
+  private _asLocator(selector: string) {
+    return asLocator('java', selector);
   }
 
   generateHeader(options: LanguageGeneratorOptions): string {

--- a/packages/isomorphic/codegen/javascript.ts
+++ b/packages/isomorphic/codegen/javascript.ts
@@ -51,8 +51,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
       return formatter.format();
     }
 
-    const locators = actionInContext.frame.framePath.map(selector => `.${this._asLocator(selector)}.contentFrame()`);
-    const subject = `${pageAlias}${locators.join('')}`;
+    const subject = pageAlias;
     const signals = toSignalMap(action);
 
     if (signals.dialog) {
@@ -67,7 +66,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
     if (signals.download)
       formatter.add(`const download${signals.download.downloadAlias}Promise = ${pageAlias}.waitForEvent('download');`);
 
-    formatter.add(wrapWithStep(actionInContext.description, this._generateActionCall(subject, actionInContext)));
+    formatter.add(this._generateActionCall(subject, actionInContext));
 
     if (signals.popup)
       formatter.add(`const ${signals.popup.popupAlias} = await ${signals.popup.popupAlias}Promise;`);
@@ -254,12 +253,6 @@ export class JavaScriptFormatter {
 
 function quote(text: string) {
   return escapeWithQuotes(text, '\'');
-}
-
-function wrapWithStep(description: string | undefined, body: string) {
-  return description ? `await test.step(\`${description}\`, async () => {
-${body}
-});` : body;
 }
 
 export function quoteMultiline(text: string, indent = '  ') {

--- a/packages/isomorphic/codegen/python.ts
+++ b/packages/isomorphic/codegen/python.ts
@@ -58,8 +58,7 @@ export class PythonLanguageGenerator implements LanguageGenerator {
       return formatter.format();
     }
 
-    const locators = actionInContext.frame.framePath.map(selector => `.${this._asLocator(selector)}.content_frame`);
-    const subject = `${pageAlias}${locators.join('')}`;
+    const subject = pageAlias;
     const signals = toSignalMap(action);
 
     if (signals.dialog)

--- a/packages/isomorphic/locatorGenerators.ts
+++ b/packages/isomorphic/locatorGenerators.ts
@@ -734,8 +734,13 @@ export class JsonlLocatorFactory implements LocatorFactory {
 
   chainLocators(locators: string[]): string {
     const objects = locators.map(l => JSON.parse(l));
-    for (let i = 0; i < objects.length - 1; ++i)
-      objects[i].next = objects[i + 1];
+    for (let i = 0; i < objects.length - 1; ++i) {
+      // A locator may already be a chain, e.g. `contentFrame()` produces one. Append to its tail.
+      let tail = objects[i];
+      while (tail.next)
+        tail = tail.next;
+      tail.next = objects[i + 1];
+    }
     return JSON.stringify(objects[0]);
   }
 }

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -552,15 +552,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     return {
       pageGuid: page.guid,
       pageAlias: this._pageAliases.get(page)!,
-      framePath: [],
-    };
-  }
-
-  private async _describeFrame(progress: Progress, frame: Frame): Promise<actions.FrameDescription> {
-    return {
-      pageGuid: frame._page.guid,
-      pageAlias: this._pageAliases.get(frame._page)!,
-      framePath: await generateFrameSelector(progress, frame),
     };
   }
 
@@ -568,19 +559,24 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     return this._params.testIdAttributeName || this._context.selectors().testIdAttributeName() || 'data-testid';
   }
 
-  private async _createActionInContext(progress: Progress, frame: Frame, action: actions.Action): Promise<actions.ActionInContext> {
-    const frameDescription = await this._describeFrame(progress, frame);
+  private async _appendContextToAction(progress: Progress, frame: Frame, action: actions.Action): Promise<actions.ActionInContext> {
+    const framePath = await generateFrameSelector(progress, frame);
+    if (framePath.length) {
+      if ('selector' in action)
+        action.selector = buildFullSelector(framePath, action.selector);
+      if (action.preconditionSelector)
+        action.preconditionSelector = buildFullSelector(framePath, action.preconditionSelector);
+    }
     const actionInContext: actions.ActionInContext = {
-      frame: frameDescription,
+      frame: this._describeMainFrame(frame._page),
       action,
-      description: undefined,
       startTime: monotonicTime(),
     };
     return actionInContext;
   }
 
   private async _performAction(progress: Progress, frame: Frame, action: actions.PerformOnRecordAction) {
-    const actionInContext = await this._createActionInContext(progress, frame, action);
+    const actionInContext = await this._appendContextToAction(progress, frame, action);
     this._signalProcessor.addAction(actionInContext);
     try {
       if (actionInContext.action.name !== 'openPage' && actionInContext.action.name !== 'closePage')
@@ -591,7 +587,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   private async _recordAction(progress: Progress, frame: Frame, action: actions.Action) {
-    const actionInContext = await this._createActionInContext(progress, frame, action);
+    const actionInContext = await this._appendContextToAction(progress, frame, action);
     this._signalProcessor.addAction(actionInContext);
   }
 

--- a/packages/playwright-core/src/server/recorder/recorderRunner.ts
+++ b/packages/playwright-core/src/server/recorder/recorderRunner.ts
@@ -15,7 +15,7 @@
  */
 
 import { toKeyboardModifiers } from '@isomorphic/codegen/language';
-import { buildFullSelector, mainFrameForAction } from './recorderUtils';
+import { mainFrameForAction } from './recorderUtils';
 import { Progress } from '../progress';
 
 import type { Page } from '../page';
@@ -44,7 +44,7 @@ async function performActionImpl(progress: Progress, mainFrame: Frame, actionInC
     return;
   }
 
-  const selector = buildFullSelector(actionInContext.frame.framePath, action.selector);
+  const selector = action.selector;
 
   if (action.name === 'click') {
     const options = toClickOptions(action);

--- a/packages/playwright-core/src/server/recorder/recorderSignalProcessor.ts
+++ b/packages/playwright-core/src/server/recorder/recorderSignalProcessor.ts
@@ -16,8 +16,6 @@
 
 import { monotonicTime } from '@isomorphic/time';
 import { isUnderTest } from '@utils/debug';
-import { generateFrameSelector } from './recorderUtils';
-import { nullProgress } from '../progress';
 
 import type { Signal } from '@isomorphic/codegen/actions';
 import type { Frame } from '../frames';
@@ -60,7 +58,6 @@ export class RecorderSignalProcessor {
           frame: {
             pageGuid: frame._page.guid,
             pageAlias,
-            framePath: [],
           },
           action: {
             name: 'navigate',
@@ -74,17 +71,13 @@ export class RecorderSignalProcessor {
       return;
     }
 
-    generateFrameSelector(nullProgress, frame).then(framePath => {
-      const signalInContext: actions.SignalInContext = {
-        frame: {
-          pageGuid: frame._page.guid,
-          pageAlias,
-          framePath,
-        },
-        signal,
-        timestamp,
-      };
-      this._delegate.addSignal(signalInContext);
+    this._delegate.addSignal({
+      frame: {
+        pageGuid: frame._page.guid,
+        pageAlias,
+      },
+      signal,
+      timestamp,
     });
   }
 }

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -64,7 +64,7 @@ export function mainFrameForAction(pageAliases: Map<Page, string>, actionInConte
 }
 
 function isSameAction(a: actions.ActionInContext, b: actions.ActionInContext): boolean {
-  return a.action.name === b.action.name && a.frame.pageAlias === b.frame.pageAlias && a.frame.framePath.join('|') === b.frame.framePath.join('|');
+  return a.action.name === b.action.name && a.frame.pageAlias === b.frame.pageAlias;
 }
 
 function isSameSelector(action: actions.ActionInContext, lastAction: actions.ActionInContext): boolean {

--- a/tests/library/inspector/cli-codegen-3.spec.ts
+++ b/tests/library/inspector/cli-codegen-3.spec.ts
@@ -61,7 +61,6 @@ await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).First.ClickAsyn
       locator: { body: 'button', kind: 'role', options: { exact: false, attrs: [], name: 'Submit' }, next: { body: '', kind: 'first', options: {} } },
       modifiers: 0,
       signals: [],
-      framePath: [],
       pageAlias: 'page',
       pageGuid: expect.any(String),
     });
@@ -131,13 +130,18 @@ await page.Locator("#frame1").ContentFrame.GetByText("Hello1").ClickAsync();`);
     const clickAction = sources.get('JSON')!.actions.map(l => JSON.parse(l)).find(a => a.name === 'click');
     expect.soft(clickAction).toEqual({
       name: 'click',
-      selector: 'internal:text="Hello1"i',
+      selector: '#frame1 >> internal:control=enter-frame >> internal:text="Hello1"i',
       button: 'left',
       clickCount: 1,
-      locator: { body: 'Hello1', kind: 'text', options: { exact: false } },
+      locator: {
+        body: '#frame1', kind: 'default', options: {},
+        next: {
+          body: '', kind: 'frame', options: {},
+          next: { body: 'Hello1', kind: 'text', options: { exact: false } },
+        },
+      },
       modifiers: 0,
       signals: [],
-      framePath: ['#frame1'],
       pageAlias: 'page',
       pageGuid: expect.any(String),
     });
@@ -170,13 +174,24 @@ await page.Locator("#frame1").ContentFrame.Locator("iframe").ContentFrame.GetByT
     const clickAction = sources.get('JSON')!.actions.map(l => JSON.parse(l)).find(a => a.name === 'click');
     expect.soft(clickAction).toEqual({
       name: 'click',
-      selector: 'internal:text="Hello2"i',
+      selector: '#frame1 >> internal:control=enter-frame >> iframe >> internal:control=enter-frame >> internal:text="Hello2"i',
       button: 'left',
       clickCount: 1,
-      locator: { body: 'Hello2', kind: 'text', options: { exact: false } },
+      locator: {
+        body: '#frame1', kind: 'default', options: {},
+        next: {
+          body: '', kind: 'frame', options: {},
+          next: {
+            body: 'iframe', kind: 'default', options: {},
+            next: {
+              body: '', kind: 'frame', options: {},
+              next: { body: 'Hello2', kind: 'text', options: { exact: false } },
+            },
+          },
+        },
+      },
       modifiers: 0,
       signals: [],
-      framePath: ['#frame1', 'iframe'],
       pageAlias: 'page',
       pageGuid: expect.any(String),
     });
@@ -209,13 +224,33 @@ await page.Locator("#frame1").ContentFrame.Locator("iframe").ContentFrame.Locato
     const clickAction = sources.get('JSON')!.actions.map(l => JSON.parse(l)).find(a => a.name === 'click');
     expect.soft(clickAction).toEqual({
       name: 'click',
-      selector: 'internal:text="HelloNameAnonymous"i',
+      selector: '#frame1 >> internal:control=enter-frame >> iframe >> internal:control=enter-frame >> iframe >> nth=2 >> internal:control=enter-frame >> internal:text="HelloNameAnonymous"i',
       button: 'left',
       clickCount: 1,
-      locator: { body: 'HelloNameAnonymous', kind: 'text', options: { exact: false } },
+      locator: {
+        body: '#frame1', kind: 'default', options: {},
+        next: {
+          body: '', kind: 'frame', options: {},
+          next: {
+            body: 'iframe', kind: 'default', options: {},
+            next: {
+              body: '', kind: 'frame', options: {},
+              next: {
+                body: 'iframe', kind: 'default', options: {},
+                next: {
+                  body: '2', kind: 'nth', options: {},
+                  next: {
+                    body: '', kind: 'frame', options: {},
+                    next: { body: 'HelloNameAnonymous', kind: 'text', options: { exact: false } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
       modifiers: 0,
       signals: [],
-      framePath: ['#frame1', 'iframe', 'iframe >> nth=2'],
       pageAlias: 'page',
       pageGuid: expect.any(String),
     });


### PR DESCRIPTION
## Summary
- Remove `FrameDescription.framePath`; the chained frame selectors are now prepended to `action.selector` (and `preconditionSelector`) with `internal:control=enter-frame` separators.
- `asLocator()` already turns that token into `contentFrame()`, so the JS/Java/Python/C# generators drop their hand-rolled frame chains, and Java loses the `inFrameLocator` flag threaded through `_generateActionCall`.
- `RecorderSignalProcessor.signal()` becomes synchronous — it was only async to compute a `framePath` no consumer read.
- Drive-by: `JsonlLocatorFactory.chainLocators()` overwrote `next` at the top level, clobbering the `frame` step that the enter-frame branch produces. Previously unreachable; now fixed.

Generated code assertions in `cli-codegen-3.spec.ts` are unchanged, which is the proof this is behaviour-preserving; only the JSONL assertions change shape.