### PR TITLE
fix(mcp): surface JSON parse errors instead of silently falling back to INI

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -447,12 +447,15 @@ export async function loadConfig(configFile: string | undefined): Promise<Config
   if (configFile.endsWith('.ini'))
     return configFromIniFile(configFile);
 
-  try {
-    const data = await fs.promises.readFile(configFile, 'utf8');
-    return JSON.parse(data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data);
-  } catch {
-    return configFromIniFile(configFile);
-  }
+  const data = await fs.promises.readFile(configFile, 'utf8');
+  const content = data.charCodeAt(0) === 0xFEFF ? data.slice(1) : data;
+
+  // If the content looks like JSON, parse it as JSON and surface parse errors
+  // instead of silently falling back to INI parsing.
+  if (content.trimStart().startsWith('{'))
+    return JSON.parse(content);
+
+  return configFromIniFile(configFile);
 }
 
 // initPage/initScript paths are resolved against a per-source base dir

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -237,6 +237,38 @@ test.describe('mobile', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Config file loading — JSON vs INI detection
+// ---------------------------------------------------------------------------
+
+test.describe('config file loading', () => {
+  test('malformed JSON config throws instead of being parsed as INI', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, '{ "browser": { "browserName": "firefox", } }');
+
+    await expect(resolveCLIConfigForMCP({ config: configFile }, emptyEnv))
+        .rejects.toThrow(SyntaxError);
+  });
+
+  test('valid JSON with UTF-8 BOM is accepted', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const json = JSON.stringify({ timeouts: { action: 3000 } });
+    await fs.promises.writeFile(configFile, '﻿' + json);
+
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.timeouts.action).toBe(3000);
+  });
+
+  test('INI content without .ini extension is still supported', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, 'browser.browserName = firefox\nbrowser.launchOptions.headless = true\n');
+
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.browser.browserName).toBe('firefox');
+    expect(config.browser.launchOptions.headless).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Shared behavior — merge order and config file
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Inspect first non-whitespace character of config content to decide JSON vs INI parsing
- JSON-looking content (`{`) now propagates `JSON.parse` errors instead of silently falling back to INI
- Non-JSON content continues to use INI fallback for backward compatibility
- Added regression tests for malformed JSON, valid JSON with BOM, and INI fallback

Fixes https://github.com/microsoft/playwright/issues/41893