### PR TITLE
test(evaluate): skip using declaration on WebKit

### DIFF
--- a/tests/page/page-evaluate.spec.ts
+++ b/tests/page/page-evaluate.spec.ts
@@ -867,9 +867,10 @@ it('should work with Array.from/map', async ({ page }) => {
   })).toBe('([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})');
 });
 
-it('should work with a using declaration', async ({ page, nodeVersion }) => {
+it('should work with a using declaration', async ({ page, nodeVersion, browserName }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41511' });
   it.skip(nodeVersion.major < 24, 'using is lowered to a module-scope helper that does not survive evaluate serialization on Node < 24');
+  it.skip(browserName === 'webkit', 'WebKit does not support using declarations');
   const disposed = await page.evaluate(() => {
     let disposed = false;
     {


### PR DESCRIPTION
WebKit does not support `using` declarations yet, so the Node 24+ test fails there with a parse error. Skip it on WebKit while keeping coverage on Chromium and Firefox.

Follow-up to #41517.