### PR TITLE
test(mcp): mark dashboard tests as slow

### DIFF
--- a/tests/mcp/cli-fixtures.ts
+++ b/tests/mcp/cli-fixtures.ts
@@ -54,7 +54,8 @@ export const test = baseTest.extend<{
       return page;
     });
   },
-  connectToDashboard: async ({ cli, playwright }, use) => {
+  connectToDashboard: async ({ cli, playwright }, use, testInfo) => {
+    testInfo.slow();
     await use(async (bindTitle: string) => {
       let endpoint = '';
       await expect(async () => {


### PR DESCRIPTION
We’ve seen three flakes that looked unrelated, but all exhausted the global test timeout during dashboard setup:

- Windows Chrome spent 2.6s in `open` and 38.3s in `show`, leaving only 18.3s to connect to the dashboard.
- Ubuntu Chrome spent 29.6s of its 30s timeout in `open` and never reached the dashboard connection.
- Windows Edge spent 36.2s in `open` and 33.2s in `show`; timeout cleanup then surfaced as a misleading “browser closed” error.

These tests launch the browser under test and a separate dashboard browser. The current 30s/60s timeout is occasionally not enough to launch both and still execute the test.

This marks the `connectToDashboard` fixture as slow. Since fixtures initialise before the test body, the larger timeout covers `open` and `show` as well. Server-only `show --port` tests are unaffected.