### PR TITLE
fix(mcp): report malformed JSON config instead of falling back to INI

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -447,10 +447,16 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
   if (configFile.endsWith('.ini'))
     return configFromIniFile(configFile);
 
+  const raw = await fs.promises.readFile(configFile, 'utf8');
+  const data = raw.charCodeAt(0) === 0xFEFF ? raw.slice(1) : raw;
   try {
-    const data = await fs.promises.readFile(configFile, 'utf8');
-    return JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
-  } catch {
+    return JSON.parse(data);
+  } catch (jsonError) {
+    // A JSON config is always an object, so JSON-looking input must surface its
+    // parse error rather than silently falling back to INI (and the default
+    // config). A leading `[` stays with INI — it is a `[section]` header there.
+    if (/^\s*\{/.test(data))
+      throw jsonError;
     return configFromIniFile(configFile);
   }
 }

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -83,6 +83,25 @@ test.describe('browserName and channel', () => {
     expect(config.browser.launchOptions.channel).toBeUndefined();
   });
 
+  test('malformed JSON config throws instead of falling back to INI', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41893' },
+  }, async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    // Trailing comma makes this invalid JSON; it must not be silently parsed as INI.
+    await fs.promises.writeFile(configFile, '{ "browser": { "browserName": "firefox", } }');
+    await expect(resolveCLIConfigForMCP({ config: configFile }, emptyEnv)).rejects.toThrow();
+  });
+
+  test('INI config starting with a section header still parses', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41893' },
+  }, async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.cfg');
+    // A leading `[section]` is INI, not JSON — it must not be treated as malformed JSON.
+    await fs.promises.writeFile(configFile, '[browser]\nbrowserName = firefox\n');
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.browser.browserName).toBe('firefox');
+  });
+
   test('config file browserName + channel are both preserved', async ({}, testInfo) => {
     const configFile = testInfo.outputPath('config.json');
     const fileConfig: Config = {


### PR DESCRIPTION
`loadConfig` fell back to INI parsing on any JSON error, so a typo'd JSON config (e.g. a trailing comma) was silently accepted as INI: the intended settings were dropped for the defaults and the raw JSON kept as an unused top-level key

surface the original `SyntaxError` when the input is a JSON object (`{`) while keeping the INI fallback (including files whose first line is a `[section]` header) and BOM handling

fixes <https://github.com/microsoft/playwright/issues/41893>