### PR TITLE
fix(screencast): auto-save video when page closes without stop

### DIFF
--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -674,6 +674,11 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
       if (isTargetClosedError(e) && !options.runBeforeUnload)
         return;
       throw e;
+    } finally {
+      // If the page actually closed, the 'close' event (and with it, screencast's
+      // auto-save) is dispatched by the server before the close response is sent,
+      // so this is guaranteed to observe an in-flight save, if any, at this point.
+      await this.screencast._waitForPendingAutoSave();
     }
   }
 

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -27,6 +27,7 @@ export class Screencast implements api.Screencast {
   private _savePath: string | undefined;
   private _onFrame: ((frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>) | null = null;
   private _artifact: Artifact | undefined;
+  private _pendingAutoSave: Promise<void> | undefined;
 
   constructor(page: Page) {
     this._page = page;
@@ -35,7 +36,8 @@ export class Screencast implements api.Screencast {
     });
     this._page.once(Events.Page.Close, () => {
       // Auto-save the video when the page closes, so recordings are not lost
-      // if the user forgets to call stop().
+      // if the user forgets to call stop(). page.close() awaits this via
+      // _waitForPendingAutoSave() before it resolves.
       if (this._started && this._savePath && this._artifact) {
         const artifact = this._artifact;
         const savePath = this._savePath;
@@ -43,9 +45,13 @@ export class Screencast implements api.Screencast {
         this._onFrame = null;
         this._artifact = undefined;
         this._savePath = undefined;
-        artifact.saveAs(savePath).catch(() => {});
+        this._pendingAutoSave = artifact.saveAs(savePath).catch(() => {});
       }
     });
+  }
+
+  async _waitForPendingAutoSave(): Promise<void> {
+    await this._pendingAutoSave;
   }
 
   async start(options: { onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any, path?: string, size?: { width: number, height: number }, quality?: number } = {}): Promise<DisposableStub> {

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -16,6 +16,7 @@
 
 import { Artifact } from './artifact';
 import { DisposableStub } from './disposable';
+import { Events } from './events';
 
 import type * as api from '../../types/types';
 import type { Page } from './page';
@@ -31,6 +32,19 @@ export class Screencast implements api.Screencast {
     this._page = page;
     this._page._channel.on('screencastFrame', ({ data, timestamp, viewportWidth, viewportHeight }) => {
       void this._onFrame?.({ data, timestamp, viewportWidth, viewportHeight });
+    });
+    this._page.once(Events.Page.Close, () => {
+      // Auto-save the video when the page closes, so recordings are not lost
+      // if the user forgets to call stop().
+      if (this._started && this._savePath && this._artifact) {
+        const artifact = this._artifact;
+        const savePath = this._savePath;
+        this._started = false;
+        this._onFrame = null;
+        this._artifact = undefined;
+        this._savePath = undefined;
+        artifact.saveAs(savePath).catch(() => {});
+      }
     });
   }
 
@@ -54,9 +68,9 @@ export class Screencast implements api.Screencast {
   }
 
   async stop(): Promise<void> {
+    this._started = false;
+    this._onFrame = null;
     await this._page._wrapApiCall(async () => {
-      this._started = false;
-      this._onFrame = null;
       await this._page._channel.screencastStop({}, undefined);
       if (this._savePath)
         await this._artifact?.saveAs(this._savePath);

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -204,6 +204,24 @@ test('start should finish when page is closed', async ({ browser }, testInfo) =>
   await context.close();
 });
 
+test('should auto-save video when page closes without stop', async ({ browser, server }, testInfo) => {
+  test.slow();
+  const size = { width: 800, height: 800 };
+  const context = await browser.newContext({ viewport: size });
+  const page = await context.newPage();
+  const videoPath = testInfo.outputPath('auto-save-video.webm');
+  await page.screencast.start({ path: videoPath, size });
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(() => document.body.style.backgroundColor = 'red');
+  await ensureSomeFrames(page);
+  // Close the page without calling stop()
+  await page.close();
+  // The video file should be saved automatically
+  expect(fs.existsSync(videoPath)).toBeTruthy();
+  expectFrames(videoPath, size, isAlmostRed);
+  await context.close();
+});
+
 test('empty video', async ({ browser }, testInfo) => {
   test.slow();
   const size = { width: 800, height: 800 };


### PR DESCRIPTION
Closes #41608

This builds on @sarang-code2's #41744, which correctly diagnosed and fixed the original problem (video never saved if the page closes before `screencast.stop()` is called). Full credit to them for that work - this PR carries their commit as-is, plus one addition:

**Original fix (unchanged from #41744):** listen for `Events.Page.Close` in the client-side `Screencast` constructor, and auto-save the artifact if a recording is active with a `path` option.

**Added on top:** in review on #41744, I flagged that the auto-save was fire-and-forget (`artifact.saveAs(savePath).catch(() => {})`, never awaited) - so `page.close()` could resolve before the video was actually written to disk, and a failed save produced no signal at all. This PR makes `Screencast` track the in-flight save (`_pendingAutoSave`) and has `Page.close()` await it in a `finally` block. Verified safe by tracing `PageDispatcher`: the server dispatches the `'close'` event (which triggers the auto-save) before it sends the response to the `close()` call, so the pending-save promise is always already assigned by the time `close()` reaches its `finally`.

Full discussion: https://github.com/microsoft/playwright/pull/41744#issuecomment-4950465126 and https://github.com/sarang-code2/playwright/pull/1 (opened against their branch first, before this one).

<details>
<summary>Test results - screencast.spec.ts, 195 runs (13 tests × 15 repeats), all passing</summary>

```
[182/195] [chromium-library] › tests\library\screencast.spec.ts:237:5 › start dispose stops recording
[183/195] [chromium-library] › tests\library\screencast.spec.ts:28:5 › screencast.start delivers frames via onFrame callback
[184/195] [chromium-library] › tests\library\screencast.spec.ts:57:5 › onFrame receives viewport size
[185/195] [chromium-library] › tests\library\screencast.spec.ts:108:5 › start returns a disposable that stops screencast
[186/195] [chromium-library] › tests\library\screencast.spec.ts:83:5 › start throws if screencast is already started
[187/195] [chromium-library] › tests\library\screencast.spec.ts:131:5 › start/stop twice without path creates two files in artifactsDir
[188/195] [chromium-library] › tests\library\screencast.spec.ts:94:5 › start allows restart with different options after stop
[189/195] [chromium-library] › tests\library\screencast.spec.ts:156:5 › start should work when recordVideo is set
[190/195] [chromium-library] › tests\library\screencast.spec.ts:179:5 › start should fail when another recording is in progress
[191/195] [chromium-library] › tests\library\screencast.spec.ts:186:5 › stop should not fail when no recording is in progress
[192/195] [chromium-library] › tests\library\screencast.spec.ts:194:5 › start should finish when page is closed
[193/195] [chromium-library] › tests\library\screencast.spec.ts:207:5 › should auto-save video when page closes without stop
[194/195] [chromium-library] › tests\library\screencast.spec.ts:225:5 › empty video
[195/195] [chromium-library] › tests\library\screencast.spec.ts:237:5 › start dispose stops recording
  195 passed (3.7m)
```
</details>

<details>
<summary>Test results - full page-close.spec.ts suite (18 tests), no regressions</summary>

```
[5/18] [chromium-library] › tests\library\page-close.spec.ts:65:5 › should set the page close state
[6/18] [chromium-library] › tests\library\page-close.spec.ts:71:5 › should pass page to close event
[7/18] [chromium-library] › tests\library\page-close.spec.ts:79:5 › should terminate network waiters
[8/18] [chromium-library] › tests\library\page-close.spec.ts:100:5 › should return null if parent page has been closed
[9/18] [chromium-library] › tests\library\page-close.spec.ts:92:5 › should be callable twice
[10/18] [chromium-library] › tests\library\page-close.spec.ts:110:5 › should fail with error upon disconnect
[11/18] [chromium-library] › tests\library\page-close.spec.ts:118:5 › page.close should work with window.close
[12/18] [chromium-library] › tests\library\page-close.spec.ts:124:5 › should not throw UnhandledPromiseRejection when page closes
[13/18] [chromium-library] › tests\library\page-close.spec.ts:133:5 › interrupt request.response() and request.allHeaders() on page.close
[14/18] [chromium-library] › tests\library\page-close.spec.ts:152:5 › should not treat navigations as new popups
[15/18] [chromium-library] › tests\library\page-close.spec.ts:166:5 › should not result in unhandled rejection
[16/18] [chromium-library] › tests\library\page-close.spec.ts:180:5 › should reject response.finished if page closes
[17/18] [chromium-library] › tests\library\page-close.spec.ts:200:5 › should not throw when continuing while page is closing
[18/18] [chromium-library] › tests\library\page-close.spec.ts:212:5 › should not throw when continuing after page is closed
  18 passed (3.3s)
```
</details>