### PR TITLE
fix(screencast): auto-save video when page closes without stop

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -674,6 +674,8 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
       if (isTargetClosedError(e) && !options.runBeforeUnload)
         return;
       throw e;
+    } finally {
+      await this.screencast._waitForPendingAutoSave();
     }
   }
 

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -27,6 +27,7 @@ export class Screencast implements api.Screencast {
   private _savePath: string | undefined;
   private _onFrame: ((frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>) | null = null;
   private _artifact: Artifact | undefined;
+  private _pendingAutoSave: Promise<void> | undefined;
 
   constructor(page: Page) {
     this._page = page;
@@ -35,7 +36,8 @@ export class Screencast implements api.Screencast {
     });
     this._page.once(Events.Page.Close, () => {
       // Auto-save the video when the page closes, so recordings are not lost
-      // if the user forgets to call stop().
+      // if the user forgets to call stop(). page.close() awaits this via
+      // _waitForPendingAutoSave() before it resolves.
       if (this._started && this._savePath && this._artifact) {
         const artifact = this._artifact;
         const savePath = this._savePath;
@@ -43,9 +45,13 @@ export class Screencast implements api.Screencast {
         this._onFrame = null;
         this._artifact = undefined;
         this._savePath = undefined;
-        artifact.saveAs(savePath).catch(() => {});
+        this._pendingAutoSave = artifact.saveAs(savePath).catch(() => {});
       }
     });
+  }
+
+  async _waitForPendingAutoSave(): Promise<void> {
+    await this._pendingAutoSave;
   }
 
   async start(options: { onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any, path?: string, size?: { width: number, height: number }, quality?: number } = {}): Promise<DisposableStub> {

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -16,6 +16,7 @@
 
 import { Artifact } from './artifact';
 import { DisposableStub } from './disposable';
+import { Events } from './events';
 
 import type * as api from '../../types/types';
 import type { Page } from './page';
@@ -31,6 +32,19 @@ export class Screencast implements api.Screencast {
     this._page = page;
     this._page._channel.on('screencastFrame', ({ data, timestamp, viewportWidth, viewportHeight }) => {
       void this._onFrame?.({ data, timestamp, viewportWidth, viewportHeight });
+    });
+    this._page.once(Events.Page.Close, () => {
+      // Auto-save the video when the page closes, so recordings are not lost
+      // if the user forgets to call stop().
+      if (this._started && this._savePath && this._artifact) {
+        const artifact = this._artifact;
+        const savePath = this._savePath;
+        this._started = false;
+        this._onFrame = null;
+        this._artifact = undefined;
+        this._savePath = undefined;
+        artifact.saveAs(savePath).catch(() => {});
+      }
     });
   }
 
@@ -54,9 +68,9 @@ export class Screencast implements api.Screencast {
   }
 
   async stop(): Promise<void> {
+    this._started = false;
+    this._onFrame = null;
     await this._page._wrapApiCall(async () => {
-      this._started = false;
-      this._onFrame = null;
       await this._page._channel.screencastStop({}, undefined);
       if (this._savePath)
         await this._artifact?.saveAs(this._savePath);

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -204,6 +204,24 @@ test('start should finish when page is closed', async ({ browser }, testInfo) =>
   await context.close();
 });
 
+test('should auto-save video when page closes without stop', async ({ browser, server }, testInfo) => {
+  test.slow();
+  const size = { width: 800, height: 800 };
+  const context = await browser.newContext({ viewport: size });
+  const page = await context.newPage();
+  const videoPath = testInfo.outputPath('auto-save-video.webm');
+  await page.screencast.start({ path: videoPath, size });
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(() => document.body.style.backgroundColor = 'red');
+  await ensureSomeFrames(page);
+  // Close the page without calling stop()
+  await page.close();
+  // The video file should be saved automatically
+  expect(fs.existsSync(videoPath)).toBeTruthy();
+  expectFrames(videoPath, size, isAlmostRed);
+  await context.close();
+});
+
 test('empty video', async ({ browser }, testInfo) => {
   test.slow();
   const size = { width: 800, height: 800 };


### PR DESCRIPTION
Closes #41608

## Problem

When using `page.screencast.start({ path: 'video.webm' })`, if the page closes before `page.screencast.stop()` is called, the video file is never saved to disk. The server already stops the recording gracefully, but the client never calls `artifact.saveAs()` to write the file.

This makes it impossible to record a video showing "the window closing when a button is pressed."

## Solution

Listen for `Events.Page.Close` in the client-side `Screencast` constructor. When the page closes while a recording is active (with a `path` option), automatically save the artifact to the specified path.

**Changes:**
- `packages/playwright-core/src/client/screencast.ts` — Register a one-time `Page.Close` listener that auto-saves the artifact
- `tests/library/screencast.spec.ts` — Add test verifying auto-save on page close

## Usage

```ts
await page.screencast.start({ path: 'video.webm' });
await page.getByRole('button', { name: 'close' }).click(); // closes the page
// video.webm is now automatically saved!