### PR TITLE
fix(ci): keep Copilot GitHub access read-only

### DIFF
--- a/.github/workflows/create_test_report.yml
+++ b/.github/workflows/create_test_report.yml
@@ -190,7 +190,7 @@ jobs:
     if: needs.triage.outputs.has_draft == 'true'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     env:
       PR_NUMBER: ${{ needs.triage.outputs.pr_number }}
       GH_TOKEN: ${{ github.token }}
@@ -206,4 +206,3 @@ jobs:
         run: |
           printf '\n\n<sub>Triaged by the Playwright bot - [agent run](%s)</sub>\n<!-- playwright-ci-triage -->\n' "$WORKFLOW_URL" >> output/triage.md
           gh issue comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file output/triage.md
-

--- a/.github/workflows/fix-flakes-prompt.md
+++ b/.github/workflows/fix-flakes-prompt.md
@@ -4,6 +4,9 @@ Turn CI test-results data into **one** concrete fix: pick a high-impact flaky-or
 confirm nobody's on it, fix the root cause *or* scope a skip, pick a reviewer, and hand off a
 single commit that becomes the PR. Fully autonomous — no approval stops.
 
+The GitHub CLI (`gh`) is not authenticated in this job. Do not use it for GitHub API operations;
+use GitHub MCP tools instead.
+
 ## 1. Pick one target
 
 Query the DB following the patterns in `.claude/skills/playwright-test-results/SKILL.md`.

--- a/.github/workflows/fix-flakes.yml
+++ b/.github/workflows/fix-flakes.yml
@@ -58,6 +58,9 @@ jobs:
           an expensive runner to fix a flaky or red test is most worthwhile right now, and hand
           off only that runner label. Do NOT fix anything.
 
+          The GitHub CLI is not authenticated in this job. Do not run gh; use GitHub MCP tools
+          for all GitHub reads.
+
           Optimise for the OS with the highest-impact actionable flakiness/reds that isn't
           already being worked on OR already fixed. A candidate is dead if a fix PR touches it
           (open, or recently merged/closed) — the DB window still holds the failing runs from

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -46,6 +46,9 @@ jobs:
           PROMPT=$(cat <<EOF
           Triage https://github.com/${{ github.repository }}/issues/$ISSUE using the playwright-triage skill.
 
+          The GitHub CLI is not authenticated in this job. Do not run gh; use GitHub MCP tools
+          for all GitHub reads.
+
           Do not post anything yourself. Write the comment to output/triage.md and a later step posts it.
           EOF
           )


### PR DESCRIPTION
This fixes two independent bugs:

- Copilot CLI jobs tried to use `gh` without credentials. In [this fix-flakes run](https://github.com/microsoft/playwright/actions/runs/29313037253), the agent got `You are not logged into any GitHub hosts` and skipped its PR search. The prompts now direct GitHub reads through MCP.
- The trusted CI-triage posting job had `issues: write`, but it comments on pull requests. [This run](https://github.com/microsoft/playwright/actions/runs/29397305753) failed with `Resource not accessible by integration`; the job now gets `pull-requests: write` instead.