### PR TITLE
fix(test runner): keep project suites in config order

### DIFF
--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -224,10 +224,10 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
       else
         topLevelProjects.push(project);
     }
-    // Keep project suites in the order they are declared in the config.
-    const suiteByProject = new Map(rootSuite.suites.map(suite => [suite._fullProject, suite]));
-    rootSuite._entries = config.projects.map(project => suiteByProject.get(project)).filter(suite => suite !== undefined);
   }
+
+  // Keep project suites in the order they are declared in the config.
+  rootSuite._entries.sort((a, b) => config.projects.indexOf((a as testNs.Suite)._fullProject!) - config.projects.indexOf((b as testNs.Suite)._fullProject!));
 
   testRun.rootSuite = rootSuite;
   testRun.topLevelProjects = topLevelProjects;

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -220,10 +220,13 @@ export async function createRootSuite(testRun: TestRun, errors: TestError[], sho
     const finalProjectClosure = buildProjectsClosure(rootSuite.suites.map(suite => suite._fullProject!));
     for (const [project, type] of finalProjectClosure) {
       if (type === 'dependency')
-        rootSuite._prependSuite(dependencySuites.get(project)!);
+        rootSuite._addSuite(dependencySuites.get(project)!);
       else
         topLevelProjects.push(project);
     }
+    // Keep project suites in the order they are declared in the config.
+    const suiteByProject = new Map(rootSuite.suites.map(suite => [suite._fullProject, suite]));
+    rootSuite._entries = config.projects.map(project => suiteByProject.get(project)).filter(suite => suite !== undefined);
   }
 
   testRun.rootSuite = rootSuite;

--- a/tests/playwright-test/list-mode.spec.ts
+++ b/tests/playwright-test/list-mode.spec.ts
@@ -197,37 +197,6 @@ test('should report errors with location', async ({ runInlineTest }) => {
   });
 });
 
