### PR TITLE
fix(tools): report closed-page navigation errors

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -332,6 +332,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     this._clearCollectedArtifacts();
 
+    const pageClosedError = () => new Error(`Navigation to "${url}" failed because the page was closed.`);
     const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
     try {
       await this.page.goto(url, { waitUntil: 'domcontentloaded', ...this.navigationTimeoutOptions });
@@ -339,7 +340,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     } catch (_e: unknown) {
       const e = _e as Error;
       if (e.message.includes('Target page, context or browser has been closed') && this.page.isClosed())
-        return;
+        throw pageClosedError();
       const mightBeDownload =
         e.message.includes('net::ERR_ABORTED') // chromium
         || e.message.includes('Download is starting'); // firefox + webkit
@@ -356,6 +357,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     // Cap load event to 5 seconds, the page is operational at this point.
     await this.waitForLoadState('load', { timeout: 5000 });
+    if (this.page.isClosed())
+      throw pageClosedError();
   }
 
   async consoleMessageCount(): Promise<{ total: number, errors: number, warnings: number }> {

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -332,7 +332,6 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     this._clearCollectedArtifacts();
 
-    const pageClosedError = () => new Error(`Navigation to "${url}" failed because the page was closed.`);
     const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
     try {
       await this.page.goto(url, { waitUntil: 'domcontentloaded', ...this.navigationTimeoutOptions });
@@ -340,7 +339,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     } catch (_e: unknown) {
       const e = _e as Error;
       if (e.message.includes('Target page, context or browser has been closed') && this.page.isClosed())
-        throw pageClosedError();
+        throw new Error(`Navigation to "${url}" failed because the page was closed.`);
       const mightBeDownload =
         e.message.includes('net::ERR_ABORTED') // chromium
         || e.message.includes('Download is starting'); // firefox + webkit
@@ -358,7 +357,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     // Cap load event to 5 seconds, the page is operational at this point.
     await this.waitForLoadState('load', { timeout: 5000 });
     if (this.page.isClosed())
-      throw pageClosedError();
+      throw new Error(`Navigation to "${url}" failed because the page was closed.`);
   }
 
   async consoleMessageCount(): Promise<{ total: number, errors: number, warnings: number }> {

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -338,6 +338,8 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       abortDownloadEvent();
     } catch (_e: unknown) {
       const e = _e as Error;
+      if (e.message.includes('Target page, context or browser has been closed') && this.page.isClosed())
+        return;
       const mightBeDownload =
         e.message.includes('net::ERR_ABORTED') // chromium
         || e.message.includes('Download is starting'); // firefox + webkit

--- a/tests/mcp/cli-navigation.spec.ts
+++ b/tests/mcp/cli-navigation.spec.ts
@@ -53,9 +53,10 @@ test('run-code', async ({ cli, server }) => {
   expect(output).toContain('"Title"');
 });
 
-test('goto chrome:// page that closes the tab does not crash the response', async ({ cli, server, mcpBrowser }) => {
+test('goto chrome:// page that closes the tab reports an error', async ({ cli, server, mcpBrowser }) => {
   test.skip(mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'chrome:// pages are chromium-specific');
   await cli('open', server.HELLO_WORLD);
   const { output } = await cli('goto', 'chrome://extensions/');
-  expect(output).toContain('No open tabs. Navigate to a URL to create one.');
+  expect(output).toContain('Error: Navigation to "chrome://extensions/" failed because the page was closed.');
+  expect(output).not.toContain('### Ran Playwright code');
 });


### PR DESCRIPTION
When navigation closes the page, `page.goto()` and page-close handling can race and produce inconsistent MCP responses.

Normalize both race orderings into an explicit navigation error, making it clear that navigation failed and the page is gone. Failed navigation no longer reports successful Playwright code execution.

Fixes the flake from #41675.