### PR TITLE
feat(test runner): add fixture resources

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -1908,5 +1908,3 @@ test('test with locale', async ({ page }) => {
 - `options` <[TestOptions]>
 
 An object with local options.
-
-

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -313,6 +313,27 @@ test('basic test', async ({ todoPage, page }) => {
 });
 ```
 
+## Resource fixtures
+
+Test-scoped fixtures can declare resources.
+Tests that use fixtures with the same resource do not run concurrently, even when they belong to different projects.
+For example, tests that use the same email inbox can use a resource fixture to avoid interfering with each other.
+
+```js title="my-test.ts"
+import { test as base } from '@playwright/test';
+import { testInbox } from './test-inbox';
+
+export const test = base.extend({
+  inbox: [
+    async ({}, use) => {
+      await testInbox.clear();
+      await use(testInbox);
+    },
+    { resources: ['test-inbox'] },
+  ],
+});
+```
+
 ## Overriding fixtures
 
 In addition to creating your own fixtures, you can also override existing fixtures to fit your needs. Consider the following example which overrides the `page` fixture by automatically navigating to the `baseURL`:

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -26,7 +26,7 @@ import type { Location } from '../../types/testReporter';
 export type FixtureScope = 'test' | 'worker';
 type FixtureAuto = boolean | 'all-hooks-included';
 const kScopeOrder: FixtureScope[] = ['test', 'worker'];
-type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' };
+type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, resources?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' };
 type FixtureTuple = [ value: any, options: FixtureOptions ];
 export type FixtureRegistration = {
   // Fixture registration location.
@@ -46,6 +46,8 @@ export type FixtureRegistration = {
   timeout?: number;
   // Names of the dependencies, comes from the declaration "({ foo, bar }) => {...}"
   deps: string[];
+  // Capacity-one resources required by this test-scoped fixture.
+  resources: string[];
   // Unique id, to differentiate between fixtures with the same name.
   id: string;
   // A fixture override can use the previous version of the fixture.
@@ -120,12 +122,25 @@ export class FixturePool {
     for (const entry of Object.entries(fixtures)) {
       const name = entry[0];
       let value = entry[1];
-      let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
+      const previous = this._registrations.get(name);
+      let resourcesSpecified = false;
+      let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, resources: string[], timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
       if (isFixtureTuple(value)) {
+        resourcesSpecified = value[1].resources !== undefined;
+        const resources = value[1].resources ?? previous?.resources ?? [];
+        if (!Array.isArray(resources)) {
+          this._addLoadError(`Fixture "${name}" option "resources" must be an array.`, location);
+          continue;
+        }
+        if (resources.some(resource => typeof resource !== 'string')) {
+          this._addLoadError(`Fixture "${name}" option "resources" must contain only strings.`, location);
+          continue;
+        }
         options = {
           auto: value[1].auto ?? false,
           scope: value[1].scope || 'test',
           option: value[1].option,
+          resources: [...resources],
           timeout: value[1].timeout,
           customTitle: value[1].title,
           box: value[1].box,
@@ -134,7 +149,6 @@ export class FixturePool {
       }
       let fn = value as (Function | any);
 
-      const previous = this._registrations.get(name);
       if (previous && options) {
         if (previous.scope !== options.scope) {
           this._addLoadError(`Fixture "${name}" has already been registered as a { scope: '${previous.scope}' } fixture defined in ${formatLocation(previous.location)}.`, location);
@@ -150,9 +164,9 @@ export class FixturePool {
         }
       } else if (previous) {
         // Note: deliberately not inheriting "options.box" so that fixture override is visible by default.
-        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle };
+        options = { auto: previous.auto, scope: previous.scope, option: previous.option, resources: previous.resources, timeout: previous.timeout, customTitle: previous.customTitle };
       } else if (!options) {
-        options = { auto: false, scope: 'test', option: false, timeout: undefined };
+        options = { auto: false, scope: 'test', option: false, resources: [], timeout: undefined };
       }
 
       if (!kScopeOrder.includes(options.scope)) {
@@ -161,6 +175,10 @@ export class FixturePool {
       }
       if (options.scope === 'worker' && disallowWorkerFixtures) {
         this._addLoadError(`Cannot use({ ${name} }) in a describe group, because it forces a new worker.\nMake it top-level in the test file or put in the configuration file.`, location);
+        continue;
+      }
+      if (options.scope === 'worker' && resourcesSpecified) {
+        this._addLoadError(`Fixture "${name}" cannot specify resources because it has worker scope.`, location);
         continue;
       }
 
@@ -174,7 +192,7 @@ export class FixturePool {
       }
 
       const deps = fixtureParameterNames(fn, location, e => this._onLoadError(e));
-      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
+      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, resources: options.resources, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
       registrationId(registration);
       this._registrations.set(name, registration);
     }
@@ -263,6 +281,34 @@ export class FixturePool {
 
   autoFixtures() {
     return [...this._registrations.values()].filter(r => r.auto !== false);
+  }
+
+  resourcesForFunction(fn: Function, location: Location): string[] {
+    const collector = new Set<FixtureRegistration>();
+    for (const name of fixtureParameterNames(fn, location, e => this._onLoadError(e))) {
+      const registration = this.resolve(name);
+      if (registration)
+        this._collectRegistrations(registration, collector);
+    }
+    return [...collector].flatMap(registration => registration.resources);
+  }
+
+  resourcesForAutoFixtures(): string[] {
+    const collector = new Set<FixtureRegistration>();
+    for (const registration of this.autoFixtures())
+      this._collectRegistrations(registration, collector);
+    return [...collector].flatMap(registration => registration.resources);
+  }
+
+  private _collectRegistrations(registration: FixtureRegistration, collector: Set<FixtureRegistration>) {
+    if (collector.has(registration))
+      return;
+    collector.add(registration);
+    for (const name of registration.deps) {
+      const dependency = this.resolve(name, registration);
+      if (dependency)
+        this._collectRegistrations(dependency, collector);
+    }
   }
 
   private _addLoadError(message: string, location: Location) {

--- a/packages/playwright/src/common/poolBuilder.ts
+++ b/packages/playwright/src/common/poolBuilder.ts
@@ -69,7 +69,21 @@ export class PoolBuilder {
     }
 
     pool.validateFunction(test.fn, 'Test', test.location);
+    // Loader metadata is the scheduling source of truth; worker pools can differ due to project overrides.
+    if (this._type === 'loader')
+      this._setResourcesForTest(test, pool, parents);
     return pool;
+  }
+
+  private _setResourcesForTest(test: TestCase, pool: FixturePool, parents: Suite[]) {
+    test._resources = pool.resourcesForAutoFixtures();
+    for (const parent of parents) {
+      for (const hook of parent._hooks)
+        test._resources.push(...pool.resourcesForFunction(hook.fn, hook.location));
+      for (const modifier of parent._modifiers)
+        test._resources.push(...pool.resourcesForFunction(modifier.fn, modifier.location));
+    }
+    test._resources.push(...pool.resourcesForFunction(test.fn, test.location));
   }
 
   private _buildTestTypePool(testType: TestTypeImpl, testErrors?: TestError[]): FixturePool {

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -283,6 +283,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   _projectId = '';
   // Explicitly declared tags that are not a part of the title.
   _tags: string[] = [];
+  _resources: string[] = [];
   _planAnnotations: TestAnnotation[] = [];
 
   constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {
@@ -342,6 +343,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       workerHash: this._workerHash,
       annotations: this.annotations.slice(),
       tags: this._tags.slice(),
+      resources: this._resources.slice(),
       projectId: this._projectId,
     };
   }
@@ -358,6 +360,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     test._workerHash = data.workerHash;
     test.annotations = data.annotations;
     test._tags = data.tags;
+    test._resources = data.resources || [];
     test._projectId = data.projectId;
     return test;
   }

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -39,6 +39,7 @@ export class Dispatcher {
   private _isolatedJobs = new Set<TestGroup>();
   private _workerLimitPerProjectId = new Map<string, number>();
   private _queuedOrRunningHashCount = new Map<string, number>();
+  private _activeResources = new Set<string>();
   private _finished = new ManualPromise<void>();
   private _isStopped = true;
   // Teardown phases keep running after maxFailures, so that cleanup is not skipped.
@@ -65,6 +66,8 @@ export class Dispatcher {
       // Isolated retries only run one at a time, after all other jobs have finished.
       if (this._isolatedJobs.has(job) && this._workerSlots.some(w => !!w.jobDispatcher))
         continue;
+      if (job.resources.some(resource => this._activeResources.has(resource)))
+        continue;
       const projectIdWorkerLimit = this._workerLimitPerProjectId.get(job.projectId);
       if (!projectIdWorkerLimit)
         return index;
@@ -75,17 +78,17 @@ export class Dispatcher {
     return -1;
   }
 
-  private _scheduleJob() {
+  private _scheduleJob(): boolean {
     // NOTE: keep this method synchronous for easier reasoning.
 
     // 0. No more running jobs after stop.
     if (this._isStopped)
-      return;
+      return false;
 
     // 1. Find a job to run.
     const jobIndex = this._findFirstJobToRun();
     if (jobIndex === -1)
-      return;
+      return false;
     const job = this._queue[jobIndex];
 
     // 2. Find a worker with the same hash, or just some free worker.
@@ -94,24 +97,36 @@ export class Dispatcher {
       workerIndex = this._workerSlots.findIndex(w => !w.jobDispatcher);
     if (workerIndex === -1) {
       // No workers available, bail out.
-      return;
+      return false;
     }
 
     // 3. Claim both the job and the worker slot.
     this._queue.splice(jobIndex, 1);
     const jobDispatcher = new JobDispatcher(job, this._testRun, this._ignoreMaxFailures ? undefined : () => this.stop().catch(() => {}));
     this._workerSlots[workerIndex].jobDispatcher = jobDispatcher;
+    for (const resource of job.resources)
+      this._activeResources.add(resource);
 
     // 4. Run the job. This is the only async operation.
     void this._runJobInWorker(workerIndex, jobDispatcher).then(() => {
 
       // 5. Release the worker slot.
       this._workerSlots[workerIndex].jobDispatcher = undefined;
+      for (const resource of job.resources)
+        this._activeResources.delete(resource);
 
       // 6. Check whether we are done or should schedule another job.
       this._checkFinished();
-      this._scheduleJob();
+      this._scheduleJobs();
     });
+    return true;
+  }
+
+  private _scheduleJobs() {
+    for (let i = 0; i < this._workerSlots.length; i++) {
+      if (!this._scheduleJob())
+        break;
+    }
   }
 
   private async _runJobInWorker(index: number, jobDispatcher: JobDispatcher) {
@@ -213,8 +228,7 @@ export class Dispatcher {
     for (let i = 0; i < this._testRun.config.config.workers; i++)
       this._workerSlots.push({});
     // 2. Schedule enough jobs.
-    for (let i = 0; i < this._workerSlots.length; i++)
-      this._scheduleJob();
+    this._scheduleJobs();
     this._checkFinished();
     // 3. More jobs are scheduled when the worker becomes free.
     // 4. Wait for all jobs to finish.
@@ -565,8 +579,8 @@ class JobDispatcher {
     }
 
     // This job is over, we will schedule new jobs for the remaining tests and isolated retries.
-    const remainingJob = remaining.length ? { ...this.job, tests: remaining } : undefined;
-    const isolatedRetriesJob = isolatedRetries.length ? { ...this.job, tests: isolatedRetries } : undefined;
+    const remainingJob = remaining.length ? { ...this.job, tests: remaining, resources: remaining.flatMap(test => test._resources) } : undefined;
+    const isolatedRetriesJob = isolatedRetries.length ? { ...this.job, tests: isolatedRetries, resources: isolatedRetries.flatMap(test => test._resources) } : undefined;
     this._finished({ didFail: true, remainingJob, isolatedRetriesJob });
   }
 

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -22,6 +22,7 @@ export type TestGroup = {
   repeatEachIndex: number;
   projectId: string;
   tests: test.TestCase[];
+  resources: string[];
 };
 
 export function createTestGroups(projectSuite: test.Suite, expectedParallelism: number): TestGroup[] {
@@ -58,6 +59,7 @@ export function createTestGroups(projectSuite: test.Suite, expectedParallelism: 
       repeatEachIndex: test.repeatEachIndex,
       projectId: test._projectId,
       tests: [],
+      resources: [],
     };
   };
 
@@ -127,6 +129,8 @@ export function createTestGroups(projectSuite: test.Suite, expectedParallelism: 
       }
     }
   }
+  for (const group of result)
+    group.resources = group.tests.flatMap(test => test._resources);
   return result;
 }
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6731,11 +6731,11 @@ type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixtu
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', resources?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
   [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, resources?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';
@@ -8671,7 +8671,6 @@ export function mergeExpects<List extends any[]>(...expects: List): MergedExpect
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export { };
-
 
 
 /**

--- a/tests/playwright-test/test-resources.spec.ts
+++ b/tests/playwright-test/test-resources.spec.ts
@@ -1,0 +1,455 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from './playwright-test-fixtures';
+
+test('should serialize tests using the macOS system pasteboard', async ({ runInlineTest }) => {
+  test.skip(process.platform !== 'darwin', 'macOS only');
+
+  // Once test-runner-stable is updated, every ttest needs to acquire the same locks as the inline test.
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default { use: { browserName: 'webkit' } };
+    `,
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import { execFileSync } from 'child_process';
+
+      type SystemPasteboard = {
+        read(): string;
+        write(text: string): void;
+      };
+
+      const test = base.extend<{ systemPasteboard: SystemPasteboard }>({
+        systemPasteboard: [async ({}, use) => {
+          const read = () => execFileSync('pbpaste', { encoding: 'utf8' });
+          const write = (text: string) => execFileSync('pbcopy', { input: text });
+          const original = read();
+          await use({ read, write });
+          write(original);
+        }, { resources: ['system-pasteboard'] }],
+      });
+
+      test.describe.configure({ mode: 'parallel' });
+      for (const value of ['one', 'two']) {
+        test(value, async ({ page, systemPasteboard }) => {
+          await page.setContent('<input id="source"><input id="target">');
+          const source = page.locator('#source');
+          const target = page.locator('#target');
+
+          await source.fill('copied-' + value);
+          await source.selectText();
+          await source.press('Meta+C');
+          expect(systemPasteboard.read()).toBe('copied-' + value);
+
+          systemPasteboard.write('pasted-' + value);
+          await target.press('Meta+V');
+          await expect(target).toHaveValue('pasted-' + value);
+        });
+      }
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
+test('should acquire multiple fixture resources atomically and refill idle workers', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ holder: void, a: void, b: void }>({
+        holder: [undefined, { resources: ['a', 'b'] }],
+        a: [undefined, { resources: ['a'] }],
+        b: [undefined, { resources: ['b'] }],
+      });
+
+      const rendezvous = async (name: string, other: string) => {
+        fs.writeFileSync(name + '.ready', '');
+        await expect.poll(() => fs.existsSync(other + '.ready')).toBe(true);
+      };
+
+      test.describe.configure({ mode: 'parallel' });
+      test('holder', async ({ holder }) => {
+        void holder;
+        console.log('\\n%%holder-begin');
+        console.log('\\n%%holder-end');
+      });
+      test('a', async ({ a }) => {
+        void a;
+        console.log('\\n%%a-begin');
+        await rendezvous('a', 'b');
+        console.log('\\n%%a-end');
+      });
+      test('b', async ({ b }) => {
+        void b;
+        console.log('\\n%%b-begin');
+        await rendezvous('b', 'a');
+        console.log('\\n%%b-end');
+      });
+    `,
+  }, { workers: 3 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(result.outputLines.slice(0, 2)).toEqual(['holder-begin', 'holder-end']);
+  expect(result.outputLines.slice(2, 4).sort()).toEqual(['a-begin', 'b-begin']);
+  expect(result.outputLines.slice(4).sort()).toEqual(['a-end', 'b-end']);
+});
+
+test('should collect resources from the used fixture graph', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ outer: void, inner: void, unused: void }>({
+        outer: [async ({}, use) => use(), { resources: ['database'] }],
+        inner: async ({ outer }, use) => {
+          void outer;
+          await use();
+        },
+        unused: [undefined, { resources: ['unused'] }],
+      });
+
+      test.describe.configure({ mode: 'parallel' });
+      for (const name of ['a', 'b']) {
+        test('protected ' + name, async ({ inner }) => {
+          void inner;
+          const fd = fs.openSync('database.lock', 'wx');
+          try {
+            await expect.poll(() => fs.existsSync('signal.ready')).toBe(true);
+          } finally {
+            fs.closeSync(fd);
+            fs.unlinkSync('database.lock');
+          }
+        });
+      }
+      test('unprotected signal', async () => fs.writeFileSync('signal.ready', ''));
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+});
+
+test('inefficient case: should preserve resources conservatively through option overrides', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        fullyParallel: true,
+        use: { account: 'override' },
+      };
+    `,
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ direct: string, database: void, account: string }>({
+        direct: ['default', { option: true, resources: ['direct'] }],
+        database: [undefined, { resources: ['database'] }],
+        account: [async ({ database }, use) => {
+          void database;
+          await use('default');
+        }, { option: true }],
+      });
+      test.use({ direct: 'override' });
+
+      const hold = async (resource: string, signal: string) => {
+        const fd = fs.openSync(resource + '.lock', 'wx');
+        try {
+          await expect.poll(() => fs.existsSync(signal + '.ready')).toBe(true);
+        } finally {
+          fs.closeSync(fd);
+          fs.unlinkSync(resource + '.lock');
+        }
+      };
+      for (const name of ['a', 'b']) {
+        test('direct ' + name, async ({ direct }) => {
+          void direct;
+          await hold('direct', 'direct-signal');
+        });
+      }
+      test('direct signal', async () => fs.writeFileSync('direct-signal.ready', ''));
+      test('overridden account', async ({ account }) => {
+        void account;
+        await hold('database', 'database-signal');
+      });
+      test('database', async ({ database }) => {
+        void database;
+        await hold('database', 'database-signal');
+      });
+      test('database signal', async () => fs.writeFileSync('database-signal.ready', ''));
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(6);
+});
+
+test('should include resources used by automatic fixtures and hooks', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a-auto.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ automatic: void }>({
+        automatic: [async ({}, use) => {
+          const fd = fs.openSync('automatic.lock', 'wx');
+          try {
+            await use();
+          } finally {
+            fs.closeSync(fd);
+            fs.unlinkSync('automatic.lock');
+          }
+        }, { auto: true, resources: ['automatic'] }],
+      });
+
+      test.describe.configure({ mode: 'parallel' });
+      for (const name of ['a', 'b']) {
+        test(name, async () => await expect.poll(() => fs.existsSync('automatic-signal.ready')).toBe(true));
+      }
+    `,
+    'b-auto-signal.test.ts': `
+      import { test } from '@playwright/test';
+      import fs from 'fs';
+
+      test('signal', async () => fs.writeFileSync('automatic-signal.ready', ''));
+    `,
+    'c-hook.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ hooked: void }>({
+        hooked: [async ({}, use) => {
+          const fd = fs.openSync('hooked.lock', 'wx');
+          try {
+            await use();
+          } finally {
+            fs.closeSync(fd);
+            fs.unlinkSync('hooked.lock');
+          }
+        }, { resources: ['hooked'] }],
+      });
+
+      test.describe.configure({ mode: 'parallel' });
+      test.beforeEach(async ({ hooked }) => void hooked);
+      for (const name of ['a', 'b']) {
+        test(name, async () => await expect.poll(() => fs.existsSync('hooked-signal.ready')).toBe(true));
+      }
+    `,
+    'd-hook-signal.test.ts': `
+      import { test } from '@playwright/test';
+      import fs from 'fs';
+
+      test('signal', async () => fs.writeFileSync('hooked-signal.ready', ''));
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(6);
+});
+
+test('should coordinate fixture resources globally across projects', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default {
+        projects: [
+          { name: 'one', grep: /@protected/ },
+          { name: 'two', grep: /@protected/ },
+          { name: 'signal', grep: /@signal/ },
+        ],
+      };
+    `,
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void }>({
+        database: [undefined, { resources: ['database'] }],
+      });
+      test('protected @protected', async ({ database }) => {
+        void database;
+        const fd = fs.openSync('database.lock', 'wx');
+        try {
+          await expect.poll(() => fs.existsSync('signal.ready')).toBe(true);
+        } finally {
+          fs.closeSync(fd);
+          fs.unlinkSync('database.lock');
+        }
+      });
+      test('signal @signal', async () => {
+        fs.writeFileSync('signal.ready', '');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+});
+
+test('should reserve the fixture resource union for a non-parallel group', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void }>({
+        database: [undefined, { resources: ['database'] }],
+      });
+      test('uses resource before fixture declaration', async () => {
+        const fd = fs.openSync('database.lock', 'wx');
+        try {
+          fs.writeFileSync('a.ready', '');
+          await expect.poll(() => fs.existsSync('signal.ready')).toBe(true);
+        } finally {
+          fs.closeSync(fd);
+          fs.unlinkSync('database.lock');
+        }
+      });
+      test('declares resource', async ({ database }) => void database);
+    `,
+    'b.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void }>({
+        database: [undefined, { resources: ['database'] }],
+      });
+      test('competing test', async ({ database }) => {
+        void database;
+        const fd = fs.openSync('database.lock', 'wx');
+        try {
+          await expect.poll(() => fs.existsSync('a.ready')).toBe(true);
+        } finally {
+          fs.closeSync(fd);
+          fs.unlinkSync('database.lock');
+        }
+      });
+    `,
+    'c.test.ts': `
+      import { test, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      test('signal', async () => {
+        fs.writeFileSync('signal.ready', '');
+        await expect.poll(() => fs.existsSync('a.ready')).toBe(true);
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4);
+});
+
+test('should not retain failed test resources in the remaining job', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      export default { retries: 1, retryStrategy: 'isolated' };
+    `,
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ a: void, b: void }>({
+        a: [undefined, { resources: ['a'] }],
+        b: [undefined, { resources: ['b'] }],
+      });
+      test('flaky', async ({ a }, testInfo) => {
+        void a;
+        expect(testInfo.retry).toBe(1);
+      });
+      test('remaining', async ({ b }) => {
+        void b;
+        fs.writeFileSync('remaining.ready', '');
+        await expect.poll(() => fs.existsSync('competing.ready')).toBe(true);
+      });
+    `,
+    'b.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ a: void }>({
+        a: [undefined, { resources: ['a'] }],
+      });
+      test('competing', async ({ a }) => {
+        void a;
+        fs.writeFileSync('competing.ready', '');
+        await expect.poll(() => fs.existsSync('remaining.ready')).toBe(true);
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.flaky).toBe(1);
+});
+
+test('should release fixture resources when a worker crashes', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const test = base.extend<{ database: void }>({
+        database: [undefined, { resources: ['database'] }],
+      });
+      test.describe.configure({ mode: 'parallel' });
+      test('crashes', async ({ database }) => {
+        void database;
+        process.exit(1);
+      });
+      test('runs after crash', async ({ database }) => {
+        void database;
+        console.log('\\n%%survived');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(1);
+  expect(result.failed).toBe(1);
+  expect(result.passed).toBe(1);
+  expect(result.outputLines).toEqual(['survived']);
+});
+
+test('should validate fixture resources', async ({ runInlineTest }) => {
+  const worker = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { scope: 'worker', resources: ['database'] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(worker.exitCode).toBe(1);
+  expect(worker.output).toContain('cannot specify resources because it has worker scope');
+
+  const empty = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { resources: [''] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(empty.exitCode).toBe(0);
+
+  const nonString = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { resources: [42] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(nonString.exitCode).toBe(1);
+  expect(nonString.output).toContain('must contain only strings');
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -206,11 +206,11 @@ type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixtu
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', resources?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
   [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, resources?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';
@@ -542,4 +542,3 @@ export function mergeExpects<List extends any[]>(...expects: List): MergedExpect
 
 // This is required to not export everything by default. See https://github.com/Microsoft/TypeScript/issues/19545#issuecomment-340490459
 export { };
-


### PR DESCRIPTION
This PR lets test-scoped fixtures declare shared resources:

```ts
export const test = base.extend({
  inbox: [
    async ({}, use) => {
      await testInbox.clear();
      await use(testInbox);
    },
    { resources: ['test-inbox'] },
  ],
});
```

Tests using the same resource won't run concurrently. The runner derives these requirements from the fixture graph before scheduling, so blocked jobs don't occupy a worker.

Resources have capacity one and coordinate jobs across workers and projects within one Playwright invocation.

Project overrides can cause us to reserve more resources than necessary. We can make this exact with some rather complicated loader plumbing in a follow-up, if it turns out to matter.