-test('should list projects in config order', async ({ runInlineTest }) => {
-  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41779' });
-  const result = await runInlineTest({
-    'playwright.config.ts': `
-      module.exports = { projects: [
-        { name: 'dev-setup', testMatch: /setup.js/ },
-        { name: 'dev', dependencies: ['dev-setup'], testMatch: /a.test.js/ },
-        { name: 'staging-setup', testMatch: /setup.js/ },
-        { name: 'staging', dependencies: ['staging-setup'], testMatch: /a.test.js/ },
-      ] };
-    `,
-    'setup.js': `
-      const { test, expect } = require('@playwright/test');
-      test('setup', async ({}) => {});
-    `,
-    'a.test.js': `
-      const { test, expect } = require('@playwright/test');
-      test('example', async ({}) => {});
-    `
-  }, { 'list': true });
-  expect(result.exitCode).toBe(0);
-  expect(result.output).toContain([
-    `Listing tests:`,
-    `  [dev-setup] › setup.js:3:7 › setup`,
-    `  [dev] › a.test.js:3:7 › example`,
-    `  [staging-setup] › setup.js:3:7 › setup`,
-    `  [staging] › a.test.js:3:7 › example`,
-    `Total: 4 tests in 2 files`
-  ].join('\n'));
-});
-
 test('should list tests once', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27087' });
   const result = await runInlineTest({

--- a/tests/playwright-test/list-mode.spec.ts
+++ b/tests/playwright-test/list-mode.spec.ts
@@ -197,6 +197,37 @@ test('should report errors with location', async ({ runInlineTest }) => {
   });
 });
 
+test('should list projects in config order', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41779' });
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { projects: [
+        { name: 'dev-setup', testMatch: /setup.js/ },
+        { name: 'dev', dependencies: ['dev-setup'], testMatch: /a.test.js/ },
+        { name: 'staging-setup', testMatch: /setup.js/ },
+        { name: 'staging', dependencies: ['staging-setup'], testMatch: /a.test.js/ },
+      ] };
+    `,
+    'setup.js': `
+      const { test, expect } = require('@playwright/test');
+      test('setup', async ({}) => {});
+    `,
+    'a.test.js': `
+      const { test, expect } = require('@playwright/test');
+      test('example', async ({}) => {});
+    `
+  }, { 'list': true });
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain([
+    `Listing tests:`,
+    `  [dev-setup] › setup.js:3:7 › setup`,
+    `  [dev] › a.test.js:3:7 › example`,
+    `  [staging-setup] › setup.js:3:7 › setup`,
+    `  [staging] › a.test.js:3:7 › example`,
+    `Total: 4 tests in 2 files`
+  ].join('\n'));
+});
+
 test('should list tests once', async ({ runInlineTest }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/27087' });
   const result = await runInlineTest({

--- a/tests/playwright-test/ui-mode-test-filters.spec.ts
+++ b/tests/playwright-test/ui-mode-test-filters.spec.ts
@@ -175,6 +175,32 @@ test('should filter by project', async ({ runUITest }) => {
   await expect(page.getByText('Projects: foo bar')).toBeVisible();
 });
 
+test('should list projects in config order', async ({ runUITest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41779' });
+  const { page } = await runUITest({
+    ...basicTestTree,
+    'playwright.config.ts': `
+      import { defineConfig } from '@playwright/test';
+      export default defineConfig({
+        projects: [
+          { name: 'dev-setup', testMatch: /a.test.ts/ },
+          { name: 'dev', dependencies: ['dev-setup'] },
+          { name: 'staging-setup', testMatch: /a.test.ts/ },
+          { name: 'staging', dependencies: ['staging-setup'] },
+        ],
+      });
+    `
+  });
+
+  await page.getByText('Status:').click();
+  await expect(page.getByTestId('project-filters').locator('.filter-entry')).toHaveText([
+    'dev-setup',
+    'dev',
+    'staging-setup',
+    'staging',
+  ]);
+});
+
 test('should not hide filtered while running', async ({ runUITest, createLatch }) => {
   const latch = createLatch();
   const { page } = await runUITest({

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -136,11 +136,11 @@ test('should run setup and teardown projects (1)', async ({ runUITest }) => {
   await expect(page.getByTestId('project-filters')).toMatchAriaSnapshot(`
     - list:
       - listitem:
-        - checkbox "teardown"
-      - listitem:
         - checkbox "setup"
       - listitem:
         - checkbox "test"
+      - listitem:
+        - checkbox "teardown"
   `);
 
   await page.getByTitle('Run all').click();
@@ -187,11 +187,11 @@ test('should run setup and teardown projects (2)', async ({ runUITest }) => {
   await expect(page.getByTestId('project-filters')).toMatchAriaSnapshot(`
     - list:
       - listitem:
-        - checkbox "teardown" [checked]
-      - listitem:
         - checkbox "setup"
       - listitem:
         - checkbox "test" [checked]
+      - listitem:
+        - checkbox "teardown" [checked]
   `);
 
   await page.getByTitle('Run all').click();
@@ -233,11 +233,11 @@ test('should run setup and teardown projects (3)', async ({ runUITest }) => {
   await expect(page.getByTestId('project-filters')).toMatchAriaSnapshot(`
     - list:
       - listitem:
-        - checkbox "teardown"
-      - listitem:
         - checkbox "setup"
       - listitem:
         - checkbox "test" [checked]
+      - listitem:
+        - checkbox "teardown"
   `);
 
   await page.getByTitle('Run all').click();
@@ -274,11 +274,11 @@ test('should run part of the setup only', async ({ runUITest }) => {
   await expect(page.getByTestId('project-filters')).toMatchAriaSnapshot(`
     - list:
       - listitem:
-        - checkbox "teardown" [checked]
-      - listitem:
         - checkbox "setup" [checked]
       - listitem:
         - checkbox "test" [checked]
+      - listitem:
+        - checkbox "teardown" [checked]
   `);
 
   await page.getByText('setup.ts').hover();


### PR DESCRIPTION
The final project closure in `createRootSuite` prepended each needed dependency suite to the root suite one at a time. This hoisted setup projects above all top-level projects and reversed their relative order, so reporters, `--list` and the UI mode project filter showed projects in a seemingly random order instead of the order they are declared in the config.

Append dependency suites instead and rebuild the root suite entries following the declaration order in the config. Execution order is unaffected, since phases are derived from the dependency graph.

Fixes https://github.com/microsoft/playwright/issues/41779