### PR TITLE
chore(test-runner): address httpCache review comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test-results
 /tests/installation/output/
 /tests/installation/.registry.json
 .cache/
+.network-cache/
 .eslintcache
 playwright.env
 /firefox/

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -108,10 +108,10 @@ The following are therefore **not** cached by default:
 * Any response carrying a personalization signal: `Cache-Control: private`, a `Set-Cookie`
   header, or `Vary: Cookie`/`Vary: Authorization`.
 
-The `Authorization` and `Cookie` request headers are deliberately ignored when deciding
-what to cache. On a gated staging environment these are a shared environment credential
-attached to every request, not a per-user identity, so caching on their presence would be
-wrong.
+A request is still cached when it carries an `Authorization` or `Cookie` header — those are
+deliberately ignored when deciding what to cache. On a gated staging environment they are a
+shared environment credential attached to every request, not a per-user identity, so
+skipping the cache whenever they are present would defeat the feature.
 
 Freshness directives (`max-age`, `no-cache`, `Expires`) are ignored: once a response is
 recorded it is replayed until `dir` is deleted, keeping runs deterministic. `Vary` is
@@ -125,7 +125,7 @@ straight through to the network. For full control, pass a callback that returns 
 object per request:
 
 * `disposition` — `'cache'` force-stores the response and serves it back, `'no-cache'`
-  bypasses the cache entirely, and `'default'` (or an empty object) applies the rules above.
+  bypasses the cache entirely, and `'default'` (or undefined) applies the rules above.
 * `identity` — a stable principal id (such as a session token) that partitions the cache.
   Entries recorded under one identity are never served to a request with a different one,
   so per-user content can be cached without leaking across contexts. The value is hashed
