### PR TITLE
docs(bfcache): add note about Back/Forward Cache (BFCache) limitations and default behavior

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -2354,6 +2354,11 @@ last redirect. If cannot go back, returns `null`.
 
 Navigate to the previous page in history.
 
+:::warning
+**Testing Back/Forward Cache (BFCache) is not supported.** 
+By default, Playwright disables the Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized `Page` state.
+:::
+
 ### option: Page.goBack.waitUntil = %%-navigation-wait-until-%%
 * since: v1.8
 
@@ -2373,6 +2378,11 @@ Returns the main resource response. In case of multiple redirects, the navigatio
 last redirect. If cannot go forward, returns `null`.
 
 Navigate to the next page in history.
+
+:::warning
+**Testing Back/Forward Cache (BFCache) is not supported.** 
+By default, Playwright disables the Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized `Page` state.
+:::
 
 ## async method: Page.requestGC
 * since: v1.48

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -150,6 +150,16 @@ await page.GetByText("Click me").ClickAsync();
 await page.WaitForURL("**/login");
 ```
 
+## Back/Forward Cache (BFCache)
+
+Modern browsers utilize a Back/Forward Cache (BFCache) to instantly load a page when a user navigates back or forward. This is achieved by freezing the page's DOM and JavaScript heap in memory, and thawing it upon return.
+
+By default, Playwright disables the BFCache across all browsers to ensure consistent, clean testing environments. 
+
+Even if you explicitly enable BFCache, **testing BFCache restorations is not supported**. Because a BFCache restore skips the network fetch phase, the browser does not fire standard navigation lifecycle events (such as `commit`, `domcontentloaded`, or `load`). Playwright's internal `Page` state heavily relies on these network-level events to stay synchronized. 
+
+Consequently, triggering a BFCache restore (e.g., via `page.goBack()`) will bypass Playwright's lifecycle tracking, resulting in timeouts and a completely desynchronized `Page` object where subsequent interactions will fail.
+
 ## Navigation events
 
 Playwright splits the process of showing a new document in a page into **navigation** and **loading**.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -3291,6 +3291,13 @@ export interface Page {
    * the last redirect. If cannot go back, returns `null`.
    *
    * Navigate to the previous page in history.
+   *
+   * **NOTE** **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright disables the
+   * Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on
+   * network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using
+   * `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized
+   * `Page` state.
+   *
    * @param options
    */
   goBack(options?: {
@@ -3332,6 +3339,13 @@ export interface Page {
    * the last redirect. If cannot go forward, returns `null`.
    *
    * Navigate to the next page in history.
+   *
+   * **NOTE** **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright disables the
+   * Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on
+   * network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using
+   * `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized
+   * `Page` state.
+   *
    * @param options
    */
   goForward(options?: {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -3291,6 +3291,13 @@ export interface Page {
    * the last redirect. If cannot go back, returns `null`.
    *
    * Navigate to the previous page in history.
+   *
+   * **NOTE** **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright disables the
+   * Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on
+   * network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using
+   * `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized
+   * `Page` state.
+   *
    * @param options
    */
   goBack(options?: {
@@ -3332,6 +3339,13 @@ export interface Page {
    * the last redirect. If cannot go forward, returns `null`.
    *
    * Navigate to the next page in history.
+   *
+   * **NOTE** **Testing Back/Forward Cache (BFCache) is not supported.**  By default, Playwright disables the
+   * Back/Forward Cache across all browsers. Even if explicitly enabled, Playwright's internal state relies on
+   * network-level navigation events. Because BFCache restores unfreeze the DOM without firing these events, using
+   * `page.goBack()` or `page.goForward()` to trigger a BFCache restore will result in timeouts and a desynchronized
+   * `Page` state.
+   *
    * @param options
    */
   goForward(options?: {


### PR DESCRIPTION
### What does this PR do?
This PR adds a brief warning to the Pages guide (`docs/pages.md`) and the API reference for `page.goBack()` / `page.goForward()` regarding the Back/Forward Cache (BFCache). It clarifies two things:
1. Playwright disables BFCache by default.
2. Even if explicitly enabled, testing BFCache restorations is not supported due to network-level lifecycle limitations.

### Why is this needed?
I recently spent quite a bit of time going down a rabbit hole trying to write an E2E test for a BFCache bug I was fixing in an open-source project. 

First, I struggled to figure out why the cache wasn't triggering at all (before realizing it was disabled by default in Playwright). Then, once I managed to trigger it, I couldn't figure out why `page.goBack()` was consistently timing out or leaving the page in a desynchronized state. 

I eventually realized that because BFCache restores unfreeze the DOM without firing standard network-level navigation events (like `commit` or `load`), Playwright's internal `Page` lifecycle tracking gets completely bypassed. (I documented my deep-dive into this limitation in [this comment on my Forgejo PR](https://codeberg.org/forgejo/forgejo/pulls/13308#issuecomment-18976100), which ultimately led to me dropping the E2E test entirely).

I thought adding a small note to the documentation might save other developers the hours of debugging I went through when trying to test this specific browser feature!

### Feedback requested
I want to defer to the maintainers on this, if you feel there is a better way to phrase this, a better place to put it (e.g., only in the API docs vs the guides), or if you feel this is too much of an edge case to include in the core documentation at all, please let me know. 

I am completely open to making adjustments or closing the PR if it doesn't align with the documentation goals. Thanks for taking a look!