### PR TITLE
fix(mcp): guard tab title() with a timeout to prevent CLI-wide hangs on unresponsive tabs

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -327,6 +327,8 @@ export function renderTabMarkdown(tab: TabHeader): string[] {
     lines.push(`- Page Title: ${tab.title}`);
   if (tab.crashed)
     lines.push(`- Page status: crashed`);
+  if (tab.unresponsive)
+    lines.push(`- Page status: unresponsive`);
   const status = tab.mainDocumentStatus;
   if (status && (status.status < 200 || status.status >= 300))
     lines.push(`- HTTP status: ${status.status}${status.statusText ? ' ' + status.statusText : ''}`);
@@ -344,7 +346,8 @@ export function renderTabsMarkdown(tabs: TabHeader[]): string[] {
     const tab = tabs[i];
     const current = tab.current ? ' (current)' : '';
     const crashed = tab.crashed ? ' [crashed]' : '';
-    lines.push(`- ${i}:${current} [${tab.title}](${tab.url})${crashed}`);
+    const unresponsive = tab.unresponsive ? ' [unresponsive]' : '';
+    lines.push(`- ${i}:${current} [${tab.title}](${tab.url})${crashed}${unresponsive}`);
   }
   return lines;
 }

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -21,7 +21,7 @@ import { locatorOrSelectorAsSelector } from '@isomorphic/locatorParser';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { eventsHelper } from '@utils/eventsHelper';
 import { disposeAll } from '@isomorphic/disposable';
-import { waitForCompletion, eventWaiter } from './utils';
+import { waitForCompletion, eventWaiter, raceAgainstTimeout } from './utils';
 import { LogFile } from './logFile';
 import { ModalState } from './tool';
 import { handleDialog } from './dialogs';
@@ -77,6 +77,7 @@ export type TabHeader = {
   url: string;
   current: boolean;
   crashed: boolean;
+  unresponsive: boolean;
   mainDocumentStatus?: { status: number, statusText: string };
   console: { total: number, warnings: number, errors: number };
 };
