### PR TITLE
test(bidi): various test updates

### DIFF
--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -31,7 +31,6 @@ library/browsercontext-page-event.spec.ts › should have about:blank url with d
 library/browsercontext-page-event.spec.ts › should have an opener [fail]
 library/browsercontext-page-event.spec.ts › should have url [fail]
 library/browsercontext-page-event.spec.ts › should report when a new page is created and closed [fail]
-library/browsercontext-page-event.spec.ts › should work with Ctrl-clicking [timeout]
 library/browsercontext-pages.spec.ts › frame.focus should work multiple times [fail]
 library/browsercontext-pages.spec.ts › should click the button with deviceScaleFactor set [fail]
 library/browsercontext-reuse.spec.ts › reuse connect › should not cache resources [fail]

--- a/tests/library/browsercontext-page-event.spec.ts
+++ b/tests/library/browsercontext-page-event.spec.ts
@@ -170,7 +170,7 @@ it('should work with Shift-clicking', async ({ browser, server, browserName }) =
   await context.close();
 });
 
-it('should work with Ctrl-clicking', async ({ browser, server, browserName, isBidi }) => {
+it('should work with Ctrl-clicking', async ({ browser, server, browserName }) => {
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
@@ -179,6 +179,6 @@ it('should work with Ctrl-clicking', async ({ browser, server, browserName, isBi
     context.waitForEvent('page'),
     page.click('a', { modifiers: ['ControlOrMeta'] }),
   ]);
-  expect(await popup.opener()).toBe(browserName === 'firefox' && !isBidi ? page : null);
+  expect(await popup.opener()).toBe(browserName === 'firefox' ? page : null);
   await context.close();
 });

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -145,8 +145,8 @@ it('should create userDataDir if it does not exist', async ({ createUserDataDir,
 
 it('should goto about:blank on relaunched persistent context', {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41216' },
-}, async ({ browserType, createUserDataDir, browserName }) => {
-  it.fixme(browserName === 'firefox');
+}, async ({ browserType, createUserDataDir, browserName, isBidi }) => {
+  it.fixme(browserName === 'firefox' && !isBidi);
   it.slow();
 
   const userDataDir = await createUserDataDir();

--- a/tests/library/download.spec.ts
+++ b/tests/library/download.spec.ts
@@ -51,7 +51,7 @@ it.describe('download event', () => {
     });
   });
 
-  it('should report download when navigation turns into download @smoke', async ({ browser, server, browserName, browserMajorVersion }) => {
+  it('should report download when navigation turns into download @smoke', async ({ browser, server, browserName, browserMajorVersion, isBidi }) => {
     it.skip(browserName === 'chromium' && browserMajorVersion < 140, 'old chromium throws net::ERR_ABORTED, depends on https://chromium-review.googlesource.com/c/chromium/src/+/6696011');
     const page = await browser.newPage();
     const [download, responseOrError] = await Promise.all([
@@ -67,12 +67,12 @@ it.describe('download event', () => {
     expect(responseOrError instanceof Error).toBeTruthy();
     expect(responseOrError.message).toContain('Download is starting');
 
-    if (browserName !== 'firefox')
+    if (browserName !== 'firefox' || isBidi)
       expect(page.url()).toBe('about:blank');
     await page.close();
   });
 
-  it('should work with Cross-Origin-Opener-Policy', async ({ browser, server, browserName, browserMajorVersion }) => {
+  it('should work with Cross-Origin-Opener-Policy', async ({ browser, server, browserName, browserMajorVersion, isBidi }) => {
     it.skip(browserName === 'chromium' && browserMajorVersion < 140, 'old chromium throws net::ERR_ABORTED, depends on https://chromium-review.googlesource.com/c/chromium/src/+/6696011');
     const page = await browser.newPage();
     const [download, responseOrError] = await Promise.all([
@@ -86,7 +86,7 @@ it.describe('download event', () => {
     expect(fs.readFileSync(path).toString()).toBe('Hello world');
     expect(responseOrError instanceof Error).toBeTruthy();
     expect(responseOrError.message).toContain('Download is starting');
-    if (browserName !== 'firefox')
+    if (browserName !== 'firefox' || isBidi)
       expect(page.url()).toBe('about:blank');
     await page.close();
   });

--- a/tests/page/interception.spec.ts
+++ b/tests/page/interception.spec.ts
@@ -35,7 +35,7 @@ it('should work with navigation @smoke', async ({ page, server }) => {
   expect(requests.get('style.css').isNavigationRequest()).toBe(false);
 });
 
-it('should intercept after a service worker', async ({ page, server, browserName, isAndroid }) => {
+it('should intercept after a service worker', async ({ page, server, browserName, isAndroid, isBidi }) => {
   it.skip(isAndroid);
 
   await page.goto(server.PREFIX + '/serviceworkers/fetchdummy/sw.html');
@@ -63,8 +63,8 @@ it('should intercept after a service worker', async ({ page, server, browserName
   const nonInterceptedResponse = await page.evaluate(() => window['fetchDummy']('passthrough'));
   expect(nonInterceptedResponse).toBe('FAILURE: Not Found');
 
-  // Firefox does not want to fetch the redirect for some reason.
-  if (browserName !== 'firefox') {
+  // Firefox/Juggler does not want to fetch the redirect for some reason.
+  if (browserName !== 'firefox' || isBidi) {
     // Page route is not applied to service worker initiated fetch with redirect.
     server.setRedirect('/serviceworkers/fetchdummy/passthrough', '/simple.json');
     const redirectedResponse = await page.evaluate(() => window['fetchDummy']('passthrough'));

--- a/tests/page/page-event-console.spec.ts
+++ b/tests/page/page-event-console.spec.ts
@@ -18,14 +18,14 @@
 import { test as it, expect } from './pageTest';
 import util from 'util';
 
-it('should work @smoke', async ({ page, browserName, channel }) => {
+it('should work @smoke', async ({ page, browserName, isBidi }) => {
   let message = null;
   page.once('console', m => message = m);
   await Promise.all([
     page.evaluate(() => console.log('hello', 5, { foo: 'bar' })),
     page.waitForEvent('console')
   ]);
-  if (browserName !== 'firefox' || channel?.startsWith('moz-firefox'))
+  if (browserName !== 'firefox' || isBidi)
     expect(message.text()).toEqual('hello 5 {foo: bar}');
   else
     expect(message.text()).toEqual('hello 5 JSHandle@object');
@@ -117,14 +117,14 @@ it('should format the message correctly with time/timeLog/timeEnd', async ({ pag
   expect(messages[1].text()).toMatch(/foo time: \d+(.\d+)? ?ms/);
 });
 
-it('should not fail for window object', async ({ page, browserName, channel }) => {
+it('should not fail for window object', async ({ page, browserName, isBidi }) => {
   let message = null;
   page.once('console', msg => message = msg);
   await Promise.all([
     page.evaluate(() => console.error(window)),
     page.waitForEvent('console')
   ]);
-  if (browserName !== 'firefox' || channel?.startsWith('moz-firefox'))
+  if (browserName !== 'firefox' || isBidi)
     expect(message.text()).toEqual('Window');
   else
     expect(message.text()).toEqual('JSHandle@object');
@@ -181,14 +181,14 @@ it('should not throw when there are console messages in detached iframes', async
   expect(await popup.evaluate('1 + 1')).toBe(2);
 });
 
-it('should use object previews for arrays and objects', async ({ page, browserName, channel }) => {
+it('should use object previews for arrays and objects', async ({ page, browserName, isBidi }) => {
   let text: string;
   page.on('console', message => {
     text = message.text();
   });
   await page.evaluate(() => console.log([1, 2, 3], { a: 1 }, window));
 
-  if (browserName !== 'firefox' || channel?.startsWith('moz-firefox'))
+  if (browserName !== 'firefox' || isBidi)
     expect(text).toEqual('[1, 2, 3] {a: 1} Window');
   else
     expect(text).toEqual('Array JSHandle@object JSHandle@object');

--- a/tests/page/page-keyboard.spec.ts
+++ b/tests/page/page-keyboard.spec.ts
@@ -98,8 +98,8 @@ it('should emit keydown, keypress, textInput and input when typing a character',
   expect(await events.jsonValue()).toEqual(['keydown', 'keypress', 'textInput', 'input', 'keyup']);
 });
 
-it('should dispatch key events in separate tasks', async ({ page, browserName }) => {
-  it.skip(browserName === 'firefox', 'Firefox dispatches keydown and keypress in the same task');
+it('should dispatch key events in separate tasks', async ({ page, browserName, isBidi }) => {
+  it.skip(browserName === 'firefox' && !isBidi, 'Firefox/Juggler dispatches keydown and keypress in the same task');
   await page.setContent(`<input>`);
   const log = await page.evaluateHandle(() => {
     const log: string[] = [];


### PR DESCRIPTION
- unskips the following tests:
  - `library/browsercontext-page-event.spec.ts`:
    - "should work with Ctrl-clicking" - use the Juggler-specific expectation for Firefox/Bidi as well
  - `library/defaultbrowsercontext-2.spec.ts`:
    - "should goto about:blank on relaunched persistent context"
  - `page/page-keyboard.spec.ts`:
    - "should dispatch key events in separate tasks"
- enables some checks for Firefox/Bidi in these tests:
  - `library/download.spec.ts`:
    - "should report download when navigation turns into download"
    - "should work with Cross-Origin-Opener-Policy"
  - `page/interception.spec.ts`:
    - "should intercept after a service worker"
- replaces the `channel?.startsWith('moz-firefox')` check in these tests:
  - `page/page-event-console.spec.ts`:
    - "should work"
    - "should not fail for window object"
    - "should use object previews for arrays and objects"
