### PR TITLE
docs(evaluate): clarify exposeFunctions scope and lifetime

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -588,7 +588,7 @@ Function to be evaluated in the page context.
 * langs: js
 - `exposeFunctions` <[boolean]>
 
-When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the page function. Calling one returns a [Promise] of its result. The page-side functions are scoped to the execution context they were passed to and disappear when the page navigates. Defaults to `false`, in which case functions are not serializable and passing one throws an error, as before.
+When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the page function. Calling one returns a [Promise] of its result. Under the hood, each function is exposed via [`method: Page.exposeFunction`], so it is technically accessible from all frames and worlds of the page. Exposed functions are cleared upon the top-level navigation. Defaults to `false`, in which case functions are not serializable and passing one throws an error.
 
 ## js-evalonselector-pagefunction
 * langs: js


### PR DESCRIPTION
## Summary
- Sharpen the `exposeFunctions` option docs: functions are exposed via `Page.exposeFunction` under the hood, are technically accessible from all frames and worlds, and are cleared upon the top-level navigation.