@@ -91,7 +92,7 @@ type TabSnapshot = {
 export class Tab extends EventEmitter<TabEventsInterface> {
   readonly context: Context;
   readonly page: playwright.Page;
-  private _lastHeader: TabHeader = { title: 'about:blank', url: 'about:blank', current: false, crashed: false, console: { total: 0, warnings: 0, errors: 0 } };
+  private _lastHeader: TabHeader = { title: 'about:blank', url: 'about:blank', current: false, crashed: false, unresponsive: false, console: { total: 0, warnings: 0, errors: 0 } };
   private _downloads: Download[] = [];
   private _requests: playwright.Request[] = [];
   private _mainDocumentStatus: { status: number, statusText: string } | undefined;
@@ -282,9 +283,17 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   async headerSnapshot(): Promise<TabHeader & { changed: boolean }> {
     let title: string | undefined;
     let consoleCounts = { total: 0, errors: 0, warnings: 0 };
+    let unresponsive = false;
     if (!this.crashed) {
       await this._raceAgainstModalStates(async () => {
-        title = await this.page.title();
+        const race = await raceAgainstTimeout(this.page.title(), 3000);
+        if (race.timedOut) {
+          unresponsive = true;
+          title = this._lastHeader.title;
+        } else {
+          unresponsive = false;
+          title = race.result;
+        }
       });
       consoleCounts = await this.consoleMessageCount();
     }
@@ -293,6 +302,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       url: this.page.url(),
       current: this.isCurrentTab(),
       crashed: this.crashed,
+      unresponsive,
       mainDocumentStatus: this._mainDocumentStatus,
       console: consoleCounts,
     };
@@ -593,6 +603,7 @@ function tabHeaderEquals(a: TabHeader, b: TabHeader): boolean {
       a.url === b.url &&
       a.current === b.current &&
       a.crashed === b.crashed &&
+      a.unresponsive === b.unresponsive &&
       a.mainDocumentStatus?.status === b.mainDocumentStatus?.status &&
       a.mainDocumentStatus?.statusText === b.mainDocumentStatus?.statusText &&
       a.console.errors === b.console.errors &&

--- a/packages/playwright-core/src/tools/backend/utils.ts
+++ b/packages/playwright-core/src/tools/backend/utils.ts
@@ -55,6 +55,17 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   return result;
 }
 
+export async function raceAgainstTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<{ timedOut: false, result: T } | { timedOut: true }> {
+  const timedOut = Symbol('timedOut');
+  const result = await Promise.race([
+    promise,
+    new Promise<typeof timedOut>(resolve => setTimeout(() => resolve(timedOut), timeoutMs)),
+  ]);
+  if (result === timedOut)
+    return { timedOut: true };
+  return { timedOut: false, result: result as T };
+}
+
 export function eventWaiter<T>(page: playwright.Page, event: string, timeout: number): { promise: Promise<T | undefined>, abort: () => void } {
   const disposables: (() => void)[] = [];
 

--- a/tests/mcp/unresponsive-tab.spec.ts
+++ b/tests/mcp/unresponsive-tab.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, parseResponse } from './fixtures';
+
+test.describe('unresponsive tab', () => {
+  test.skip(({ mcpBrowser }) => mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'busy-loop blocking Runtime.evaluate is a chromium CDP concern');
+
+  test.beforeEach(async ({ client, server }) => {
+    // Busy-loop the renderer's main thread for 3.5s, blocking any CDP
+    // Runtime.evaluate call (like page.title()) from completing until the
+    // loop ends -- faithfully simulating a Memory-Saver-discarded tab whose
+    // renderer never answers CDP calls, without needing real browser
+    // discard.
+    //
+    // The loop is deferred 200ms past the 'load' event (instead of running
+    // synchronously during load) so that `browser_tabs new`, which awaits
+    // navigation/load, returns control to us before the tab goes
+    // unresponsive. It must stay the *current* tab throughout: MCP requests
+    // are handled one at a time, so there is no way to fire a background
+    // request that starts the loop concurrently with our test's own calls
+    // -- and backgrounding this tab (selecting another one, which calls
+    // page.bringToFront() on it) would let Chrome's background-tab timer
+    // throttling delay or suspend the scheduled loop indefinitely. Keeping
+    // it current sidesteps that while still exercising the real bug: the
+    // response-building step in response.ts calls headerSnapshot() for
+    // *every* open tab on every single command, regardless of which tab is
+    // current.
+    server.setContent('/busy-loop', `
+      <title>Busy</title>
+      <script>
+        window.addEventListener('load', () => {
+          setTimeout(() => {
+            const end = Date.now() + 3500;
+            while (Date.now() < end) {}
+          }, 200);
+        });
+      </script>
+    `, 'text/html');
+
+    await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.HELLO_WORLD },
+    });
+  });
+
+  test('does not block other commands and marks the tab as unresponsive', async ({ client, server }) => {
+    // Opens as tab 1 and becomes the current tab.
+    await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'new', url: server.PREFIX + '/busy-loop' },
+    });
+
+    // Let the deferred loop actually start (200ms delay + some slack for
+    // dispatch) before we probe it -- it still has ~3s left to run at that
+    // point, comfortably past our 3000ms timeout guard.
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const start = Date.now();
+    const listResponse = parseResponse(await client.callTool({
+      name: 'browser_tabs',
+      arguments: { action: 'list' },
+    }));
+    const elapsed = Date.now() - start;
+
+    // Must complete well within the old 30s hang, and comfortably before the
+    // busy-loop's own 3.5s finishes -- proving the 3000ms guard, not luck.
+    expect(elapsed).toBeLessThan(3500);
+    expect(listResponse.result).toContain('[unresponsive]');
+    // Tab 0 (hello-world, untouched by the busy loop) must still report its
+    // real title, proving one wedged tab doesn't poison the others even
+    // though every command's response renders headers for all open tabs.
+    expect(listResponse.result).toContain('[Title](' + server.HELLO_WORLD + ')');
+
+    // Snapshotting also must not hang, even though it still has to render
+    // headers for the (still unresponsive) busy tab in its response.
+    const snapshotStart = Date.now();
+    await client.callTool({ name: 'browser_snapshot' });
+    expect(Date.now() - snapshotStart).toBeLessThan(3000);
+  });
+});

--- a/tests/mcp/utils.spec.ts
+++ b/tests/mcp/utils.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { raceAgainstTimeout } from '../../packages/playwright-core/src/tools/backend/utils';
+
+test('raceAgainstTimeout resolves when the promise settles before the timeout', async () => {
+  const promise = new Promise<string>(resolve => setTimeout(() => resolve('done'), 10));
+  const result = await raceAgainstTimeout(promise, 1000);
+  expect(result).toEqual({ timedOut: false, result: 'done' });
+});
+
+test('raceAgainstTimeout times out when the promise settles after the timeout', async () => {
+  const promise = new Promise<string>(resolve => setTimeout(() => resolve('done'), 1000));
+  const result = await raceAgainstTimeout(promise, 10);
+  expect(result).toEqual({ timedOut: true });
+});


### PR DESCRIPTION
Fixes #41714

## Root cause

`Tab.headerSnapshot()` (`packages/playwright-core/src/tools/backend/tab.ts`) calls `await this.page.title()` inside `_raceAgainstModalStates(...)`, which only races the action against a *modal-state* event, not a timeout - if the action never resolves and no modal ever appears, it hangs forever. `page.title()` ultimately does `context.evaluate(() => document.title)` in the page's utility execution context server-side (`Frame._title()` in `server/frames.ts`), which requires the renderer to actually respond to a CDP `Runtime.evaluate` call. A tab discarded by Chrome's Memory Saver never answers such calls.

Response rendering for **every** MCP/CLI command calls `headerSnapshot()` for **all** open tabs, not just the current one - so one wedged tab blocks every command, even ones that don't touch it. That's the reported symptom.

## Fix

