### PR TITLE
fix(extension): pass client name on token-bypass connect

### DIFF
--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -59,9 +59,10 @@ const ConnectApp: React.FC = () => {
         return;
       }
 
+      let info: string;
       try {
         const client = JSON.parse(params.get('client') || '{}');
-        const info = `${client.name || 'unknown'}`;
+        info = `${client.name || 'unknown'}`;
         setClientInfo(info);
         setStatus({
           type: 'connecting',
@@ -97,7 +98,9 @@ const ConnectApp: React.FC = () => {
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
       if (token === expectedToken) {
-        await handleConnectToTab();
+        // Pass `info` explicitly: setClientInfo only schedules a re-render, so
+        // handleConnectToTab would still close over the initial 'unknown' state.
+        await handleConnectToTab(undefined, info);
         return;
       }
       if (token) {
@@ -128,28 +131,29 @@ const ConnectApp: React.FC = () => {
       setStatus({ type: 'error', message: 'Failed to load tabs: ' + response.error });
   }, []);
 
-  const handleConnectToTab = useCallback(async (tab?: chrome.tabs.Tab) => {
+  const handleConnectToTab = useCallback(async (tab?: chrome.tabs.Tab, clientNameOverride?: string) => {
     setShowTabList(false);
+    const name = clientNameOverride ?? clientInfo;
 
     try {
       const response = await chrome.runtime.sendMessage({
         type: 'connectToTab',
         tab,
-        clientName: clientInfo,
+        clientName: name,
       });
 
       if (response?.success) {
-        setStatus({ type: 'connected', message: `"${clientInfo}" connected.` });
+        setStatus({ type: 'connected', message: `"${name}" connected.` });
       } else {
         setStatus({
           type: 'error',
-          message: response?.error || `"${clientInfo}" failed to connect.`
+          message: response?.error || `"${name}" failed to connect.`
         });
       }
     } catch (e) {
       setStatus({
         type: 'error',
-        message: `"${clientInfo}" failed to connect: ${e}`
+        message: `"${name}" failed to connect: ${e}`
       });
     }
   }, [clientInfo]);

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -27,11 +27,19 @@ type Status =
 
 const SUPPORTED_PROTOCOL_VERSION = 2;
 
+// Client name comes from the URL and never changes for the lifetime of this page.
+const clientInfo = (() => {
+  try {
+    return JSON.parse(new URLSearchParams(window.location.search).get('client') || '{}').name || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
+
 const ConnectApp: React.FC = () => {
   const [tabs, setTabs] = useState<chrome.tabs.Tab[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
   const [showTabList, setShowTabList] = useState(true);
-  const [clientInfo, setClientInfo] = useState('unknown');
 
   const setError = useCallback((message: string) => {
     setShowTabList(false);
@@ -59,19 +67,10 @@ const ConnectApp: React.FC = () => {
         return;
       }
 
-      let info: string;
-      try {
-        const client = JSON.parse(params.get('client') || '{}');
-        info = `${client.name || 'unknown'}`;
-        setClientInfo(info);
-        setStatus({
-          type: 'connecting',
-          message: `"${info}" is trying to connect to the Playwright Extension.`
-        });
-      } catch (e) {
-        setStatus({ type: 'error', message: 'Failed to parse client version.' });
-        return;
-      }
+      setStatus({
+        type: 'connecting',
+        message: `"${clientInfo}" is trying to connect to the Playwright Extension.`
+      });
 
       const parsedVersion = parseInt(params.get('protocolVersion') ?? '', 10);
       const requestedVersion = isNaN(parsedVersion) ? 1 : parsedVersion;
@@ -98,9 +97,7 @@ const ConnectApp: React.FC = () => {
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
       if (token === expectedToken) {
-        // Pass `info` explicitly: setClientInfo only schedules a re-render, so
-        // handleConnectToTab would still close over the initial 'unknown' state.
-        await handleConnectToTab(undefined, info);
+        await handleConnectToTab();
         return;
       }
       if (token) {
@@ -131,32 +128,31 @@ const ConnectApp: React.FC = () => {
       setStatus({ type: 'error', message: 'Failed to load tabs: ' + response.error });
   }, []);
 
-  const handleConnectToTab = useCallback(async (tab?: chrome.tabs.Tab, clientNameOverride?: string) => {
+  const handleConnectToTab = useCallback(async (tab?: chrome.tabs.Tab) => {
     setShowTabList(false);
-    const name = clientNameOverride ?? clientInfo;
 
     try {
       const response = await chrome.runtime.sendMessage({
         type: 'connectToTab',
         tab,
-        clientName: name,
+        clientName: clientInfo,
       });
 
       if (response?.success) {
-        setStatus({ type: 'connected', message: `"${name}" connected.` });
+        setStatus({ type: 'connected', message: `"${clientInfo}" connected.` });
       } else {
         setStatus({
           type: 'error',
-          message: response?.error || `"${name}" failed to connect.`
+          message: response?.error || `"${clientInfo}" failed to connect.`
         });
       }
     } catch (e) {
       setStatus({
         type: 'error',
-        message: `"${name}" failed to connect: ${e}`
+        message: `"${clientInfo}" failed to connect: ${e}`
       });
     }
-  }, [clientInfo]);
+  }, []);
 
   useEffect(() => {
     const listener = (message: any) => {

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -328,7 +328,9 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   const token = await page.locator('.auth-token-code').textContent();
   const [, value] = token?.split('=') || [];
 
+  const clientName = 'token-bypass-client';
   const { client } = await startClient({
+    clientName,
     args: [`--extension`],
     env: {
       PLAYWRIGHT_MCP_EXTENSION_TOKEN: value,
@@ -344,6 +346,9 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   expect(await navigateResponse).toHaveResponse({
     snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
+
+  await page.goto(`chrome-extension://${extensionId}/status.html`);
+  await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
 });
 
 test(`pending connection closed when client disconnects`, async ({ startExtensionClient, server, protocolVersion }) => {


### PR DESCRIPTION
## Summary
- On the token-bypass connect path, `handleConnectToTab` was called in the same effect that called `setClientInfo(info)`, so it still closed over the initial `"unknown"` client name.
- Pass the freshly parsed client name into `handleConnectToTab` at that call site so the status page and tab group show the real MCP client name.
- Extend the existing token-bypass extension test to assert `Connected to "token-bypass-client"` on the status page.

Fixes #41839

## Test plan
- [x] `npm run test-extension -- --grep "bypass connection"` (chromium + legacy v1)
- [x] Full `npm run test-extension` suite (2 unrelated flaky tab tests failed once, passed on rerun; bypass tests passed)