### PR TITLE
feat(html): add configurable groupBy for the HTML report

### DIFF
--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -244,6 +244,20 @@ export default defineConfig({
 });
 ```
 
+By default, tests are grouped into collapsible sections by the spec file they belong to. Use the `groupBy` option to
+change the default grouping of a generated report — for example, group by the top-level `test.describe` title. This is
+handy in monorepos where many tests share a single spec file but are wrapped in a `test.describe('@scope/<package>')`
+block. Each viewer can still change the grouping from the "Group by" control in the report UI, which overrides this
+default.
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [['html', { groupBy: 'suite' }]],
+});
+```
+
 A quick way of opening the last test run report is:
 
 ```bash
@@ -275,6 +289,7 @@ HTML report supports the following configuration options and environment variabl
 | `PLAYWRIGHT_HTML_NO_COPY_PROMPT` | `noCopyPrompt` | If true, disable rendering of the Copy prompt for errors. Supports `true`, `1`, `false`, and `0`. | `false`
 | `PLAYWRIGHT_HTML_NO_SNIPPETS` | `noSnippets` | If true, disable rendering code snippets in the action log. If there is a top level error, that report section with code snippet will still render. Supports `true`, `1`, `false`, and `0`. | `false`
 | `PLAYWRIGHT_HTML_DO_NOT_INLINE_ASSETS` | `doNotInlineAssets` | If true, JavaScript, CSS and report data are written as separate files alongside `index.html` instead of being embedded inline. Use this when serving the report under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) that disallows inline scripts and styles. Supports `true`, `1`, `false`, and `0`. | `false`
+| `PLAYWRIGHT_HTML_GROUP_BY` | `groupBy` | How tests are grouped into collapsible sections by default. One of `'file'`, `'suite'` (top-level `test.describe` title), `'project'` or `'tag'`. Each viewer can override this from the "Group by" control in the report UI. | `'file'`
 
 ### Blob reporter
 

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -26,7 +26,6 @@ import { filterWithQuery } from './filter';
 import { linkifyText } from '@web/renderUtils';
 import { Dialog } from '@web/shared/dialog';
 import { kThemeOptions, type Theme, useThemeSetting } from '@web/theme';
-import { useSetting } from '@web/uiUtils';
 
 export const HeaderView: React.FC<{
   title: string | undefined,
@@ -132,7 +131,6 @@ const SettingsButton: React.FC = () => {
   const settingsRef = React.useRef<HTMLDivElement>(null);
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [theme, setTheme] = useThemeSetting();
-  const [mergeFiles, setMergeFiles] = useSetting('mergeFiles', false);
 
   return <>
     <div
@@ -164,11 +162,6 @@ const SettingsButton: React.FC = () => {
             <option key={option.value} value={option.value}>{option.label}</option>
           ))}
         </select>
-      </label>
-
-      <label style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 }}>
-        <input type='checkbox' checked={mergeFiles} onChange={() => setMergeFiles(!mergeFiles)}></input>
-        Merge files
       </label>
     </Dialog>
   </>;

--- a/packages/html-reporter/src/reportView.tsx
+++ b/packages/html-reporter/src/reportView.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import type { FilteredStats, TestCase, TestCaseSummary, TestFile, TestFileSummary } from './types';
+import type { FilteredStats, GroupBy, TestCase, TestCaseSummary, TestFile, TestFileSummary } from './types';
 import * as React from 'react';
 import './colors.css';
 import './common.css';
@@ -54,7 +54,11 @@ export const ReportView: React.FC<{
   const [metadataVisible, setMetadataVisible] = React.useState(false);
   const [errorsVisible, setErrorsVisible] = React.useState(true);
   const speedboard = searchParams.has('speedboard');
-  const [mergeFiles] = useSetting('mergeFiles', false);
+  const configGroupBy = report?.json()?.options.groupBy ?? 'file';
+  const urlGroupBy = searchParams.get('groupBy') as GroupBy | null;
+  // Precedence: URL param > stored per-viewer setting > report config default.
+  const [storedGroupBy] = useSetting<GroupBy>('groupBy', configGroupBy);
+  const groupBy = urlGroupBy ?? storedGroupBy;
   const testId = searchParams.get('testId');
   const q = searchParams.get('q')?.toString() || '';
   const filterParam = q ? '&q=' + q : '';
@@ -74,10 +78,10 @@ export const ReportView: React.FC<{
   const testModel = React.useMemo(() => {
     if (speedboard)
       return createSpeedboardFilesModel(report, filter);
-    if (mergeFiles)
-      return createMergedFilesModel(report, filter);
+    if (groupBy !== 'file')
+      return createGroupedFilesModel(report, filter, groupBy);
     return createFilesModel(report, filter);
-  }, [report, filter, mergeFiles, speedboard]);
+  }, [report, filter, groupBy, speedboard]);
 
   const { prev, next } = React.useMemo(() => {
     const index = testModel.tests.findIndex(t => t.testId === testId);
@@ -242,26 +246,25 @@ function createFilesModel(report: LoadedReport | undefined, filter: Filter): Tes
   return result;
 }
 
-function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter): TestModelSummary {
+function createGroupedFilesModel(report: LoadedReport | undefined, filter: Filter, groupBy: Exclude<GroupBy, 'file'>): TestModelSummary {
   const groups: TestFileSummary[] = [];
   const groupMap = new Map<string, TestFileSummary>();
 
   for (const file of report?.json().files || []) {
     const tests = file.tests.filter(t => filter.matches(t));
     for (const test of tests) {
-      const describe = test.path[0] ?? '<anonymous>';
-      let group = groupMap.get(describe);
+      const { key, test: testCopy } = groupTest(test, groupBy);
+      let group = groupMap.get(key);
       if (!group) {
         group = {
-          fileId: describe,
-          fileName: describe,
+          fileId: key,
+          fileName: key,
           tests: [],
           stats: { total: 0, expected: 0, unexpected: 0, flaky: 0, skipped: 0, ok: true }
         };
-        groupMap.set(describe, group);
+        groupMap.set(key, group);
         groups.push(group);
       }
-      const testCopy = { ...test, path: test.path.slice(1) };
       group.tests.push(testCopy);
     }
   }
@@ -272,6 +275,18 @@ function createMergedFilesModel(report: LoadedReport | undefined, filter: Filter
   for (const group of groups)
     result.tests.push(...group.tests);
   return result;
+}
+
+function groupTest(test: TestCaseSummary, groupBy: Exclude<GroupBy, 'file'>): { key: string, test: TestCaseSummary } {
+  switch (groupBy) {
+    case 'suite':
+      // The first path segment is the top-level describe title, which becomes the group header.
+      return { key: test.path[0] ?? '<anonymous>', test: { ...test, path: test.path.slice(1) } };
+    case 'project':
+      return { key: test.projectName || '<no project>', test };
+    case 'tag':
+      return { key: test.tags[0] ?? '<no tag>', test };
+  }
 }
 
 function createSpeedboardFilesModel(report: LoadedReport | undefined, filter: Filter): TestModelSummary {

--- a/packages/html-reporter/src/testFileView.css
+++ b/packages/html-reporter/src/testFileView.css
@@ -86,6 +86,15 @@
   height: 0;
 }
 
+.group-by-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 10px;
+  color: var(--color-fg-muted);
+  white-space: nowrap;
+}
+
 .test-file-no-files {
   margin-top: 12px;
 

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import type { FilteredStats, HTMLReport, TestFileSummary } from './types';
+import type { FilteredStats, GroupBy, HTMLReport, TestFileSummary } from './types';
 import * as React from 'react';
 import { TestFileView } from './testFileView';
 import './testFileView.css';
@@ -25,7 +25,7 @@ import { CodeSnippet } from './testErrorView';
 import * as icons from './icons';
 import { isMetadataEmpty, MetadataView } from './metadataView';
 import { HeaderView } from './headerView';
-import { clsx } from '@web/uiUtils';
+import { clsx, useSetting } from '@web/uiUtils';
 
 export const TestFilesView: React.FC<{
   files: TestFileSummary[],
@@ -93,6 +93,7 @@ export const TestFilesHeader: React.FC<{
   </div>;
 
   const rightSuperHeader = <>
+    <GroupByControl report={report} />
     <div data-testid='overall-time' style={{ marginRight: '10px' }}>{report ? new Date(report.startTime).toLocaleString() : ''}</div>
     <div data-testid='overall-duration'>Total time: {msToString(report.duration ?? 0)}</div>
   </>;
@@ -105,4 +106,21 @@ export const TestFilesHeader: React.FC<{
       {report.errors.map((error, index) => <CodeSnippet key={'test-report-error-message-' + index} code={error}/>)}
     </Chip>}
   </>;
+};
+
+const groupByOptions: { value: GroupBy, label: string }[] = [
+  { value: 'file', label: 'File' },
+  { value: 'suite', label: 'Suite' },
+  { value: 'project', label: 'Project' },
+  { value: 'tag', label: 'Tag' },
+];
+
+const GroupByControl: React.FC<{ report: HTMLReport }> = ({ report }) => {
+  const [groupBy, setGroupBy] = useSetting<GroupBy>('groupBy', report.options.groupBy ?? 'file');
+  return <label className='group-by-control' title='Group tests by'>
+    Group by:
+    <select data-testid='group-by-select' value={groupBy} onChange={e => setGroupBy(e.target.value as GroupBy)}>
+      {groupByOptions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+    </select>
+  </label>;
 };

--- a/packages/html-reporter/src/types.d.ts
+++ b/packages/html-reporter/src/types.d.ts
@@ -36,10 +36,13 @@ export type Location = {
   column: number;
 };
 
+export type GroupBy = 'file' | 'suite' | 'project' | 'tag';
+
 export type HTMLReportOptions = {
   title?: string;
   noCopyPrompt?: boolean;
   noSnippets?: boolean;
+  groupBy?: GroupBy;
 };
 
 export type HTMLReport = {

--- a/packages/playwright/src/reporters/html.ts
+++ b/packages/playwright/src/reporters/html.ts
@@ -162,6 +162,7 @@ class HtmlReporter implements ReporterV2 {
       title: process.env.PLAYWRIGHT_HTML_TITLE || this._options.title,
       noSnippets,
       noCopyPrompt,
+      groupBy: (process.env.PLAYWRIGHT_HTML_GROUP_BY as HTMLReportOptions['groupBy']) || this._options.groupBy,
     });
     this._buildResult = await builder.build(this.config.metadata, projectSuites, result, this._topLevelErrors, this._machines);
   }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -32,6 +32,16 @@ export type HtmlReporterOptions = {
   noSnippets?: boolean;
   noCopyPrompt?: boolean;
   doNotInlineAssets?: boolean;
+
+  /**
+   * How the tests are grouped into collapsible sections in the report. Each viewer can still override this from the
+   * "Group by" control in the report UI.
+   * - `'file'` (default) - group by the spec file the test belongs to.
+   * - `'suite'` - group by the top-level `test.describe` title.
+   * - `'project'` - group by the project name.
+   * - `'tag'` - group by the test tag.
+   */
+  groupBy?: 'file' | 'suite' | 'project' | 'tag';
 };
 
 export type ReporterDescription = Readonly<
@@ -10706,4 +10716,3 @@ interface TestConfigWebServer {
    */
   url?: string;
 }
-

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3506,7 +3506,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
   });
 }
 
-test('should support merge files option', async ({ runInlineTest, showReport, page }) => {
+test('should group tests by suite via the Group by control', async ({ runInlineTest, showReport, page }) => {
   await runInlineTest({
     'a.test.js': `
       import { test, expect } from '@playwright/test';
