### PR TITLE
chore(expect): preserve _expect call shape

### DIFF
--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -496,8 +496,8 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return (await this._channel.title({}, kNoTimeout)).value;
   }
 
-  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'> & { timeout: number }, signal: AbortSignal | undefined): Promise<ExpectResult> {
-    const { timeout, ...rest } = options;
+  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'> & { timeout: number, signal?: AbortSignal }): Promise<ExpectResult> {
+    const { timeout, signal, ...rest } = options;
     const params: channels.FrameExpectParams = { expression, ...rest, isNot: !!rest.isNot };
     params.expectedValue = serializeArgument(rest.expectedValue);
     try {

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -404,11 +404,11 @@ export class Locator implements api.Locator {
   }
 
 
-  async _expect(expression: string, options: FrameExpectParams, signal: AbortSignal | undefined): Promise<ExpectResult> {
+  async _expect(expression: string, options: FrameExpectParams): Promise<ExpectResult> {
     return this._frame._expect(expression, {
       ...options,
       selector: this._selector,
-    }, signal);
+    });
   }
 
   private _inspect() {

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -147,4 +147,4 @@ export type AnnotateOptions = { duration?: number, position?: AnnotatePosition, 
 export type RemoteAddr = channels.RemoteAddr;
 export type SecurityDetails = channels.SecurityDetails;
 
-export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any, timeout: number };
+export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any, timeout: number, signal?: AbortSignal };

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -66,11 +66,11 @@ function serializeExpectedTextValues(items: (string | RegExp)[], options: { matc
 
 export interface LocatorEx extends Locator {
   _selector: string;
-  _expect(expression: string, options: FrameExpectParams, signal: AbortSignal | undefined): Promise<ExpectResult>;
+  _expect(expression: string, options: FrameExpectParams): Promise<ExpectResult>;
 }
 
 export interface FrameEx extends Frame {
-  _expect(expression: string, options: FrameExpectParams, signal: AbortSignal | undefined): Promise<ExpectResult>;
+  _expect(expression: string, options: FrameExpectParams): Promise<ExpectResult>;
 }
 
 interface APIResponseEx extends APIResponse {
@@ -86,7 +86,7 @@ export function toBeAttached(
   const expected = attached ? 'attached' : 'detached';
   const arg = attached ? '' : '{ attached: false }';
   return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout }, signal);
+    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout, signal });
   }, options);
 }
 
@@ -111,7 +111,7 @@ export function toBeChecked(
     arg = options?.checked === false ? `{ checked: false }` : '';
   }
   return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue }, signal);
+    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue, signal });
   }, options);
 }
 
@@ -121,7 +121,7 @@ export function toBeDisabled(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.disabled', { isNot, timeout }, signal);
+    return await locator._expect('to.be.disabled', { isNot, timeout, signal });
   }, options);
 }
 
@@ -134,7 +134,7 @@ export function toBeEditable(
   const expected = editable ? 'editable' : 'readOnly';
   const arg = editable ? '' : '{ editable: false }';
   return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout }, signal);
+    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout, signal });
   }, options);
 }
 
@@ -144,7 +144,7 @@ export function toBeEmpty(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.empty', { isNot, timeout }, signal);
+    return await locator._expect('to.be.empty', { isNot, timeout, signal });
   }, options);
 }
 
@@ -157,7 +157,7 @@ export function toBeEnabled(
   const expected = enabled ? 'enabled' : 'disabled';
   const arg = enabled ? '' : '{ enabled: false }';
   return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout }, signal);
+    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout, signal });
   }, options);
 }
 
@@ -167,7 +167,7 @@ export function toBeFocused(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.focused', { isNot, timeout }, signal);
+    return await locator._expect('to.be.focused', { isNot, timeout, signal });
   }, options);
 }
 
@@ -177,7 +177,7 @@ export function toBeHidden(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.hidden', { isNot, timeout }, signal);
+    return await locator._expect('to.be.hidden', { isNot, timeout, signal });
   }, options);
 }
 
@@ -190,7 +190,7 @@ export function toBeVisible(
   const expected = visible ? 'visible' : 'hidden';
   const arg = visible ? '' : '{ visible: false }';
   return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout }, signal);
+    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout, signal });
   }, options);
 }
 
@@ -200,7 +200,7 @@ export function toBeInViewport(
   options?: { timeout?: number, ratio?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout }, signal);
+    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout, signal });
   }, options);
 }
 
@@ -213,12 +213,12 @@ export function toContainText(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, signal);
+      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
     }, expected, { ...options, contains: true });
   } else {
     return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout }, signal);
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
     }, expected, { ...options, matchSubstring: true });
   }
 }
