### PR TITLE
chore(recorder): turn preconditionSelector into an expect signal

### DIFF
--- a/packages/injected/src/recorder/pollingRecorder.ts
+++ b/packages/injected/src/recorder/pollingRecorder.ts
@@ -22,7 +22,7 @@ import type * as actions from '@isomorphic/codegen/actions';
 import type { ElementInfo, Mode, OverlayState, UIState } from '@recorder/recorderTypes';
 
 interface Embedder {
-  __pw_recorderPerformAction(action: actions.PerformOnRecordAction): Promise<void>;
+  __pw_recorderPerformAction(action: actions.PerformOnRecordAction, preconditionSelector?: string): Promise<void>;
   __pw_recorderRecordAction(action: actions.Action): Promise<void>;
   __pw_recorderState(): Promise<UIState>;
   __pw_recorderElementPicked(element: { selector: string, ariaSnapshot?: string }): Promise<void>;
@@ -76,8 +76,8 @@ export class PollingRecorder implements RecorderDelegate {
     this._pollRecorderModeTimer = this._recorder.injectedScript.utils.builtins.setTimeout(() => this._pollRecorderMode(), pollPeriod);
   }
 
-  async performAction(action: actions.PerformOnRecordAction) {
-    await this._embedder.__pw_recorderPerformAction(action);
+  async performAction(action: actions.PerformOnRecordAction, preconditionSelector?: string) {
+    await this._embedder.__pw_recorderPerformAction(action, preconditionSelector);
   }
 
   async recordAction(action: actions.Action): Promise<void> {

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -35,7 +35,7 @@ const HighlightColors = {
 };
 
 export interface RecorderDelegate {
-  performAction?(action: actions.PerformOnRecordAction): Promise<void>;
+  performAction?(action: actions.PerformOnRecordAction, preconditionSelector?: string): Promise<void>;
   recordAction?(action: actions.Action): Promise<void>;
   elementPicked?(elementInfo: ElementInfo): Promise<void>;
   setMode?(mode: Mode): Promise<void>;
@@ -1698,13 +1698,14 @@ export class Recorder {
   async performAction(action: actions.PerformOnRecordAction) {
     const previousSnapshot = this._lastActionAutoexpectSnapshot;
     this._lastActionAutoexpectSnapshot = this._captureAutoExpectSnapshot();
+    let preconditionSelector: string | undefined;
     if (!isAssertAction(action) && this._lastActionAutoexpectSnapshot) {
       const element = this.injectedScript.utils.findNewElement(previousSnapshot?.root, this._lastActionAutoexpectSnapshot?.root);
-      action.preconditionSelector = element ? this.injectedScript.generateSelector(element, { testIdAttributeName: this.state.testIdAttributeName }).selector : undefined;
-      if (action.preconditionSelector === action.selector)
-        action.preconditionSelector = undefined;
+      preconditionSelector = element ? this.injectedScript.generateSelector(element, { testIdAttributeName: this.state.testIdAttributeName }).selector : undefined;
+      if (preconditionSelector === action.selector)
+        preconditionSelector = undefined;
     }
-    await this._delegate.performAction?.(action).catch(() => {});
+    await this._delegate.performAction?.(action, preconditionSelector).catch(() => {});
   }
 
   async recordAction(action: actions.Action) {

--- a/packages/isomorphic/codegen/actions.d.ts
+++ b/packages/isomorphic/codegen/actions.d.ts
@@ -38,7 +38,6 @@ export type ActionBase = {
   name: ActionName,
   signals: Signal[],
   ariaSnapshot?: string,
-  preconditionSelector?: string,
 };
 
 export type ActionWithSelector = ActionBase & {
@@ -156,7 +155,13 @@ export type DialogSignal = BaseSignal & {
   dialogAlias: string,
 };
 
-export type Signal = NavigationSignal | PopupSignal | DownloadSignal | DialogSignal;
+// An element that appeared since the previous action, asserted before this action runs.
+export type ExpectSignal = BaseSignal & {
+  name: 'expect',
+  selector: string,
+};
+
+export type Signal = NavigationSignal | PopupSignal | DownloadSignal | DialogSignal | ExpectSignal;
 
 export type FrameDescription = {
   pageGuid: string;

--- a/packages/isomorphic/codegen/csharp.ts
+++ b/packages/isomorphic/codegen/csharp.ts
@@ -16,7 +16,7 @@
 
 import { asLocator } from '../locatorGenerators';
 import { escapeWithQuotes } from '../stringUtils';
-import { sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
+import { expectSignalAction, sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
 import { deviceDescriptors } from '../deviceDescriptors';
 
 import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './types';
@@ -51,14 +51,14 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
     this._mode = mode;
   }
 
-  generateAction(actionInContext: actions.ActionInContext): string {
-    const action = this._generateActionInner(actionInContext);
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
+    const action = this._generateActionInner(actionInContext, options);
     if (action)
       return action;
     return '';
   }
 
-  _generateActionInner(actionInContext: actions.ActionInContext): string {
+  _generateActionInner(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
     const action = actionInContext.action;
     if (this._mode !== 'library' && (action.name === 'openPage' || action.name === 'closePage'))
       return '';
@@ -100,6 +100,9 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
 
     for (const line of lines)
       formatter.add(line);
+
+    if (options.generateExpectSignal && signals.expect)
+      formatter.add(this.generateAction(expectSignalAction(actionInContext, signals.expect), options));
 
     return formatter.format();
   }

--- a/packages/isomorphic/codegen/java.ts
+++ b/packages/isomorphic/codegen/java.ts
@@ -16,7 +16,7 @@
 
 import { asLocator } from '../locatorGenerators';
 import { escapeWithQuotes } from '../stringUtils';
-import { toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
+import { expectSignalAction, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
 import { deviceDescriptors } from '../deviceDescriptors';
 import { JavaScriptFormatter } from './javascript';
 
@@ -47,7 +47,7 @@ export class JavaLanguageGenerator implements LanguageGenerator {
     this._mode = mode;
   }
 
-  generateAction(actionInContext: actions.ActionInContext): string {
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
     const action = actionInContext.action;
     const pageAlias = actionInContext.frame.pageAlias;
     const offset = this._mode === 'junit' ? 4 : 6;
@@ -88,6 +88,9 @@ export class JavaLanguageGenerator implements LanguageGenerator {
     }
 
     formatter.add(code);
+
+    if (options.generateExpectSignal && signals.expect)
+      formatter.add(this.generateAction(expectSignalAction(actionInContext, signals.expect), options));
 
     return formatter.format();
   }

--- a/packages/isomorphic/codegen/javascript.ts
+++ b/packages/isomorphic/codegen/javascript.ts
@@ -16,7 +16,7 @@
 
 import { asLocator } from '../locatorGenerators';
 import { escapeWithQuotes, formatObject, formatObjectOrVoid } from '../stringUtils';
-import { sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
+import { expectSignalAction, sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
 import { deviceDescriptors } from '../deviceDescriptors';
 
 import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './types';
@@ -36,7 +36,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
     this._isTest = isTest;
   }
 
-  generateAction(actionInContext: actions.ActionInContext): string {
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
     const action = actionInContext.action;
     if (this._isTest && (action.name === 'openPage' || action.name === 'closePage'))
       return '';
@@ -72,6 +72,8 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
       formatter.add(`const ${signals.popup.popupAlias} = await ${signals.popup.popupAlias}Promise;`);
     if (signals.download)
       formatter.add(`const download${signals.download.downloadAlias} = await download${signals.download.downloadAlias}Promise;`);
+    if (options.generateExpectSignal && signals.expect)
+      formatter.add(this.generateAction(expectSignalAction(actionInContext, signals.expect), options));
 
     return formatter.format();
   }

--- a/packages/isomorphic/codegen/jsonl.ts
+++ b/packages/isomorphic/codegen/jsonl.ts
@@ -15,6 +15,7 @@
  */
 
 import { asLocator } from '../locatorGenerators';
+import { expectSignalAction, toSignalMap } from './language';
 
 import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './types';
 import type * as actions from './actions';
@@ -25,7 +26,7 @@ export class JsonlLanguageGenerator implements LanguageGenerator {
   name = 'JSONL';
   highlighter = 'javascript' as Language;
 
-  generateAction(actionInContext: actions.ActionInContext): string {
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
     const locator = (actionInContext.action as any).selector ? JSON.parse(asLocator('jsonl', (actionInContext.action as any).selector)) : undefined;
     const entry = {
       ...actionInContext.action,
@@ -33,7 +34,11 @@ export class JsonlLanguageGenerator implements LanguageGenerator {
       locator,
       ariaSnapshot: undefined,
     };
-    return JSON.stringify(entry);
+    const lines = [JSON.stringify(entry)];
+    const expect = toSignalMap(actionInContext.action).expect;
+    if (options.generateExpectSignal && expect)
+      lines.push(this.generateAction(expectSignalAction(actionInContext, expect), options));
+    return lines.join('\n');
   }
 
   generateHeader(options: LanguageGeneratorOptions): string {

--- a/packages/isomorphic/codegen/language.ts
+++ b/packages/isomorphic/codegen/language.ts
@@ -22,31 +22,22 @@ import type * as actions from './actions';
 export function generateCode(actions: actions.ActionInContext[], languageGenerator: LanguageGenerator, options: LanguageGeneratorOptions) {
   const header = languageGenerator.generateHeader(options);
   const footer = languageGenerator.generateFooter(options.saveStorage);
-  const actionTexts = actions.map(a => generateActionText(languageGenerator, a, !!options.generateAutoExpect)).filter(Boolean) as string[];
+  const actionTexts = actions.map(a => languageGenerator.generateAction(a, options)).filter(Boolean);
   const text = [header, ...actionTexts, footer].join('\n');
   return { header, footer, actionTexts, text };
 }
 
-function generateActionText(generator: LanguageGenerator, action: actions.ActionInContext, generateAutoExpect: boolean): string | undefined {
-  let text = generator.generateAction(action);
-  if (!text)
-    return;
-  if (generateAutoExpect && action.action.preconditionSelector) {
-    const expectAction: actions.ActionInContext = {
-      frame: action.frame,
-      startTime: action.startTime,
-      endTime: action.startTime,
-      action: {
-        name: 'assertVisible',
-        selector: action.action.preconditionSelector,
-        signals: [],
-      },
-    };
-    const expectText = generator.generateAction(expectAction);
-    if (expectText)
-      text = expectText + '\n\n' + text;
-  }
-  return text;
+export function expectSignalAction(actionInContext: actions.ActionInContext, signal: actions.ExpectSignal): actions.ActionInContext {
+  return {
+    frame: actionInContext.frame,
+    startTime: actionInContext.startTime,
+    endTime: actionInContext.startTime,
+    action: {
+      name: 'assertVisible',
+      selector: signal.selector,
+      signals: [],
+    },
+  };
 }
 
 export function sanitizeDeviceOptions(device: any, options: BrowserContextOptions): BrowserContextOptions {
@@ -63,6 +54,7 @@ export function toSignalMap(action: actions.Action) {
   let popup: actions.PopupSignal | undefined;
   let download: actions.DownloadSignal | undefined;
   let dialog: actions.DialogSignal | undefined;
+  let expect: actions.ExpectSignal | undefined;
   for (const signal of action.signals) {
     if (signal.name === 'popup')
       popup = signal;
@@ -70,11 +62,14 @@ export function toSignalMap(action: actions.Action) {
       download = signal;
     else if (signal.name === 'dialog')
       dialog = signal;
+    else if (signal.name === 'expect')
+      expect = signal;
   }
   return {
     popup,
     download,
     dialog,
+    expect,
   };
 }
 

--- a/packages/isomorphic/codegen/python.ts
+++ b/packages/isomorphic/codegen/python.ts
@@ -16,7 +16,7 @@
 
 import { asLocator } from '../locatorGenerators';
 import { escapeWithQuotes, toSnakeCase } from '../stringUtils';
-import { sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
+import { expectSignalAction, sanitizeDeviceOptions, toClickOptionsForSourceCode, toKeyboardModifiers, toSignalMap } from './language';
 import { deviceDescriptors } from '../deviceDescriptors';
 
 import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './types';
@@ -43,7 +43,7 @@ export class PythonLanguageGenerator implements LanguageGenerator {
     this._asyncPrefix = isAsync ? 'async ' : '';
   }
 
-  generateAction(actionInContext: actions.ActionInContext): string {
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string {
     const action = actionInContext.action;
     if (this._isPyTest && (action.name === 'openPage' || action.name === 'closePage'))
       return '';
@@ -81,6 +81,9 @@ export class PythonLanguageGenerator implements LanguageGenerator {
     }
 
     formatter.add(code);
+
+    if (options.generateExpectSignal && signals.expect)
+      formatter.add(this.generateAction(expectSignalAction(actionInContext, signals.expect), options));
 
     return formatter.format();
   }

--- a/packages/isomorphic/codegen/types.ts
+++ b/packages/isomorphic/codegen/types.ts
@@ -36,7 +36,7 @@ export type LanguageGeneratorOptions = {
   contextOptions: BrowserContextOptions;
   deviceName?: string;
   saveStorage?: string;
-  generateAutoExpect?: boolean;
+  generateExpectSignal?: boolean;
 };
 
 export interface LanguageGenerator {
@@ -45,6 +45,6 @@ export interface LanguageGenerator {
   name: string;
   highlighter: Language;
   generateHeader(options: LanguageGeneratorOptions): string;
-  generateAction(actionInContext: actions.ActionInContext): string;
+  generateAction(actionInContext: actions.ActionInContext, options: LanguageGeneratorOptions): string;
   generateFooter(saveStorage: string | undefined): string;
 }

--- a/packages/playwright-core/src/server/debugController.ts
+++ b/packages/playwright-core/src/server/debugController.ts
@@ -193,7 +193,7 @@ function wireListeners(recorder: Recorder, debugController: DebugController) {
       browserName: 'chromium',
       launchOptions: {},
       contextOptions: {},
-      generateAutoExpect: debugController._generateAutoExpect,
+      generateExpectSignal: debugController._generateAutoExpect,
     });
     debugController.emit(DebugController.Events.SourceChanged, { text, header, footer, actions: actionTexts });
   };

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -229,7 +229,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       // Input actions that potentially lead to navigation are intercepted on the page and are
       // performed by the Playwright.
       await this._context.exposeBinding(progress, '__pw_recorderPerformAction',
-          (source: BindingSource, action: actions.PerformOnRecordAction) => this._performAction(progress, source.frame, action));
+          (source: BindingSource, action: actions.PerformOnRecordAction, preconditionSelector?: string) => this._performAction(progress, source.frame, action, preconditionSelector));
 
       // Other non-essential actions are simply being recorded.
       await this._context.exposeBinding(progress, '__pw_recorderRecordAction',
@@ -559,14 +559,9 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     return this._params.testIdAttributeName || this._context.selectors().testIdAttributeName() || 'data-testid';
   }
 
-  private async _appendContextToAction(progress: Progress, frame: Frame, action: actions.Action): Promise<actions.ActionInContext> {
-    const framePath = await generateFrameSelector(progress, frame);
-    if (framePath.length) {
-      if ('selector' in action)
-        action.selector = buildFullSelector(framePath, action.selector);
-      if (action.preconditionSelector)
-        action.preconditionSelector = buildFullSelector(framePath, action.preconditionSelector);
-    }
+  private _appendContextToAction(frame: Frame, action: actions.Action, framePath: string[]): actions.ActionInContext {
+    if (framePath.length && 'selector' in action)
+      action.selector = buildFullSelector(framePath, action.selector);
     const actionInContext: actions.ActionInContext = {
       frame: this._describeMainFrame(frame._page),
       action,
@@ -575,8 +570,11 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     return actionInContext;
   }
 
-  private async _performAction(progress: Progress, frame: Frame, action: actions.PerformOnRecordAction) {
-    const actionInContext = await this._appendContextToAction(progress, frame, action);
+  private async _performAction(progress: Progress, frame: Frame, action: actions.PerformOnRecordAction, preconditionSelector?: string) {
+    const framePath = await generateFrameSelector(progress, frame);
+    if (preconditionSelector)
+      this._signalProcessor.signal(this._pageAliases.get(frame._page)!, frame, { name: 'expect', selector: buildFullSelector(framePath, preconditionSelector) });
+    const actionInContext = this._appendContextToAction(frame, action, framePath);
     this._signalProcessor.addAction(actionInContext);
     try {
       if (actionInContext.action.name !== 'openPage' && actionInContext.action.name !== 'closePage')
@@ -587,7 +585,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   private async _recordAction(progress: Progress, frame: Frame, action: actions.Action) {
-    const actionInContext = await this._appendContextToAction(progress, frame, action);
+    const framePath = await generateFrameSelector(progress, frame);
+    const actionInContext = this._appendContextToAction(frame, action, framePath);
     this._signalProcessor.addAction(actionInContext);
   }
 

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -147,7 +147,7 @@ export class RecorderApp {
         }
       },
       setAutoExpect: async (params: { autoExpect: boolean }) => {
-        this._languageGeneratorOptions.generateAutoExpect = params.autoExpect;
+        this._languageGeneratorOptions.generateExpectSignal = params.autoExpect;
         this._updateActions();
       },
       setMode: async (params: { mode: Mode }) => {

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -208,6 +208,35 @@ test('test', async ({ page }) => {
   expect(events).toHaveLength(length);
 });
 
+test('should record expect signal', async ({ backend, connectedBrowser }) => {
+  const events = [];
+  backend.on('sourceChanged', event => events.push(event));
+
+  await backend.setRecorderMode({ mode: 'recording', generateAutoExpect: true }, undefined);
+
+  const context = await connectedBrowser.newContextForReuse();
+  const [page] = context.pages();
+
+  // Clicking "Show" reveals "Saved", which becomes the precondition of the next action.
+  await page.setContent(`
+    <button onclick="document.getElementById('msg').style.display = 'block'">Show</button>
+    <button>Other</button>
+    <button id=msg style="display: none">Saved</button>
+  `);
+
+  await page.getByRole('button', { name: 'Show' }).click();
+  // A click stalls for 200ms to detect a double click, and the next click cancels a pending one.
+  await expect.poll(() => events[events.length - 1]?.actions.length).toBe(2);
+  await page.getByRole('button', { name: 'Other' }).click();
+
+  // The signal is attached to the "Show" click, so the assertion renders right after it.
+  await expect.poll(() => events[events.length - 1]?.actions).toEqual([
+    `  await page.goto('about:blank');`,
+    `  await page.getByRole('button', { name: 'Show' }).click();\n  await expect(page.getByRole('button', { name: 'Saved' })).toBeVisible();`,
+    `  await page.getByRole('button', { name: 'Other' }).click();`,
+  ]);
+});
+
 test('should record custom data-testid', async ({ backend, connectedBrowser }) => {
   // This test emulates "record at cursor" functionality
   // with custom test id attribute in the config.

--- a/tests/library/inspector/cli-codegen-2.spec.ts
+++ b/tests/library/inspector/cli-codegen-2.spec.ts
@@ -579,28 +579,28 @@ await page.Locator("#textarea").FillAsync(\"Hello'\\"\`\\nWorld\");`);
     ]);
 
     expect.soft(sources.get('Playwright Test')!.text).toContain(`
+  await page.getByRole('button', { name: 'one' }).click();
   await expect(page.getByRole('heading', { name: 'new header' })).toBeVisible();
-
   await page.getByRole('button', { name: 'two' }).click();`);
 
     expect.soft(sources.get('Python')!.text).toContain(`
+    page.get_by_role("button", name="one").click()
     expect(page.get_by_role("heading", name="new header")).to_be_visible()
-
     page.get_by_role("button", name="two").click()`);
 
     expect.soft(sources.get('Python Async')!.text).toContain(`
+    await page.get_by_role("button", name="one").click()
     await expect(page.get_by_role("heading", name="new header")).to_be_visible()
-
     await page.get_by_role("button", name="two").click()`);
 
     expect.soft(sources.get('Java')!.text).toContain(`
+      page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("one")).click();
       assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("new header"))).isVisible();
-
       page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("two")).click();`);
 
     expect.soft(sources.get('C#')!.text).toContain(`
+await page.GetByRole(AriaRole.Button, new() { Name = "one" }).ClickAsync();
 await Expect(page.GetByRole(AriaRole.Heading, new() { Name = "new header" })).ToBeVisibleAsync();
-
 await page.GetByRole(AriaRole.Button, new() { Name = "two" }).ClickAsync();`);
   });
 });


### PR DESCRIPTION
> Stacked on #41725 — the first commit belongs to that PR and will disappear from this diff once it merges.

## Summary
- Remove `ActionBase.preconditionSelector`. The injected recorder passes the selector to the server as a separate binding argument instead of stamping it onto the action.
- The server turns it into an `ExpectSignal` and routes it through `_signalProcessor.signal()`, so it attaches to the preceding action like every other signal.
- Each language generator now renders the signal itself, appending an `assertVisible` after the action it is attached to. `generateAction()` takes `LanguageGeneratorOptions` so generators can honour the flag, renamed `generateAutoExpect` → `generateExpectSignal`.

The generated assertion still lands immediately before the next action, so `should auto-generate toBeVisible` only changes by losing the blank line that the old prepend inserted.