### PR TITLE
fix(clock): reject out-of-range timestamps

### DIFF
--- a/docs/src/api/class-clock.md
+++ b/docs/src/api/class-clock.md
@@ -75,7 +75,7 @@ Time to initialize with, current system time by default.
 * since: v1.45
 - `time` <[float]|[string]|[Date]>
 
-Time to initialize with, current system time by default.
+Time to initialize with, current system time by default. Numeric values are Unix time in seconds.
 
 ### option: Clock.install.time
 * langs: csharp
@@ -208,7 +208,7 @@ Time to pause at.
 * since: v1.45
 - `time` <[float]|[string]|[Date]>
 
-Time to pause at.
+Time to pause at. Numeric values are Unix time in seconds.
 
 ### param: Clock.pauseAt.time
 * langs: csharp
@@ -274,7 +274,7 @@ Time to be set in milliseconds.
 * since: v1.45
 - `time` <[float]|[string]|[Date]>
 
-Time to be set.
+Time to be set. Numeric values are Unix time in seconds.
 
 ### param: Clock.setFixedTime.time
 * langs: csharp
@@ -332,7 +332,7 @@ Time to be set in milliseconds.
 * since: v1.45
 - `time` <[float]|[string]|[Date]>
 
-Time to be set.
+Time to be set. Numeric values are Unix time in seconds.
 
 ### param: Clock.setSystemTime.time
 * langs: csharp

--- a/packages/playwright-core/src/server/clock.ts
+++ b/packages/playwright-core/src/server/clock.ts
@@ -148,10 +148,8 @@ function parseTicks(value: number | string): number {
 function parseTime(epoch: string | number | undefined): number {
   if (!epoch)
     return 0;
-  if (typeof epoch === 'number')
-    return epoch;
   const parsed = new Date(epoch);
   if (!isFinite(parsed.getTime()))
     throw new Error(`Invalid date: ${epoch}`);
-  return parsed.getTime();
+  return typeof epoch === 'number' ? epoch : parsed.getTime();
 }

--- a/tests/library/page-clock.spec.ts
+++ b/tests/library/page-clock.spec.ts
@@ -440,6 +440,18 @@ it.describe('while running', () => {
     expect(now).toBe(60000);
   });
 
+  it('should reject an invalid target time with an active requestAnimationFrame loop', {
+    annotation: {
+      type: 'issue',
+      description: 'https://github.com/microsoft/playwright-python/issues/3137',
+    }
+  }, async ({ page }) => {
+    await page.clock.install();
+    await page.setContent(`<script>function tick() { requestAnimationFrame(tick); } requestAnimationFrame(tick);</script>`);
+    const invalidTime = await page.evaluate(() => Date.now()) * 1_000_000;
+    await expect(page.clock.pauseAt(invalidTime)).rejects.toThrow(`clock.pauseAt: Invalid date: ${invalidTime}`);
+  });
+
   it('should pause and fastForward', async ({ page }) => {
     await page.clock.install({ time: 0 });
     await page.goto('data:text/html,');


### PR DESCRIPTION
This rejects absolute clock times outside the JavaScript Date range before evaluating them in pages. Without this, a self-scheduling `requestAnimationFrame` at an unsafe timestamp can loop forever.

It also documents that numeric Python absolute times are Unix seconds.

Fixes microsoft/playwright-python#3137