### PR TITLE
chore(bidi): add support for download ids

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -256,7 +256,9 @@ export class BidiPage implements PageDelegate {
   }
 
   private _onDownloadWillBegin(event: bidi.BrowsingContext.DownloadWillBeginParams) {
-    if (!event.navigation)
+    // TODO: remove the event.navigation fallback when Chrome supports event.download
+    // See https://github.com/GoogleChromeLabs/chromium-bidi/issues/4155
+    if (!event.download && !event.navigation)
       return;
 
     this._page.frameManager.frameAbortedNavigation(event.context, 'Download is starting');
@@ -268,13 +270,15 @@ export class BidiPage implements PageDelegate {
     if (!originPage)
       return;
 
-    this._browserContext._browser.downloadCreated(originPage, event.navigation, event.url, event.suggestedFilename, event.suggestedFilename);
+    this._browserContext._browser.downloadCreated(originPage, event.download ?? event.navigation, event.url, event.suggestedFilename, event.suggestedFilename);
   }
 
   private _onDownloadEnded(event: bidi.BrowsingContext.DownloadEndParams) {
-    if (!event.navigation)
+    // TODO: remove the event.navigation fallback when Chrome supports event.download
+    // See https://github.com/GoogleChromeLabs/chromium-bidi/issues/4155
+    if (!event.download && !event.navigation)
       return;
-    this._browserContext._browser.downloadFinished(event.navigation, event.status === 'canceled' ? 'canceled' : undefined);
+    this._browserContext._browser.downloadFinished(event.download ?? event.navigation, event.status === 'canceled' ? 'canceled' : undefined);
   }
 
   private _onLogEntryAdded(params: bidi.Log.Entry) {

--- a/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
+++ b/packages/playwright-core/src/server/bidi/third_party/bidiProtocolCore.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC.
+ * Copyright 2026 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,6 +101,7 @@ export const enum ErrorCode {
   NoSuchNetworkData = 'no such network data',
   NoSuchNode = 'no such node',
   NoSuchRequest = 'no such request',
+  NoSuchScreencast = 'no such screencast',
   NoSuchScript = 'no such script',
   NoSuchStoragePartition = 'no such storage partition',
   NoSuchUserContext = 'no such user context',
@@ -473,7 +474,10 @@ export type BrowsingContextCommand =
   | BrowsingContext.Navigate
   | BrowsingContext.Print
   | BrowsingContext.Reload
+  | BrowsingContext.SetBypassCsp
   | BrowsingContext.SetViewport
+  | BrowsingContext.StartScreencast
+  | BrowsingContext.StopScreencast
   | BrowsingContext.TraverseHistory;
 export type BrowsingContextResult =
   | BrowsingContext.ActivateResult
@@ -486,7 +490,10 @@ export type BrowsingContextResult =
   | BrowsingContext.NavigateResult
   | BrowsingContext.PrintResult
   | BrowsingContext.ReloadResult
+  | BrowsingContext.SetBypassCspResult
   | BrowsingContext.SetViewportResult
+  | BrowsingContext.StartScreencastResult
+  | BrowsingContext.StopScreencastResult
   | BrowsingContext.TraverseHistoryResult;
 export type BrowsingContextEvent =
   | BrowsingContext.ContextCreated
@@ -570,11 +577,15 @@ export namespace BrowsingContext {
   export type Navigation = string;
 }
 export namespace BrowsingContext {
+  export type Download = string;
+}
+export namespace BrowsingContext {
   export type BaseNavigationInfo = {
     context: BrowsingContext.BrowsingContext;
     navigation: BrowsingContext.Navigation | null;
     timestamp: JsUint;
     url: string;
+    userContext?: Browser.UserContext;
   };
 }
 export namespace BrowsingContext {
@@ -704,6 +715,7 @@ export namespace BrowsingContext {
 export namespace BrowsingContext {
   export type CreateResult = {
     context: BrowsingContext.BrowsingContext;
+    userContext?: Browser.UserContext;
   };
 }
 export namespace BrowsingContext {
@@ -879,6 +891,25 @@ export namespace BrowsingContext {
   export type ReloadResult = BrowsingContext.NavigateResult;
 }
 export namespace BrowsingContext {
+  export type SetBypassCsp = {
+    method: 'browsingContext.setBypassCSP';
+    params: BrowsingContext.SetBypassCspParameters;
+  };
+}
+export namespace BrowsingContext {
+  export type SetBypassCspParameters = {
+    bypass: true | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace BrowsingContext {
+  export type SetBypassCspResult = EmptyResult;
+}
+export namespace BrowsingContext {
   export type SetViewport = {
     method: 'browsingContext.setViewport';
     params: BrowsingContext.SetViewportParameters;
@@ -903,6 +934,56 @@ export namespace BrowsingContext {
 }
 export namespace BrowsingContext {
   export type SetViewportResult = EmptyResult;
+}
+export namespace BrowsingContext {
+  export type StartScreencast = {
+    method: 'browsingContext.startScreencast';
+    params: BrowsingContext.StartScreencastParameters;
+  };
+}
+export namespace BrowsingContext {
+  export type StartScreencastParameters = {
+    context: BrowsingContext.BrowsingContext;
+    mimeType?: string;
+    video?: BrowsingContext.MediaTrackConstraints;
+    /**
+     * @defaultValue `false`
+     */
+    audio?: boolean;
+  };
+}
+export namespace BrowsingContext {
+  export type MediaTrackConstraints = {
+    width?: JsUint;
+    height?: JsUint;
+    frameRate?: JsUint;
+  };
+}
+export namespace BrowsingContext {
+  export type StartScreencastResult = {
+    screencast: BrowsingContext.Screencast;
+    path: string;
+  };
+}
+export namespace BrowsingContext {
+  export type Screencast = string;
+}
+export namespace BrowsingContext {
+  export type StopScreencast = {
+    method: 'browsingContext.stopScreencast';
+    params: BrowsingContext.StopScreencastParameters;
+  };
+}
+export namespace BrowsingContext {
+  export type StopScreencastParameters = {
+    screencast: BrowsingContext.Screencast;
+  };
+}
+export namespace BrowsingContext {
+  export type StopScreencastResult = {
+    path: string;
+    error?: string;
+  };
 }
 export namespace BrowsingContext {
   export type TraverseHistory = {
@@ -954,6 +1035,7 @@ export namespace BrowsingContext {
     context: BrowsingContext.BrowsingContext;
     timestamp: JsUint;
     url: string;
+    userContext?: Browser.UserContext;
   };
 }
 export namespace BrowsingContext {
@@ -976,6 +1058,7 @@ export namespace BrowsingContext {
 }
 export namespace BrowsingContext {
   export type DownloadWillBeginParams = {
+    download: BrowsingContext.Download;
     suggestedFilename: string;
   } & BrowsingContext.BaseNavigationInfo;
 }
@@ -993,11 +1076,13 @@ export namespace BrowsingContext {
 export namespace BrowsingContext {
   export type DownloadCanceledParams = {
     status: 'canceled';
+    download: BrowsingContext.Download;
   } & BrowsingContext.BaseNavigationInfo;
 }
 export namespace BrowsingContext {
   export type DownloadCompleteParams = {
     status: 'complete';
+    download: BrowsingContext.Download;
     filepath: string | null;
   } & BrowsingContext.BaseNavigationInfo;
 }
@@ -1030,6 +1115,7 @@ export namespace BrowsingContext {
     context: BrowsingContext.BrowsingContext;
     accepted: boolean;
     type: BrowsingContext.UserPromptType;
+    userContext?: Browser.UserContext;
     userText?: string;
   };
 }
@@ -1045,6 +1131,7 @@ export namespace BrowsingContext {
     handler: Session.UserPromptHandlerType;
     message: string;
     type: BrowsingContext.UserPromptType;
+    userContext?: Browser.UserContext;
     defaultValue?: string;
   };
 }
@@ -1054,8 +1141,11 @@ export type EmulationCommand =
   | Emulation.SetLocaleOverride
   | Emulation.SetNetworkConditions
   | Emulation.SetScreenOrientationOverride
+  | Emulation.SetScreenSettingsOverride
   | Emulation.SetScriptingEnabled
+  | Emulation.SetScrollbarTypeOverride
   | Emulation.SetTimezoneOverride
+  | Emulation.SetTouchOverride
   | Emulation.SetUserAgentOverride;
 export type EmulationResult =
   | Emulation.SetForcedColorsModeThemeOverrideResult
@@ -1063,7 +1153,9 @@ export type EmulationResult =
   | Emulation.SetLocaleOverrideResult
   | Emulation.SetScreenOrientationOverrideResult
   | Emulation.SetScriptingEnabledResult
+  | Emulation.SetScrollbarTypeOverrideResult
   | Emulation.SetTimezoneOverrideResult
+  | Emulation.SetTouchOverrideResult
   | Emulation.SetUserAgentOverrideResult;
 export namespace Emulation {
   export type SetForcedColorsModeThemeOverride = {
@@ -1308,6 +1400,25 @@ export namespace Emulation {
   export type SetScriptingEnabledResult = EmptyResult;
 }
 export namespace Emulation {
+  export type SetScrollbarTypeOverride = {
+    method: 'emulation.setScrollbarTypeOverride';
+    params: Emulation.SetScrollbarTypeOverrideParameters;
+  };
+}
+export namespace Emulation {
+  export type SetScrollbarTypeOverrideParameters = {
+    scrollbarType: 'classic' | 'overlay' | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace Emulation {
+  export type SetScrollbarTypeOverrideResult = EmptyResult;
+}
+export namespace Emulation {
   export type SetTimezoneOverride = {
     method: 'emulation.setTimezoneOverride';
     params: Emulation.SetTimezoneOverrideParameters;
@@ -1325,6 +1436,28 @@ export namespace Emulation {
 }
 export namespace Emulation {
   export type SetTimezoneOverrideResult = EmptyResult;
+}
+export namespace Emulation {
+  export type SetTouchOverride = {
+    method: 'emulation.setTouchOverride';
+    params: Emulation.SetTouchOverrideParameters;
+  };
+}
+export namespace Emulation {
+  export type SetTouchOverrideParameters = {
+    /**
+     * Must be greater than or equal to `1`.
+     */
+    maxTouchPoints: JsUint | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace Emulation {
+  export type SetTouchOverrideResult = EmptyResult;
 }
 export type NetworkCommand =
   | Network.AddDataCollector
@@ -1381,6 +1514,7 @@ export namespace Network {
     redirectCount: JsUint;
     request: Network.RequestData;
     timestamp: JsUint;
+    userContext?: Browser.UserContext | null;
     intercepts?: [Network.Intercept, ...Network.Intercept[]];
   };
 }
@@ -2059,6 +2193,7 @@ export namespace Script {
   export type WindowRealmInfo = Script.BaseRealmInfo & {
     type: 'window';
     context: BrowsingContext.BrowsingContext;
+    userContext?: Browser.UserContext;
     sandbox?: string;
   };
 }
@@ -2367,6 +2502,7 @@ export namespace Script {
   export type Source = {
     realm: Script.Realm;
     context?: BrowsingContext.BrowsingContext;
+    userContext?: Browser.UserContext;
   };
 }
 export namespace Script {
@@ -2833,38 +2969,26 @@ export namespace Input {
 }
 export namespace Input {
   export type PointerCommonProperties = {
-    /**
-     * @defaultValue `1`
-     */
     width?: JsUint;
-    /**
-     * @defaultValue `1`
-     */
     height?: JsUint;
     /**
-     * @defaultValue `0`
+     * Must be between `0` and `1`, inclusive.
      */
     pressure?: number;
     /**
-     * @defaultValue `0`
+     * Must be between `-1` and `1`, inclusive.
      */
     tangentialPressure?: number;
     /**
      * Must be between `0` and `359`, inclusive.
-     *
-     * @defaultValue `0`
      */
     twist?: number;
     /**
      * Must be between `0` and `1.5707963267948966`, inclusive.
-     *
-     * @defaultValue `0`
      */
     altitudeAngle?: number;
     /**
      * Must be between `0` and `6.283185307179586`, inclusive.
-     *
-     * @defaultValue `0`
      */
     azimuthAngle?: number;
   };
@@ -2914,6 +3038,7 @@ export namespace Input {
 export namespace Input {
   export type FileDialogInfo = {
     context: BrowsingContext.BrowsingContext;
+    userContext?: Browser.UserContext;
     element?: Script.SharedReference;
     multiple: boolean;
   };

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -101,7 +101,6 @@ library/defaultbrowsercontext-2.spec.ts › should support hasTouch option [fail
 library/defaultbrowsercontext-2.spec.ts › should support reducedMotion option [fail]
 library/defaultbrowsercontext-2.spec.ts › should work in persistent context [fail]
 library/download.spec.ts › download event › should be able to cancel pending downloads [timeout]
-library/download.spec.ts › download event › should report download path within page.on('download', …) handler for Blobs [timeout]
 library/download.spec.ts › download event › should report new window downloads [timeout]
 library/download.spec.ts › download event › should throw if browser dies [fail]
 library/emulation-focus.spec.ts › should focus popups by default [fail]


### PR DESCRIPTION
Fixes "should report download path within page.on('download', …) handler for Blobs" in `library/download.spec.ts`.