### PR TITLE
fix(dispatcher): catch validation errors in outbound `sendEvent`

### DIFF
--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -19,6 +19,7 @@ import { EventEmitter } from 'events';
 import { getMetainfo } from '@isomorphic/protocolMetainfo';
 import { eventsHelper } from '@utils/eventsHelper';
 import { isUnderTest } from '@utils/debug';
+import { debugLogger } from '@utils/debugLogger';
 import { assert } from '@isomorphic/assert';
 import { monotonicTime } from '@isomorphic/time';
 import { rewriteErrorMessage } from '@utils/stackTrace';
@@ -205,8 +206,15 @@ export class DispatcherConnection {
   }
 
   sendEvent(dispatcher: DispatcherScope, event: string, params: any) {
-    const validator = findValidator(dispatcher._type, event, 'Event');
-    params = validator(params, '', this._validatorToWireContext());
+    try {
+      const validator = findValidator(dispatcher._type, event, 'Event');
+      params = validator(params, '', this._validatorToWireContext());
+    } catch (e) {
+      if (isUnderTest() || !(e instanceof ValidationError))
+        throw e;
+      debugLogger.log('error', `sendEvent validation error for ${dispatcher._type}.${event}: ${e}`);
+      return;
+    }
     this.onmessage({ guid: dispatcher._guid, method: event, params });
   }
 

--- a/tests/library/dispatcher-connection.spec.ts
+++ b/tests/library/dispatcher-connection.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { contextTest as it, expect } from '../config/browserTest';
+
+it.skip(({ mode }) => mode !== 'default');
+
+it('should survive sendEvent validation error and keep working', async ({ page, toImpl }) => {
+  const pageDispatcher = toImpl(page);
+  const connection = pageDispatcher.connection;
+
+  expect(() => {
+    connection.sendEvent(pageDispatcher, 'viewportSizeChanged', {
+      viewportSize: { width: { bad: true }, height: 720 },
+    });
+  }).toThrow(/expected float, got object/);
+
+  await page.setContent('<div>still alive</div>');
+  expect(await page.textContent('div')).toBe('still alive');
+});


### PR DESCRIPTION
## Rationale

The inbound `dispatch()` path catches validator errors, but the outbound `sendEvent`/`sendCreate` side doesn't seem to. A validation failure there can go uncaught and take down the driver process.

Followed the same `isUnderTest()` convention used elsewhere in this file.

References #41865 (fixes the sendEvent part; sendCreate would need a separate fix).
