### PR TITLE
feat(test): support default tags via test.use() and project use

### DIFF
--- a/docs/src/test-annotations-js.md
+++ b/docs/src/test-annotations-js.md
@@ -155,7 +155,44 @@ npx playwright test --grep "(?=.*@fast)(?=.*@slow)"
 
 You can also filter tests in the configuration file via [`property: TestConfig.grep`] and [`property: TestProject.grep`].
 
+### Set default tags
 
+Use `test.use()` to apply tags to all tests in a file or describe block without repeating them on each test:
+
+```js title="auth.spec.ts"
+import { test, expect } from '@playwright/test';
+
+test.use({ tag: '@auth' });
+
+test('login', async ({ page }) => {
+  // has @auth tag
+});
+
+test('logout', async ({ page }) => {
+  // has @auth tag
+});
+```
+
+You can also apply default tags at the project level in your config. Every test in that project will carry the tag:
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'app1',
+      use: { tag: ['@app1', '@smoke'] },
+    },
+    {
+      name: 'app2',
+      use: { tag: '@app2' },
+    },
+  ],
+});
+```
+
+Tags from all sources accumulate: a test picks up tags from its project, its file, any enclosing describe block, and the test declaration itself.
 
 ## Annotate tests
 

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -162,6 +162,7 @@ export class FullProjectInternal {
   readonly respectGitIgnore: boolean;
   readonly snapshotPathTemplate: string | undefined;
   readonly workers: number | undefined;
+  readonly _tags: string[];
   id = '';
   deps: FullProjectInternal[] = [];
   teardown: FullProjectInternal | undefined;
@@ -193,6 +194,13 @@ export class FullProjectInternal {
     };
     this.fullyParallel = takeFirst(configCLIOverrides.fullyParallel, projectConfig.fullyParallel, config.fullyParallel, undefined);
     this.expect = takeFirst(projectConfig.expect, config.expect, {});
+    const projectTag = (this.project.use as { tag?: string | string[] }).tag;
+    const projectTags = projectTag === undefined ? [] : Array.isArray(projectTag) ? projectTag : [projectTag];
+    for (const t of projectTags) {
+      if (t[0] !== '@')
+        throw new Error(`Tag must start with "@" symbol, got "${t}" instead.`);
+    }
+    this._tags = projectTags;
     if (this.expect.toHaveScreenshot?.stylePath) {
       const stylePaths = Array.isArray(this.expect.toHaveScreenshot.stylePath) ? this.expect.toHaveScreenshot.stylePath : [this.expect.toHaveScreenshot.stylePath];
       this.expect.toHaveScreenshot.stylePath = stylePaths.map(stylePath => path.resolve(configDir, stylePath));

--- a/packages/playwright/src/common/suiteUtils.ts
+++ b/packages/playwright/src/common/suiteUtils.ts
@@ -40,6 +40,7 @@ export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suit
   // Clone suite.
   const result = suite._deepClone();
   result._fileId = fileId;
+  result._tags.push(...project._tags);
 
   // Assign test properties with project-specific values.
   result.forEachTest((test, suite) => {

--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -269,6 +269,19 @@ export class TestTypeImpl {
     const suite = this._currentSuite(location, `test.use()`);
     if (!suite)
       return;
+    const fixturesWithTag = fixtures as Fixtures & { tag?: string | string[] };
+    if (fixturesWithTag.tag !== undefined) {
+      const tags = Array.isArray(fixturesWithTag.tag) ? fixturesWithTag.tag : [fixturesWithTag.tag];
+      for (const t of tags) {
+        if (t[0] !== '@')
+          throw new Error(`Tag must start with "@" symbol, got "${t}" instead.`);
+      }
+      suite._tags.push(...tags);
+      const { tag: _, ...rest } = fixturesWithTag;
+      fixtures = rest as Fixtures;
+      if (!Object.keys(rest).length)
+        return;
+    }
     suite._use.push({ fixtures, location });
   }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -47,7 +47,7 @@ export type ReporterDescription = Readonly<
   [string] | [string, any]
 >;
 
-type UseOptions<TestArgs, WorkerArgs> = Partial<WorkerArgs> & Partial<TestArgs>;
+type UseOptions<TestArgs, WorkerArgs> = Partial<WorkerArgs> & Partial<TestArgs> & { tag?: string | string[] };
 
 /**
  * Playwright Test supports running multiple test projects at the same time. This is useful for running tests in
@@ -6273,7 +6273,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    *
    * @param options An object with local options.
    */
-  use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
+  use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs> & { tag?: string | string[] }): void;
   /**
    * Declares a test step that is shown in the report.
    *

--- a/tests/playwright-test/test-tag.spec.ts
+++ b/tests/playwright-test/test-tag.spec.ts
@@ -184,6 +184,239 @@ test('should be included in testInfo if coming from describe or global tag', asy
   expect(result.exitCode).toBe(0);
 });
 
+test('test.use should apply tags to all tests in scope', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = { reporter: './reporter' };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test.use({ tag: '@file-tag' });
+      test('test1', () => {});
+      test('test2', { tag: '@extra' }, () => {});
+      test.describe('suite', () => {
+        test('test3', () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test1, tags=@file-tag',
+    'title=test2, tags=@file-tag,@extra',
+    'title=test3, tags=@file-tag',
+  ]);
+});
+
+test('test.use inside describe should apply tags only within describe', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = { reporter: './reporter' };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('outside', () => {});
+      test.describe('suite', () => {
+        test.use({ tag: ['@app1', '@smoke'] });
+        test('inside', () => {});
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=outside, tags=',
+    'title=inside, tags=@app1,@smoke',
+  ]);
+});
+
+test('test.use tag should be available in testInfo.tags', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test.use({ tag: '@use-tag' });
+      test('test1', ({}, testInfo) => {
+        expect(testInfo.tags).toContain('@use-tag');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test('test.use tag should be filterable with --grep', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test.use({ tag: '@app1' });
+      test('test1', () => {});
+      test('test2', () => {});
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      test('test3', () => {});
+    `,
+  }, { grep: '@app1' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
+test('test.use tag should validate @ prefix', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test.use({ tag: 'missing-at' });
+      test('test1', () => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Tag must start with "@" symbol`);
+});
+
+test('project use.tag should apply to all tests in project', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%title=' + test.title + ', tags=' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: './reporter',
+        projects: [
+          { name: 'p1', use: { tag: '@app1' } },
+          { name: 'p2', use: { tag: ['@app2', '@smoke'] } },
+        ],
+      };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('test1', () => {});
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'title=test1, tags=@app1',
+    'title=test1, tags=@app2,@smoke',
+  ]);
+});
+
+test('project use.tag should be filterable with --grep', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [
+          { name: 'p1', use: { tag: '@app1' } },
+          { name: 'p2', use: { tag: '@app2' } },
+        ],
+      };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('test1', () => { console.log('\\n%% ' + test.info().project.name); });
+    `,
+  }, { grep: '@app1', workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual(['p1']);
+});
+
+test('project use.tag should be included in testInfo.tags', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [{ name: 'p1', use: { tag: '@proj-tag' } }],
+      };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test1', ({}, testInfo) => {
+        expect(testInfo.tags).toContain('@proj-tag');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+});
+
+test('project use.tag should validate @ prefix', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        projects: [{ name: 'p1', use: { tag: 'nope' } }],
+      };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('test1', () => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Tag must start with "@" symbol`);
+});
+
+test('test.use tag and global config tag and test tag should all accumulate', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'reporter.ts': `
+      export default class Reporter {
+        onBegin(config, suite) {
+          const visit = suite => {
+            for (const test of suite.tests || [])
+              console.log('\\n%%' + test.tags.join(','));
+            for (const child of suite.suites || [])
+              visit(child);
+          };
+          visit(suite);
+        }
+      }
+    `,
+    'playwright.config.ts': `
+      module.exports = {
+        reporter: './reporter',
+        tag: '@global',
+        projects: [{ name: 'p1', use: { tag: '@project' } }],
+      };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test.use({ tag: '@file' });
+      test('test1', { tag: '@test' }, () => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual(['@global,@file,@project,@test']);
+});
+
 test('should not parse file names as tags', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'reporter.ts': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -46,7 +46,7 @@ export type ReporterDescription = Readonly<
   [string] | [string, any]
 >;
 
-type UseOptions<TestArgs, WorkerArgs> = Partial<WorkerArgs> & Partial<TestArgs>;
+type UseOptions<TestArgs, WorkerArgs> = Partial<WorkerArgs> & Partial<TestArgs> & { tag?: string | string[] };
 
 interface TestProject<TestArgs = {}, WorkerArgs = {}> {
   use?: UseOptions<TestArgs, WorkerArgs>;
@@ -188,7 +188,7 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
   beforeAll(title: string, inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   afterAll(inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
   afterAll(title: string, inner: (args: TestArgs & WorkerArgs, testInfo: TestInfo) => Promise<any> | any): void;
-  use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs>): void;
+  use(fixtures: Fixtures<{}, {}, TestArgs, WorkerArgs> & { tag?: string | string[] }): void;
   step: {
     <T>(title: string, body: (step: TestStepInfo) => T | Promise<T>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<T>;
     skip(title: string, body: (step: TestStepInfo) => any | Promise<any>, options?: { box?: boolean, location?: Location, timeout?: number }): Promise<void>;


### PR DESCRIPTION
Adds `tag` as a recognized option in `test.use()` and `project.use`, so default tags can be declared where fixtures live rather than repeated on every test.

```ts
// file-level
test.use({ tag: '@app1' });
test.use({ tag: ['@app1', '@app2'] });

// project-level
projects: [{ name: 'app1', use: { tag: '@app1' } }]
projects: [{ name: 'app1', use: { tag: ['@app1', '@app2'] } }]
```

Tags accumulate across all scopes (project → file → describe → test).

Closes #37128, closes #37683 (reopening since the idea was closed despite 7 upvotes)