### PR TITLE
fix(dashboard): avoid stdout readiness race

### DIFF
--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -296,8 +296,6 @@ export async function openDashboardApp() {
     stopSelfDestruct();
     // eslint-disable-next-line no-console
     console.log(`Dashboard is running pid=${acquired.daemonPid}`);
-    // eslint-disable-next-line no-restricted-properties
-    await new Promise(f => process.stdout.write('', f));  // Make sure stdout is flushed.
     return;
   }
   const { server } = acquired;
@@ -319,8 +317,6 @@ export async function openDashboardApp() {
       // eslint-disable-next-line no-console
       console.log(`Dashboard is running pid=${process.pid}`);
     }
-    // eslint-disable-next-line no-restricted-properties
-    await new Promise(f => process.stdout.write('', f));  // Make sure stdout is flushed.
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);


### PR DESCRIPTION
Apparently on a busy box, the first "Dashboard ready" message arrives separate from the empty string.
The parent detaches and consequently closes stdout. Now when the client sends its empty string, it crashes because it tries writing to a closed pipe.

Healthy:

1. Client sends "Ready"
2. Client sends ""
3. Parent receives "ready", ""
4. Parent closes stdout

Unhealthy:

1. Client sends "Ready"
2. Parent receives "ready"
3. Parent closes stdout
4. Client sends "" onto a closed stdout


I didn't find a reason why we need to await the flush, so I removed it. Alternatively we can catch the error and would also be fine.

This PR drops the redundant flushes. On `macos-15-xlarge`, the original repro went from 6–9 failures per 100 runs to 0.