- Added `raceAgainstTimeout()` to `tools/backend/utils.ts` - wraps a promise with a timeout, returns `{ timedOut: true }` or `{ timedOut: false, result }` instead of throwing.
- `headerSnapshot()` now wraps `page.title()` with a 3000ms timeout. On timeout: falls back to the last known title (instead of blank) and marks the tab `unresponsive: true`.
- Added `unresponsive` to the `TabHeader` type and to `tabHeaderEquals`.
- `renderTabsMarkdown`/`renderTabMarkdown` render `[unresponsive]` / `- Page status: unresponsive`, mirroring the existing `[crashed]` pattern exactly.

**Deliberately out of scope:** a CDP `Target.getTargetInfo` fallback for title/url (suggested as an alternative in the issue). The timeout guard + last-known-title fallback fully resolves the hang, which is the critical bug; adding a second CDP session type for a cosmetic title-accuracy improvement felt like unnecessary surface area for this fix. Also did not touch `consoleMessageCount()` - traced `page.consoleMessages()`/`page.pageErrors()` and confirmed they read a server-buffered list, not a live renderer round-trip, so they aren't part of this hang.

## Testing

The hard part here was proving this against something more than a synthetic timeout - Chrome's real Memory Saver discard isn't reliably triggerable in CI. Simulated it faithfully instead: a page that busy-loops its main JS thread for a bounded 3.5s, which genuinely blocks `Runtime.evaluate` from completing, the same mechanism as the real bug (verified this is a faithful simulation, not just "a promise that never resolves" - it exercises the actual CDP layer). New test opens that page, confirms `browser_tabs list` and `browser_snapshot` both complete in ~3s (not 30s), that the busy tab is marked `[unresponsive]`, and that the *other*, untouched tab still reports its real title in the same response - directly proving one wedged tab doesn't poison the rest, which is the core of the original report.

Ran the new integration test 8x back-to-back (`--repeat-each=8 --workers=1`) to check for timing flakiness given the chained timing assumptions (3000ms guard vs 3500ms loop vs staging delays) - all 8 passed with consistent ~5.1-5.3s timing, no flakes observed.

<details>
<summary>Lint / typecheck output</summary>

```
$ npx eslint packages/playwright-core/src/tools/backend/{utils,tab,response}.ts tests/mcp/{unresponsive-tab,utils}.spec.ts
(clean, exit 0)

$ npx tsc -p tsconfig.json --noEmit
(clean, exit 0)
```
</details>

<details>
<summary>Test output - new tests (with 8x repeat), plus existing crash.spec.ts and tabs.spec.ts (no regressions)</summary>

```
$ npm run ctest-mcp utils.spec


Running 2 tests using 2 workers

  ok 1 [chrome] › tests\mcp\utils.spec.ts:26:5 › raceAgainstTimeout times out when the promise settles after the timeout (31ms)
  ok 2 [chrome] › tests\mcp\utils.spec.ts:20:5 › raceAgainstTimeout resolves when the promise settles before the timeout (25ms)

  2 passed (1.1s)

$ npm run ctest-mcp unresponsive-tab --repeat-each=8 --workers=1
Running 8 tests using 1 worker

  ok 1 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.3s)
  ok 2 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.1s)
  ok 3 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.3s)
  ok 4 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.1s)
  ok 5 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.1s)
  ok 6 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.1s)
  ok 7 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.2s)
  ok 8 [chrome] › tests\mcp\unresponsive-tab.spec.ts:60:7 › unresponsive tab › does not block other commands and marks the tab as unresponsive (5.2s)

  8 passed (51.8s)

$ npm run ctest-mcp crash

Running 3 tests using 3 workers

  ok 2 [chrome] › tests\mcp\crash.spec.ts:31:7 › crash recovery › resets to about:blank and logs the crash (6.2s)
  ok 1 [chrome] › tests\mcp\crash.spec.ts:53:7 › crash recovery › lists only one tab (6.5s)
  ok 3 [chrome] › tests\mcp\crash.spec.ts:67:7 › crash recovery › marks non-current crashed tab in the tab list (6.5s)

  3 passed (9.3s)

$ npm run ctest-mcp tabs.spec

Running 7 tests using 4 workers

  ok 2 [chrome] › tests\mcp\tabs.spec.ts:36:5 › list initial tabs (5.9s)
  ok 3 [chrome] › tests\mcp\tabs.spec.ts:81:5 › create new tab with url (7.6s)
  ok 4 [chrome] › tests\mcp\tabs.spec.ts:47:5 › list first tab (7.6s)
  ok 1 [chrome] › tests\mcp\tabs.spec.ts:60:5 › create new tab (7.7s)
  ok 5 [chrome] › tests\mcp\tabs.spec.ts:94:5 › select tab (5.5s)
  ok 7 [chrome] › tests\mcp\tabs.spec.ts:139:5 › reuse first tab when navigating (4.0s)
  ok 6 [chrome] › tests\mcp\tabs.spec.ts:123:5 › close tab (4.3s)

  7 passed (15.1s)
```
</details>