### PR TITLE
fix(chromium): keep closing the target so page.close() cannot hang on a navigation commit

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -272,7 +272,24 @@ export class CRBrowser extends Browser {
   }
 
   async _closePage(crPage: CRPage) {
-    await this._session.send('Target.closeTarget', { targetId: crPage._targetId });
+    // When a `Target.closeTarget` happens at the same time as a navigation commit it can report success even though it
+    // actually doesnt do anything, leaving the target alive and causing this to hang forever (crbug.com/536385539).
+    const closed = crPage._page.closedPromise.then(() => true);
+    while (true) {
+      await this._session.send('Target.closeTarget', { targetId: crPage._targetId }).catch(() => {});
+      let timer: NodeJS.Timeout | undefined;
+      const success = await Promise.race([
+        closed,
+        new Promise<boolean>(resolve => {
+          timer = setTimeout(() => {
+            resolve(false);
+          }, 500);
+        }),
+      ]);
+      clearTimeout(timer);
+      if (success)
+        return;
+    }
   }
 
   async newBrowserCDPSession(): Promise<CDPSession> {

--- a/tests/page/page-autowaiting-no-hang.spec.ts
+++ b/tests/page/page-autowaiting-no-hang.spec.ts
@@ -173,3 +173,19 @@ it('goBack in the middle of navigation that commits', async ({ page, server }) =
 
   await goBackPromise;
 });
+
+it('page.close() should not hang when racing a cross-origin navigation commit', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41900' },
+}, async ({ page, server, browserName }) => {
+  it.skip(browserName !== 'chromium', 'Chromium-specific Target.closeTarget commit race');
+  it.slow();
+  const context = page.context();
+  for (let i = 0; i < 15; i++) {
+    const other = await context.newPage();
+    await other.goto(server.PREFIX + '/empty.html');
+    other.goto(server.CROSS_PROCESS_PREFIX + '/empty.html').catch(() => {});
+    await new Promise(resolve => setTimeout(resolve, 10));
+    other.goto(server.PREFIX + '/empty.html').catch(() => {});
+    await other.close();
+  }
+});


### PR DESCRIPTION
`page.close()` has no timeout and resolves only once the browser reports `Target.detachedFromTarget`

if the close happens at the same time as a navigation commit, the `Target.closeTarget` responds with success but silently drops the actual close (crbug.com/536385539)

repeatedly dispatch `Target.closeTarget` until the target actually detaches (note that a close on an already-closing target is a no-op)

this fix is very similar to <https://github.com/microsoft/playwright/pull/41695>

fixes <https://github.com/microsoft/playwright/issues/41900>