### PR TITLE
fix(role): derive accessible name from associated label for meter and progress

### DIFF
--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -843,6 +843,16 @@ function getTextAlternativeInternal(element: Element, options: AccessibleNameOpt
       return compositeString(element.getAttribute('title') || '', element, options.collectElements);
     }
 
+    // <meter> and <progress> are labelable elements, so use their associated <label>.
+    // https://github.com/microsoft/playwright/issues/41891
+    if (!labelledBy && (tagName === 'METER' || tagName === 'PROGRESS')) {
+      options.visitedElements.add(element);
+      const labels = (element as HTMLMeterElement | HTMLProgressElement).labels || [];
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+      return compositeString(element.getAttribute('title') || '', element, options.collectElements);
+    }
+
     // https://w3c.github.io/html-aam/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
     // https://w3c.github.io/html-aam/#other-form-elements-accessible-name-computation
     // For "other form elements", we count select and any other input.

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -312,6 +312,11 @@ test('native controls', async ({ page }) => {
 
     <input id="file1" type=file>
     <label for="file2">FILE2</label><input id="file2" type=file>
+
+    <label for="meter1">METER1</label><meter id="meter1" value="0.5"></meter>
+    <meter id="meter2" value="0.5" title="METER2"></meter>
+    <label for="progress1">PROGRESS1</label><progress id="progress1" value="0.5"></progress>
+    <progress id="progress2" value="0.5" title="PROGRESS2"></progress>
   `);
 
   expect.soft(await getNameAndRole(page, '#text1')).toEqual({ role: 'textbox', name: 'TEXT1' });
@@ -327,6 +332,10 @@ test('native controls', async ({ page }) => {
   expect.soft(await getNameAndRole(page, '#button4')).toEqual({ role: 'button', name: 'BUTTON4' });
   expect.soft(await getNameAndRole(page, '#file1')).toEqual({ role: 'button', name: 'Choose File' });
   expect.soft(await getNameAndRole(page, '#file2')).toEqual({ role: 'button', name: 'FILE2' });
+  expect.soft(await getNameAndRole(page, '#meter1')).toEqual({ role: 'meter', name: 'METER1' });
+  expect.soft(await getNameAndRole(page, '#meter2')).toEqual({ role: 'meter', name: 'METER2' });
+  expect.soft(await getNameAndRole(page, '#progress1')).toEqual({ role: 'progressbar', name: 'PROGRESS1' });
+  expect.soft(await getNameAndRole(page, '#progress2')).toEqual({ role: 'progressbar', name: 'PROGRESS2' });
 });
 
 test('native controls labelled-by', async ({ page }) => {


### PR DESCRIPTION
## Summary
- `<meter>` and `<progress>` are labelable elements, but the accessible name computation had no branch for their associated `<label>` — so `getByRole({ name })` and `toHaveAccessibleName` never matched them. `<output>` had the same gap (fixed in #27415); this mirrors that handling.

Fixes https://github.com/microsoft/playwright/issues/41891