### PR TITLE
fix(mcp): identify downloads explicitly

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -332,19 +332,31 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     this._clearCollectedArtifacts();
 
-    const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
+    const eventTimeout = Math.max(this.actionTimeoutOptions.timeout || 0, 5000);
+    const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', eventTimeout);
+    const { promise: crashEvent, abort: abortCrashEvent } = eventWaiter<playwright.Page>(this.page, 'crash', eventTimeout);
     try {
       await this.page.goto(url, { waitUntil: 'domcontentloaded', ...this.navigationTimeoutOptions });
       abortDownloadEvent();
+      abortCrashEvent();
     } catch (_e: unknown) {
       const e = _e as Error;
       const mightBeDownload =
         e.message.includes('net::ERR_ABORTED') // chromium
         || e.message.includes('Download is starting'); // firefox + webkit
-      if (!mightBeDownload)
+      if (!mightBeDownload) {
+        abortDownloadEvent();
+        abortCrashEvent();
         throw e;
-      // on chromium, the download event is fired *after* page.goto rejects, so we wait a lil bit
-      const download = await downloadEvent;
+      }
+      // Chromium reports both downloads and renderer crashes as net::ERR_ABORTED.
+      const event = await Promise.race([
+        downloadEvent.then(download => ({ download })),
+        crashEvent.then(crashed => ({ crashed })),
+      ]);
+      abortDownloadEvent();
+      abortCrashEvent();
+      const download = 'download' in event ? event.download : undefined;
       if (!download)
         throw e;
       // Make sure other "download" listeners are notified first.

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -332,31 +332,17 @@ export class Tab extends EventEmitter<TabEventsInterface> {
 
     this._clearCollectedArtifacts();
 
-    const eventTimeout = Math.max(this.actionTimeoutOptions.timeout || 0, 5000);
-    const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', eventTimeout);
-    const { promise: crashEvent, abort: abortCrashEvent } = eventWaiter<playwright.Page>(this.page, 'crash', eventTimeout);
+    const { promise: downloadEvent, abort: abortDownloadEvent } = eventWaiter<playwright.Download>(this.page, 'download', 3000);
     try {
       await this.page.goto(url, { waitUntil: 'domcontentloaded', ...this.navigationTimeoutOptions });
       abortDownloadEvent();
-      abortCrashEvent();
     } catch (_e: unknown) {
       const e = _e as Error;
-      const mightBeDownload =
-        e.message.includes('net::ERR_ABORTED') // chromium
-        || e.message.includes('Download is starting'); // firefox + webkit
-      if (!mightBeDownload) {
+      if (!e.message.includes('Download is starting')) {
         abortDownloadEvent();
-        abortCrashEvent();
         throw e;
       }
-      // Chromium reports both downloads and renderer crashes as net::ERR_ABORTED.
-      const event = await Promise.race([
-        downloadEvent.then(download => ({ download })),
-        crashEvent.then(crashed => ({ crashed })),
-      ]);
-      abortDownloadEvent();
-      abortCrashEvent();
-      const download = 'download' in event ? event.download : undefined;
+      const download = await downloadEvent;
       if (!download)
         throw e;
       // Make sure other "download" listeners are notified first.

--- a/tests/mcp/crash.spec.ts
+++ b/tests/mcp/crash.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import { test, expect, parseResponse, consoleEntries } from './fixtures';
 
@@ -48,6 +49,44 @@ test.describe('crash recovery', () => {
     })).toHaveResponse({
       page: `- Page URL: ${server.HELLO_WORLD}\n- Page Title: Title`,
     });
+  });
+
+  test('waits for a delayed crash event', async ({ startClient, server }, testInfo) => {
+    const preloadPath = testInfo.outputPath('delayCrashEvent.cjs');
+    await fs.promises.writeFile(preloadPath, `
+      const { EventEmitter } = require('events');
+      const emit = EventEmitter.prototype.emit;
+      EventEmitter.prototype.emit = function(event, ...args) {
+        if (event === 'crash') {
+          setTimeout(() => emit.call(this, event, ...args), 3500);
+          return true;
+        }
+        return emit.call(this, event, ...args);
+      };
+    `);
+    const { client } = await startClient({
+      args: ['--isolated', '--timeout-action=0'],
+      env: { NODE_OPTIONS: `--require=${preloadPath.replaceAll('\\', '/')}` },
+      omitArgs: ['--timeout-action=10000'],
+    });
+    await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.HELLO_WORLD },
+    });
+    await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: 'chrome://crash' },
+    });
+
+    const result = await client.callTool({
+      name: 'browser_snapshot',
+    });
+    expect(result).toHaveResponse({
+      page: '- Page URL: about:blank',
+    });
+
+    const log = await consoleEntries(parseResponse(result));
+    expect(log).toContain('Page crashed and was reset to about:blank.');
   });
 
   test('lists only one tab', async ({ client }) => {

--- a/tests/mcp/crash.spec.ts
+++ b/tests/mcp/crash.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 import { test, expect, parseResponse, consoleEntries } from './fixtures';
 
@@ -29,19 +28,24 @@ test.describe('crash recovery', () => {
     });
   });
 
