### PR TITLE
fix(fetch): use case-insensitive host header lookup on redirect

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -461,9 +461,7 @@ export abstract class APIRequestContext extends SdkObject {
               return;
             }
 
-            const hostKey = Object.keys(headers).find(k => k.toLowerCase() === 'host');
-            if (hostKey)
-              headers[hostKey] = locationURL.host;
+            setHeader(headers, 'host', locationURL.host);
 
             // Drop credentials scoped to the original origin on cross-origin redirects.
             if (locationURL.origin !== url.origin)

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -461,8 +461,9 @@ export abstract class APIRequestContext extends SdkObject {
               return;
             }
 
-            if (headers['host'])
-              headers['host'] = locationURL.host;
+            const hostKey = Object.keys(headers).find(k => k.toLowerCase() === 'host');
+            if (hostKey)
+              headers[hostKey] = locationURL.host;
 
             // Drop credentials scoped to the original origin on cross-origin redirects.
             if (locationURL.origin !== url.origin)

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1386,7 +1386,7 @@ it('should update host header on redirect', async ({ context, server }) => {
   });
   const reqPromise = server.waitForRequest('/test');
   const response = await context.request.get(server.PREFIX + '/redirect', {
-    headers: { host: new URL(server.PREFIX).host }
+    headers: { HosT: new URL(server.PREFIX).host }
   });
   expect(redirectCount).toBe(2);
   await expect(response).toBeOK();


### PR DESCRIPTION
## Summary

The redirect host header update used \headers['host']\ (lowercase only), but \setHeader()\ preserves the original casing of header names. If \extraHTTPHeaders\ set \'Host'\ (capital H), the host was never updated on redirect, causing the request to be sent with the original origin's Host header.

Now uses case-insensitive lookup (\Object.keys().find()\), consistent with \setHeader\, \getHeader\, and \emoveHeader\ in the same file.

Fixes: https://github.com/microsoft/playwright/issues/41766