### PR TITLE
test: add a regression test for #40510

### DIFF
--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -149,6 +149,31 @@ it('should return body with compression', async ({ page, server, asset }) => {
   expect(responseBuffer.equals(imageBuffer)).toBe(true);
 });
 
+it('should return non-utf8 body even when content-type says utf8', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/40510' },
+}, async ({ page, server, browserName }) => {
+  it.fixme(browserName === 'webkit', 'webkit encodes the response body');
+
+  // Binary data with bytes that are invalid UTF-8.
+  const bytes = [0x80, 0x81, 0x82, 0xFF, 0xFE, 0x00, 0x01, 0x02];
+  const buffer = Buffer.from(bytes);
+  server.setRoute('/binary-as-text', (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/plain;charset=UTF-8',
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  });
+  await page.goto(server.EMPTY_PAGE);
+  const [response, bytesReceived] = await Promise.all([
+    page.waitForResponse(server.PREFIX + '/binary-as-text'),
+    page.evaluate(url => fetch(url).then(r => r.bytes()), server.PREFIX + '/binary-as-text'),
+  ]);
+  const body = await response.body();
+  expect(body.equals(buffer)).toBe(true);
+  expect(Array.from(bytesReceived)).toEqual(bytes);
+});
+
 it('should return status text', async ({ page, server }) => {
   server.setRoute('/cool', (req, res) => {
     res.writeHead(200, 'cool!');


### PR DESCRIPTION
The issue was fixed upstream in Chromium.
Closes #40510.