### PR TITLE
devops: use GitHub App client ID

### DIFF
--- a/.github/workflows/fix-flakes.yml
+++ b/.github/workflows/fix-flakes.yml
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+          client-id: ${{ vars.PLAYWRIGHT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
 
       - name: Apply commit and open PR

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+        client-id: ${{ vars.PLAYWRIGHT_APP_CLIENT_ID }}
         private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
         repositories: trace.playwright.dev
     - name: Deploy Canary

--- a/.github/workflows/roll_browser_into_playwright.yml
+++ b/.github/workflows/roll_browser_into_playwright.yml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+        client-id: ${{ vars.PLAYWRIGHT_APP_CLIENT_ID }}
         private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
     - name: Create Pull Request
       uses: actions/github-script@v9

--- a/.github/workflows/roll_nodejs.yml
+++ b/.github/workflows/roll_nodejs.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+          client-id: ${{ vars.PLAYWRIGHT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}

--- a/.github/workflows/roll_stable_test_runner.yml
+++ b/.github/workflows/roll_stable_test_runner.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+          client-id: ${{ vars.PLAYWRIGHT_APP_CLIENT_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}


### PR DESCRIPTION
See https://github.com/microsoft/playwright/actions/runs/29406489743 for an example of the deprecation.

This PR migrates all `actions/create-github-app-token@v3` usages from the deprecated `app-id` input to `client-id`, following [actions/create-github-app-token#353](https://github.com/actions/create-github-app-token/pull/353).

I've already added `PLAYWRIGHT_APP_CLIENT_ID` as a repository variable using the client ID of the existing `microsoft-playwright-automation` GitHub App. The private key and App permissions remain unchanged.
