### PR TITLE
fix(video): avoid MJPEG interlace inference

### DIFF
--- a/packages/playwright-core/src/server/ebml.ts
+++ b/packages/playwright-core/src/server/ebml.ts
@@ -90,7 +90,7 @@ function element(id: Buffer, payload: Buffer): Buffer {
 
 // Emits the Matroska header: EBML head, an unknown-size (streaming) Segment, stream Info with a
 // 1ms timestamp scale, and a single MJPEG video track. Frames follow as Clusters via writeClusterHeader.
-export function writeHeader(width: number, height: number): Buffer {
+export function writeHeader(): Buffer {
   const ebml = element(kEBML, Buffer.concat([
     element(kEBMLVersion, uint(1)),
     element(kEBMLReadVersion, uint(1)),
@@ -112,11 +112,12 @@ export function writeHeader(width: number, height: number): Buffer {
     element(kTrackType, uint(1)), // 1 = video.
     element(kFlagLacing, uint(0)),
     element(kCodecID, Buffer.from('V_MJPEG')),
-    // PixelWidth/PixelHeight describe the input JPEG frames. The output video filters normalize
-    // them to the requested recording size.
+    // PixelWidth/PixelHeight are mandatory, but the actual JPEG dimensions are not known yet.
+    // A larger placeholder can make ffmpeg mistake a short progressive JPEG for an interlaced
+    // field, so use 1x1 and let the MJPEG decoder read the real dimensions from each frame.
     element(kVideo, Buffer.concat([
-      element(kPixelWidth, uint(width)),
-      element(kPixelHeight, uint(height)),
+      element(kPixelWidth, uint(1)),
+      element(kPixelHeight, uint(1)),
     ])),
   ]));
   const tracks = element(kTracks, track);

--- a/packages/playwright-core/src/server/ebml.ts
+++ b/packages/playwright-core/src/server/ebml.ts
@@ -112,8 +112,8 @@ export function writeHeader(width: number, height: number): Buffer {
     element(kTrackType, uint(1)), // 1 = video.
     element(kFlagLacing, uint(0)),
     element(kCodecID, Buffer.from('V_MJPEG')),
-    // PixelWidth/PixelHeight are advisory: ffmpeg's mjpeg decoder uses the dimensions encoded in
-    // each JPEG frame, and the output video filters normalize to the requested size.
+    // PixelWidth/PixelHeight describe the input JPEG frames. The output video filters normalize
+    // them to the requested recording size.
     element(kVideo, Buffer.concat([
       element(kPixelWidth, uint(width)),
       element(kPixelHeight, uint(height)),

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -108,6 +108,9 @@ class FfmpegVideoRecorder {
   private _ffmpegPath: string;
   private _launchPromise: Promise<Error | null>;
   private _outputFile: string;
+  private _frameDiagnostics: string[] = [];
+  private _receivedFrameCount = 0;
+  private _emittedFrameCount = 0;
 
   constructor(ffmpegPath: string, size: types.Size, outputFile: string, page: PageDelegate) {
     if (!outputFile.endsWith('.webm'))
@@ -185,7 +188,7 @@ class FfmpegVideoRecorder {
       onExit: (exitCode, signal) => {
         const message = `ffmpeg onkill exitCode=${exitCode} signal=${signal}`;
         ffmpegLogs.push(message);
-        fs.writeFileSync(this._outputFile + '.ffmpeg.log', ffmpegLogs.join('\n'));
+        fs.writeFileSync(this._outputFile + '.ffmpeg.log', [...this._frameDiagnostics, '', ...ffmpegLogs].join('\n'));
         debugLogger.log('browser', message);
       },
     });
@@ -213,6 +216,7 @@ class FfmpegVideoRecorder {
     if (this._isStopped)
       return;
 
+    this._frameDiagnostics.push(`received[${this._receivedFrameCount++}] timestamp=${timestamp} ${describeFrame(frame)}`);
     if (!this._firstFrameTimestamp)
       this._firstFrameTimestamp = timestamp;
 
@@ -226,6 +230,7 @@ class FfmpegVideoRecorder {
 
   private _emitFrame(frame: Buffer, frameNumber: number) {
     const timestampMs = Math.max(0, Math.round(frameNumber * 1000 / fps));
+    this._frameDiagnostics.push(`emitted[${this._emittedFrameCount++}] frameNumber=${frameNumber} timestampMs=${timestampMs} ${describeFrame(frame)}`);
     this._process!.stdin!.write(writeClusterHeader(timestampMs, frame.length));
     this._process!.stdin!.write(frame);
   }
@@ -260,4 +265,36 @@ class FfmpegVideoRecorder {
 function createWhiteImage(width: number, height: number): Buffer {
   const data = Buffer.alloc(width * height * 4, 255);
   return jpegjs.encode({ data, width, height }, 80).data;
+}
+
+function describeFrame(frame: Buffer): string {
+  let dimensions = 'not-jpeg';
+  if (frame.length >= 4 && frame[0] === 0xff && frame[1] === 0xd8) {
+    dimensions = 'unknown';
+    let offset = 2;
+    while (offset + 4 <= frame.length) {
+      while (frame[offset] === 0xff)
+        ++offset;
+      const marker = frame[offset++];
+      if (marker === 0xd9 || marker === 0xda)
+        break;
+      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7))
+        continue;
+      if (offset + 2 > frame.length)
+        break;
+      const segmentLength = frame.readUInt16BE(offset);
+      const isStartOfFrame = (marker >= 0xc0 && marker <= 0xc3) ||
+        (marker >= 0xc5 && marker <= 0xc7) ||
+        (marker >= 0xc9 && marker <= 0xcb) ||
+        (marker >= 0xcd && marker <= 0xcf);
+      if (isStartOfFrame && offset + 7 <= frame.length) {
+        dimensions = `${frame.readUInt16BE(offset + 5)}x${frame.readUInt16BE(offset + 3)}`;
+        break;
+      }
+      if (segmentLength < 2)
+        break;
+      offset += segmentLength;
+    }
+  }
+  return `bytes=${frame.length} dimensions=${dimensions} prefix=${frame.subarray(0, 8).toString('hex')} suffix=${frame.subarray(-8).toString('hex')}`;
 }

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import path from 'path';
 
 import jpegjs from 'jpeg-js';
@@ -166,19 +167,26 @@ class FfmpegVideoRecorder {
     const videoFilterArgs = page.getFFmpegVideoFilterArgs?.({ width: w, height: h }) ?? `pad=${w}:${h}:0:0:gray,crop=${w}:${h}:0:0`;
     const args = `-loglevel error -f matroska -fpsprobesize 0 -probesize 32 -analyzeduration 0 -i pipe:0 -y -an -r ${fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -speed 8 -b:v 1M -threads 1 -vf ${videoFilterArgs}`.split(' ');
     args.push(this._outputFile);
+    const ffmpegLogs: string[] = [];
 
     const { launchedProcess, gracefullyClose } = await launchProcess({
       command: this._ffmpegPath,
       args,
       stdio: 'stdin',
-      log: (message: string) => debugLogger.log('browser', message),
+      log: (message: string) => {
+        ffmpegLogs.push(message);
+        debugLogger.log('browser', message);
+      },
       tempDirectories: [],
       attemptToGracefullyClose: async () => {
         debugLogger.log('browser', 'Closing stdin...');
         launchedProcess.stdin!.end();
       },
       onExit: (exitCode, signal) => {
-        debugLogger.log('browser', `ffmpeg onkill exitCode=${exitCode} signal=${signal}`);
+        const message = `ffmpeg onkill exitCode=${exitCode} signal=${signal}`;
+        ffmpegLogs.push(message);
+        fs.writeFileSync(this._outputFile + '.ffmpeg.log', ffmpegLogs.join('\n'));
+        debugLogger.log('browser', message);
       },
     });
     launchedProcess.stdin!.on('finish', () => {

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -107,7 +107,6 @@ class FfmpegVideoRecorder {
   private _ffmpegPath: string;
   private _launchPromise: Promise<Error | null>;
   private _outputFile: string;
-  private _headerWritten = false;
 
   constructor(ffmpegPath: string, size: types.Size, outputFile: string, page: PageDelegate) {
     if (!outputFile.endsWith('.webm'))
@@ -190,6 +189,7 @@ class FfmpegVideoRecorder {
     });
     this._process = launchedProcess;
     this._gracefullyClose = gracefullyClose;
+    launchedProcess.stdin!.write(writeHeader());
   }
 
   writeFrame(frame: Buffer, timestamp: number) {
@@ -218,13 +218,6 @@ class FfmpegVideoRecorder {
 
   private _emitFrame(frame: Buffer, frameNumber: number) {
     const timestampMs = Math.max(0, Math.round(frameNumber * 1000 / fps));
-    if (!this._headerWritten) {
-      // Matroska dimensions initialize ffmpeg's MJPEG decoder. Describing a substantially taller
-      // frame makes ffmpeg mistake the first progressive JPEG for one field of an interlaced frame.
-      const frameSize = jpegSize(frame) ?? this._size;
-      this._process!.stdin!.write(writeHeader(frameSize.width, frameSize.height));
-      this._headerWritten = true;
-    }
     this._process!.stdin!.write(writeClusterHeader(timestampMs, frame.length));
     this._process!.stdin!.write(frame);
   }
@@ -259,34 +252,4 @@ class FfmpegVideoRecorder {
 function createWhiteImage(width: number, height: number): Buffer {
   const data = Buffer.alloc(width * height * 4, 255);
   return jpegjs.encode({ data, width, height }, 80).data;
-}
-
-function jpegSize(frame: Buffer): types.Size | undefined {
-  if (frame.length < 4 || frame[0] !== 0xff || frame[1] !== 0xd8)
-    return;
-  let offset = 2;
-  while (offset + 4 <= frame.length) {
-    while (frame[offset] === 0xff)
-      ++offset;
-    const marker = frame[offset++];
-    if (marker === 0xd9 || marker === 0xda)
-      return;
-    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7))
-      continue;
-    if (offset + 2 > frame.length)
-      return;
-    const segmentLength = frame.readUInt16BE(offset);
-    if (segmentLength < 2 || offset + segmentLength > frame.length)
-      return;
-    const isStartOfFrame = (marker >= 0xc0 && marker <= 0xc3) ||
-      (marker >= 0xc5 && marker <= 0xc7) ||
-      (marker >= 0xc9 && marker <= 0xcb) ||
-      (marker >= 0xcd && marker <= 0xcf);
-    if (isStartOfFrame && segmentLength >= 7) {
-      const width = frame.readUInt16BE(offset + 5);
-      const height = frame.readUInt16BE(offset + 3);
-      return width && height ? { width, height } : undefined;
-    }
-    offset += segmentLength;
-  }
 }

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import path from 'path';
 
 import jpegjs from 'jpeg-js';
@@ -108,9 +107,7 @@ class FfmpegVideoRecorder {
   private _ffmpegPath: string;
   private _launchPromise: Promise<Error | null>;
   private _outputFile: string;
-  private _frameDiagnostics: string[] = [];
-  private _receivedFrameCount = 0;
-  private _emittedFrameCount = 0;
+  private _headerWritten = false;
 
   constructor(ffmpegPath: string, size: types.Size, outputFile: string, page: PageDelegate) {
     if (!outputFile.endsWith('.webm'))
@@ -170,26 +167,19 @@ class FfmpegVideoRecorder {
     const videoFilterArgs = page.getFFmpegVideoFilterArgs?.({ width: w, height: h }) ?? `pad=${w}:${h}:0:0:gray,crop=${w}:${h}:0:0`;
     const args = `-loglevel error -f matroska -fpsprobesize 0 -probesize 32 -analyzeduration 0 -i pipe:0 -y -an -r ${fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -speed 8 -b:v 1M -threads 1 -vf ${videoFilterArgs}`.split(' ');
     args.push(this._outputFile);
-    const ffmpegLogs: string[] = [];
 
     const { launchedProcess, gracefullyClose } = await launchProcess({
       command: this._ffmpegPath,
       args,
       stdio: 'stdin',
-      log: (message: string) => {
-        ffmpegLogs.push(message);
-        debugLogger.log('browser', message);
-      },
+      log: (message: string) => debugLogger.log('browser', message),
       tempDirectories: [],
       attemptToGracefullyClose: async () => {
         debugLogger.log('browser', 'Closing stdin...');
         launchedProcess.stdin!.end();
       },
       onExit: (exitCode, signal) => {
-        const message = `ffmpeg onkill exitCode=${exitCode} signal=${signal}`;
-        ffmpegLogs.push(message);
-        fs.writeFileSync(this._outputFile + '.ffmpeg.log', [...this._frameDiagnostics, '', ...ffmpegLogs].join('\n'));
-        debugLogger.log('browser', message);
+        debugLogger.log('browser', `ffmpeg onkill exitCode=${exitCode} signal=${signal}`);
       },
     });
     launchedProcess.stdin!.on('finish', () => {
@@ -200,7 +190,6 @@ class FfmpegVideoRecorder {
     });
     this._process = launchedProcess;
     this._gracefullyClose = gracefullyClose;
-    launchedProcess.stdin!.write(writeHeader(w, h));
   }
 
   writeFrame(frame: Buffer, timestamp: number) {
@@ -216,7 +205,6 @@ class FfmpegVideoRecorder {
     if (this._isStopped)
       return;
 
-    this._frameDiagnostics.push(`received[${this._receivedFrameCount++}] timestamp=${timestamp} ${describeFrame(frame)}`);
     if (!this._firstFrameTimestamp)
       this._firstFrameTimestamp = timestamp;
 
@@ -230,7 +218,13 @@ class FfmpegVideoRecorder {
 
   private _emitFrame(frame: Buffer, frameNumber: number) {
     const timestampMs = Math.max(0, Math.round(frameNumber * 1000 / fps));
-    this._frameDiagnostics.push(`emitted[${this._emittedFrameCount++}] frameNumber=${frameNumber} timestampMs=${timestampMs} ${describeFrame(frame)}`);
+    if (!this._headerWritten) {
+      // Matroska dimensions initialize ffmpeg's MJPEG decoder. Describing a substantially taller
+      // frame makes ffmpeg mistake the first progressive JPEG for one field of an interlaced frame.
+      const frameSize = jpegSize(frame) ?? this._size;
+      this._process!.stdin!.write(writeHeader(frameSize.width, frameSize.height));
+      this._headerWritten = true;
+    }
     this._process!.stdin!.write(writeClusterHeader(timestampMs, frame.length));
     this._process!.stdin!.write(frame);
   }
@@ -267,34 +261,32 @@ function createWhiteImage(width: number, height: number): Buffer {
   return jpegjs.encode({ data, width, height }, 80).data;
 }
 
-function describeFrame(frame: Buffer): string {
-  let dimensions = 'not-jpeg';
-  if (frame.length >= 4 && frame[0] === 0xff && frame[1] === 0xd8) {
-    dimensions = 'unknown';
-    let offset = 2;
-    while (offset + 4 <= frame.length) {
-      while (frame[offset] === 0xff)
-        ++offset;
-      const marker = frame[offset++];
-      if (marker === 0xd9 || marker === 0xda)
-        break;
-      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7))
-        continue;
-      if (offset + 2 > frame.length)
-        break;
-      const segmentLength = frame.readUInt16BE(offset);
-      const isStartOfFrame = (marker >= 0xc0 && marker <= 0xc3) ||
-        (marker >= 0xc5 && marker <= 0xc7) ||
-        (marker >= 0xc9 && marker <= 0xcb) ||
-        (marker >= 0xcd && marker <= 0xcf);
-      if (isStartOfFrame && offset + 7 <= frame.length) {
-        dimensions = `${frame.readUInt16BE(offset + 5)}x${frame.readUInt16BE(offset + 3)}`;
-        break;
-      }
-      if (segmentLength < 2)
-        break;
-      offset += segmentLength;
+function jpegSize(frame: Buffer): types.Size | undefined {
+  if (frame.length < 4 || frame[0] !== 0xff || frame[1] !== 0xd8)
+    return;
+  let offset = 2;
+  while (offset + 4 <= frame.length) {
+    while (frame[offset] === 0xff)
+      ++offset;
+    const marker = frame[offset++];
+    if (marker === 0xd9 || marker === 0xda)
+      return;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7))
+      continue;
+    if (offset + 2 > frame.length)
+      return;
+    const segmentLength = frame.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > frame.length)
+      return;
+    const isStartOfFrame = (marker >= 0xc0 && marker <= 0xc3) ||
+      (marker >= 0xc5 && marker <= 0xc7) ||
+      (marker >= 0xc9 && marker <= 0xcb) ||
+      (marker >= 0xcd && marker <= 0xcf);
+    if (isStartOfFrame && segmentLength >= 7) {
+      const width = frame.readUInt16BE(offset + 5);
+      const height = frame.readUInt16BE(offset + 3);
+      return width && height ? { width, height } : undefined;
     }
+    offset += segmentLength;
   }
-  return `bytes=${frame.length} dimensions=${dimensions} prefix=${frame.subarray(0, 8).toString('hex')} suffix=${frame.subarray(-8).toString('hex')}`;
 }

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -468,6 +468,15 @@ it.describe('screencast', () => {
     await context.close();
 
     const videoFile = await page.video().path();
+    const videoBuffer = fs.readFileSync(videoFile);
+    await testInfo.attach('recorded-video', { path: videoFile, contentType: 'video/webm' });
+    await testInfo.attach('recorded-video-metadata', {
+      body: Buffer.from(JSON.stringify({
+        size: videoBuffer.length,
+        prefix: videoBuffer.subarray(0, 64).toString('hex'),
+      })),
+      contentType: 'application/json',
+    });
     const videoPlayer = new VideoPlayer(videoFile);
     expect(videoPlayer.videoWidth).toBe(800);
     expect(videoPlayer.videoHeight).toBe(600);

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -130,6 +130,25 @@ it.describe('screencast', () => {
     expectRedFrames(videoFile, size);
   });
 
+  it('should pad a short frame to the video size', async ({ browser }, testInfo) => {
+    const videoSize = { width: 800, height: 600 };
+    const context = await browser.newContext({
+      recordVideo: {
+        dir: testInfo.outputPath(''),
+        size: videoSize,
+      },
+      viewport: { width: 800, height: 396 },
+    });
+    const page = await context.newPage();
+    await ensureSomeFrames(page);
+    await context.close();
+
+    const videoFile = await page.video().path();
+    const videoPlayer = new VideoPlayer(videoFile);
+    expect(videoPlayer.videoWidth).toBe(videoSize.width);
+    expect(videoPlayer.videoHeight).toBe(videoSize.height);
+  });
+
   it('should continue recording main page after popup closes', async ({ browser, browserName }, testInfo) => {
     it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30837' });
     // Firefox does not have a mobile variant and has a large minimum size (500 on windows and 450 elsewhere).
@@ -468,16 +487,6 @@ it.describe('screencast', () => {
     await context.close();
 
     const videoFile = await page.video().path();
-    const videoBuffer = fs.readFileSync(videoFile);
-    await testInfo.attach('recorded-video', { path: videoFile, contentType: 'video/webm' });
-    await testInfo.attach('producer-ffmpeg-log', { path: videoFile + '.ffmpeg.log', contentType: 'text/plain' });
-    await testInfo.attach('recorded-video-metadata', {
-      body: Buffer.from(JSON.stringify({
-        size: videoBuffer.length,
-        prefix: videoBuffer.subarray(0, 64).toString('hex'),
-      })),
-      contentType: 'application/json',
-    });
     const videoPlayer = new VideoPlayer(videoFile);
     expect(videoPlayer.videoWidth).toBe(800);
     expect(videoPlayer.videoHeight).toBe(600);

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -470,6 +470,7 @@ it.describe('screencast', () => {
     const videoFile = await page.video().path();
     const videoBuffer = fs.readFileSync(videoFile);
     await testInfo.attach('recorded-video', { path: videoFile, contentType: 'video/webm' });
+    await testInfo.attach('producer-ffmpeg-log', { path: videoFile + '.ffmpeg.log', contentType: 'text/plain' });
     await testInfo.attach('recorded-video-metadata', {
       body: Buffer.from(JSON.stringify({
         size: videoBuffer.length,


### PR DESCRIPTION
This fixes recordings occasionally becoming empty after the Matroska input change.

The internal Matroska track advertised the requested output size. If the first JPEG was less than three quarters of that height - for example, `800x396` into `800x600` - FFmpeg's MJPEG decoder treated it as a single interlaced field, doubled it to `800x792`, and then rejected it in `pad=800:600`.

The Matroska stream is only an internal pipe into FFmpeg. It now advertises the mandatory track dimensions as `1x1`, allowing the MJPEG decoder to derive each frame's real dimensions from the JPEG. The output filter still produces the requested recording size.

Also adds a regression test for the `800x396` to `800x600` case.