### PR TITLE
fix(mcp): auto-reconnect extension relay after disconnect

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -71,6 +71,8 @@ export class CDPRelayServer {
   private _protocolVersion: number;
   private _handler: ExtensionProtocolHandler;
   private _extensionConnectionPromise = new ManualPromise<void>();
+  private _clientName: string = '';
+  private _stopped: boolean = false;
 
   constructor(server: http.Server, browserChannel: string, executablePath?: string) {
     this._wsHost = addressToString(server.address(), { protocol: 'ws' });
@@ -107,6 +109,7 @@ export class CDPRelayServer {
   }
 
   async establishExtensionConnection(clientName: string) {
+    this._clientName = clientName;
     debugLogger('Establishing extension connection');
     this._openConnectPageInBrowser(clientName);
     debugLogger('Waiting for incoming extension connection');
@@ -158,6 +161,7 @@ export class CDPRelayServer {
   }
 
   stop(): void {
+    this._stopped = true;
     this._closeConnections('Server stopped');
     this._wss.close();
   }
@@ -229,8 +233,14 @@ export class CDPRelayServer {
     this._extensionConnection = new ExtensionConnection(ws);
     this._extensionConnection.onclose = reason => {
       debugLogger('Extension WebSocket closed:', reason);
+      this._extensionConnection = null;
       this._handler.onExtensionDisconnect(reason);
       this._closeCDPConnection(`Extension disconnected: ${reason}`);
+      if (!this._stopped) {
+        this._extensionConnectionPromise = new ManualPromise<void>();
+        void this._extensionConnectionPromise.catch(logUnhandledError);
+        this._openConnectPageInBrowser(this._clientName);
+      }
     };
     this._extensionConnection.onmessage = (method, params) => this._handler.handleExtensionEvent(method, params);
     this._extensionConnectionPromise.resolve();


### PR DESCRIPTION
Fixes #41874

## Problem

When the browser extension disconnects from the MCP relay (Chrome MV3 service worker idle timeout ~5 min, browser restart, extension reload), the relay leaves `_extensionConnection` null and never re-opens `connect.html`. Every subsequent MCP tool call fails with `Extension not connected`; the only recovery is restarting the entire MCP server.

## Fix

In `_handleExtensionConnection.onclose`:
- Null out `_extensionConnection` (so a reconnecting extension is not rejected by the "already established" guard)
- Reset `_extensionConnectionPromise` to a fresh `ManualPromise`
- Call `_openConnectPageInBrowser` to re-spawn the connect tab

Two supporting changes:
- `_clientName` is stored when `establishExtensionConnection` is first called, so the reconnect path has the client name without requiring a new caller argument
- `_stopped` flag is set in `stop()` to prevent reconnect attempts after intentional shutdown