### PR TITLE
fix(winldd): harden PrintDeps against invalid inputs

### DIFF
--- a/browser_patches/winldd/PrintDeps.cpp
+++ b/browser_patches/winldd/PrintDeps.cpp
@@ -47,36 +47,60 @@ SOFTWARE.
 
 using DepsMap = std::map<std::string, std::string>;
 
-std::string getLastErrorString()
+std::string getErrorString(DWORD dw)
 {
-    LPTSTR lpMsgBuf;
-    DWORD dw = GetLastError();
-    FormatMessage(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-        NULL,
+    LPSTR lpMsgBuf = nullptr;
+    DWORD chars = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr,
         dw,
         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        (LPTSTR)&lpMsgBuf,
-        0, NULL);
-    std::string result(lpMsgBuf);
+        reinterpret_cast<LPSTR>(&lpMsgBuf),
+        0,
+        nullptr);
+    if (!chars || !lpMsgBuf)
+        return "error " + std::to_string(dw);
+
+    std::string result(lpMsgBuf, chars);
     LocalFree(lpMsgBuf);
     return result;
+}
+
+std::string getLastErrorString()
+{
+    return getErrorString(GetLastError());
+}
+
+HMODULE loadLibraryForDependencyScan(LPCSTR library, DWORD* error)
+{
+    DWORD oldErrorMode = 0;
+    BOOL changedErrorMode = SetThreadErrorMode(SEM_FAILCRITICALERRORS, &oldErrorMode);
+    HMODULE hMod = LoadLibraryEx(library, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_SYSTEM32);
+    if (hMod == NULL && error)
+        *error = GetLastError();
+    if (changedErrorMode)
+        SetThreadErrorMode(oldErrorMode, nullptr);
+    return hMod;
 }
 
 const DepsMap getDependencies(const HMODULE hMod)
 {
     // See https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/february/inside-windows-win32-portable-executable-file-format-in-detail
     // for PE format description.
-    ULONG size;
+    ULONG size = 0;
     PIMAGE_IMPORT_DESCRIPTOR pImportDesc =  (PIMAGE_IMPORT_DESCRIPTOR)ImageDirectoryEntryToData(hMod, true, IMAGE_DIRECTORY_ENTRY_IMPORT, &size);
     DepsMap deps;
+    if (!pImportDesc || size < sizeof(IMAGE_IMPORT_DESCRIPTOR))
+        return deps;
+
     // According to https://docs.microsoft.com/en-us/archive/msdn-magazine/2002/march/inside-windows-an-in-depth-look-into-the-win32-portable-executable-file-format-part-2
     // "The end of the IMAGE_IMPORT_DESCRIPTOR array is indicated by an entry with fields all set to 0."
-    while (pImportDesc->Name)
+    ULONG descriptorCount = size / sizeof(IMAGE_IMPORT_DESCRIPTOR);
+    for (ULONG i = 0; i < descriptorCount && pImportDesc[i].Name; ++i)
     {
-        LPCSTR dllName = (LPCSTR)((BYTE*)hMod + pImportDesc->Name);
+        LPCSTR dllName = (LPCSTR)((BYTE*)hMod + pImportDesc[i].Name);
         std::string dllPath = "not found";
-        HMODULE hModDep = LoadLibraryEx(dllName, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_SYSTEM32);
+        HMODULE hModDep = loadLibraryForDependencyScan(dllName, nullptr);
         if (hModDep != NULL)
         {
             TCHAR pathBuffer[_MAX_PATH];
@@ -88,7 +112,6 @@ const DepsMap getDependencies(const HMODULE hMod)
             FreeLibrary(hModDep);
         }
         deps[std::string(dllName)] = dllPath;
-        pImportDesc++;
     }
 
     return deps;
@@ -97,10 +120,11 @@ const DepsMap getDependencies(const HMODULE hMod)
 int printDependencies(const char* library)
 {
     SetDllDirectoryA(".");
-    HMODULE hMod = LoadLibraryEx(library, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_SEARCH_USER_DIRS | LOAD_LIBRARY_SEARCH_SYSTEM32);
+    DWORD loadError = ERROR_SUCCESS;
+    HMODULE hMod = loadLibraryForDependencyScan(library, &loadError);
     if (hMod == NULL)
     {
-        std::cerr << "Failed to load " << library << "  Error: " << getLastErrorString() << std::endl;
+        std::cerr << "Failed to load " << library << "  Error: " << getErrorString(loadError) << std::endl;
         return -1;
     }
     const DepsMap& deps = getDependencies(hMod);


### PR DESCRIPTION
## Summary

- avoid `PrintDeps.exe` crashing when `FormatMessageA` fails while formatting `LoadLibraryExA` errors
- handle PE files without import directories by returning an empty dependency map
- suppress system critical-error dialogs while probing invalid/bad-image inputs, restoring the previous thread error mode afterwards

## Details

`PrintDeps.exe` currently assumes two Windows API calls always return usable pointers:

- `FormatMessage(...)` in `getLastErrorString()`
- `ImageDirectoryEntryToData(...)` in `getDependencies()`

Both can fail or return `NULL`. When that happens, `PrintDeps.exe` can crash with `0xC0000005` on unsupported inputs instead of returning a controlled result.

This patch initializes the `FormatMessageA` output pointer, checks the return value, and falls back to a numeric error string. It also checks the import directory pointer and size before walking `IMAGE_IMPORT_DESCRIPTOR` entries.

`SetThreadErrorMode(SEM_FAILCRITICALERRORS, ...)` prevents `LoadLibraryExA` probes from showing system critical-error dialogs for invalid/bad-image inputs, which is important for automation callers. The helper restores the previous thread error mode immediately after the probe and preserves the original `LoadLibraryExA` error code for diagnostics.

Return code behavior is unchanged for failed loads: invalid/non-PE inputs still return `-1`. PE files with no import table now return `0` with an empty dependency list, matching the fact that there are no imports to report.

## Verification

Built locally with Visual Studio 2022 by overriding the project toolset to `v143`:

```powershell
$env:CL='/DBUILD_NUMBER=1007'
MSBuild.exe browser_patches\winldd\PrintDeps.sln /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v143
```

Manual checks:

```powershell
.\x64\Release\PrintDeps.exe <non-PE package.json>
# Before: crashed with 0xC0000005 at PrintDeps+0x23f3
# After: returns -1 with a controlled "not a valid Win32 application" error, no dialog

.\x64\Release\PrintDeps.exe C:\Windows\System32\adtschema.dll
# Before: crashed with 0xC0000005 at PrintDeps+0x1f94
# After: returns 0 with an empty dependency list

.\x64\Release\PrintDeps.exe C:\Windows\System32\version.dll
# After: prints dependencies normally and returns 0
```
