### PR TITLE
perf(aria): cache computed values when building aria snapshots

### DIFF
--- a/packages/injected/src/domUtils.ts
+++ b/packages/injected/src/domUtils.ts
@@ -85,6 +85,15 @@ export function getElementComputedStyle(element: Element, pseudo?: string): CSSS
 }
 
 export function isElementStyleVisibilityVisible(element: Element, style?: CSSStyleDeclaration): boolean {
+  const cached = cacheStyleVisibility?.get(element);
+  if (cached !== undefined)
+    return cached;
+  const result = computeElementStyleVisibilityVisible(element, style);
+  cacheStyleVisibility?.set(element, result);
+  return result;
+}
+
+function computeElementStyleVisibilityVisible(element: Element, style?: CSSStyleDeclaration): boolean {
   style = style ?? getElementComputedStyle(element);
   if (!style)
     return true;
@@ -144,8 +153,15 @@ export function isVisibleTextNode(node: Text) {
 
 export function elementSafeTagName(element: Element) {
   const tagName = element.tagName;
-  if (typeof tagName === 'string')  // Fast path.
-    return tagName.toUpperCase();
+  if (typeof tagName === 'string') {  // Fast path.
+    // Tag names in html documents are already uppercase. Lowercase names come from
+    // svg/mathml elements and from xml/xhtml documents, and they all start with
+    // a lowercase letter, so uppercasing can be skipped otherwise.
+    const firstCharCode = tagName.charCodeAt(0);
+    if (firstCharCode >= 97 && firstCharCode <= 122)
+      return tagName.toUpperCase();
+    return tagName;
+  }
   // Named inputs, e.g. <input name=tagName>, will be exposed as fields on the parent <form>
   // and override its properties.
   if (element instanceof HTMLFormElement)
@@ -157,6 +173,7 @@ export function elementSafeTagName(element: Element) {
 let cacheStyle: Map<Element, CSSStyleDeclaration | undefined> | undefined;
 let cacheStyleBefore: Map<Element, CSSStyleDeclaration | undefined> | undefined;
 let cacheStyleAfter: Map<Element, CSSStyleDeclaration | undefined> | undefined;
+let cacheStyleVisibility: Map<Element, boolean> | undefined;
 let cachesCounter = 0;
 
 export function beginDOMCaches() {
@@ -164,6 +181,7 @@ export function beginDOMCaches() {
   cacheStyle ??= new Map();
   cacheStyleBefore ??= new Map();
   cacheStyleAfter ??= new Map();
+  cacheStyleVisibility ??= new Map();
 }
 
 export function endDOMCaches() {
@@ -171,5 +189,6 @@ export function endDOMCaches() {
     cacheStyle = undefined;
     cacheStyleBefore = undefined;
     cacheStyleAfter = undefined;
+    cacheStyleVisibility = undefined;
   }
 }

--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -279,6 +279,15 @@ function hasPresentationConflictResolution(element: Element, role: string | null
 }
 
 export function getAriaRole(element: Element): AriaRole | null {
+  const cached = cacheAriaRole?.get(element);
+  if (cached !== undefined)
+    return cached;
+  const role = computeAriaRole(element);
+  cacheAriaRole?.set(element, role);
+  return role;
+}
+
+function computeAriaRole(element: Element): AriaRole | null {
   const explicitRole = getExplicitAriaRole(element);
   if (!explicitRole)
     return getImplicitAriaRole(element);
@@ -1164,19 +1173,28 @@ function belongsToDisabledFieldSet(element: Element): boolean {
   return !legendElement || !legendElement.contains(element);
 }
 
-function hasExplicitAriaDisabled(element: Element | undefined, isAncestor = false): boolean {
-  if (!element)
+function hasExplicitAriaDisabled(element: Element): boolean {
+  if (!kAriaDisabledRoles.includes(getAriaRole(element) || ''))
     return false;
-  if (isAncestor || kAriaDisabledRoles.includes(getAriaRole(element) || '')) {
+  return hasAriaDisabledInChain(element);
+}
+
+function hasAriaDisabledInChain(element: Element): boolean {
+  let result = cacheAriaDisabled?.get(element);
+  if (result === undefined) {
     const attribute = (element.getAttribute('aria-disabled') || '').toLowerCase();
-    if (attribute === 'true')
-      return true;
-    if (attribute === 'false')
-      return false;
-    // aria-disabled works across shadow boundaries.
-    return hasExplicitAriaDisabled(parentElementOrShadowHost(element), true);
+    if (attribute === 'true') {
+      result = true;
+    } else if (attribute === 'false') {
+      result = false;
+    } else {
+      // aria-disabled works across shadow boundaries.
+      const parent = parentElementOrShadowHost(element);
+      result = parent ? hasAriaDisabledInChain(parent) : false;
+    }
+    cacheAriaDisabled?.set(element, result);
   }
-  return false;
+  return result;
 }
 
 function getAccessibleNameFromAssociatedLabels(labels: Iterable<HTMLLabelElement>, options: AccessibleNameOptions): CompositeString {
@@ -1236,11 +1254,15 @@ let cachePseudoContent: Map<Element, string | undefined> | undefined;
 let cachePseudoContentBefore: Map<Element, string | undefined> | undefined;
 let cachePseudoContentAfter: Map<Element, string | undefined> | undefined;
 let cachePointerEvents: Map<Element, boolean> | undefined;
+let cacheAriaRole: Map<Element, AriaRole | null> | undefined;
+let cacheAriaDisabled: Map<Element, boolean> | undefined;
 let cachesCounter = 0;
 
 export function beginAriaCaches() {
   beginDOMCaches();
   ++cachesCounter;
+  cacheAriaRole ??= new Map();
+  cacheAriaDisabled ??= new Map();
   cacheAccessibleName ??= new Map();
   cacheAccessibleNameHidden ??= new Map();
   cacheAccessibleNameText ??= new Map();
@@ -1269,6 +1291,8 @@ export function endAriaCaches() {
     cachePseudoContentBefore = undefined;
     cachePseudoContentAfter = undefined;
     cachePointerEvents = undefined;
+    cacheAriaRole = undefined;
+    cacheAriaDisabled = undefined;
   }
   endDOMCaches();
 }


### PR DESCRIPTION
## Summary

- Cache aria role, `aria-disabled` chain and style visibility (`checkVisibility`) per element for the duration of a snapshot, following the existing `beginAriaCaches()` lifecycle. These values were recomputed up to 5-10 times per element.
- Skip `toUpperCase()` in `elementSafeTagName()` when the tag name is already uppercase (only svg/mathml elements and xml documents have lowercase tag names, and those always start with a lowercase letter).

Measured on the fixture from https://github.com/microsoft/playwright/issues/41717#issuecomment-4994058313 (2,400 buttons, ~4,800 elements), headless Chromium on arm64 macOS, median of 30 runs, changes applied cumulatively:

| Change | `ariaSnapshot()` | `ariaSnapshot({ mode: 'ai' })` |
|---|---|---|
| baseline | 53.1ms | 57.0ms |
| + aria role cache | 50.3ms | 52.0ms |
| + aria-disabled cache | 47.4ms | 49.4ms |
| + style visibility cache | 45.9ms | 48.9ms |
| + tag name fast path | 42.7ms | 48.4ms |

Snapshot output is byte-identical to baseline throughout.

References https://github.com/microsoft/playwright/issues/41717.