@@ -231,7 +231,7 @@ export function toHaveAccessibleDescription(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -243,7 +243,7 @@ export function toHaveAccessibleName(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -255,7 +255,7 @@ export function toHaveAccessibleErrorMessage(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -275,12 +275,12 @@ export function toHaveAttribute(
   }
   if (expected === undefined) {
     return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout, signal) => {
-      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout }, signal);
+      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout, signal });
     }, options);
   }
   return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected as (string | RegExp)], { ignoreCase: options?.ignoreCase });
-    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout, signal });
   }, expected as (string | RegExp), options);
 }
 
@@ -293,12 +293,12 @@ export function toHaveClass(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout }, signal);
+      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout, signal });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.have.class', { expectedText, isNot, timeout }, signal);
+      return await locator._expect('to.have.class', { expectedText, isNot, timeout, signal });
     }, expected, options);
   }
 }
@@ -314,14 +314,14 @@ export function toContainClass(
       throw new Error(`"expected" argument in toContainClass cannot contain RegExp values`);
     return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout }, signal);
+      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout, signal });
     }, expected, options);
   } else {
     if (isRegExp(expected))
       throw new Error(`"expected" argument in toContainClass cannot be a RegExp value`);
     return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.contain.class', { expectedText, isNot, timeout }, signal);
+      return await locator._expect('to.contain.class', { expectedText, isNot, timeout, signal });
     }, expected, options);
   }
 }
@@ -333,7 +333,7 @@ export function toHaveCount(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout, signal) => {
-    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout }, signal);
+    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -347,7 +347,7 @@ export function toHaveCSS(
 ) {
   return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout }, signal);
+    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout, signal });
   }, expected, options);
 }
 
@@ -359,7 +359,7 @@ export function toHaveId(
 ) {
   return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.id', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.id', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -371,7 +371,7 @@ export function toHaveJSProperty(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout, signal) => {
-    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout }, signal);
+    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -385,7 +385,7 @@ export function toHaveRole(
     throw new Error(`"role" argument in toHaveRole must be a string`);
   return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.role', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.role', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -398,12 +398,12 @@ export function toHaveText(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, signal);
+      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout }, signal);
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
     }, expected, options);
   }
 }
@@ -416,7 +416,7 @@ export function toHaveValue(
 ) {
   return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.value', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.value', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -428,7 +428,7 @@ export function toHaveValues(
 ) {
   return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues(expected);
-    return await locator._expect('to.have.values', { expectedText, isNot, timeout }, signal);
+    return await locator._expect('to.have.values', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -440,7 +440,7 @@ export function toHaveTitle(
 ) {
   return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout }, signal);
+    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 
@@ -461,7 +461,7 @@ export function toHaveURL(
   expected = typeof expected === 'string' ? constructURLBasedOnBaseURL(baseURL, expected) : expected;
   return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout }, signal);
+    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout, signal });
   }, expected, options);
 }
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -91,10 +91,10 @@ export async function toMatchAriaSnapshot(
   if (globalChildren && !expected.match(/^- \/children:/m))
     expected = `- /children: ${globalChildren}\n` + expected;
 
-  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout };
+  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout, signal: options.signal };
   const { matches: pass, received, log, timedOut, errorMessage } = locator ?
-    await (locator as LocatorEx)._expect('to.match.aria', expectParams, options.signal) :
-    await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams, options.signal);
+    await (locator as LocatorEx)._expect('to.match.aria', expectParams) :
+    await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams);
   const typedReceived = received?.value as MatcherReceived;
 
   const message = () => {


### PR DESCRIPTION
This PR follows up on [Dima’s review comment](https://github.com/microsoft/playwright/pull/41712#discussion_r3577465660) by keeping `signal` and `timeout` together in `_expect`’s existing options object.

Although `_expect` isn’t documented, external matcher integrations rely on its two-argument shape:

- [`shotest` calls `_expect(method, options)` directly](https://github.com/vanviegen/shotest/blob/d9cef7705c45917ad05b47e245f67e4c255c6fda/src/fixture.ts#L553-L557).
- `mobilewright` implements compatible [`Locator`](https://github.com/mobile-next/mobilewright/blob/9ad23cac9ba3710b2c79c6e4c2b22499e5a75edc/packages/mobilewright-core/src/web-locator.ts#L404-L410) and [`Frame`](https://github.com/mobile-next/mobilewright/blob/9ad23cac9ba3710b2c79c6e4c2b22499e5a75edc/packages/mobilewright-core/src/page.ts#L66-L70) `_expect(expression, options)` hooks.

Keeping `_expect(expression, options)` avoids breaking those integrations while still keeping timeout and signal out of protocol params.