### PR TITLE
feat(expect): support unordered text matching

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -2147,7 +2147,7 @@ await Expect(locator).ToHaveTextAsync(new Regex("Welcome, .*"));
 If you pass an array as an expected value, the expectations are:
 1. Locator resolves to a list of elements.
 1. The number of elements equals the number of expected values in the array.
-1. Elements from the list have text matching expected array values, one by one, in order.
+1. Elements from the list have text matching expected array values, one by one, in order, unless `ignoreOrder` is set.
 
 For example, consider the following list:
 
@@ -2173,6 +2173,12 @@ await expect(page.locator('ul > li')).toHaveText(['Text 1', 'Text 2', 'Text']);
 
 // ✖ Locator points to the outer list element, not to the list items
 await expect(page.locator('ul')).toHaveText(['Text 1', 'Text 2', 'Text 3']);
+
+// ✓ Has the right items in any order
+await expect(page.locator('ul > li')).toHaveText(
+    ['Text 3', 'Text 2', 'Text 1'],
+    { ignoreOrder: true },
+);
 ```
 
 ```java
@@ -2258,6 +2264,12 @@ Expected string or RegExp or a list of those.
 
 ### option: LocatorAssertions.toHaveText.ignoreCase = %%-assertions-ignore-case-%%
 * since: v1.23
+
+### option: LocatorAssertions.toHaveText.ignoreOrder
+* since: v1.62
+- `ignoreOrder` <[boolean]>
+
+Whether to match expected values against the located elements in any order. Each expected value must match exactly one distinct element. Only applies when `expected` is an array.
 
 ### option: LocatorAssertions.toHaveText.useInnerText
 * since: v1.18

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -55,6 +55,7 @@ export type FrameExpectParams = {
   expectedNumber?: number,
   expectedValue?: any,
   useInnerText?: boolean,
+  ignoreOrder?: boolean,
   isNot: boolean,
 };
 
