### PR TITLE
fix: allow config use section to set a built-in option overridden by a plain fixture

### DIFF
--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -97,6 +97,18 @@ export class FixturePool {
         this._appendFixtureList({ fixtures: selectedOverrides, location: optionOverrides!.location }, !!disallowWorkerFixtures, true);
     }
 
+    if (optionOverrides) {
+      for (const key of overrideKeys) {
+        let registration = this._registrations.get(key);
+        if (!registration)
+          continue;
+        while (!registration.option && registration.super)
+          registration = registration.super;
+        if (!registration.option)
+          this._addLoadError(`Fixture "${key}" cannot be overridden in the configuration "use" section. Only fixtures registered with { option: true } can be set in the config.`, optionOverrides.location);
+      }
+    }
+
     this.digest = this.validate();
   }
 

--- a/tests/playwright-test/fixture-errors.spec.ts
+++ b/tests/playwright-test/fixture-errors.spec.ts
@@ -370,6 +370,83 @@ test('should throw for unknown fixture parameter', async ({ runInlineTest }) => 
   expect(result.exitCode).toBe(1);
 });
 
+test('should allow config to set an option overridden by a fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { baseURL: 'from-config' } };
+    `,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend({
+        baseURL: [async ({}, use) => use('from-fixture'), { scope: 'test' }],
+      });
+
+      test('works', async ({ baseURL }) => {
+        expect(baseURL).toBe('from-fixture');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('should allow config to set an option overridden by multiple fixtures', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { baseURL: 'from-config' } };
+    `,
+    'a.spec.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test1 = base.extend({
+        baseURL: [async ({}, use) => use('first'), { scope: 'test' }],
+      });
+      const test2 = test1.extend({
+        baseURL: [async ({ baseURL }, use) => use(baseURL + '-second'), { scope: 'test' }],
+      });
+
+      test2('works', async ({ baseURL }) => {
+        expect(baseURL).toBe('first-second');
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
+test('should throw when config overrides a non-option fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { foo: 'from-config' } };
+    `,
+    'a.spec.ts': `
+      import { test as base } from '@playwright/test';
+      const test = base.extend({
+        foo: async ({}, use) => use('from-fixture'),
+      });
+
+      test('does not run', async ({ foo }) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('Fixture "foo" cannot be overridden in the configuration "use" section. Only fixtures registered with { option: true } can be set in the config.');
+});
+
+test('should allow config to set an option and ignore unknown keys', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { headless: false, unknownThing: 'ignored' } };
+    `,
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      test('works', async ({ headless }) => {
+        expect(headless).toBe(false);
+      });
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+});
+
 test('should throw when calling runTest twice', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'f.spec.ts': `


### PR DESCRIPTION
## Summary
In `packages/playwright/src/common/fixtures.ts`, the guard added by #40197 checks only `registration.option` on the final registration for each config-`use` key. When a built-in option such as `baseURL` is overridden by a plain fixture, that final registration has `option: false`, but its `super` chain still leads back to the original `option: true` registration (every override sets `super: previous`).

## Why this matters
Since 1.60.0 a config `use` section can no longer set an option (e.g. `baseURL`) that the user has overridden with a plain, test-scoped fixture via `test.extend`. Doing so now fails at load time with `Fixture "baseURL" cannot be overridden in the configuration "use" section. Only fixtures registered with { option: true } can be set in the config.`, so the whole run aborts. This is a regression introduced by PR #40197 ("feat(test-runner): error when overriding non-option fixture in config"), which added a guard in `FixturePool`'s constructor that errors whenever a config-`use` key resolves to a registration whose `option` flag is false. The reporter cannot work around it because `{ option: true }` cannot be attached to a test-scoped fixture override (TypeScript rejects it). The pattern (override `baseURL` with a per-worker fixture while still declaring a default `baseURL` in the config) worked "like a charm" in 1.59.x.

## Testing
- Regression case: a test file overrides the built-in option `baseURL` with a plain (non-option) test-scoped fixture, and `playwright.config.ts` sets `use.baseURL`; the run loads with no error, exit code 0, and the fixture value from the override is what the test observes.
- Preserved guard (from #40197): setting a genuinely non-option user fixture (`foo`) in config `use` still fails with exit code 1 and the "cannot be overridden in the configuration" message.
- Preserved allow-list: a real built-in option (`headless`) set in config `use` does not error, and an unknown key (`unknownThing`) in config `use` is silently ignored (no error for either).
- Edge: option overridden multiple times (option -> plain override -> plain override) still resolves as an option via the `super` chain and does not error.

Fixes #41757

AI was used for assistance.