### PR TITLE
fix(test-runner): add orphaned dependency projects with matching --last-failed tests as independent entries

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -148,7 +148,20 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   }
 
   // Add post-filtered top-level projects to the root suite for sharding and 'only' processing.
-  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], project => filteredProjectSuites.get(project)!._hasTests());
+  // A project only counts as having tests (and therefore as a candidate root-level project) if it
+  // has tests that also survive the post-shard filters (e.g. --last-failed). Otherwise a project
+  // that is only reachable through another project's "dependencies" (and therefore classified as
+  // a "dependency" project below) could end up entirely excluded from consideration, even though
+  // it is the project that actually contains the tests we are looking for.
+  const projectHasMatchingTests = (project: commonConfig.FullProjectInternal) => {
+    const filteredProjectSuite = filteredProjectSuites.get(project)!;
+    if (!filteredProjectSuite._hasTests())
+      return false;
+    if (!testRun.postShardTestFilters.length)
+      return true;
+    return filteredProjectSuite.allTests().some(test => testRun.postShardTestFilters.every(filter => filter(test)));
+  };
+  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], projectHasMatchingTests);
   for (const [project, type] of projectClosure) {
     if (type === 'top-level') {
       project.project.repeatEach = project.fullConfig.configCLIOverrides.repeatEach ?? project.project.repeatEach;

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -148,20 +148,7 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
   }
 
   // Add post-filtered top-level projects to the root suite for sharding and 'only' processing.
-  // A project only counts as having tests (and therefore as a candidate root-level project) if it
-  // has tests that also survive the post-shard filters (e.g. --last-failed). Otherwise a project
-  // that is only reachable through another project's "dependencies" (and therefore classified as
-  // a "dependency" project below) could end up entirely excluded from consideration, even though
-  // it is the project that actually contains the tests we are looking for.
-  const projectHasMatchingTests = (project: commonConfig.FullProjectInternal) => {
-    const filteredProjectSuite = filteredProjectSuites.get(project)!;
-    if (!filteredProjectSuite._hasTests())
-      return false;
-    if (!testRun.postShardTestFilters.length)
-      return true;
-    return filteredProjectSuite.allTests().some(test => testRun.postShardTestFilters.every(filter => filter(test)));
-  };
-  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], projectHasMatchingTests);
+  const projectClosure = buildProjectsClosure([...filteredProjectSuites.keys()], project => filteredProjectSuites.get(project)!._hasTests());
   for (const [project, type] of projectClosure) {
     if (type === 'top-level') {
       project.project.repeatEach = project.fullConfig.configCLIOverrides.repeatEach ?? project.project.repeatEach;
@@ -218,6 +205,36 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
         rootSuite._prependSuite(buildProjectSuite(project, projectSuites.get(project)!));
       else
         topLevelProjects.push(project);
+    }
+  }
+
+  // A project that is structurally a "dependency" of another project is excluded from the
+  // top-level closure above, and is normally only pulled in (unfiltered, in full) when a
+  // surviving top-level project needs it as a prerequisite. If post-shard filters (e.g.
+  // --last-failed) eliminated every project that would have pulled it in, but the dependency
+  // project has matching tests of its own, treat it as an independent entry point instead of
+  // silently dropping it - see https://github.com/microsoft/playwright/issues/39811.
+  // Note: this does not participate in --shard, matching the pre-existing dependency-prepend
+  // behavior above, which is also unaffected by sharding.
+  if (testRun.postShardTestFilters.length) {
+    const includedProjects = new Set(rootSuite.suites.map(suite => suite._fullProject!));
+    for (const project of filteredProjectSuites.keys()) {
+      if (includedProjects.has(project))
+        continue;
+      const filteredProjectSuite = filterProjectSuite(filteredProjectSuites.get(project)!, testRun.postShardTestFilters);
+      if (!filteredProjectSuite._hasTests())
+        continue;
+      project.project.repeatEach = project.fullConfig.configCLIOverrides.repeatEach ?? project.project.repeatEach;
+      rootSuite._addSuite(buildProjectSuite(project, filteredProjectSuite));
+      topLevelProjects.push(project);
+      includedProjects.add(project);
+      // Pull in this project's own prerequisites, in full, same as any other top-level project.
+      for (const [depProject, level] of buildProjectsClosure([project])) {
+        if (level === 'dependency' && !includedProjects.has(depProject)) {
+          rootSuite._prependSuite(buildProjectSuite(depProject, projectSuites.get(depProject)!));
+          includedProjects.add(depProject);
+        }
+      }
     }
   }
 

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -847,6 +847,41 @@ test('should run last failed tests', async ({ runInlineTest }) => {
   expect(result2.failed).toBe(1);
 });
 
