### PR TITLE
fix(mcp): remove stale --output-mode CLI option

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -46,7 +46,6 @@ export type ContextConfig = {
   };
   outputDir?: string;
   outputMaxSize?: number;
-  outputMode?: 'file' | 'stdout';
   saveSession?: boolean;
   secrets?: Record<string, string>;
   snapshot?: {

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -61,7 +61,6 @@ export function decorateMCPCommand(command: Command) {
       .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')
       .option('--output-dir <path>', 'path to the directory for output files.')
       .option('--output-max-size <bytes>', 'Threshold for evicting old output files, in bytes.', numberParser)
-      .option('--output-mode <mode>', 'whether to save snapshots, console messages, network logs to a file or to the standard output. Can be "file" or "stdout". Default is "stdout".', enumParser.bind(null, '--output-mode', ['file', 'stdout']))
       .option('--port <port>', 'port to listen on for SSE transport.')
       .option('--proxy-bypass <bypass>', 'comma-separated domains to bypass proxy, for example ".com,chromium.org,.domain.com"')
       .option('--proxy-server <proxy>', 'specify proxy server, for example "http://myproxy:3128" or "socks5://myproxy:8080"')

--- a/packages/playwright-core/src/tools/trace/traceSnapshot.ts
+++ b/packages/playwright-core/src/tools/trace/traceSnapshot.ts
@@ -190,7 +190,6 @@ async function runCommandOnSnapshot(server: { url: string, stop: () => Promise<v
 
   const backend = new BrowserBackend({
     snapshot: { mode: 'full' },
-    outputMode: 'file',
     skillMode: true,
   }, context, browserTools);
   await backend.initialize({ cwd: process.cwd(), clientName: 'playwright-cli' });


### PR DESCRIPTION
## Summary
- Remove the `--output-mode` CLI flag left behind after the `outputMode` config option was removed — its value was parsed and silently discarded, and it kept showing up in the generated playwright-mcp README with an incorrect "stdout" default.
- Remove the unused `ContextConfig.outputMode` field and its write-only assignment in the trace snapshot code.

Fixes https://github.com/microsoft/playwright-mcp/issues/1680