### PR TITLE
fix(network): request.postData() returns null for empty string body override

### DIFF
--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -137,7 +137,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
   }
 
   postData(): string | null {
-    return (this._fallbackOverrides.postDataBuffer || this._initializer.postData)?.toString('utf-8') || null;
+    return (this._fallbackOverrides.postDataBuffer ?? this._initializer.postData)?.toString('utf-8') ?? null;
   }
 
   postDataBuffer(): Buffer | null {
@@ -221,7 +221,8 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
         'Frame for this navigation request is not available, because the request',
         'was issued before the frame is created. You can check whether the request',
         'is a navigation request by calling isNavigationRequest() method.',
-      ].join('\n'));
+      ].join('
+'));
     }
     return frame;
   }
@@ -885,7 +886,9 @@ export class RouteHandler {
       if (isTargetClosedError(e)) {
         // We are failing in the handler because the target close closed.
         // Give user a hint!
-        rewriteErrorMessage(e, `"${e.message}" while running route callback.\nConsider awaiting \`await page.unrouteAll({ behavior: 'ignoreErrors' })\`\nbefore the end of the test to ignore remaining routes in flight.`);
+        rewriteErrorMessage(e, `"${e.message}" while running route callback.
+Consider awaiting \`await page.unrouteAll({ behavior: 'ignoreErrors' })\`
+before the end of the test to ignore remaining routes in flight.`);
       }
       throw e;
     } finally {
@@ -949,7 +952,8 @@ export class RawHeaders {
     const values = this.getAll(name);
     if (!values || !values.length)
       return null;
-    return values.join(name.toLowerCase() === 'set-cookie' ? '\n' : ', ');
+    return values.join(name.toLowerCase() === 'set-cookie' ? '
+' : ', ');
   }
 
   getAll(name: string): string[] {

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -221,8 +221,7 @@ export class Request extends ChannelOwner<channels.RequestChannel> implements ap
         'Frame for this navigation request is not available, because the request',
         'was issued before the frame is created. You can check whether the request',
         'is a navigation request by calling isNavigationRequest() method.',
-      ].join('
-'));
+      ].join('\n'));
     }
     return frame;
   }
@@ -886,9 +885,7 @@ export class RouteHandler {
       if (isTargetClosedError(e)) {
         // We are failing in the handler because the target close closed.
         // Give user a hint!
-        rewriteErrorMessage(e, `"${e.message}" while running route callback.
-Consider awaiting \`await page.unrouteAll({ behavior: 'ignoreErrors' })\`
-before the end of the test to ignore remaining routes in flight.`);
+        rewriteErrorMessage(e, `"${e.message}" while running route callback.\nConsider awaiting \`await page.unrouteAll({ behavior: 'ignoreErrors' })\`\nbefore the end of the test to ignore remaining routes in flight.`);
       }
       throw e;
     } finally {
@@ -952,8 +949,7 @@ export class RawHeaders {
     const values = this.getAll(name);
     if (!values || !values.length)
       return null;
-    return values.join(name.toLowerCase() === 'set-cookie' ? '
-' : ', ');
+    return values.join(name.toLowerCase() === 'set-cookie' ? '\n' : ', ');
   }
 
   getAll(name: string): string[] {

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -1010,3 +1010,21 @@ it('should not forward Host header on cross-origin redirect', {
   expect(firstHost).toBe(new URL(server.PREFIX).host);
   expect(redirectedHost).toBe(new URL(server.CROSS_PROCESS_PREFIX).host);
 });
+
+it('postData should return empty string when overriding body with empty string', async ({ page, server }) => {
+  server.setRoute('/empty-post', (req, res) => { req.resume(); res.end('OK'); });
+
+  const captured: (string | null)[] = [];
+  await page.route(`${server.PREFIX}/empty-post`, async route => {
+    await route.continue({ postData: '' });
+  });
+
+  page.on('request', request => {
+    if (request.url().includes('empty-post'))
+      captured.push(request.postData());
+  });
+
+  await page.evaluate(url => fetch(url, { method: 'POST', body: 'original' }), `${server.PREFIX}/empty-post`);
+  expect(captured).toHaveLength(1);
+  expect(captured[0]).toBe('');
+});

--- a/tests/page/page-request-continue.spec.ts
+++ b/tests/page/page-request-continue.spec.ts
@@ -1012,19 +1012,13 @@ it('should not forward Host header on cross-origin redirect', {
 });
 
 it('postData should return empty string when overriding body with empty string', async ({ page, server }) => {
-  server.setRoute('/empty-post', (req, res) => { req.resume(); res.end('OK'); });
-
-  const captured: (string | null)[] = [];
-  await page.route(`${server.PREFIX}/empty-post`, async route => {
-    await route.continue({ postData: '' });
+  await page.goto(server.EMPTY_PAGE);
+  await page.route('**/*', route => {
+    void route.continue({ postData: '' });
   });
-
-  page.on('request', request => {
-    if (request.url().includes('empty-post'))
-      captured.push(request.postData());
-  });
-
-  await page.evaluate(url => fetch(url, { method: 'POST', body: 'original' }), `${server.PREFIX}/empty-post`);
-  expect(captured).toHaveLength(1);
-  expect(captured[0]).toBe('');
+  const [request] = await Promise.all([
+    page.waitForRequest('**'),
+    page.evaluate(({ url }) => fetch(url, { method: 'POST', body: 'original' }), { url: server.PREFIX + '/sleep.zzz' }),
+  ]);
+  expect(request.postData()).toBe('');
 });


### PR DESCRIPTION
## Summary

`request.postData()` incorrectly returns `null` when the POST body is set to an empty string via `route.continue({ postData: '' })` or `route.fallback({ postData: '' })`.

### Root cause

In `packages/playwright-core/src/client/network.ts`, the `postData()` method uses `|| null` at the end:

```ts
// before
postData(): string | null {
  return (this._fallbackOverrides.postDataBuffer || this._initializer.postData)?.toString('utf-8') || null;
}
```

When the override is set to an empty string, `Buffer.from('', 'utf-8')` is stored in `_fallbackOverrides.postDataBuffer`. Since an empty `Buffer` is a truthy object, the left-hand side resolves correctly to the empty buffer, and `.toString('utf-8')` yields `''`. However, `'' || null` evaluates to `null`, discarding the empty-string body.

This is inconsistent with `postDataBuffer()`, which returns the correct empty `Buffer` for the same input.

### Fix

Switch the trailing `|| null` to `?? null` (nullish coalescing), which only falls back to `null` when the value is `null` or `undefined`, not when it is an empty string:

```ts
// after
postData(): string | null {
  return (this._fallbackOverrides.postDataBuffer ?? this._initializer.postData)?.toString('utf-8') ?? null;
}
```

The inner `||` is similarly changed to `??` so that a zero-length override buffer isn't accidentally skipped in favour of the original request's body.

### Reproduction

```ts
test('postData returns empty string for empty body override', async ({ page }) => {
  await page.route('**/api', async route => {
    await route.continue({ postData: '' });
  });

  page.on('request', request => {
    // Before fix: null  After fix: ''
    expect(request.postData()).toBe('');
  });

  await page.evaluate(() => fetch('/api', { method: 'POST', body: 'original' }));
});
```