+test('should run last failed tests when the failing project is a dependency of another project', async ({ runInlineTest }) => {
+  const workspace = {
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'default', testIgnore: /setup/ },
+          { name: 'sequential', testMatch: /setup/, dependencies: ['default'] },
+        ],
+      });
+    `,
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async () => {});
+      test('fail', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+    'setup.spec.js': `
+      import { test } from '@playwright/test';
+      test('setup', async () => {});
+    `,
+  };
+  const result1 = await runInlineTest(workspace);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(1);
+  expect(result1.failed).toBe(1);
+
+  const result2 = await runInlineTest(workspace, {}, {}, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  expect(result2.passed).toBe(0);
+  expect(result2.failed).toBe(1);
+  expect(result2.output).toContain('a.spec.js:4:11 › fail');
+});
+
 test('should run nothing with --last-failed when previous run had no failures', async ({ runInlineTest }) => {
   const workspace = {
     'a.spec.js': `

--- a/tests/playwright-test/runner.spec.ts
+++ b/tests/playwright-test/runner.spec.ts
@@ -882,6 +882,46 @@ test('should run last failed tests when the failing project is a dependency of a
   expect(result2.output).toContain('a.spec.js:4:11 › fail');
 });
 
+test('should run a dependency project in full when it is needed by a surviving top-level project under --last-failed', async ({ runInlineTest }) => {
+  // Regression guard: a dependency project pulled in because a surviving top-level project
+  // needs it as a prerequisite must still run ALL of its tests, not just whichever ones happen
+  // to match --last-failed (it may have had no failures of its own at all).
+  const workspace = {
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'setup', testMatch: /setup/ },
+          { name: 'main', testIgnore: /setup/, dependencies: ['setup'] },
+        ],
+      });
+    `,
+    'a.spec.js': `
+      import { test, expect } from '@playwright/test';
+      test('fail', async () => {
+        expect(1).toBe(2);
+      });
+    `,
+    'setup.spec.js': `
+      import { test } from '@playwright/test';
+      test('setup one', async () => {});
+      test('setup two', async () => {});
+    `,
+  };
+  const result1 = await runInlineTest(workspace);
+  expect(result1.exitCode).toBe(1);
+  expect(result1.passed).toBe(2);
+  expect(result1.failed).toBe(1);
+
+  const result2 = await runInlineTest(workspace, {}, {}, { additionalArgs: ['--last-failed'] });
+  expect(result2.exitCode).toBe(1);
+  // The setup project has no failed tests of its own, but must still run in full as main's
+  // prerequisite: both setup tests pass, plus main's single failing test reruns.
+  expect(result2.passed).toBe(2);
+  expect(result2.failed).toBe(1);
+  expect(result2.output).toContain('a.spec.js:3:11 › fail');
+});
+
 test('should run nothing with --last-failed when previous run had no failures', async ({ runInlineTest }) => {
   const workspace = {
     'a.spec.js': `


### PR DESCRIPTION
Follow-up to #41622 (closed, I cannot reopen it as a non-collaborator) addressing @yury-s review feedback there.

Fixes #39811

The previous approach (#41622) conflated a project's structural dependency role with test filtering by changing the top-level/dependency classification predicate itself, which risked regressing the existing dependencies-always-run-in-full guarantee.

This instead leaves the classification and existing dependency-prepend logic untouched, and adds a distinct step: after --last-failed filtering, any project excluded solely because it is someone else's dependency (and that someone didn't survive filtering) is checked for its own matching tests. If found, it is added as an independent entry point, pulling in its own prerequisites in full - never affecting how already-surviving top-level projects' dependencies are run.

Added a dedicated regression test for the exact scenario flagged in review: a dependency project needed by a surviving top-level project still runs in full under --last-failed, even with no matching failures of its own.

Full context/discussion: https://github.com/microsoft/playwright/pull/41622#issuecomment-4950371392