@@ -3525,8 +3525,11 @@ test('should support merge files option', async ({ runInlineTest, showReport, pa
 
   await showReport();
 
-  await page.getByRole('button', { name: 'Settings' }).click();
-  await page.getByRole('checkbox', { name: 'Merge files' }).click();
+  // Default groups by file.
+  await expect(page.getByRole('button', { name: 'a.test.js' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'b.test.js' })).toBeVisible();
+
+  await page.getByTestId('group-by-select').selectOption('suite');
 
   await expect(page).toMatchAriaSnapshot(`
     - button "<anonymous>" [expanded]
@@ -3545,6 +3548,72 @@ test('should support merge files option', async ({ runInlineTest, showReport, pa
           - link "test 3"
           - link "b.test.js:4"
   `);
+});
+
+test('should group tests by suite via config option', async ({ runInlineTest, showReport, page }) => {
+  await runInlineTest({
+    'playwright.config.js': `
+      module.exports = {
+        reporter: [['dot'], ['html', { groupBy: 'suite' }]],
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.describe('describe', () => {
+        test('test 1', async ({}) => {});
+      });
+      test('test 2', async ({}) => {});
+    `,
+    'b.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.describe('describe', () => {
+        test('test 3', async ({}) => {});
+      });
+    `,
+  }, {}, { PLAYWRIGHT_HTML_OPEN: 'never' });
+
+  await showReport();
+
+  await expect(page).toMatchAriaSnapshot(`
+    - button "<anonymous>" [expanded]
+    - region:
+      - list:
+        - listitem:
+          - link "test 2"
+          - link "a.test.js:6"
+    - button "describe" [expanded]
+    - region:
+      - list:
+        - listitem:
+          - link "test 1"
+          - link "a.test.js:4"
+        - listitem:
+          - link "test 3"
+          - link "b.test.js:4"
+  `);
+});
+
+test('should group tests by file by default', async ({ runInlineTest, showReport, page }) => {
+  await runInlineTest({
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.describe('describe', () => {
+        test('test 1', async ({}) => {});
+      });
+    `,
+    'b.test.js': `
+      import { test, expect } from '@playwright/test';
+      test.describe('describe', () => {
+        test('test 3', async ({}) => {});
+      });
+    `,
+  }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+
+  await showReport();
+
+  await expect(page.getByRole('button', { name: 'a.test.js' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'b.test.js' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'describe', exact: true })).toHaveCount(0);
 });
 
 test.describe('show-report .zip support', () => {


### PR DESCRIPTION
In a monorepo we generate hundreds of tests inside one shared spec file, each wrapped in `test.describe('@scope/<package>')`. In the merged HTML report every test collapses under that single file header, so you can't tell which package a failure belongs to. The grouping I want already exists — it's the hidden `mergeFiles` localStorage toggle from #38870 — but it's per-viewer, can't be shared via link, and can't be baked into a CI-published report.

This promotes that capability to a supported, configurable feature.

## What
- New `groupBy` option on the `html` reporter: `'file'` (default), `'suite'`, `'project'`, `'tag'`. Threaded into the report JSON via `HTMLReportOptions` (plus a `PLAYWRIGHT_HTML_GROUP_BY` env override).
- Visible "Group by" control in the report header, replacing the hidden `mergeFiles` setting.
- Precedence: `?groupBy=` URL param > per-viewer setting > config default > `'file'`.
- Generalized the old `createMergedFilesModel` into one `groupBy`-driven grouping function.

## Why
CI-published reports can now open already grouped by describe/project/tag, and a grouping can be deep-linked. Default stays `'file'`, so existing reports and blob merge-reports render exactly as before.

Closes #41761
