### PR TITLE
chore(cli): remove init-skills command

### DIFF
--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -185,20 +185,6 @@ function addInitAgentsCommand(program: Command) {
   });
 }
 
-function addInitSkillsCommand(program: Command) {
-  const command = program.command('init-skills');
-  command.description('Initialize the workspace and install Playwright CLI skills');
-  const option = command.createOption('--loop <loop>', 'Agentic loop provider');
-  option.choices(['claude', 'generic']);
-  option.default('generic');
-  command.addOption(option);
-  command.action(async opts => {
-    // Claude Code only reads skills from `.claude/skills`, every other agent reads
-    // them from the universal `.agents/skills` folder.
-    await tools.initWorkspace(opts.loop === 'claude' ? 'claude' : 'agents');
-  });
-}
-
 const kTraceModes: TraceMode[] = ['on', 'off', 'on-first-retry', 'on-all-retries', 'retain-on-failure', 'retain-on-first-failure', 'retain-on-failure-and-retries'];
 
 // Note: update docs/src/test-cli-js.md when you update this, program is the source of truth.
@@ -251,4 +237,3 @@ addClearCacheCommand(program);
 addTestMCPServerCommand(program);
 addTestServerCommand(program);
 addInitAgentsCommand(program);
-addInitSkillsCommand(program);


### PR DESCRIPTION
## Summary
- Remove the `playwright init-skills` CLI command from `packages/playwright/src/program.ts`.

The separate `playwright-core` cli-daemon `--init-skills` flag and `initWorkspace` helper are unaffected.