### PR TITLE
fix(cli): avoid hanging on unresponsive tab titles

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -283,9 +283,19 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     let title: string | undefined;
     let consoleCounts = { total: 0, errors: 0, warnings: 0 };
     if (!this.crashed) {
-      await this._raceAgainstModalStates(async () => {
-        title = await this.page.title();
-      });
+      // A discarded or unresponsive page (e.g. when attached over CDP) may never
+      // resolve the title lookup. Cap it so that one bad tab does not block
+      // rendering of the whole response.
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const titleTimeout = new Promise<void>(resolve => timeoutId = setTimeout(resolve, 5000));
+      await Promise.race([
+        this._raceAgainstModalStates(async () => {
+          title = await this.page.title();
+        }).catch(() => {}),
+        titleTimeout,
+      ]);
+      if (timeoutId)
+        clearTimeout(timeoutId);
       consoleCounts = await this.consoleMessageCount();
     }
     const newHeader: TabHeader = {

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -149,3 +149,28 @@ test('reuse first tab when navigating', async ({ startClient, cdpServer, server 
   expect(pages.length).toBe(1);
   expect(await pages[0].title()).toBe('Title');
 });
+
+test('unresponsive tab does not block tab listing', async ({ startClient, cdpServer, server }) => {
+  const browserContext = await cdpServer.start();
+  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  // Second tab whose main thread is blocked, so that title lookup never resolves.
+  const page = await browserContext.newPage();
+  await page.goto(server.HELLO_WORLD);
+  page.evaluate(() => { while (true) {} }).catch(() => {});
+  await new Promise(f => setTimeout(f, 1000));
+
+  expect(await client.callTool({
+    name: 'browser_tabs',
+    arguments: {
+      action: 'list',
+    },
+  })).toHaveResponse({
+    result: `- 0: (current) [Title](${server.HELLO_WORLD})
+- 1: [](${server.HELLO_WORLD})`,
+  });
+});


### PR DESCRIPTION
## Summary

Prevents Playwright CLI response rendering from hanging when one attached CDP tab is discarded or unresponsive.

## Why

`Tab.headerSnapshot()` currently waits on `page.title()` while building tab headers. If one tab never resolves renderer-bound calls, response rendering can block while collecting headers for all tabs, causing unrelated CLI commands to time out.

This intentionally does not change `connectOverCDP` initialization behavior. It only guards CLI response rendering so one unresponsive tab header cannot block unrelated commands after the connection has already succeeded.

## Change

Adds a narrow timeout/catch around tab title collection so an unresponsive tab falls back to the existing empty-title path instead of blocking the whole response.

## Tests

- `npm run ctest-mcp tabs.spec.ts -- --grep "unresponsive tab"`
- `npm run ctest-mcp tabs.spec.ts`

References #41714.