### PR TITLE
fix(worker): ensure worker.evaluate rejects when page crashes

### DIFF
--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -69,8 +69,8 @@ export class ExecutionContext extends SdkObject {
     this.delegate = delegate;
   }
 
-  contextDestroyed(reason: string) {
-    this._contextDestroyedScope.close(new Error(reason));
+  contextDestroyed(reason: Error | string) {
+    this._contextDestroyedScope.close(reason instanceof Error ? reason : new Error(reason));
   }
 
   async raceAgainstContextDestroyed<T>(promise: Promise<T>): Promise<T> {

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -300,6 +300,7 @@ export class Page extends SdkObject<PageEventMap> {
     this.frameManager.dispose(error);
     this.screencast.dispose();
     this.overlay.dispose();
+    this.clearWorkers(error);
     this.openScope.close(error);
   }
 
@@ -874,9 +875,9 @@ export class Page extends SdkObject<PageEventMap> {
     this._workers.delete(workerId);
   }
 
-  clearWorkers() {
+  clearWorkers(error?: Error) {
     for (const [workerId, worker] of this._workers) {
-      worker.didClose();
+      worker.didClose(error);
       this._workers.delete(workerId);
     }
   }
@@ -1014,6 +1015,7 @@ export class Worker extends SdkObject<WorkerEventMap> {
       this.existingExecutionContext.contextDestroyed(errorMessage);
     this.existingExecutionContext = null;
     this._workerScriptLoaded = false;
+    this._executionContextPromise.reject(new Error(errorMessage));
     this._executionContextPromise = new ManualPromise<js.ExecutionContext>();
   }
 
@@ -1023,11 +1025,13 @@ export class Worker extends SdkObject<WorkerEventMap> {
       this._executionContextPromise.resolve(this.existingExecutionContext);
   }
 
-  didClose() {
+  didClose(error?: Error) {
+    const e = error || new Error('Worker closed');
     if (this.existingExecutionContext)
-      this.existingExecutionContext.contextDestroyed('Worker was closed');
+      this.existingExecutionContext.contextDestroyed(e);
+    this._executionContextPromise.reject(e);
     this.emit(Worker.Events.Close, this);
-    this.openScope.close(new Error('Worker closed'));
+    this.openScope.close(e);
   }
 
   async evaluateExpression(progress: Progress, expression: string, isFunction: boolean | undefined, arg: any): Promise<any> {

--- a/tests/library/page-event-crash.spec.ts
+++ b/tests/library/page-event-crash.spec.ts
@@ -106,7 +106,7 @@ test('should be able to close page after crash', async ({ page, crash }) => {
   expect(page.isClosed()).toBe(true);
 });
 
-test.fixme('should reject in-flight worker.evaluate when page crashes', async ({ page, crash, server }) => {
+test('should reject in-flight worker.evaluate when page crashes', async ({ page, crash, server }) => {
   await page.goto(server.EMPTY_PAGE);
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
@@ -116,5 +116,5 @@ test.fixme('should reject in-flight worker.evaluate when page crashes', async ({
   const evalPromise = worker.evaluate(() => new Promise(() => {})).catch((e: Error) => e); // never resolves in-worker
   crash();
   const error = await evalPromise as Error;
-  expect(error.message).toContain('crash');
+  expect(error.message).toMatch(/crash|closed/);
 });


### PR DESCRIPTION
Fixes an issue where `worker.evaluate()` promises would hang indefinitely instead of rejecting when the target page crashes.