### PR TITLE
devops(roll): sync firefox patches from playwright-browsers when rolling firefox

### DIFF
--- a/browser_patches/roll_from_upstream.sh
+++ b/browser_patches/roll_from_upstream.sh
@@ -4,39 +4,67 @@
 set -e
 set +x
 
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+  echo "Usage: $0 <path to playwright-browsers checkout> [firefox|webkit|winldd]"
+  exit 1
+fi
+
+if ! [[ -d "$1" ]]; then
+  echo "ERROR: the source directory $1 does not exist"
+  exit 1
+fi
+
+SOURCE_DIRECTORY="$(cd "$1" && pwd -P)"
+FILTER="${2:-}"
+
 trap "cd $(pwd -P)" EXIT
 cd "$(dirname "$0")"
 
 SCRIPT_PATH=$(pwd -P)
 
-if [[ "$#" -ne 1 ]]; then
-  echo "Usage: $0 <path to playwright-browsers checkout>"
+# On CI, the playwright-browsers checkout directory can have an arbitrary name,
+# so detect the checkout by a marker file instead of the directory name.
+if ! [[ -f "${SOURCE_DIRECTORY}/browser_patches/build_flavors.sh" ]]; then
+  echo "ERROR: ${SOURCE_DIRECTORY} does not look like a playwright-browsers checkout"
   exit 1
 fi
 
-SOURCE_DIRECTORY="$1"
-
-if [[ $(basename "${SOURCE_DIRECTORY}") != "playwright-browsers" ]]; then
-  echo "ERROR: the source directory must be named 'playwright-browsers'"
-  exit 1
-fi
-
-if ! [[ -d "${SOURCE_DIRECTORY}/browser_patches" ]]; then
-  echo "ERROR: the ${SOURCE_DIRECTORY}/browser_patches does not exist"
-  exit 1
-fi
-
-files=(
+firefox_files=(
   "./firefox/juggler/"
   "./firefox/patches/"
   "./firefox/preferences/"
   "./firefox/UPSTREAM_CONFIG.sh"
+)
+
+webkit_files=(
   "./webkit/embedder/"
   "./webkit/patches/"
   "./webkit/pw_run.sh"
   "./webkit/UPSTREAM_CONFIG.sh"
+)
+
+winldd_files=(
   "./winldd/"
 )
+
+case "${FILTER}" in
+  firefox)
+    files=("${firefox_files[@]}")
+    ;;
+  webkit)
+    files=("${webkit_files[@]}")
+    ;;
+  winldd)
+    files=("${winldd_files[@]}")
+    ;;
+  "")
+    files=("${firefox_files[@]}" "${webkit_files[@]}" "${winldd_files[@]}")
+    ;;
+  *)
+    echo "ERROR: unknown filter '${FILTER}'; supported filters: firefox, webkit, winldd"
+    exit 1
+    ;;
+esac
 
 for file in "${files[@]}"; do
   rsync -av --delete "${SOURCE_DIRECTORY}/browser_patches/${file}" "${SCRIPT_PATH}/${file}"

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -20,7 +20,7 @@ const path = require('path');
 const { Registry } = require('../packages/playwright-core/lib/coreBundle').registry;
 const fs = require('fs');
 const protocolGenerator = require('./protocol-types-generator');
-const {execSync} = require('child_process');
+const {execSync, execFileSync} = require('child_process');
 const playwright = require('playwright-core');
 
 const SCRIPT_NAME = path.basename(__filename);
@@ -33,6 +33,10 @@ usage: ${SCRIPT_NAME} <browser> <revision> [version]
 Roll the <browser> to a specific <revision> and generate new protocol.
 Version is required for chromium-based browsers.
 Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-beta.
+
+Rolling firefox or firefox-beta requires a playwright-browsers checkout
+next to the playwright checkout, to roll browser patches from upstream.
+Set PW_BROWSERS_CHECKOUT to point to a checkout in a custom location.
 
 Example:
   ${SCRIPT_NAME} chromium 123456 123.0.1234.56
@@ -83,7 +87,15 @@ Example:
     process.exit(1);
   }
 
-  // 2. Update browser revisions in browsers.json.
+  // 2. Rolling Firefox requires a playwright-browsers checkout to roll browser patches from.
+  const browsersCheckoutPath = process.env.PW_BROWSERS_CHECKOUT || path.resolve(__dirname, '..', '..', 'playwright-browsers');
+  if (browserTypeName === 'firefox' && !fs.existsSync(path.join(browsersCheckoutPath, 'browser_patches', 'build_flavors.sh'))) {
+    console.log(`Rolling ${browserName} requires a playwright-browsers checkout at "${browsersCheckoutPath}".`);
+    console.log(`Use PW_BROWSERS_CHECKOUT to point to a custom location.`);
+    process.exit(1);
+  }
+
+  // 3. Update browser revisions in browsers.json.
   console.log('\nUpdating revision in browsers.json...');
   for (const descriptor of descriptors) {
     descriptor.revision = String(revision);
@@ -92,14 +104,14 @@ Example:
   }
   fs.writeFileSync(path.join(CORE_PATH, 'browsers.json'), JSON.stringify(browsersJSON, null, 2) + '\n');
 
-  // 3. Download new browser.
+  // 4. Download new browser.
   console.log('\nDownloading new browser...');
   const registry = new Registry(browsersJSON);
   const executable = registry.findExecutable(browserName);
   await registry.installDeps([executable]);
   await registry.install([...registry.defaultExecutables(), executable]);
 
-  // 4. Update browser version if rolling WebKit / Firefox, validate if rolling Chromium.
+  // 5. Update browser version if rolling WebKit / Firefox, validate if rolling Chromium.
   const browserType = playwright[browserTypeName];
   if (browserType) {
     const browser = await browserType.launch({
@@ -122,13 +134,20 @@ Example:
     }
   }
 
+  // 6. Roll firefox browser patches from the playwright-browsers checkout.
+  if (browserTypeName === 'firefox') {
+    console.log('\nRolling firefox browser patches from the playwright-browsers checkout...');
+    const rollScript = path.join(__dirname, '..', 'browser_patches', 'roll_from_upstream.sh');
+    execFileSync(rollScript, [browsersCheckoutPath, 'firefox'], { stdio: 'inherit' });
+  }
+
   if (browserType && descriptors[0].installByDefault) {
-    // 5. Generate types.
+    // 7. Generate types.
     console.log('\nGenerating protocol types...');
     const executablePath = registry.findExecutable(browserName).executablePathOrDie();
     await protocolGenerator.generateProtocol(browserName, executablePath);
 
-    // 6. Update docs.
+    // 8. Update docs.
     console.log('\nUpdating documentation...');
     try {
       execSync('npm run doc', { stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- `roll_browser.js` now requires a playwright-browsers checkout when rolling firefox/firefox-beta (defaults to `../playwright-browsers`, override with `PW_BROWSERS_CHECKOUT`) and syncs the firefox browser patches from it via `roll_from_upstream.sh`.
- `roll_from_upstream.sh` accepts an optional `firefox|webkit|winldd` filter with explicit per-filter file lists, detects the checkout by a marker file instead of the directory name, and works with relative source paths.