### PR TITLE
fix(role): map input[type=search] to searchbox unless list is a datalist

### DIFF
--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -123,12 +123,12 @@ const kImplicitRoleByTagName: { [tagName: string]: (e: Element) => AriaRole | nu
   'IMG': (e: Element) => (e.getAttribute('alt') === '') && !e.getAttribute('title') && !hasGlobalAriaAttribute(e) && !hasTabIndex(e) ? 'presentation' : 'img',
   'INPUT': (e: Element) => {
     const type = (e as HTMLInputElement).type.toLowerCase();
-    if (type === 'search')
-      return e.hasAttribute('list') ? 'combobox' : 'searchbox';
-    if (['email', 'tel', 'text', 'url', ''].includes(type)) {
+    if (['email', 'search', 'tel', 'text', 'url', ''].includes(type)) {
       // https://html.spec.whatwg.org/multipage/input.html#concept-input-list
       const list = getIdRefs(e, e.getAttribute('list'))[0];
-      return (list && elementSafeTagName(list) === 'DATALIST') ? 'combobox' : 'textbox';
+      if (list && elementSafeTagName(list) === 'DATALIST')
+        return 'combobox';
+      return type === 'search' ? 'searchbox' : 'textbox';
     }
     if (type === 'hidden')
       return null;

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -329,6 +329,21 @@ test('native controls', async ({ page }) => {
   expect.soft(await getNameAndRole(page, '#file2')).toEqual({ role: 'button', name: 'FILE2' });
 });
 
+test('input type=search maps to searchbox unless list points at a datalist', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41899' },
+}, async ({ page }) => {
+  await page.setContent(`
+    <input id="search1" type=search>
+    <input id="search2" type=search list=nope>
+    <input id="search3" type=search list=dv><div id=dv></div>
+    <input id="search4" type=search list=dl><datalist id=dl></datalist>
+  `);
+  expect.soft(await getNameAndRole(page, '#search1')).toEqual({ role: 'searchbox', name: '' });
+  expect.soft(await getNameAndRole(page, '#search2')).toEqual({ role: 'searchbox', name: '' });
+  expect.soft(await getNameAndRole(page, '#search3')).toEqual({ role: 'searchbox', name: '' });
+  expect.soft(await getNameAndRole(page, '#search4')).toEqual({ role: 'combobox', name: '' });
+});
+
 test('native controls labelled-by', async ({ page }) => {
   await page.setContent(`
     <label id="for-text1">TEXT1</label><input aria-labelledby="for-text1" id="text1" type=text>


### PR DESCRIPTION
the `search` branch only checked `hasAttribute('list')`, so an `input[type=search]` whose `list` points at nothing or a non-`<datalist>` element was reported as `combobox`, unlike the neighbouring `text`/`email`/... branch and unlike what the browser computes (`searchbox`)

resolve the `list` idref and only map to `combobox` when it points at an actual `<datalist>`, matching the html spec's concept-input-list

fixes <https://github.com/microsoft/playwright/issues/41899>