### PR TITLE
chore: infer correct types for evalutes with exposeFunctions

### DIFF
--- a/packages/playwright-core/types/structs.d.ts
+++ b/packages/playwright-core/types/structs.d.ts
@@ -25,10 +25,12 @@ export type Serializable = any;
  */
 export type EvaluationArgument = {};
 
-export type NoHandles<Arg> = Arg extends JSHandle ? never : (Arg extends object ? { [Key in keyof Arg]: NoHandles<Arg[Key]> } : Arg);
+type CallbackResult<T> = T extends PromiseLike<infer U> ? Promise<Unboxed<U>> : Promise<Unboxed<T>>;
+export type NoHandles<Arg> = Arg extends JSHandle ? never : (Arg extends Function ? never : (Arg extends object ? { [Key in keyof Arg]: NoHandles<Arg[Key]> } : Arg));
 export type Unboxed<Arg> =
   Arg extends ElementHandle<infer T> ? T :
   Arg extends JSHandle<infer T> ? T :
+  Arg extends (...args: infer T) => infer R ? (...args: T) => CallbackResult<R> :
   Arg extends NoHandles<Arg> ? Arg :
   Arg extends [infer A0] ? [Unboxed<A0>] :
   Arg extends [infer A0, infer A1] ? [Unboxed<A0>, Unboxed<A1>] :

--- a/tests/page/page-evaluate-callback.spec.ts
+++ b/tests/page/page-evaluate-callback.spec.ts
@@ -18,7 +18,7 @@ import { attachFrame } from '../config/utils';
 import { test as it, expect } from './pageTest';
 
 it('should throw without the exposeFunctions option', async ({ page }) => {
-  await expect(page.evaluate(({ cb }) => (cb as any)(), { cb: () => {} }))
+  await expect(page.evaluate(({ cb }) => cb(), { cb: () => {} }))
       .rejects.toThrow(/Attempting to serialize unexpected value at position "cb": \(\) => {}/);
 });
 
@@ -27,7 +27,7 @@ it('should call a function passed as an argument', async ({ page }) => {
   await page.evaluate(async ({ cb }) => {
     await cb(1);
     await cb(2);
-  }, { cb: async (n: number) => { received.push(n); } }, { exposeFunctions: true });
+  }, { cb: (n: number) => { received.push(n); } }, { exposeFunctions: true });
   expect(received).toEqual([1, 2]);
 });
 
@@ -54,6 +54,26 @@ it('should return the callback result to the page', async ({ page }) => {
     cb: async (n: number) => n * 2,
   }, { exposeFunctions: true });
   expect(doubled).toBe(42);
+});
+
+it('should support handle as a callback result', async ({ page }) => {
+  const result = await page.evaluate(async cb => {
+    const value = await cb(42);
+    return value + 17;
+  }, (n: number) => page.evaluateHandle(x => 2 * x, n), { exposeFunctions: true });
+  expect(result).toBe(101);
+});
+
+it('should support nested handles in the callback result', async ({ page }) => {
+  const result = await page.evaluate(async cb => {
+    const res = await cb(42);
+    return res.mul[0] + res.mul[1] + res.add;
+  }, async (n: number) => {
+    const double = await page.evaluateHandle(x => 2 * x, n);
+    const triple = await page.evaluateHandle(x => 3 * x, n);
+    return { mul: [double, triple] as const, add: 17 };
+  }, { exposeFunctions: true });
+  expect(result).toBe(227);
 });
 
 it('should await an async callback result', async ({ page }) => {

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -428,6 +428,34 @@ playwright.chromium.launch().then(async browser => {
   {
     await locator.evaluateAll((sel: HTMLSelectElement[]) => {})
   }
+  {
+    await locator.evaluate((e, cb) => {
+      const value = cb(2);
+      const assertion: AssertType<Promise<number>, typeof value> = true;
+    }, (x: number) => 2 * x);
+  }
+  {
+    await locator.evaluate((e, cb) => {
+      const value = cb(2);
+      const assertion: AssertType<Promise<number>, typeof value> = true;
+    }, async (x: number) => 2 * x);
+  }
+  {
+    await locator.evaluate((e, { cb }) => {
+      const value = cb(2);
+      const assertion: AssertType<Promise<number>, typeof value> = true;
+    }, { cb: (x: number) => page.evaluateHandle(y => 2 * y, x) });
+  }
+  {
+    const func = async (x: number) => {
+      const double = await page.evaluateHandle(y => 2 * y, x);
+      return { double, add: 17 };
+    };
+    await locator.evaluate((e, { cb }) => {
+      const value = cb(2);
+      const assertion: AssertType<Promise<{ double: number, add: number }>, typeof value> = true;
+    }, { cb: func });
+  }
   await browser.close();
 })();
 


### PR DESCRIPTION
- Make sure callback in the page is always async.
- Unbox handles from the callback result.
- Add tests for returning handles.