### PR TITLE
fix(webview): route `exposeFunctions` callbacks to the originating frame

### DIFF
--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -538,7 +538,7 @@ export class WVPage implements PageDelegate {
       const [bindingName, bindingArg] = parameters;
 
       if (bindingName.value === BINDING_CALL_TAG && bindingArg.type === 'string') {
-        const context = [...this._contextIdToContext.values()].find(c => c.frame === this._page.mainFrame());
+        const context = this._bindingCallContext(parameters);
         if (context)
           this._page.onBindingCalled(bindingArg.value, context).catch(e => debugLogger.log('error', e));
         return;
@@ -607,6 +607,15 @@ export class WVPage implements PageDelegate {
       },
     };
     this._onConsoleRepeatCountUpdated({ count: 1, timestamp: event.message.timestamp });
+  }
+
+  private _bindingCallContext(parameters: Protocol.Runtime.RemoteObject[]): dom.FrameExecutionContext | undefined {
+    const contextObject = parameters[2];
+    if (contextObject?.objectId) {
+      this._session.sendMayFail('Runtime.releaseObject', { objectId: contextObject.objectId });
+      return this._contextIdToContext.get(JSON.parse(contextObject.objectId).injectedScriptId);
+    }
+    return [...this._contextIdToContext.values()].find(c => c.frame === this._page.mainFrame());
   }
 
   _onConsoleRepeatCountUpdated(event: Protocol.Console.messageRepeatCountUpdatedPayload) {
@@ -1261,7 +1270,10 @@ const bindingBridgeSource = `
     Object.defineProperty(window, '${PageBinding.kBindingName}', {
       configurable: true,
       writable: false,
-      value: function(payload) { console.debug('${BINDING_CALL_TAG}', payload); },
+      value: function(payload) {
+        const contextObject = {};
+        console.debug('${BINDING_CALL_TAG}', payload, contextObject);
+      },
     });
   }
 `;

--- a/tests/page/page-evaluate-callback.spec.ts
+++ b/tests/page/page-evaluate-callback.spec.ts
@@ -132,6 +132,18 @@ it('should work in a child frame', async ({ page, server }) => {
   expect(received).toEqual([42]);
 });
 
+it('should route callbacks back to the calling frame', async ({ page, server }) => {
+  await page.goto(server.EMPTY_PAGE);
+  const frame = await attachFrame(page, 'frame1', server.EMPTY_PAGE);
+  const greet = async (where: string) => `hello ${where}`;
+  const [fromMain, fromChild] = await Promise.all([
+    page.evaluate(async ({ cb }) => await cb('main'), { cb: greet }, { exposeFunctions: true }),
+    frame.evaluate(async ({ cb }) => await cb('child'), { cb: greet }, { exposeFunctions: true }),
+  ]);
+  expect(fromMain).toBe('hello main');
+  expect(fromChild).toBe('hello child');
+});
+
 it('should work with jsHandle.evaluate', async ({ page }) => {
   const handle = await page.evaluateHandle(() => window);
   const received: number[] = [];


### PR DESCRIPTION
WebKit has no `Runtime.addBinding`, so the webview delegate has to handle bindings through `console.debug(BINDING_CALL_TAG, payload)` instead

the console message carries no execution context id, so every call was dispatched against the main frame, meaning a callback fired from a child frame (e.g. `frame.evaluate(..., { exposeFunctions: true })`) reached the wrong `BindingsController` and never resolved the calling frame's pending promise, hanging until the 30s timeout tore the page down

tag each call with an empty object created in the calling context, as an `objectId` carries the injected script id, meaning that the host can route the call to the frame it came from and release the marker afterwards