### PR TITLE
chore(protocol): promote timeout to call metadata

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -356,12 +356,9 @@ export class DispatcherConnection {
       type: dispatcher._type,
       method,
       params: params || {},
+      timeout: validMetadata.timeout,
       log: [],
     };
-
-    // TODO(skn0tt): promote to top-level metadata instead of smuggling through params.
-    if (validMetadata.timeout)
-      callMetadata.params = { ...callMetadata.params, timeout: validMetadata.timeout };
 
     const controller = dispatcher.createProgressController(callMetadata);
     this._activeProgressControllers.set(callMetadata.id, controller);

--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -90,6 +90,7 @@ export type CallMetadata = {
   type: string;
   method: string;
   params: any;
+  timeout?: number;
   title?: string;
   // Client is making an internal call that should not show up in
   // the inspector or trace.

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -738,7 +738,7 @@ function createBeforeActionTraceEvent(metadata: CallMetadata, parentId?: string)
     title: metadata.title,
     class: metadata.type,
     method: metadata.method,
-    params: metadata.params,
+    params: metadata.timeout ? { ...metadata.params, timeout: metadata.timeout } : metadata.params,
     stepId: metadata.stepId,
     pageId: metadata.pageId,
   };


### PR DESCRIPTION
Follow-up to #41712: promote `timeout` to a proper `CallMetadata` field instead of temporarily smuggling it through `params`.

Traces keep their existing shape by adding the timeout back at the serialization boundary. This is covered by `should show params and return value` in `trace-viewer.spec.ts`, which verifies `timeout:10000` in the Call tab.