### PR TITLE
test(screenshot): skip blocked event loop test in driver

### DIFF
--- a/tests/library/screenshot.spec.ts
+++ b/tests/library/screenshot.spec.ts
@@ -210,8 +210,9 @@ browserTest.describe('page screenshot', () => {
     expect(pixel(0, 999).b).toBeGreaterThan(128);
   });
 
-  browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page, trace }) => {
+  browserTest('should not hang when event loop is blocked', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/36702' } }, async ({ page, trace, mode }) => {
     browserTest.skip(trace === 'on', 'taking a snapshot hangs when the page is blocked');
+    browserTest.skip(mode === 'driver', 'test hooks are not available in driver mode');
     browserTest.setTimeout(5000);
     const __testHookBeforeScreenshot = async () => {
       page.evaluate(() => {


### PR DESCRIPTION
The blocked-event-loop screenshot test relies on a function-valued test hook, which is not available through the out-of-process driver transport. Skip it in driver mode instead of failing consistently when the screenshot succeeds.

Example failure: https://github.com/microsoft/playwright/actions/runs/29017723928