### PR TITLE
test(bidi): install libavcodec in CI for Firefox

### DIFF
--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -55,6 +55,8 @@ jobs:
     - run: npx playwright install --with-deps chromium
     - if: matrix.channel == 'moz-firefox-nightly'
       run: |
+        sudo apt-get update
+        sudo apt-get install -y libavcodec60
         echo "BIDI_FFPATH=$(npx -y @puppeteer/browsers install firefox@nightly | tail -n1 | sed 's/^[^ ]* *//')" >> "$GITHUB_ENV"
     - name: Run tests
       run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run biditest -- --retries=${{ matrix.isPullRequest && 2 || 0 }} --project=${{ matrix.channel }}*

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -63,7 +63,6 @@ library/browsertype-connect.spec.ts › run-server › should save download [fai
 library/browsertype-connect.spec.ts › run-server › should upload a folder [fail]
 library/browsertype-launch.spec.ts › should reject if launched browser fails immediately [fail]
 library/capabilities.spec.ts › SharedArrayBuffer should work @smoke [timeout]
-library/capabilities.spec.ts › should play video @smoke [timeout]
 library/channels.spec.ts › should work with the domain module [timeout]
 library/chromium/chromium.spec.ts › PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1 › serviceWorker(), and fromServiceWorker() work [timeout]
 library/chromium/chromium.spec.ts › PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1 › setExtraHTTPHeaders [timeout]


### PR DESCRIPTION
Fixes "should play video" in `library/capabilities.spec.ts`.