### PR TITLE
fix(aria): do not hang ai snapshot on frameset pages

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -1116,7 +1116,9 @@ export async function ariaSnapshotForFrame(progress: Progress, frame: frames.Fra
   const snapshot = await frame.retryWithProgressAndTimeouts(progress, [1000, 2000, 4000, 8000], async (progress, continuePolling) => {
     try {
       // Note: the resolved frame might differ from the original |frame|.
-      const resolved = await progress.race(frame.selectors.callOnSelector(selector || 'body', { strict: true }, ({ injected, elements }, ariaOptions) => {
+      // See https://developer.mozilla.org/en-US/docs/Web/API/Document/body for body/frameset explanation.
+      // Non-strict, because pages with nested framesets have multiple "frameset" elements.
+      const resolved = await progress.race(frame.selectors.callOnSelector(selector || 'body,frameset', { strict: !!selector }, ({ injected, elements }, ariaOptions) => {
         return injected.ariaSnapshotWithRefs(elements[0], ariaOptions);
       }, {
         mode: options.mode ?? 'default',

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -668,6 +668,12 @@ it('should support many properties on iframes', async ({ page }) => {
   `);
 });
 
+it('should not timeout on frameset pages', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41784' } }, async ({ page, server }) => {
+  await page.goto(server.PREFIX + '/frames/frameset.html');
+  const snapshot = await snapshotForAI(page, { timeout: 3000 });
+  expect(snapshot).toBe('');
+});
+
 it('should collapse inline generic nodes', async ({ page }) => {
   await page.setContent(`
     <ul>


### PR DESCRIPTION
## Summary
- Query `body,frameset` instead of just `body` when taking an aria snapshot without an explicit selector, following the `document.body` spec. Otherwise, snapshot never resolves on frameset pages that do not have a `body` element.
- Non-strict query, because pages with nested framesets have multiple `frameset` elements.

Fixes https://github.com/microsoft/playwright/issues/41784