@@ -1676,8 +1677,32 @@ export class InjectedScript {
     if (!matchesLength)
       return { received, matches: false };
 
-    const matches = this._matchSequentially(options.expectedText, received, (matcher, r) => matcher.matches(r));
+    const matches = options.ignoreOrder
+      ? this._matchInAnyOrder(options.expectedText, received, (matcher, r) => matcher.matches(r))
+      : this._matchSequentially(options.expectedText, received, (matcher, r) => matcher.matches(r));
     return { received, matches };
+  }
+
+  private _matchInAnyOrder<T>(
+    expectedText: ExpectedTextValue[],
+    received: T[],
+    matchFn: (matcher: ExpectedTextMatcher, received: T) => boolean
+  ): boolean {
+    const matchers = expectedText.map(e => new ExpectedTextMatcher(e));
+    const matchedReceived = new Array(received.length).fill(-1);
+    const match = (matcherIndex: number, visited: boolean[]): boolean => {
+      for (let receivedIndex = 0; receivedIndex < received.length; ++receivedIndex) {
+        if (visited[receivedIndex] || !matchFn(matchers[matcherIndex], received[receivedIndex]))
+          continue;
+        visited[receivedIndex] = true;
+        if (matchedReceived[receivedIndex] === -1 || match(matchedReceived[receivedIndex], visited)) {
+          matchedReceived[receivedIndex] = matcherIndex;
+          return true;
+        }
+      }
+      return false;
+    };
+    return matchers.every((_, matcherIndex) => match(matcherIndex, new Array(received.length).fill(false)));
   }
 
   private _matchSequentially<T>(

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -2922,6 +2922,7 @@ export type FrameExpectParams = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  ignoreOrder?: boolean,
   isNot: boolean,
 };
 export type FrameExpectOptions = {
@@ -2932,6 +2933,7 @@ export type FrameExpectOptions = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  ignoreOrder?: boolean,
 };
 export type FrameExpectResult = void;
 export type FrameExpectErrorDetails = {

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -2923,6 +2923,7 @@ export type FrameExpectParams = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  ignoreOrder?: boolean,
   isNot: boolean,
 };
 export type FrameExpectOptions = {
@@ -2933,6 +2934,7 @@ export type FrameExpectOptions = {
   expectedNumber?: number,
   expectedValue?: SerializedArgument,
   useInnerText?: boolean,
+  ignoreOrder?: boolean,
 };
 export type FrameExpectResult = void;
 export type FrameExpectErrorDetails = {

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -393,12 +393,12 @@ export function toHaveText(
   this: ExpectMatcherStateInternal,
   locator: LocatorEx,
   expected: string | RegExp | (string | RegExp)[],
-  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, signal?: AbortSignal } = {},
+  options: { timeout?: number, useInnerText?: boolean, ignoreCase?: boolean, ignoreOrder?: boolean, signal?: AbortSignal } = {},
 ) {
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
+      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options.useInnerText, ignoreOrder: options.ignoreOrder, timeout, signal });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -9770,7 +9770,8 @@ interface LocatorAssertions {
    * If you pass an array as an expected value, the expectations are:
    * 1. Locator resolves to a list of elements.
    * 1. The number of elements equals the number of expected values in the array.
-   * 1. Elements from the list have text matching expected array values, one by one, in order.
+   * 1. Elements from the list have text matching expected array values, one by one, in order, unless `ignoreOrder`
+   *    is set.
    *
    * For example, consider the following list:
    *
@@ -9796,6 +9797,12 @@ interface LocatorAssertions {
    *
    * // ✖ Locator points to the outer list element, not to the list items
    * await expect(page.locator('ul')).toHaveText(['Text 1', 'Text 2', 'Text 3']);
+   *
+   * // ✓ Has the right items in any order
+   * await expect(page.locator('ul > li')).toHaveText(
+   *   ['Text 3', 'Text 2', 'Text 1'],
+   *   { ignoreOrder: true },
+   * );
    * ```
    *
    * @param expected Expected string or RegExp or a list of those.
@@ -9808,6 +9815,12 @@ interface LocatorAssertions {
      * option takes precedence over the corresponding regular expression flag if specified.
      */
     ignoreCase?: boolean;
+
+    /**
+     * Whether to match expected values against the located elements in any order. Each expected value must match exactly
+     * one distinct element. Only applies when `expected` is an array.
+     */
+    ignoreOrder?: boolean;
 
     /**
      * An optional [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) that can cancel the

--- a/packages/protocol/spec/frame.yml
+++ b/packages/protocol/spec/frame.yml
@@ -769,6 +769,7 @@ Frame:
         expectedNumber: float?
         expectedValue: SerializedArgument?
         useInnerText: boolean?
+        ignoreOrder: boolean?
         isNot: boolean
       errorDetails:
         received:

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -1632,6 +1632,7 @@ scheme.FrameExpectParams = tObject({
   expectedNumber: tOptional(tFloat),
   expectedValue: tOptional(tType('SerializedArgument')),
   useInnerText: tOptional(tBoolean),
+  ignoreOrder: tOptional(tBoolean),
   isNot: tBoolean,
 });
 scheme.FrameExpectResult = tOptional(tObject({}));

--- a/tests/page/expect-to-have-text.spec.ts
+++ b/tests/page/expect-to-have-text.spec.ts
@@ -224,6 +224,27 @@ test.describe('toHaveText with array', () => {
     await expect(locator).toHaveText(['tEXT 1', 'TExt 2A'], { ignoreCase: true });
   });
 
+  test('pass with ignoreOrder', async ({ page }) => {
+    await page.setContent('<div>Complete</div><div>Pending</div>');
+    const locator = page.locator('div');
+    await expect(locator).toHaveText(['Pending', 'Complete'], { ignoreOrder: true });
+    await expect(locator).toHaveText([/pending/i, /complete/i], { ignoreOrder: true });
+  });
+
+  test('match each element once with ignoreOrder', async ({ page }) => {
+    await page.setContent('<div>foobar</div><div>foo</div>');
+    const locator = page.locator('div');
+    await expect(locator).toHaveText([/foo/, 'foobar'], { ignoreOrder: true });
+    await expect(locator).toHaveText([/foo/, /foo/], { ignoreOrder: true });
+    await expect(locator).not.toHaveText(['foobar', 'foobar'], { ignoreOrder: true });
+  });
+
+  test('fail on different lengths with ignoreOrder', async ({ page }) => {
+    await page.setContent('<div>Text 1</div><div>Text 2</div>');
+    const locator = page.locator('div');
+    await expect(locator).not.toHaveText(['Text 1'], { ignoreOrder: true });
+  });
+
   test('pass lazy', async ({ page }) => {
     await page.setContent('<div id=div></div>');
     const locator = page.locator('p');


### PR DESCRIPTION
Adds an `ignoreOrder` option to `expect(locator).toHaveText()` for cases where a collection’s contents matter but its DOM order does not.

When enabled, every expected string or regular expression must match exactly one distinct located element, and the collection lengths must remain equal. The implementation uses one-to-one matching instead of sorting, allowing it to correctly handle regular expressions, duplicate values, and overlapping matches such as `[/foo/, 'foobar']`.

Existing order-sensitive behavior remains unchanged by default. The option also retains Playwright’s web-first retries, text normalization, `ignoreCase`, `useInnerText`, and assertion diagnostics.

```
await expect(page.locator('li')).toHaveText(
  ['Pending', 'Complete'],
  { ignoreOrder: true },
);
```

Fixes #22275
Fixes #41803