### PR TITLE
fix(mcp): tolerate dialogs handled outside tools

### DIFF
--- a/packages/playwright-core/src/tools/backend/dialogs.ts
+++ b/packages/playwright-core/src/tools/backend/dialogs.ts
@@ -38,15 +38,33 @@ export const handleDialog = defineTabTool({
 
     tab.clearModalState(dialogState);
     await tab.waitForCompletion(async () => {
-      if (params.accept)
-        await dialogState.dialog.accept(params.promptText);
-      else
-        await dialogState.dialog.dismiss();
+      try {
+        if (params.accept)
+          await dialogState.dialog.accept(params.promptText);
+        else
+          await dialogState.dialog.dismiss();
+      } catch (error) {
+        if (!isStaleDialogError(error))
+          throw error;
+        // The modal state is already cleared above, so report instead of failing.
+        response.addTextResult(`Dialog was already handled in the browser, e.g. dismissed by the user.`);
+      }
     });
   },
 
   clearsModalState: 'dialog',
 });
+
+// Chromium reports a protocol error when the dialog was already handled outside of
+// this session, e.g. by the user in headed mode. Firefox and WebKit silently succeed.
+// The "already handled" assertion covers dialogs that were handled through the same
+// server twice, e.g. by two concurrent clients.
+function isStaleDialogError(error: unknown): boolean {
+  return error instanceof Error && (
+    error.message.includes('No dialog is showing') ||
+    error.message.includes('dialog which is already handled')
+  );
+}
 
 export default [
   handleDialog,

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -199,6 +199,11 @@ export class Tab extends EventEmitter<TabEventsInterface> {
   }
 
   private _dialogShown(dialog: playwright.Dialog) {
+    // Only one native dialog can be open per page at a time. If we still track one
+    // when a new dialog opens, the tracked dialog was already handled outside of the
+    // tools, e.g. by the user in headed mode, and must not linger as a modal state.
+    for (const state of this._modalStates.filter(state => state.type === 'dialog'))
+      this.clearModalState(state);
     this.setModalState({
       type: 'dialog',
       description: `"${dialog.type()}" dialog with message "${dialog.message()}"`,

--- a/tests/mcp/dialogs.spec.ts
+++ b/tests/mcp/dialogs.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, parseResponse } from './fixtures';
 
 test('alert dialog', async ({ client, server }) => {
   server.setContent('/', `<title>Title</title><button onclick="alert('Alert')">Button</button>`, 'text/html');
@@ -212,6 +212,64 @@ test('prompt dialog', async ({ client, server }) => {
 
   expect(result).toHaveResponse({
     modalState: undefined,
+  });
+});
+
+test('dialogs handled outside of the session', async ({ cdpServer, startClient, server }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41837' });
+
+  const browserContext = await cdpServer.start();
+  // Handle dialogs from a second client attached to the same browser. To this client,
+  // it is indistinguishable from the user dismissing them manually in headed mode.
+  const dismissed: string[] = [];
+  browserContext.on('dialog', dialog => {
+    dismissed.push(dialog.message());
+    void dialog.dismiss();
+  });
+
+  server.setContent('/', `
+    <title>Title</title>
+    <button onclick="alert('Alert 1');alert('Alert 2');alert('Alert 3')">Button</button>
+  `, 'text/html');
+
+  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`- button "Button"`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Button', target: 'button' },
+  })).toHaveResponse({
+    modalState: expect.stringContaining(`"alert" dialog`),
+  });
+
+  await expect.poll(() => dismissed).toEqual(['Alert 1', 'Alert 2', 'Alert 3']);
+
+  // Every dialog opening proves the previous one was closed, so at most the last
+  // dialog may linger as a stale modal state.
+  await expect.poll(async () => {
+    const response = await client.callTool({ name: 'browser_snapshot' });
+    return parseResponse(response)?.modalState;
+  }).toBe(`- ["alert" dialog with message "Alert 3"]: can be handled by browser_handle_dialog`);
+
+  // Handling the stale dialog reports it was already handled instead of failing.
+  expect(await client.callTool({
+    name: 'browser_handle_dialog',
+    arguments: { accept: false },
+  })).toHaveResponse({
+    result: expect.stringContaining(`Dialog was already handled`),
+    modalState: undefined,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_snapshot',
+  })).toHaveResponse({
+    modalState: undefined,
+    inlineSnapshot: expect.stringContaining(`- button "Button"`),
   });
 });
 


### PR DESCRIPTION
## Summary

Improves handling for dialogs that were accepted or dismissed outside of the MCP/tools session, such as manually by a user in headed mode.

## Why

The tools backend tracks dialog modal states when a `dialog` event is observed, but there is no tools-level close notification when that dialog is handled outside of `browser_handle_dialog`.

This can leave stale modal state behind and cause later tool calls to report a phantom active dialog.

## Change

- When a new native dialog opens, clears any previously tracked dialog modal states for that tab, since only one native dialog can be open on a page at a time.
- Makes `browser_handle_dialog` tolerate known stale-dialog errors, reporting that the dialog was already handled instead of failing with a protocol error.
- Keeps normal programmatic dialog handling unchanged.

This does not fully auto-clear the final manually handled dialog because there is no cross-browser dialog-closed signal available at this layer.

## Tests

- `npm run ctest-mcp dialogs`

References #41837.