### PR TITLE
feat(extension): support multiple concurrent client connections

### DIFF
--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -7,7 +7,8 @@
     "debugger",
     "activeTab",
     "tabs",
-    "tabGroups"
+    "tabGroups",
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -18,6 +18,8 @@ import { debugLog } from './relayConnection';
 import { PendingConnections } from './pendingConnection';
 import { ConnectedTabGroup, cleanupStalePlaywrightGroups, isNonDebuggableUrl } from './connectedTabGroup';
 
+import type { GroupStyle } from './connectedTabGroup';
+
 type PageMessage = {
   type: 'connectionRequested';
   mcpRelayUrl: string;
@@ -33,13 +35,25 @@ type PageMessage = {
   type: 'getConnectionStatus';
 } | {
   type: 'disconnect';
+  // Absent to disconnect all clients.
+  connectionId?: number;
 } | {
   type: 'keepalive';
 };
 
+type ActiveConnection = {
+  id: number;
+  clientName: string | undefined;
+  label: string;
+  group: ConnectedTabGroup;
+};
+
+// Rotated per connection so concurrent clients get visually distinct groups.
+const GROUP_COLORS: GroupStyle['color'][] = ['green', 'blue', 'purple', 'orange', 'pink', 'cyan', 'red', 'yellow'];
+
 class PlaywrightExtension {
-  private _activeGroup: ConnectedTabGroup | undefined;
-  private _activeClientName: string | undefined;
+  private _connections = new Map<number, ActiveConnection>();
+  private _lastConnectionId = 0;
   private _pendingConnections = new PendingConnections();
   // Service worker restarts lose all connection state, so any existing
   // Playwright groups are stale. Connections wait on this before reconciling.
@@ -69,20 +83,25 @@ class PlaywrightExtension {
         // sender.tab and UI-supplied tabs come from chrome.tabs.query / runtime
         // message sender, where `id` is always defined.
         const selectedTab = (message.tab ?? sender.tab!) as chrome.tabs.Tab & { id: number };
-        this._connectTab(sender.tab!.id!, selectedTab, message.clientName).then(
+        const userSelected = message.tab !== undefined;
+        this._connectTab(sender.tab!.id!, selectedTab, message.clientName, userSelected).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true; // Return true to indicate that the response will be sent asynchronously
       }
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabIds: this._activeGroup?.connectedTabIds() ?? [],
-          clientName: this._activeClientName,
+          connections: [...this._connections.values()].map(connection => ({
+            id: connection.id,
+            clientName: connection.clientName,
+            label: connection.label,
+            connectedTabIds: connection.group.connectedTabIds(),
+          })),
         });
         return false;
       case 'disconnect':
         try {
-          this._disconnect('User disconnected');
+          this._disconnect(message.connectionId, 'User disconnected');
           sendResponse({ success: true });
         } catch (error: any) {
           sendResponse({ success: false, error: error.message });
@@ -95,29 +114,30 @@ class PlaywrightExtension {
     }
   }
 
-  private async _connectTab(selectorTabId: number, tab: chrome.tabs.Tab & { id: number }, clientName: string | undefined): Promise<void> {
+  private async _connectTab(selectorTabId: number, tab: chrome.tabs.Tab & { id: number }, clientName: string | undefined, userSelected: boolean): Promise<void> {
     try {
       await this._cleanupPromise;
-      this._disconnect('Another connection is requested');
 
       const connection = await this._pendingConnections.take(selectorTabId);
       if (!connection)
         throw new Error('Pending client connection closed');
 
-      const group = new ConnectedTabGroup(connection, tab);
-      group.onclose = () => {
-        if (this._activeGroup === group) {
-          this._activeGroup = undefined;
-          this._activeClientName = undefined;
-        }
-      };
-      this._activeGroup = group;
-      this._activeClientName = clientName;
+      const id = ++this._lastConnectionId;
+      const label = `${clientName || 'Playwright'} #${id}`;
+      const style: GroupStyle = { title: label, color: GROUP_COLORS[(id - 1) % GROUP_COLORS.length] };
+      const group = new ConnectedTabGroup(connection, tab, style);
+      group.onclose = () => this._connections.delete(id);
+      this._connections.set(id, { id, clientName, label, group });
 
-      await Promise.all([
-        chrome.tabs.update(tab.id, { active: true }),
-        chrome.windows.update(tab.windowId, { focused: true }),
-      ]).catch(() => {});
+      // Honor the "Allow & select" semantics when the user explicitly picked a
+      // tab. Token-bypass connections skip this so a background agent never
+      // steals window focus.
+      if (userSelected) {
+        await Promise.all([
+          chrome.tabs.update(tab.id, { active: true }),
+          chrome.windows.update(tab.windowId, { focused: true }),
+        ]).catch(() => {});
+      }
 
       if (tab.id !== selectorTabId)
         await chrome.tabs.remove(selectorTabId).catch(() => {});
@@ -139,12 +159,14 @@ class PlaywrightExtension {
     });
   }
 
-  // Closes the active group's connection if any. ConnectedTabGroup's onclose
-  // handles state cleanup (connectedTabIds, badges, reconcile).
-  private _disconnect(reason: string) {
-    this._activeGroup?.close(reason);
-    this._activeGroup = undefined;
-    this._activeClientName = undefined;
+  // Closes one connection when connectionId is given, all of them otherwise.
+  // ConnectedTabGroup's onclose removes the entry from _connections.
+  private _disconnect(connectionId: number | undefined, reason: string) {
+    const targets = connectionId === undefined
+      ? [...this._connections.values()]
+      : [this._connections.get(connectionId)].filter((c): c is ActiveConnection => c !== undefined);
+    for (const connection of targets)
+      connection.group.close(reason);
   }
 }
 

--- a/packages/extension/src/connectedTabGroup.ts
+++ b/packages/extension/src/connectedTabGroup.ts
@@ -14,25 +14,55 @@
  * limitations under the License.
  */
 
-import { RelayConnection, debugLog } from './relayConnection';
+import { RelayConnection, debugLog, isOwnUiUrl } from './relayConnection';
 
-const PLAYWRIGHT_GROUP_TITLE = 'Playwright';
-const PLAYWRIGHT_GROUP_COLOR = 'green';
 const NON_DEBUGGABLE_SCHEMES = ['chrome:', 'edge:', 'devtools:'];
 const CONNECTED_BADGE = { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' };
+// Title used by extension versions that supported a single connection. Still
+// matched during cleanup so an upgrade reconciles groups they left behind.
+const LEGACY_GROUP_TITLE = 'Playwright';
+// storage.local key listing tab group titles created by this extension, so a
+// restarted service worker can recognize which groups are stale.
+const GROUP_TITLES_KEY = 'playwrightGroupTitles';
+
+export type GroupStyle = {
+  title: string;
+  color: NonNullable<chrome.tabGroups.UpdateProperties['color']>;
+};
 
 export function isNonDebuggableUrl(url: string | undefined): boolean {
   return !!url && NON_DEBUGGABLE_SCHEMES.some(s => url.startsWith(s));
 }
 
-// Ungroups any Playwright-titled groups left behind by a prior service worker.
+// storage.local writes are read-modify-write, so serialize them to avoid
+// losing a title when two connections create groups at the same time.
+let groupTitlesWriteQueue: Promise<void> = Promise.resolve();
+
+function registerGroupTitle(title: string): Promise<void> {
+  groupTitlesWriteQueue = groupTitlesWriteQueue.then(async () => {
+    const stored = await chrome.storage.local.get(GROUP_TITLES_KEY);
+    const titles: string[] = stored[GROUP_TITLES_KEY] ?? [];
+    if (!titles.includes(title))
+      await chrome.storage.local.set({ [GROUP_TITLES_KEY]: [...titles, title] });
+  }).catch((error: any) => {
+    debugLog('Error registering group title:', error);
+  });
+  return groupTitlesWriteQueue;
+}
+
+// Ungroups any groups left behind by a prior service worker, identified by the
+// titles that service worker registered in storage.local.
 export async function cleanupStalePlaywrightGroups(): Promise<void> {
   try {
-    const groups = await chrome.tabGroups.query({ title: PLAYWRIGHT_GROUP_TITLE });
-    const tabsPerGroup = await Promise.all(groups.map(g => chrome.tabs.query({ groupId: g.id })));
+    const stored = await chrome.storage.local.get(GROUP_TITLES_KEY);
+    const staleTitles = new Set<string>([...(stored[GROUP_TITLES_KEY] ?? []), LEGACY_GROUP_TITLE]);
+    const groups = await chrome.tabGroups.query({});
+    const staleGroups = groups.filter(g => g.title !== undefined && staleTitles.has(g.title));
+    const tabsPerGroup = await Promise.all(staleGroups.map(g => chrome.tabs.query({ groupId: g.id })));
     const tabIds = tabsPerGroup.flat().map(t => t.id).filter((id): id is number => id !== undefined);
     if (tabIds.length)
       await chrome.tabs.ungroup(tabIds);
+    await chrome.storage.local.remove(GROUP_TITLES_KEY);
   } catch (error: any) {
     debugLog('Error cleaning up stale groups:', error);
   }
@@ -48,6 +78,7 @@ export async function cleanupStalePlaywrightGroups(): Promise<void> {
 // in `_onTabUpdated` stay synchronous.
 export class ConnectedTabGroup {
   private _connection: RelayConnection;
+  private _style: GroupStyle;
   private _groupId: number | null = null;
   private _groupTabIds: Set<number> = new Set();
   private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
@@ -55,8 +86,9 @@ export class ConnectedTabGroup {
 
   onclose?: () => void;
 
-  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab) {
+  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab, style: GroupStyle) {
     this._connection = connection;
+    this._style = style;
     this._connection.onclose = () => this._onConnectionClose();
     this._connection.ontabattached = (tabId: number) => this._onTabAttached(tabId);
     this._connection.ontabdetached = (tabId: number) => this._onTabDetached(tabId);
@@ -88,7 +120,7 @@ export class ConnectedTabGroup {
     // Chrome resets per-tab badge state on navigation, so re-apply it.
     if (this._connection.attachedTabs.has(tabId))
       void this._updateBadge(tabId, CONNECTED_BADGE);
-    else if (this._groupTabIds.has(tabId) && !isNonDebuggableUrl(changeInfo.url))
+    else if (this._groupTabIds.has(tabId) && !isNonDebuggableUrl(changeInfo.url) && !isOwnUiUrl(changeInfo.url))
       this._connection.attachTab(tab);
   }
 
@@ -103,7 +135,7 @@ export class ConnectedTabGroup {
       return;
     if (inOurGroup) {
       this._groupTabIds.add(tabId);
-      if (!isNonDebuggableUrl(tab.url))
+      if (!isNonDebuggableUrl(tab.url) && !isOwnUiUrl(tab.url))
         this._connection.attachTab(tab);
     } else {
       this._groupTabIds.delete(tabId);
@@ -164,7 +196,8 @@ export class ConnectedTabGroup {
       await this._retryOnDrag(async () => {
         if (this._groupId === null) {
           this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
-          await chrome.tabGroups.update(this._groupId, { color: PLAYWRIGHT_GROUP_COLOR, title: PLAYWRIGHT_GROUP_TITLE });
+          await chrome.tabGroups.update(this._groupId, { color: this._style.color, title: this._style.title });
+          await registerGroupTitle(this._style.title);
         } else {
           await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
         }

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+// Tabs showing this extension's own UI (connect/status pages) are transient
+// chrome. Chrome records the previously active tab as their opener and may
+// place them inside another connection's tab group; neither must grant the
+// tab to that connection. Such pages can still be attached explicitly when
+// they are a connection's selected initial tab.
+export function isOwnUiUrl(url: string | undefined): boolean {
+  return !!url && url.startsWith(chrome.runtime.getURL(''));
+}
+
 export function debugLog(...args: unknown[]): void {
   const enabled = true;
   if (enabled) {
@@ -185,6 +194,10 @@ export class RelayConnection {
         return (args[0] as chrome.debugger.Debuggee | undefined)?.tabId;
       case 'chrome.tabs.onCreated': {
         const tab = args[0] as chrome.tabs.Tab;
+        // Own UI pages (e.g. another client's connect page) are never genuine
+        // popups of an attached tab, even when Chrome records one as opener.
+        if (isOwnUiUrl(tab.url) || isOwnUiUrl(tab.pendingUrl))
+          return undefined;
         // Forward only popups opened by an attached tab; report the opener so cdpRelay
         // can filter / decide. We use the openerTabId for the attached-tab check.
         return tab.openerTabId;

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -179,7 +179,7 @@ const ConnectApp: React.FC = () => {
         {showTabList && (
           <div>
             <div className='tab-section-title'>
-              You can drag tabs into the Playwright group later to make them accessible to the client.
+              You can drag tabs into this client's tab group later to make them accessible to the client.
               Optionally, select a tab to allow and immediately switch to it:
             </div>
             <div>

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -19,19 +19,32 @@ import { createRoot } from 'react-dom/client';
 import { Button, TabItem  } from './tabItem';
 import { AuthTokenSection } from './authToken';
 
+type ConnectionInfo = {
+  id: number;
+  clientName?: string;
+  label: string;
+  connectedTabIds: number[];
+};
+
+type ConnectionView = {
+  info: ConnectionInfo;
+  tabs: chrome.tabs.Tab[];
+};
+
 const StatusApp: React.FC = () => {
-  const [connectedTabs, setConnectedTabs] = useState<chrome.tabs.Tab[]>([]);
-  const [clientName, setClientName] = useState<string | undefined>(undefined);
+  const [connections, setConnections] = useState<ConnectionView[]>([]);
 
   useEffect(() => {
     void loadStatus();
   }, []);
 
   const loadStatus = async () => {
-    const { connectedTabIds, clientName } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
-    const tabs = await Promise.all((connectedTabIds as number[] ?? []).map(tabId => chrome.tabs.get(tabId)));
-    setConnectedTabs(tabs);
-    setClientName(clientName);
+    const { connections: infos } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+    const views = await Promise.all(((infos ?? []) as ConnectionInfo[]).map(async info => {
+      const tabs = await Promise.all(info.connectedTabIds.map(tabId => chrome.tabs.get(tabId).catch(() => undefined)));
+      return { info, tabs: tabs.filter((tab): tab is chrome.tabs.Tab => tab !== undefined) };
+    }));
+    setConnections(views);
   };
 
   const openTab = async (tabId: number) => {
@@ -39,29 +52,29 @@ const StatusApp: React.FC = () => {
     window.close();
   };
 
-  const disconnect = async () => {
-    await chrome.runtime.sendMessage({ type: 'disconnect' });
-    window.close();
+  const disconnect = async (connectionId: number) => {
+    await chrome.runtime.sendMessage({ type: 'disconnect', connectionId });
+    await loadStatus();
   };
 
   return (
     <div className='app-container'>
       <div className='content-wrapper'>
-        {connectedTabs.length > 0 ? (
-          <div>
+        {connections.length > 0 ? connections.map(({ info, tabs }) => (
+          <div key={info.id}>
             <div className='connection-header'>
               <div className='client-info'>
-                Connected to <strong>"{clientName || 'unknown'}"</strong>
+                Connected to <strong>"{info.label}"</strong>
               </div>
-              <Button variant='primary' onClick={disconnect}>
+              <Button variant='primary' onClick={() => disconnect(info.id)}>
                 Disconnect
               </Button>
             </div>
             <div className='tab-section-title'>
-              {connectedTabs.length === 1 ? 'Accessible page:' : 'Accessible pages:'}
+              {tabs.length === 1 ? 'Accessible page:' : 'Accessible pages:'}
             </div>
             <div>
-              {connectedTabs.map(tab => (
+              {tabs.map(tab => (
                 <TabItem
                   key={tab.id}
                   tab={tab}
@@ -70,7 +83,7 @@ const StatusApp: React.FC = () => {
               ))}
             </div>
           </div>
-        ) : (
+        )) : (
           <div className='status-banner'>
             No clients are currently connected. You can connect from the Playwright CLI or MCP server by passing the --extension flag.
           </div>

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -342,5 +342,5 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   });
 
   await page.goto(`chrome-extension://${extensionId}/status.html`);
-  await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
+  await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName} #1"`);
 });

--- a/tests/extension/multi-connection.spec.ts
+++ b/tests/extension/multi-connection.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect, extensionId, clickAllowAndSelect } from './extension-fixtures';
+
+import type { BrowserContext } from 'playwright';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { StartClient } from '../mcp/fixtures';
+
+async function connectExtensionClient(
+  clientName: string,
+  userDataDir: string,
+  startClient: StartClient,
+  browserContext: BrowserContext,
+  url: string,
+): Promise<Client> {
+  const { client } = await startClient({
+    args: ['--extension'],
+    clientName,
+    env: { PWTEST_EXTENSION_USER_DATA_DIR: userDataDir },
+  });
+  const connectPagePromise = browserContext.waitForEvent('page', page =>
+    page.url().startsWith(`chrome-extension://${extensionId}/connect.html`));
+  const navigatePromise = client.callTool({ name: 'browser_navigate', arguments: { url } });
+  const connectPage = await connectPagePromise;
+  await clickAllowAndSelect(connectPage, 'Welcome');
+  const response = await navigatePromise;
+  expect(response.isError ?? false).toBe(false);
+  return client;
+}
+
+test('second client does not disconnect the first', async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/a', '<title>PageA</title><body>A</body>', 'text/html');
+  server.setContent('/b', '<title>PageB</title><body>B</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const clientA = await connectExtensionClient('AgentA', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/a');
+  await connectExtensionClient('AgentB', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/b');
+
+  // Single-tenant extension closes A's relay when B connects, failing this call.
+  const response = await clientA.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+  expect(response.isError ?? false).toBe(false);
+  expect(response).toHaveResponse({ snapshot: expect.stringContaining('Hello, world!') });
+});
+
+test('each client gets its own labeled tab group', async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/a', '<title>PageA</title><body>A</body>', 'text/html');
+  server.setContent('/b', '<title>PageB</title><body>B</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  await connectExtensionClient('AgentA', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/a');
+  await connectExtensionClient('AgentB', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/b');
+
+  const [sw] = browserContext.serviceWorkers();
+  await expect.poll(async () => {
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
+      const groups = await chrome.tabGroups.query({});
+      return groups
+          .map((g: any) => ({ title: g.title, color: g.color }))
+          .sort((a: any, b: any) => a.title.localeCompare(b.title));
+    });
+  }).toEqual([
+    { title: 'AgentA #1', color: 'green' },
+    { title: 'AgentB #2', color: 'blue' },
+  ]);
+});
+
+test('tabs are isolated per connection', async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/a', '<title>PageA</title><body>A</body>', 'text/html');
+  server.setContent('/b', '<title>PageB</title><body>B</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  await connectExtensionClient('AgentA', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/a');
+  await connectExtensionClient('AgentB', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/b');
+
+  const [sw] = browserContext.serviceWorkers();
+  await expect.poll(async () => {
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
+      const groups = await chrome.tabGroups.query({});
+      const result: Record<string, string[]> = {};
+      for (const group of groups) {
+        const tabs = await chrome.tabs.query({ groupId: group.id });
+        result[group.title] = tabs.map((t: any) => new URL(t.url).pathname).sort();
+      }
+      return result;
+    });
+  }).toEqual({
+    'AgentA #1': ['/a'],
+    'AgentB #2': ['/b'],
+  });
+});
+
+test('disconnecting one client keeps the other alive', async ({ browserWithExtension, startClient, server }) => {
+  server.setContent('/a', '<title>PageA</title><body>A</body>', 'text/html');
+  server.setContent('/b', '<title>PageB</title><body>B</body>', 'text/html');
+  const browserContext = await browserWithExtension.launch();
+
+  const clientA = await connectExtensionClient('AgentA', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/a');
+  const clientB = await connectExtensionClient('AgentB', browserWithExtension.userDataDir, startClient, browserContext, server.PREFIX + '/b');
+
+  await clientA.close();
+
+  const [sw] = browserContext.serviceWorkers();
+  await expect.poll(async () => {
+    return sw.evaluate(async () => {
+      const chrome = (globalThis as any).chrome;
+      const groups = await chrome.tabGroups.query({});
+      return groups.map((g: any) => g.title).sort();
+    });
+  }).toEqual(['AgentB #2']);
+
+  const response = await clientB.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+  expect(response.isError ?? false).toBe(false);
+});

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -74,7 +74,7 @@ test('connected tab is in green Playwright group, connect page is closed', async
       const g = await chrome.tabGroups.get(connectedTab.groupId);
       return { color: g.color, title: g.title };
     });
-  }).toEqual({ color: 'green', title: 'Playwright' });
+  }).toEqual({ color: 'green', title: 'test #1' });
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server }) => {
@@ -325,7 +325,8 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
   // Second connection.
   await connect();
 
-  // The tab must end up in a green Playwright group again.
+  // The tab must end up in a labeled group again; the second connection in
+  // this service worker lifetime gets the next id and color.
   await expect.poll(async () => {
     return sw.evaluate(async () => {
       const chrome = (globalThis as any).chrome;
@@ -337,5 +338,5 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
       const g = await chrome.tabGroups.get(tab.groupId);
       return { color: g.color, title: g.title };
     });
-  }).toEqual({ color: 'green', title: 'Playwright' });
+  }).toEqual({ color: 'blue', title: 'test #2' });
 });


### PR DESCRIPTION
## Summary
- The bridge extension previously allowed one active client; a new connection force-disconnected the previous one ("Another connection is requested"). It now keeps a connection map so multiple MCP clients (e.g. parallel agent sessions) can drive the browser concurrently.
- Each connection gets its own labeled Chrome tab group (`<client name> #<n>`, rotating colors). Per-connection tab isolation follows from the existing per-connection `_attachedTabs` filtering.
- The extension's own UI pages are excluded from popup forwarding and group auto-attach: Chrome records the previously active tab as a new connect page's opener, which would otherwise hand one client's connect page to another client.
- Token-bypass connections no longer steal window focus; explicit "Allow & select" still focuses the picked tab. Status page lists all connected clients with per-client disconnect.