### PR TITLE
docs(assertions): document attribute presence checks for Python

### DIFF
--- a/docs/src/api/class-locatorassertions.md
+++ b/docs/src/api/class-locatorassertions.md
@@ -315,6 +315,13 @@ Attribute name.
 
 Expected attribute value.
 
+### param: LocatorAssertions.NotToHaveAttribute.value
+* since: v1.62
+* langs: python
+- `value` ?<[string]|[RegExp]>
+
+Expected attribute value. If not specified, the assertion verifies that the attribute is absent.
+
 ### option: LocatorAssertions.NotToHaveAttribute.ignoreCase = %%-assertions-ignore-case-%%
 * since: v1.40
 
@@ -1533,6 +1540,8 @@ from playwright.async_api import expect
 
 locator = page.locator("input")
 await expect(locator).to_have_attribute("type", "text")
+await expect(locator).to_have_attribute("disabled")
+await expect(locator).not_to_have_attribute("readonly")
 ```
 
 ```python sync
@@ -1540,6 +1549,8 @@ from playwright.sync_api import expect
 
 locator = page.locator("input")
 expect(locator).to_have_attribute("type", "text")
+expect(locator).to_have_attribute("disabled")
+expect(locator).not_to_have_attribute("readonly")
 ```
 
 ```csharp
@@ -1558,6 +1569,13 @@ Attribute name.
 - `value` <[string]|[RegExp]>
 
 Expected attribute value.
+
+### param: LocatorAssertions.toHaveAttribute.value
+* since: v1.62
+* langs: python
+- `value` ?<[string]|[RegExp]>
+
+Expected attribute value. If not specified, the assertion verifies that the attribute is present.
 
 ### option: LocatorAssertions.toHaveAttribute.timeout = %%-js-assertions-timeout-%%
 * since: v1.18


### PR DESCRIPTION
Playwright added `toHaveAttribute(name)` for JS in #27418, leaving other languages out because supporting the overload added unjustified generator complexity. A user has now asked for the equivalent Python API in microsoft/playwright-python#3133.

Turns out there's a simpler route: mark `value` as optional for Python through the existing per-language parameter override, rather than exposing the duplicate JS overload. This keeps JS unchanged and avoids teaching Python's generator about overloads.

The generated Python argument has a `None` default, so users can omit it entirely:

```python
expect(locator).to_have_attribute("disabled")
expect(locator).not_to_have_attribute("readonly")
```

Re https://github.com/microsoft/playwright-python/issues/3133