### PR TITLE
Revert "fix(cli): don't crash the response when navigating closes the last tab"

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -275,8 +275,7 @@ export class Response {
     if (this._includeSnapshot !== 'none' || tabHeaders.some(header => header.changed)) {
       if (tabHeaders.length !== 1)
         addSection('Open tabs', renderTabsMarkdown(tabHeaders));
-      if (tabHeaders.length)
-        addSection('Page', renderTabMarkdown(tabHeaders.find(h => h.current) ?? tabHeaders[0]));
+      addSection('Page', renderTabMarkdown(tabHeaders.find(h => h.current) ?? tabHeaders[0]));
     }
 
     // Handle modal states.

--- a/tests/mcp/cli-navigation.spec.ts
+++ b/tests/mcp/cli-navigation.spec.ts
@@ -52,10 +52,3 @@ test('run-code', async ({ cli, server }) => {
   const { output } = await cli('run-code', '() => page.title()');
   expect(output).toContain('"Title"');
 });
-
-test('goto chrome:// page that closes the tab does not crash the response', async ({ cli, server, mcpBrowser }) => {
-  test.skip(mcpBrowser !== 'chromium' && mcpBrowser !== 'chrome', 'chrome:// pages are chromium-specific');
-  await cli('open', server.HELLO_WORLD);
-  const { output } = await cli('goto', 'chrome://extensions/');
-  expect(output).toContain('No open tabs. Navigate to a URL to create one.');
-});


### PR DESCRIPTION
Reverts microsoft/playwright#41675

While working on https://github.com/microsoft/playwright/pull/41675, we realised that the premise of this fix was totally wrong. When you go to `chrome://extensions` on an isolated context, the browser process crashes. This surfaces as page closing in our code, but it's not what's really happening. Reverting.