### PR TITLE
fix(firefox): do not override Accept-Language header set by the page

### DIFF
--- a/packages/playwright-core/src/server/firefox/ffBrowser.ts
+++ b/packages/playwright-core/src/server/firefox/ffBrowser.ts
@@ -305,10 +305,7 @@ export class FFBrowserContext extends BrowserContext {
   }
 
   async doUpdateExtraHTTPHeaders(): Promise<void> {
-    let allHeaders = this._options.extraHTTPHeaders || [];
-    if (this._options.locale)
-      allHeaders = network.mergeHeaders([allHeaders, network.singleHeader('Accept-Language', this._options.locale)]);
-    await this._browser.session.send('Browser.setExtraHTTPHeaders', { browserContextId: this._browserContextId, headers: allHeaders });
+    await this._browser.session.send('Browser.setExtraHTTPHeaders', { browserContextId: this._browserContextId, headers: this._options.extraHTTPHeaders || [] });
   }
 
   async setUserAgent(userAgent: string | undefined): Promise<void> {

--- a/tests/library/browsercontext-locale.spec.ts
+++ b/tests/library/browsercontext-locale.spec.ts
@@ -189,3 +189,38 @@ it('should affect Intl.DateTimeFormat().resolvedOptions().locale', async ({ brow
   expect(await page.evaluate(() => (new Intl.DateTimeFormat()).resolvedOptions().locale)).toBe('en-GB');
   await context.close();
 });
+
+it('should send user Accept-Language header', {
+  annotation: [{ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23732' }],
+}, async ({ browser, server, browserName }) => {
+  it.fixme(browserName === 'webkit', 'Implementation set Accept-Language header as extra HTTP header');
+  const context = await browser.newContext({ locale: 'en-GB' });
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  {
+    const reqPromise = server.waitForRequest('/empty.html');
+    await page.evaluate(async url => {
+      await fetch(url, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': 'de'
+        },
+      });
+    }, server.EMPTY_PAGE);
+    const req = await reqPromise;
+    expect(req.headers['accept-language']).toBe('de');
+  }
+  {
+    const reqPromise = server.waitForRequest('/empty.html');
+    await page.evaluate(async url => {
+      await fetch(url, {
+        headers: {
+          'Content-Type': 'application/json'
+        },
+      });
+    }, server.EMPTY_PAGE);
+    const req = await reqPromise;
+    expect(req.headers['accept-language']).toContain('en-GB');
+  }
+  await context.close();
+});


### PR DESCRIPTION
## Summary
- Do not merge the locale-derived `Accept-Language` header into Firefox extra HTTP headers — the browser-side language override already produces the header, and the extra-header mechanism was clobbering an `Accept-Language` explicitly set on a `fetch`/XHR request.
- Add a test that an explicit `Accept-Language` on a fetch is preserved and that the locale-derived one is still sent when the request does not specify it. Marked fixme on WebKit until the corresponding browser fix rolls.

References https://github.com/microsoft/playwright/issues/23732 (fixes the Firefox part; WebKit needs a separate fix).