### PR TITLE
fix(firefox): network instrumentation misses `WebSocket` handshakes in `Worker`

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -78,7 +78,11 @@ export class CRNetworkManager {
       sessionInfo.eventListeners.push(...[
         eventsHelper.addEventListener(session, 'Network.webSocketCreated', e => this._page!.frameManager.onWebSocketCreated(e.requestId, e.url)),
         eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', event => this._onWebSocketWillSendHandshakeRequest(event)),
-        eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page!.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, '\n'))),
+        eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page!.frameManager.onWebSocketResponse(e.requestId, {
+          status: e.response.status,
+          statusText: e.response.statusText,
+          headers: headersObjectToArray(e.response.headers, '\n'),
+        })),
         eventsHelper.addEventListener(session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page!.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
         eventsHelper.addEventListener(session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page!.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
         eventsHelper.addEventListener(session, 'Network.webSocketClosed', event => this._onWebSocketClosed(event)),
@@ -527,7 +531,10 @@ export class CRNetworkManager {
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.wallTime * 1000;
     this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
-    this._page!.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers, '\n'), wallTimeMs);
+    this._page!.frameManager.onWebSocketRequest(event.requestId, {
+      headers: headersObjectToArray(event.request.headers, '\n'),
+      wallTimeMs,
+    });
   }
 
   _onWebSocketClosed(event: Protocol.Network.webSocketClosedPayload) {

--- a/packages/playwright-core/src/server/firefox/ffPage.ts
+++ b/packages/playwright-core/src/server/firefox/ffPage.ts
@@ -150,25 +150,31 @@ export class FFPage implements PageDelegate {
       url.protocol = url.protocol === 'https' ? 'wss' : 'ws';
 
       this._page.frameManager.onWebSocketCreated(requestId, url.toString());
-      this._page.frameManager.onWebSocketRequest(requestId, request.headers);
-      this._page.frameManager.onWebSocketResponse(requestId, response.status, response.statusText, response.headers);
+      this._page.frameManager.onWebSocketRequest(requestId, request);
+      this._page.frameManager.onWebSocketResponse(requestId, response);
       this._page.frameManager.webSocketClosed(requestId);
       return;
     }
   }
 
   _onWebSocketOpened(event: Protocol.Page.webSocketOpenedPayload) {
+    const socketId = webSocketId(event.frameId, event.wsid);
     const request = this._webSocketRequests.get(event.requestId);
-    assert(request);
-
     const response = this._webSocketResponses.get(event.requestId);
-    assert(response);
+    // A `WebSocket` opened inside a worker is reported here, but its upgrade request is
+    // never seen by the network stack, so there is no handshake metadata to attach.
+    // TODO: Remove this workaround and make `requestData` required in `FrameManager.onWebSocketRequest`
+    // once Playwright's bundled Firefox includes https://phabricator.services.mozilla.com/D310690.
+    if (!request || !response) {
+      this._page.frameManager.onWebSocketRequest(socketId);
+      return;
+    }
 
     this._webSocketRequests.delete(event.requestId);
     this._webSocketResponses.delete(event.requestId);
 
-    this._page.frameManager.onWebSocketRequest(webSocketId(event.frameId, event.wsid), request.headers);
-    this._page.frameManager.onWebSocketResponse(webSocketId(event.frameId, event.wsid), response.status, response.statusText, response.headers);
+    this._page.frameManager.onWebSocketRequest(socketId, request);
+    this._page.frameManager.onWebSocketResponse(socketId, response);
   }
 
   _onWebSocketClosed(event: Protocol.Page.webSocketClosedPayload) {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -433,29 +433,30 @@ export class FrameManager {
     this._webSockets.set(requestId, ws);
   }
 
-  onWebSocketRequest(requestId: string, headers: types.HeadersArray, wallTimeMs?: number) {
+  onWebSocketRequest(requestId: string, requestData?: { headers: types.HeadersArray, wallTimeMs?: number }) {
     const ws = this._webSockets.get(requestId);
     if (!ws)
       return;
 
-    ws.setWallTimeMs(wallTimeMs);
+    ws.setWallTimeMs(requestData?.wallTimeMs);
 
     if (ws.markAsNotified()) {
       this._page.emit(Page.Events.WebSocket, ws);
       this._page.browserContext.emit(BrowserContext.Events.WebSocket, ws, this._page);
     }
 
-    ws.requestSent(headers);
+    if (requestData)
+      ws.requestSent(requestData.headers);
   }
 
-  onWebSocketResponse(requestId: string, status: number, statusText: string, headers: types.HeadersArray) {
+  onWebSocketResponse(requestId: string, responseData: { status: number, statusText: string, headers: types.HeadersArray }) {
     const ws = this._webSockets.get(requestId);
     if (!ws)
       return;
 
-    ws.responseReceived(status, statusText, headers);
-    if (status >= 400)
-      ws.error(`${statusText}: ${status}`);
+    ws.responseReceived(responseData.status, responseData.statusText, responseData.headers);
+    if (responseData.status >= 400)
+      ws.error(`${responseData.statusText}: ${responseData.status}`);
   }
 
   onWebSocketFrameSent(requestId: string, opcode: number, data: string, wallTimeMs: number) {

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -387,7 +387,11 @@ export class WVPage implements PageDelegate {
       eventsHelper.addEventListener(session, 'Network.loadingFailed', e => this._onLoadingFailed(session, e)),
       eventsHelper.addEventListener(session, 'Network.webSocketCreated', e => this._page.frameManager.onWebSocketCreated(e.requestId, e.url)),
       eventsHelper.addEventListener(session, 'Network.webSocketWillSendHandshakeRequest', event => this._onWebSocketWillSendHandshakeRequest(event)),
-      eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, ','))),
+      eventsHelper.addEventListener(session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, {
+        status: e.response.status,
+        statusText: e.response.statusText,
+        headers: headersObjectToArray(e.response.headers, ','),
+      })),
       eventsHelper.addEventListener(session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
       eventsHelper.addEventListener(session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
       eventsHelper.addEventListener(session, 'Network.webSocketClosed', event => this._onWebSocketClosed(event)),
@@ -1173,7 +1177,10 @@ export class WVPage implements PageDelegate {
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.walltime * 1000;
     this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
-    this._page.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers), wallTimeMs);
+    this._page.frameManager.onWebSocketRequest(event.requestId, {
+      headers: headersObjectToArray(event.request.headers),
+      wallTimeMs,
+    });
   }
 
   _onWebSocketClosed(event: Protocol.Network.webSocketClosedPayload) {

--- a/packages/playwright-core/src/server/webkit/wkPage.ts
+++ b/packages/playwright-core/src/server/webkit/wkPage.ts
@@ -398,7 +398,11 @@ export class WKPage implements PageDelegate {
       eventsHelper.addEventListener(this._session, 'Network.loadingFailed', e => this._onLoadingFailed(this._session, e)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketCreated', e => this._page.frameManager.onWebSocketCreated(e.requestId, e.url)),
       eventsHelper.addEventListener(this._session, 'Network.webSocketWillSendHandshakeRequest', event => this._onWebSocketWillSendHandshakeRequest(event)),
-      eventsHelper.addEventListener(this._session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, e.response.status, e.response.statusText, headersObjectToArray(e.response.headers, ',', wkSetCookieSeparator))),
+      eventsHelper.addEventListener(this._session, 'Network.webSocketHandshakeResponseReceived', e => this._page.frameManager.onWebSocketResponse(e.requestId, {
+        status: e.response.status,
+        statusText: e.response.statusText,
+        headers: headersObjectToArray(e.response.headers, ',', wkSetCookieSeparator),
+      })),
       eventsHelper.addEventListener(this._session, 'Network.webSocketFrameSent', e => e.response.payloadData && this._page.frameManager.onWebSocketFrameSent(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
       eventsHelper.addEventListener(this._session, 'Network.webSocketFrameReceived', e => e.response.payloadData && this._page.frameManager.webSocketFrameReceived(e.requestId, e.response.opcode, e.response.payloadData, this._timestampToWallTimeMsForWebSocket(e.requestId, e.timestamp))),
       eventsHelper.addEventListener(this._session, 'Network.webSocketClosed', event => this._onWebSocketClosed(event)),
@@ -1218,7 +1222,10 @@ export class WKPage implements PageDelegate {
   _onWebSocketWillSendHandshakeRequest(event: Protocol.Network.webSocketWillSendHandshakeRequestPayload) {
     const wallTimeMs = event.walltime * 1000;
     this._timestampBaselineForWebSocket.set(event.requestId, wallTimeMs - event.timestamp * 1000);
-    this._page.frameManager.onWebSocketRequest(event.requestId, headersObjectToArray(event.request.headers), wallTimeMs);
+    this._page.frameManager.onWebSocketRequest(event.requestId, {
+      headers: headersObjectToArray(event.request.headers),
+      wallTimeMs,
+    });
   }
 
   _onWebSocketClosed(event: Protocol.Network.webSocketClosedPayload) {

--- a/tests/library/web-socket.spec.ts
+++ b/tests/library/web-socket.spec.ts
@@ -197,6 +197,24 @@ it('should reject waitForEvent on page close', async ({ page, server }) => {
   expect((await error).message).toContain(kTargetClosedErrorMessage);
 });
 
+it('should not tear down the page when a WebSocket is opened inside a worker', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41742' },
+}, async ({ page, server }) => {
+  server.sendOnWebSocketConnection('incoming');
+  await page.goto(server.EMPTY_PAGE);
+  const received = await page.evaluate(host => {
+    const code = `
+      const ws = new WebSocket(${JSON.stringify('ws://' + host + '/ws')});
+      ws.addEventListener('message', event => self.postMessage(event.data));
+    `;
+    const worker = new Worker(URL.createObjectURL(new Blob([code], { type: 'text/javascript' })));
+    return new Promise(resolve => worker.addEventListener('message', event => resolve(event.data)));
+  }, server.HOST);
+  expect(received).toBe('incoming');
+  // Opening a `WebSocket` inside a worker must not tear down the page session.
+  expect(await page.evaluate(() => 1 + 1)).toBe(2);
+});
+
 it('should turn off when offline', async ({ page }) => {
   it.fixme();
 


### PR DESCRIPTION
this is being fixed upstream <https://phabricator.services.mozilla.com/D310690>

temporarily working around it for now as only HAR uses the request/response info (e.g. headers, status, etc.)

fixes <https://github.com/microsoft/playwright/issues/41742>