-  test('resets to about:blank and logs the crash', async ({ client, server }) => {
-    await client.callTool({
+  test('reports the navigation error, then resets and logs the crash', async ({ client, server }) => {
+    expect(await client.callTool({
       name: 'browser_navigate',
       arguments: { url: 'chrome://crash' },
+    })).toHaveResponse({
+      error: expect.stringContaining('net::ERR_ABORTED'),
+      isError: true,
     });
 
-    const response = parseResponse(await client.callTool({
-      name: 'browser_snapshot',
-    }));
-    expect(response.page).toBe('- Page URL: about:blank');
+    await expect(async () => {
+      const response = parseResponse(await client.callTool({
+        name: 'browser_snapshot',
+      }));
+      expect(response.page).toBe('- Page URL: about:blank');
 
-    const log = await consoleEntries(response);
-    expect(log).toContain('Page crashed and was reset to about:blank.');
+      const log = await consoleEntries(response);
+      expect(log).toContain('Page crashed and was reset to about:blank.');
+    }).toPass();
 
     expect(await client.callTool({
       name: 'browser_navigate',
@@ -51,48 +55,17 @@ test.describe('crash recovery', () => {
     });
   });
 
-  test('waits for a delayed crash event', async ({ startClient, server }, testInfo) => {
-    const preloadPath = testInfo.outputPath('delayCrashEvent.cjs');
-    await fs.promises.writeFile(preloadPath, `
-      const { EventEmitter } = require('events');
-      const emit = EventEmitter.prototype.emit;
-      EventEmitter.prototype.emit = function(event, ...args) {
-        if (event === 'crash') {
-          setTimeout(() => emit.call(this, event, ...args), 3500);
-          return true;
-        }
-        return emit.call(this, event, ...args);
-      };
-    `);
-    const { client } = await startClient({
-      args: ['--isolated', '--timeout-action=0'],
-      env: { NODE_OPTIONS: `--require=${preloadPath.replaceAll('\\', '/')}` },
-      omitArgs: ['--timeout-action=10000'],
-    });
-    await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: server.HELLO_WORLD },
-    });
-    await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: 'chrome://crash' },
-    });
-
-    const result = await client.callTool({
-      name: 'browser_snapshot',
-    });
-    expect(result).toHaveResponse({
-      page: '- Page URL: about:blank',
-    });
-
-    const log = await consoleEntries(parseResponse(result));
-    expect(log).toContain('Page crashed and was reset to about:blank.');
-  });
-
   test('lists only one tab', async ({ client }) => {
     await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: 'chrome://crash' },
+      name: 'browser_run_code_unsafe',
+      arguments: {
+        code: `async page => {
+          await Promise.all([
+            page.waitForEvent('crash'),
+            page.goto('chrome://crash').catch(() => {}),
+          ]);
+        }`,
+      },
     });
 
     expect(await client.callTool({
@@ -105,12 +78,16 @@ test.describe('crash recovery', () => {
 
   test('marks non-current crashed tab in the tab list', async ({ client, server }) => {
     await client.callTool({
-      name: 'browser_tabs',
-      arguments: { action: 'new', url: 'chrome://crash' },
-    });
-    await client.callTool({
-      name: 'browser_tabs',
-      arguments: { action: 'select', index: 0 },
+      name: 'browser_run_code_unsafe',
+      arguments: {
+        code: `async page => {
+          const otherPage = await page.context().newPage();
+          await Promise.all([
+            otherPage.waitForEvent('crash'),
+            otherPage.goto('chrome://crash').catch(() => {}),
+          ]);
+        }`,
+      },
     });
 
     expect(await client.callTool({


### PR DESCRIPTION
This PR stops treating every Chromium `net::ERR_ABORTED` navigation as a possible download. Since Chromium 140, released in September 2025, [`Page.navigate` reports downloads explicitly](https://chromium-review.googlesource.com/c/chromium/src/+/6696011), which Playwright surfaces as `Download is starting`.

Previously, MCP waited up to three seconds for a download event before returning `net::ERR_ABORTED`. This didn’t change the result, but happened to give the renderer’s `crash` event time to arrive. The error is now returned immediately. Crash recovery stays the same: once the event arrives, a subsequent MCP call resets the page to `about:blank` and reports `Page crashed and was reset to about:blank.`

The crash tests now poll for recovery instead of relying on the download wait, and explicitly await the crash event when asserting tab state.