### PR TITLE
fix(bindings): tolerate Array.prototype.toJSON on the page

### DIFF
--- a/packages/injected/src/bindingsController.ts
+++ b/packages/injected/src/bindingsController.ts
@@ -64,7 +64,17 @@ export class BindingsController {
       });
     }
     const payload: BindingPayload = { name: bindingName, seq, serializedArgs };
-    (this._global as any)[this._globalBindingName](JSON.stringify(payload));
+    // Some pages (e.g. Prototype.js) define Array.prototype.toJSON, which
+    // makes JSON.stringify turn arrays into strings and breaks binding args.
+    const arrayToJSON = (Array.prototype as any).toJSON;
+    if (arrayToJSON)
+      delete (Array.prototype as any).toJSON;
+    try {
+      (this._global as any)[this._globalBindingName](JSON.stringify(payload));
+    } finally {
+      if (arrayToJSON)
+        (Array.prototype as any).toJSON = arrayToJSON;
+    }
     return promise;
   }
 

--- a/tests/page/page-expose-function.spec.ts
+++ b/tests/page/page-expose-function.spec.ts
@@ -235,12 +235,13 @@ it('should work with busted Array.prototype.map/push', async ({ page, server }) 
   expect(await page.evaluate('add(5, 6)')).toBe(11);
 });
 
-it('should fail with busted Array.prototype.toJSON', async ({ page }) => {
+it('should work with busted Array.prototype.toJSON', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41359' } }, async ({ page }) => {
   await page.evaluateHandle(() => (Array.prototype as any).toJSON = () => '"[]"');
 
   await page.exposeFunction('add', (a, b) => a + b);
-  await expect(() => page.evaluate(`add(5, 6)`)).rejects.toThrowError('serializedArgs is not an array. This can happen when Array.prototype.toJSON is defined incorrectly');
+  expect(await page.evaluate(`add(5, 6)`)).toBe(11);
 
+  // Page-defined toJSON must remain installed after binding calls.
   expect.soft(await page.evaluate(() => ([] as any).toJSON())).toBe('"[]"');
 });
 


### PR DESCRIPTION
## Summary

Pages that install `Array.prototype.toJSON` (Prototype.js pattern) break
`exposeFunction` / recorder bindings: `JSON.stringify` turns
`serializedArgs` into a string, and dispatch fails with
`serializedArgs is not an array`.

Fix: while stringifying the binding payload in `BindingsController`,
temporarily remove `Array.prototype.toJSON` and restore it afterward so
the page's serializer stays intact.

Public repro / user impact: matching issue #41359 (codegen click fails
after page defines Array.prototype.toJSON). Existing unit test updated
from expecting failure to expecting success.

Fixes #41359

## Test plan

- [x] Updated `should work with busted Array.prototype.toJSON` in
  `tests/page/page-expose-function.spec.ts`
- [ ] CI page tests