### PR TITLE
fix(server): guard invalid JSON in PageBinding.dispatch

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1076,7 +1076,16 @@ export class PageBinding extends DisposableObject {
   }
 
   static async dispatch(page: Page, payload: string, context: dom.FrameExecutionContext) {
-    const { name, seq, serializedArgs } = JSON.parse(payload) as BindingPayload;
+    let name: string;
+    let seq: number;
+    let serializedArgs: any;
+    try {
+      ({ name, seq, serializedArgs } = JSON.parse(payload) as BindingPayload);
+    } catch (error) {
+      // Malformed payload from the page must not crash the binding pipeline.
+      debugLogger.log('error', error);
+      return;
+    }
     try {
       assert(context.world);
       const binding = page.getBinding(name);

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -254,3 +254,12 @@ it('exposeBinding should work in parallel', { annotation: { type: 'issue', descr
     (window as any).bar();
   });
 });
+
+it('should not crash when binding payload is invalid JSON', async ({ page, toImpl }) => {
+  await page.exposeBinding('echo', (source, v) => v);
+  const pageImpl = toImpl(page);
+  const context = await pageImpl.mainFrame().mainContext();
+  // Malformed payload must not escape as an uncaught SyntaxError.
+  await pageImpl.onBindingCalled('{not-valid-json', context);
+  expect(await page.evaluate(() => 7 * 6)).toBe(42);
+});


### PR DESCRIPTION
## Summary

`PageBinding.dispatch` parsed the binding payload with `JSON.parse` **outside** the existing try/catch. A malformed payload from the page (or a corrupted protocol message) threw an uncaught `SyntaxError` and aborted the binding pipeline.

## Fix

Parse the payload in a dedicated try/catch. On invalid JSON, log via `debugLogger` and return. When parse succeeds, the existing try/catch still delivers binding errors to the page with `name`/`seq`.

## Evidence (red / green)

```text
# Red (before fix)
SyntaxError: Expected property name or '}' in JSON at position 1
  await pageImpl.onBindingCalled('{not-valid-json', context);

# Green (after fix)
1 passed — page continues to evaluate after bad payload
page-expose-function.spec.ts: 22 passed (chromium-page)
```

## Test plan

- [x] New test: invalid binding payload does not crash
- [x] Full `page-expose-function.spec.ts` on chromium-page