@@ -169,7 +169,7 @@ export default defineConfig({
     match: request => {
       if (request.url.includes('/api/config'))
         return { disposition: 'cache', identity: request.headers.get('authorization') };
-      if (request.url.includes('/telemetry'))
+      if (request.url.includes('/status'))
         return { disposition: 'no-cache' };
       return {};
     },

--- a/examples/todomvc/.gitignore
+++ b/examples/todomvc/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 test-results/
 playwright-report/
 package-lock.json
+.network-cache/

--- a/examples/todomvc/playwright.config.ts
+++ b/examples/todomvc/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
 
   testDir: './tests',
 
+  /* Cache large static assets from the remote demo app across runs. */
+  httpCache: { dir: '.network-cache' },
+
   /* Maximum time one test can run for. */
   timeout: 15_000,
 

--- a/packages/playwright/src/plugins/cacheProxy/cache.ts
+++ b/packages/playwright/src/plugins/cacheProxy/cache.ts
@@ -63,18 +63,15 @@ export class ResponseCache {
   }
 
   async load() {
-    let content: string;
-    try {
-      content = await fs.promises.readFile(this._indexFile, 'utf8');
-    } catch {
+    if (!await existsAsync(this._indexFile))
       return; // No cache yet.
-    }
-    // Discard an incompatible cache instead of mis-parsing it.
+    // Discard an incompatible cache instead of reading and mis-parsing it.
     if (await this._onDiskVersion() !== CACHE_VERSION) {
       await fs.promises.rm(this._indexFile, { force: true }).catch(() => {});
       await fs.promises.rm(this._blobsDir, { recursive: true, force: true }).catch(() => {});
       return;
     }
+    const content = await fs.promises.readFile(this._indexFile, 'utf8');
     for (const line of content.split('\n')) {
       if (!line.trim())
         continue;

--- a/packages/playwright/src/plugins/cacheProxy/server.ts
+++ b/packages/playwright/src/plugins/cacheProxy/server.ts
@@ -44,18 +44,26 @@ export type CacheEntry = { cache: ResponseCache, match: HttpCacheMatch };
 
 type Selection = { cache: ResponseCache, read: boolean, write: 'force' | 'never' | 'default', identity: string };
 
+export type CacheProxyOptions = { proxy?: ProxySettings, ignoreHTTPSErrors?: boolean };
+
 export class CacheProxy {
   private _entry: CacheEntry;
   private _proxy: ProxySettings | undefined;
   private _proxyAgent: http.Agent | undefined;
+  private _rejectUnauthorized: boolean;
   private _httpServer: http.Server;
   private _httpsServer: https.Server;
   private _inflight = new Map<string, Promise<CachedResponse | undefined>>();
 
-  constructor(entry: CacheEntry, proxy?: ProxySettings) {
+  constructor(entry: CacheEntry, options: CacheProxyOptions = {}) {
     this._entry = entry;
-    this._proxy = proxy;
-    this._proxyAgent = createProxyAgent(proxy, undefined, { keepAlive: true });
+    this._proxy = options.proxy;
+    // Cache misses are fetched over TLS with verification on, unless the user
+    // opted into ignoring HTTPS errors (e.g. a staging server's self-signed
+    // certificate). The browser <-> proxy leg uses a self-signed MITM cert, so
+    // certificate checking happens on this upstream leg instead.
+    this._rejectUnauthorized = !options.ignoreHTTPSErrors;
+    this._proxyAgent = createProxyAgent(options.proxy, undefined, { keepAlive: true });
     const { cert, key } = generateSelfSignedCertificate();
 
     this._httpServer = createHttpServer((req, res) => this._handleRequest(req, res, false));
@@ -92,9 +100,9 @@ export class CacheProxy {
       if (first[0] === 0x16) {
         this._httpsServer.emit('connection', socket);
       } else {
-        // The http server does not resume a socket handed over while paused
-        // (the TLS server does), so the tunnelled request would never parse.
         this._httpServer.emit('connection', socket);
+        // The plain http server, unlike the TLS server, does not resume a
+        // paused socket on its own; resume it so the request is read.
         socket.resume();
       }
     };
@@ -247,7 +255,7 @@ export class CacheProxy {
       method,
       headers,
       agent,
-      rejectUnauthorized: false,
+      rejectUnauthorized: this._rejectUnauthorized,
     });
   }
 
@@ -267,7 +275,7 @@ export class CacheProxy {
       upstream.pipe(socket);
     };
     const upstream = isTls
-      ? tls.connect({ host, port, rejectUnauthorized: false, servername: net.isIP(host) ? undefined : host }, onConnect)
+      ? tls.connect({ host, port, rejectUnauthorized: this._rejectUnauthorized, servername: net.isIP(host) ? undefined : host }, onConnect)
       : net.connect({ host, port }, onConnect);
     upstream.on('error', () => socket.destroy());
   }

--- a/packages/playwright/src/plugins/cacheProxyPlugin.ts
+++ b/packages/playwright/src/plugins/cacheProxyPlugin.ts
@@ -19,11 +19,14 @@ import { ResponseCache } from './cacheProxy/cache';
 
 import type { TestRunnerPlugin } from '.';
 import type { FullConfigInternal } from '../common';
+import type { PlaywrightTestOptions } from '../../types/test';
 
 export const cacheProxyPluginForConfig = (config: FullConfigInternal): TestRunnerPlugin[] => {
   const httpCache = config.httpCache;
   if (!httpCache)
     return [];
+  // Skip upstream certificate verification only when the user opted into it.
+  const ignoreHTTPSErrors = config.projects.some(project => (project.project.use as PlaywrightTestOptions).ignoreHTTPSErrors);
 
   let cache: ResponseCache | undefined;
   let proxy: CacheProxy | undefined;
@@ -32,7 +35,7 @@ export const cacheProxyPluginForConfig = (config: FullConfigInternal): TestRunne
     setup: async () => {
       cache = new ResponseCache(httpCache.dir);
       await cache.load();
-      proxy = new CacheProxy({ cache, match: httpCache.match }, httpCache.proxy);
+      proxy = new CacheProxy({ cache, match: httpCache.match }, { proxy: httpCache.proxy, ignoreHTTPSErrors });
       process.env.PLAYWRIGHT_TEST_CACHE_PROXY = await proxy.start();
     },
     teardown: async () => {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -1442,9 +1442,9 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    * - Any response carrying a personalization signal: `Cache-Control: private`, a `Set-Cookie` header, or `Vary:
    *   Cookie`/`Vary: Authorization`.
    *
-   * The `Authorization` and `Cookie` request headers are deliberately ignored when deciding what to cache. On a gated
-   * staging environment these are a shared environment credential attached to every request, not a per-user identity,
-   * so caching on their presence would be wrong.
+   * A request is still cached when it carries an `Authorization` or `Cookie` header — those are deliberately ignored
+   * when deciding what to cache. On a gated staging environment they are a shared environment credential attached to
+   * every request, not a per-user identity, so skipping the cache whenever they are present would defeat the feature.
    *
    * Freshness directives (`max-age`, `no-cache`, `Expires`) are ignored: once a response is recorded it is replayed
    * until `dir` is deleted, keeping runs deterministic. `Vary` is honored — responses are keyed by the request-header
@@ -1455,7 +1455,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    * A string or [RegExp] restricts caching to requests whose URL matches; other requests pass straight through to the
    * network. For full control, pass a callback that returns a decision object per request:
    * - `disposition` — `'cache'` force-stores the response and serves it back, `'no-cache'` bypasses the cache
-   *   entirely, and `'default'` (or an empty object) applies the rules above.
+   *   entirely, and `'default'` (or undefined) applies the rules above.
    * - `identity` — a stable principal id (such as a session token) that partitions the cache. Entries recorded under
    *   one identity are never served to a request with a different one, so per-user content can be cached without
    *   leaking across contexts. The value is hashed into the cache key and never written to disk.
@@ -1501,7 +1501,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    *     match: request => {
    *       if (request.url.includes('/api/config'))
    *         return { disposition: 'cache', identity: request.headers.get('authorization') };
-   *       if (request.url.includes('/telemetry'))
+   *       if (request.url.includes('/status'))
    *         return { disposition: 'no-cache' };
    *       return {};
    *     },
@@ -2174,8 +2174,8 @@ export type HttpCacheDecision = {
   /**
    * A stable principal id, such as a session token, that partitions the cache. Entries recorded under one identity
    * are never served to a request with a different one, so per-user content can be cached without leaking across
-   * contexts. The value is hashed into the cache key and never written to disk. `null` is treated as anonymous, so
-   * `request.headers.get()` results can be passed directly.
+   * contexts. The value is hashed into the cache key and never written to disk. `null` and `undefined` both mean "no
+   * identity" (the default, shared partition), so the result of `request.headers.get()` can be passed directly.
    */
   identity?: string | null;
 };

--- a/tests/config/proxy.ts
+++ b/tests/config/proxy.ts
@@ -19,6 +19,7 @@ import type { ProxyServer } from '../third_party/proxy';
 import { createProxy } from '../third_party/proxy';
 import net from 'net';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
+import { kResolvableLoopbackHost } from './testserver';
 
 type SocksSocketClosedPayload = utils.SocksSocketClosedPayload;
 type SocksSocketDataPayload = utils.SocksSocketDataPayload;
@@ -152,7 +153,7 @@ export async function setupSocksForwardingServer({
   const socksProxy = new SocksProxy();
   socksProxy.setPattern('*');
   socksProxy.addListener(SocksProxy.Events.SocksRequested, async (payload: SocksSocketRequestedPayload) => {
-    if (!['127.0.0.1', 'fake-localhost-127-0-0-1.nip.io', 'localhost'].includes(payload.host) || payload.port !== allowedTargetPort) {
+    if (!['127.0.0.1', kResolvableLoopbackHost, 'localhost'].includes(payload.host) || payload.port !== allowedTargetPort) {
       socksProxy.sendSocketError({ uid: payload.uid, error: 'ECONNREFUSED' });
       return;
     }

--- a/tests/config/testserver/index.ts
+++ b/tests/config/testserver/index.ts
@@ -40,6 +40,10 @@ type UpgradeActions = {
 
 type IncomingMessageWithBody = http.IncomingMessage & { postBody: Promise<Buffer> };
 
+// A hostname that resolves to 127.0.0.1 but is not treated as loopback, so
+// traffic to a local test server is routed through a configured proxy.
+export const kResolvableLoopbackHost = 'fake-localhost-127-0-0-1.nip.io';
+
 export class TestServer {
   private _server: http.Server;
   private _wsServer: WebSocketServer;

--- a/tests/playwright-test/cache-proxy-unit.spec.ts
+++ b/tests/playwright-test/cache-proxy-unit.spec.ts
@@ -14,72 +14,45 @@
  * limitations under the License.
  */
 
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect } from './playwright-test-fixtures';
 import http from 'http';
 import https from 'https';
 import net from 'net';
 import fs from 'fs';
 import path from 'path';
-import { WebSocket, WebSocketServer } from 'ws';
+import { WebSocket } from 'ws';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import { generateSelfSignedCertificate } from '@utils/crypto';
-import { CacheProxy } from '../../../packages/playwright/src/plugins/cacheProxy/server';
-import { ResponseCache } from '../../../packages/playwright/src/plugins/cacheProxy/cache';
-import type { CacheEntry } from '../../../packages/playwright/src/plugins/cacheProxy/server';
-import type { ProxySettings } from '@utils/network';
-
-// A non-loopback name that resolves to 127.0.0.1, so the proxy's loopback
-// bypass does not skip our local origin.
-const HOST = 'fake-localhost-127-0-0-1.nip.io';
+import { CacheProxy } from '../../packages/playwright/src/plugins/cacheProxy/server';
+import { ResponseCache } from '../../packages/playwright/src/plugins/cacheProxy/cache';
+import { kResolvableLoopbackHost } from '../config/testserver';
+import type { CacheEntry, CacheProxyOptions } from '../../packages/playwright/src/plugins/cacheProxy/server';
+import type { TestServer } from '../config/testserver';
 
 type RouteHandler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
 type Origin = {
-  port: number;
   url: (p: string) => string;
   loopbackUrl: (p: string) => string;
   wsUrl: (p: string) => string;
   setRoute: (p: string, h: RouteHandler) => void;
   hits: (p: string) => number;
   onWebSocket: (h: (ws: WebSocket) => void) => void;
-  close: () => Promise<void>;
 };
 
-async function startOrigin(tls?: https.ServerOptions): Promise<Origin> {
+// Adapts a shared TestServer into a hit-counting origin addressed through a
+// resolvable non-loopback host, so its traffic is not bypassed by the proxy.
+function wrapOrigin(server: TestServer, tls: boolean): Origin {
   const hits = new Map<string, number>();
-  const routes = new Map<string, RouteHandler>();
-  const handler: RouteHandler = (req, res) => {
-    const p = new URL(req.url || '/', 'http://x').pathname;
-    hits.set(p, (hits.get(p) || 0) + 1);
-    const route = routes.get(p);
-    if (route) {
-      route(req, res);
-    } else {
-      res.writeHead(404);
-      res.end('not found');
-    }
-  };
-  const server = tls ? https.createServer(tls, handler) : http.createServer(handler);
-  const wss = new WebSocketServer({ server });
-  let wsHandler: ((ws: WebSocket) => void) | undefined;
-  wss.on('connection', ws => wsHandler?.(ws));
-  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-  const port = (server.address() as net.AddressInfo).port;
   const scheme = tls ? 'https' : 'http';
   return {
-    port,
-    url: p => `${scheme}://${HOST}:${port}${p}`,
-    loopbackUrl: p => `${scheme}://127.0.0.1:${port}${p}`,
-    wsUrl: p => `${tls ? 'wss' : 'ws'}://${HOST}:${port}${p}`,
-    setRoute: (p, h) => routes.set(p, h),
-    hits: p => hits.get(p) || 0,
-    onWebSocket: h => { wsHandler = h; },
-    close: () => new Promise<void>(resolve => {
-      for (const client of wss.clients)
-        client.terminate();
-      wss.close();
-      server.closeAllConnections();
-      server.close(() => resolve());
+    url: p => `${scheme}://${kResolvableLoopbackHost}:${server.PORT}${p}`,
+    loopbackUrl: p => `${scheme}://127.0.0.1:${server.PORT}${p}`,
+    wsUrl: p => `${tls ? 'wss' : 'ws'}://${kResolvableLoopbackHost}:${server.PORT}${p}`,
+    setRoute: (p, handler) => server.setRoute(p, (req, res) => {
+      hits.set(p, (hits.get(p) || 0) + 1);
+      handler(req, res);
     }),
+    hits: p => hits.get(p) || 0,
+    onWebSocket: handler => server.onceWebSocketConnection(handler),
   };
 }
 
@@ -151,28 +124,22 @@ type Fixtures = {
   origin: Origin;
   httpsOrigin: Origin;
   cacheDir: () => string;
-  startProxy: (entry: CacheEntry, upstream?: ProxySettings) => Promise<string>;
+  startProxy: (entry: CacheEntry, options?: CacheProxyOptions) => Promise<string>;
 };
 
 const it = base.extend<Fixtures>({
-  origin: async ({}, use) => {
-    const origin = await startOrigin();
-    await use(origin);
-    await origin.close();
-  },
-  httpsOrigin: async ({}, use) => {
-    const origin = await startOrigin(generateSelfSignedCertificate());
-    await use(origin);
-    await origin.close();
-  },
+  origin: async ({ server }, use) => use(wrapOrigin(server, false)),
+  httpsOrigin: async ({ httpsServer }, use) => use(wrapOrigin(httpsServer, true)),
   cacheDir: async ({}, use, testInfo) => {
     let index = 0;
     await use(() => testInfo.outputPath('cache-' + (index++)));
   },
   startProxy: async ({}, use) => {
     const started: CacheProxy[] = [];
-    await use(async (entry, upstream) => {
-      const proxy = new CacheProxy(entry, upstream);
+    await use(async (entry, options) => {
+      // The shared test https server is self-signed, so ignore upstream
+      // certificate errors unless a test opts back into verification.
+      const proxy = new CacheProxy(entry, { ignoreHTTPSErrors: true, ...options });
       const address = await proxy.start();
       started.push(proxy);
       return address;
@@ -182,10 +149,10 @@ const it = base.extend<Fixtures>({
 });
 
 // Convenience: a single-cache proxy over a fresh directory.
-async function cachingProxy(startProxy: Fixtures['startProxy'], cacheDir: Fixtures['cacheDir'], match: CacheEntry['match'] = undefined, upstream?: ProxySettings) {
+async function cachingProxy(startProxy: Fixtures['startProxy'], cacheDir: Fixtures['cacheDir'], match: CacheEntry['match'] = undefined, options?: CacheProxyOptions) {
   const dir = cacheDir();
   const cache = new ResponseCache(dir);
-  const address = await startProxy({ cache, match }, upstream);
+  const address = await startProxy({ cache, match }, options);
   return { address, dir, cache };
 }
 
@@ -452,7 +419,7 @@ it.describe('match callback', () => {
       url: origin.url('/probe'),
       method: 'GET',
       dest: 'image',
-      host: `${HOST}:${origin.port}`,
+      host: new URL(origin.url('/probe')).host,
       cookie: 'sid=1', // Node's Request keeps "forbidden" headers.
     });
   });
@@ -515,13 +482,25 @@ it.describe('https MITM', () => {
     expect((await driveTls(address, httpsOrigin.url('/img'), { 'sec-fetch-dest': 'image' })).body).toBe('secure');
     expect(httpsOrigin.hits('/img')).toBe(1);
   });
+
+  it('rejects a self-signed upstream when not ignoring HTTPS errors', async ({ httpsOrigin, startProxy, cacheDir }) => {
+    httpsOrigin.setRoute('/img', (req, res) => { res.writeHead(200, { 'content-type': 'image/png' }); res.end('secure'); });
+    const { address } = await cachingProxy(startProxy, cacheDir, undefined, { ignoreHTTPSErrors: false });
+    expect((await driveTls(address, httpsOrigin.url('/img'), { 'sec-fetch-dest': 'image' })).status).toBe(502);
+    expect(httpsOrigin.hits('/img')).toBe(0);
+  });
 });
 
 it.describe('errors and edge cases', () => {
-  it('returns 502 when the upstream is unreachable', async ({ origin, startProxy, cacheDir }) => {
-    const url = origin.url('/gone');
-    await origin.close();
+  it('returns 502 when the upstream is unreachable', async ({ startProxy, cacheDir }) => {
+    // Bind then release a port so nothing is listening on it.
+    const dead = http.createServer();
+    await new Promise<void>(resolve => dead.listen(0, '127.0.0.1', resolve));
+    const deadPort = (dead.address() as net.AddressInfo).port;
+    await new Promise<void>(resolve => dead.close(() => resolve()));
+
     const { address } = await cachingProxy(startProxy, cacheDir);
+    const url = `http://${kResolvableLoopbackHost}:${deadPort}/gone`;
     expect((await drive(address, url, { 'sec-fetch-dest': 'image' })).status).toBe(502);
   });
 
@@ -586,7 +565,7 @@ it.describe('upstream proxy chaining', () => {
 
     origin.setRoute('/img', (req, res) => { res.writeHead(200, { 'content-type': 'image/png' }); res.end('x'); });
     try {
-      const { address } = await cachingProxy(startProxy, cacheDir, undefined, { server: upstreamUrl });
+      const { address } = await cachingProxy(startProxy, cacheDir, undefined, { proxy: { server: upstreamUrl } });
       expect((await drive(address, origin.url('/img'), { 'sec-fetch-dest': 'image' })).body).toBe('x');
       expect(tunnelled.length).toBeGreaterThan(0);
       await drive(address, origin.url('/img'), { 'sec-fetch-dest': 'image' });

--- a/tests/playwright-test/cache-proxy.spec.ts
+++ b/tests/playwright-test/cache-proxy.spec.ts
@@ -65,7 +65,7 @@ test('should record and replay responses across runs', async ({ runInlineTest, h
   });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -102,7 +102,7 @@ test('should cache https responses via MITM', async ({ runInlineTest, httpsServe
   });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -127,7 +127,7 @@ test('should tunnel secure WebSockets through the MITM proxy', async ({ runInlin
   httpsServer.onceWebSocketConnection(ws => ws.on('message', () => ws.send('pong')));
 
   const result = await runInlineTest({
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('wss', async ({ page }) => {
@@ -152,7 +152,7 @@ test('should tunnel plaintext WebSockets', async ({ runInlineTest, server }, tes
   server.onceWebSocketConnection(ws => ws.on('message', () => ws.send('pong')));
 
   const result = await runInlineTest({
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('ws', async ({ page }) => {
@@ -181,7 +181,7 @@ test('should stream non-storable responses without buffering', async ({ runInlin
   });
 
   const result = await runInlineTest({
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('stream', async ({ page }) => {
@@ -212,7 +212,7 @@ test('should cache only shared static assets by default', async ({ runInlineTest
   httpsServer.setRoute('/no-store', (req, res) => { ++counts.noStore; res.writeHead(200, { 'cache-control': 'no-store' }); res.end('a'); });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -243,7 +243,7 @@ test('should isolate cached entries by identity', async ({ runInlineTest, server
   server.setRoute('/me', (req, res) => { ++hits; res.end('user:' + (req.headers['x-user'] || 'guest')); });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: {
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: {
       dir: ${JSON.stringify(cacheDir)},
       match: request => ({ disposition: 'cache', identity: request.headers.get('x-user') }),
     } };`,
@@ -279,7 +279,7 @@ test('should key cached variants by Vary', async ({ runInlineTest, server }, tes
 
   const files = {
     // Force-cache so the fetch is stored; this isolates the Vary keying.
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -311,7 +311,7 @@ test('should not cache Vary: * responses', async ({ runInlineTest, server }, tes
 
   const files = {
     // Even when caching is forced, Vary: * is hard-blocked and never stored.
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -337,7 +337,7 @@ test('should cache redirects', async ({ runInlineTest, server }, testInfo) => {
   server.setRoute('/new', (req, res) => { res.end('arrived'); });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -364,7 +364,7 @@ test('should not cache loopback traffic', async ({ runInlineTest, server }, test
   });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)} } };`,
     // Reached over loopback (localhost), which the cache proxy bypasses.
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -399,7 +399,7 @@ test('should respect the match callback disposition', async ({ runInlineTest, ht
   });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: {
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: {
       dir: ${JSON.stringify(cacheDir)},
       match: request => {
         if (request.url.includes('/api/pinned'))
@@ -440,7 +440,7 @@ test('should coalesce concurrent identical requests into one upstream fetch', as
 
   const result = await runInlineTest({
     // Force-cache everything so that concurrent fetch() misses coalesce.
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)}, match: () => ({ disposition: 'cache' }) } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('parallel', async ({ page }) => {
@@ -464,7 +464,7 @@ test('should only cache requests matching the filter', async ({ runInlineTest, h
   httpsServer.setRoute('/api/data.png', (req, res) => { ++api; res.end('data'); });
 
   const files = {
-    'playwright.config.ts': `export default { httpCache: { dir: ${JSON.stringify(cacheDir)}, match: '**/assets/**' } };`,
+    'playwright.config.ts': `export default { use: { ignoreHTTPSErrors: true }, httpCache: { dir: ${JSON.stringify(cacheDir)}, match: '**/assets/**' } };`,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('load', async ({ page }) => {
@@ -496,6 +496,7 @@ test('should chain to the configured proxy', async ({ runInlineTest, httpsServer
 
   const files = {
     'playwright.config.ts': `export default {
+      use: { ignoreHTTPSErrors: true },
       httpCache: { dir: ${JSON.stringify(cacheDir)}, proxy: { server: ${JSON.stringify(upstreamProxy.url)} } },
     };`,
     'a.test.ts': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -88,8 +88,8 @@ export type HttpCacheDecision = {
   /**
    * A stable principal id, such as a session token, that partitions the cache. Entries recorded under one identity
    * are never served to a request with a different one, so per-user content can be cached without leaking across
-   * contexts. The value is hashed into the cache key and never written to disk. `null` is treated as anonymous, so
-   * `request.headers.get()` results can be passed directly.
+   * contexts. The value is hashed into the cache key and never written to disk. `null` and `undefined` both mean "no
+   * identity" (the default, shared partition), so the result of `request.headers.get()` can be passed directly.
    */
   identity?: string | null;
 };


### PR DESCRIPTION
## Summary

Follow-up to #41687 addressing review feedback:

- Verify upstream TLS certificates by default; only skip when the user opted into `ignoreHTTPSErrors`.
- Move the proxy unit test to `tests/playwright-test` and drive it via the shared `TestServer`; share the resolvable-loopback host constant with `tests/config/proxy.ts`.
- Read the cache version before loading the index file.
- Docs and comment clarifications.