### PR TITLE
fix(fetch): use case-insensitive host header lookup on redirect

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -476,8 +476,7 @@ export abstract class APIRequestContext extends SdkObject {
               return;
             }
 
-            if (headers['host'])
-              headers['host'] = locationURL.host;
+            setHeader(headers, 'host', locationURL.host);
 
             // Drop credentials scoped to the original origin on cross-origin redirects.
             if (locationURL.origin !== url.origin)

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1436,7 +1436,7 @@ it('should update host header on redirect', async ({ context, server }) => {
   });
   const reqPromise = server.waitForRequest('/test');
   const response = await context.request.get(server.PREFIX + '/redirect', {
-    headers: { host: new URL(server.PREFIX).host }
+    headers: { HosT: new URL(server.PREFIX).host }
   });
   expect(redirectCount).toBe(2);
   await expect(response).toBeOK();


### PR DESCRIPTION
## Summary
- The redirect handler updated the host header via `headers['host']` (lowercase-only lookup), while header names preserve their original casing. A `Host` header set through `extraHTTPHeaders` was never updated on redirect.
- Now uses the case-insensitive `setHeader()` helper, consistent with `getHeader`/`removeHeader` in the same file.

Fixes https://github.com/microsoft/playwright/issues/41766