### PR TITLE
fix: correct pending navigation log spacing

### DIFF
--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -553,7 +553,7 @@ export class Page extends SdkObject<PageEventMap> {
     if (!mainFrame || !mainFrame.pendingDocument())
       return;
     const url = mainFrame.pendingDocument()?.request?.url();
-    const toUrl = url ? `" ${trimStringWithEllipsis(url, 200)}"` : '';
+    const toUrl = url ? ` "${trimStringWithEllipsis(url, 200)}"` : '';
     progress.log(`  waiting for${toUrl} navigation to finish...`);
     await helper.waitForEvent(progress, mainFrame, frames.Frame.Events.InternalNavigation, (e: frames.NavigationEvent) => {
       if (!e.isPublic)


### PR DESCRIPTION
This fixes a misplaced space in the pending-navigation call log, so it prints `waiting for "http://..."` instead of `waiting for" http://..."`.