### PR TITLE
fix(mcp): surface the missing executable path when a browser isn't installed

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -250,12 +250,15 @@ export function isProfileLocked(userDataDir: string): boolean {
 function throwIfExecutableMissing(error: Error, config: FullConfig): void {
   // The "Executable doesn't exist" prefix is shared by all managed binaries
   // (browser, ffmpeg, winldd). Disambiguate by the path so the user is told
-  // which dependency to install.
+  // which dependency to install, and surface the executable path itself so a
+  // version mismatch (an installed build vs. the expected build) is
+  // diagnosable rather than looking like a missing install.
   if (!error.message.includes(`Executable doesn't exist`))
     return;
   const target = error.message.includes('ffmpeg') ? 'ffmpeg' : (config.browser.launchOptions?.channel ?? config.browser.browserName);
   const label = target === 'ffmpeg' ? 'FFmpeg' : `Browser "${target}"`;
-  if (config.skillMode)
-    throw new Error(`${label} is not installed. Run \`playwright-cli install-browser ${target}\` to install`);
-  throw new Error(`${label} is not installed. Run \`npx @playwright/mcp install-browser ${target}\` to install`);
+  const command = config.skillMode ? `playwright-cli install-browser ${target}` : `npx @playwright/mcp install-browser ${target}`;
+  const match = error.message.match(/Executable doesn't exist at ([^\r\n]+)/);
+  const location = match ? `; expected executable at ${match[1].trim()}` : '';
+  throw new Error(`${label} is not installed${location}. Run \`${command}\` to install`);
 }

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -61,6 +61,36 @@ test('executable path', async ({ startClient, server }) => {
   });
 });
 
+test('surfaces the missing browser executable path so a version mismatch is diagnosable', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41871' },
+}, async ({ startClient, server, mcpBrowser }, testInfo) => {
+  test.skip(mcpBrowser === 'chrome' || mcpBrowser === 'msedge', 'Channel browsers use system-installed binaries, which are unaffected by PLAYWRIGHT_BROWSERS_PATH');
+
+  const emptyBrowsersPath = testInfo.outputPath('empty-browsers');
+  await fs.promises.mkdir(emptyBrowsersPath, { recursive: true });
+
+  const { client } = await startClient({
+    env: { PLAYWRIGHT_BROWSERS_PATH: emptyBrowsersPath },
+  });
+
+  const response = await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+  // The surfaced path must include the version-specific browser directory
+  // (e.g. chromium-1234) — that's the detail that reveals a version mismatch,
+  // as opposed to a generic "not installed".
+  const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  expect.soft(response).toHaveResponse({
+    isError: true,
+    error: expect.stringContaining('is not installed'),
+  });
+  expect.soft(response).toHaveResponse({
+    isError: true,
+    error: expect.stringMatching(new RegExp(escapeRegExp(emptyBrowsersPath) + String.raw`[\\/][\w.]+-\d+[\\/]`)),
+  });
+});
+
 test('persistent context', async ({ startClient, server }, testInfo) => {
   server.setContent('/', `
     <body>


### PR DESCRIPTION
when a browser binary is missing, `throwIfExecutableMissing` caught playwright-core's `Executable doesn't exist at <path>` and rethrew a generic `Browser "<name>" is not installed`, dropping the path

that path holds the version-specific directory (e.g. `firefox-1534`), which is what tells a genuinely missing install apart from a version mismatch

browsers from a standalone `playwright install` land in a differently-versioned directory than the bundled `playwright-core` expects

keep the path in the rethrown message so the mismatch is diagnosable

this is a further improvement for <https://github.com/microsoft/playwright/pull/40867>

referenced in <https://github.com/microsoft/playwright/issues/41871>