### PR TITLE
chore(recorder): unify action coalescing and simplify action types

### DIFF
--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -171,7 +171,6 @@ class InspectTool implements RecorderTool {
       void this._recorder.recordAction({
         name: 'assertVisible',
         selector,
-        signals: [],
       });
       this._recorder.setMode('recording');
       this._recorder.overlay?.flashToolSucceeded('assertingVisibility');
@@ -269,39 +268,14 @@ class RecordActionTool implements RecorderTool {
       this._recordAction({
         name: checkbox.checked ? 'check' : 'uncheck',
         selector: this._hoveredModel?.selector ?? this._selectorForElement(target),
-        signals: [],
       }, { autoExpect: true });
       return;
     }
 
-    // Only single clicks are recorded here; double clicks are recorded in onDblClick.
-    if (event.detail !== 1)
-      return;
     this._recordAction({
       name: 'click',
       selector: this._hoveredModel?.selector ?? this._selectorForElement(target),
       position: positionForEvent(event),
-      signals: [],
-      button: buttonForEvent(event),
-      modifiers: modifiersForEvent(event),
-      clickCount: event.detail
-    }, { autoExpect: true });
-  }
-
-  onDblClick(event: MouseEvent) {
-    if (this._dialog.isShowing())
-      return;
-    if (isRangeInput(this._hoveredElement))
-      return;
-    if (this._shouldIgnoreMouseEvent(event))
-      return;
-
-    const target = this._recorder.deepEventTarget(event);
-    this._recordAction({
-      name: 'click',
-      selector: this._hoveredModel?.selector ?? this._selectorForElement(target),
-      position: positionForEvent(event),
-      signals: [],
       button: buttonForEvent(event),
       modifiers: modifiersForEvent(event),
       clickCount: event.detail
@@ -324,7 +298,6 @@ class RecordActionTool implements RecorderTool {
         name: 'click',
         selector: this._hoveredModel?.selector ?? this._selectorForElement(target),
         position: positionForEvent(event),
-        signals: [],
         button: 'right',
         modifiers: modifiersForEvent(event),
         clickCount: 1,
@@ -409,7 +382,6 @@ class RecordActionTool implements RecorderTool {
       this._recordAction({
         name: 'setInputFiles',
         selector,
-        signals: [],
         files: [...((target as HTMLInputElement).files || [])].map(file => file.name),
       });
       return;
@@ -420,7 +392,6 @@ class RecordActionTool implements RecorderTool {
         name: 'fill',
         // must use hoveredModel instead of activeModel for it to work in webkit
         selector: this._hoveredModel?.selector ?? this._selectorForElement(target),
-        signals: [],
         text: target.value,
       });
       return;
@@ -435,7 +406,6 @@ class RecordActionTool implements RecorderTool {
       this._recordAction({
         name: 'fill',
         selector: this._activeSelectorForEvent(event),
-        signals: [],
         text: target.isContentEditable ? target.innerText : (target as HTMLInputElement).value,
       });
     }
@@ -446,7 +416,6 @@ class RecordActionTool implements RecorderTool {
         name: 'select',
         selector: this._activeSelectorForEvent(event),
         options: [...selectElement.selectedOptions].map(option => option.value),
-        signals: []
       });
     }
   }
@@ -463,7 +432,6 @@ class RecordActionTool implements RecorderTool {
         this._recordAction({
           name: checkbox.checked ? 'uncheck' : 'check',
           selector: this._activeSelectorForEvent(event),
-          signals: [],
         }, { autoExpect: true });
         return;
       }
@@ -472,7 +440,6 @@ class RecordActionTool implements RecorderTool {
     this._recordAction({
       name: 'press',
       selector: this._activeSelectorForEvent(event),
-      signals: [],
       key: event.key,
       modifiers: modifiersForEvent(event),
     }, { autoExpect: true });
@@ -498,7 +465,6 @@ class RecordActionTool implements RecorderTool {
           name: 'click',
           selector: model.selector,
           position: actionPosition,
-          signals: [],
           button: 'left',
           modifiers: 0,
           clickCount: 1,
@@ -510,7 +476,6 @@ class RecordActionTool implements RecorderTool {
           name: 'click',
           selector: model.selector,
           position: actionPosition,
-          signals: [],
           button: 'right',
           modifiers: 0,
           clickCount: 1,
@@ -522,7 +487,6 @@ class RecordActionTool implements RecorderTool {
           name: 'click',
           selector: model.selector,
           position: actionPosition,
-          signals: [],
           button: 'left',
           modifiers: 0,
           clickCount: 2,
@@ -534,7 +498,6 @@ class RecordActionTool implements RecorderTool {
           name: 'hover',
           selector: model.selector,
           position: actionPosition,
-          signals: [],
         }),
       },
       {
@@ -731,7 +694,6 @@ class JsonRecordActionTool implements RecorderTool {
         name: checkbox.checked ? 'check' : 'uncheck',
         selector,
         ref,
-        signals: [],
         ariaSnapshot,
       });
       return;
@@ -743,7 +705,6 @@ class JsonRecordActionTool implements RecorderTool {
       ref,
       ariaSnapshot,
       position: positionForEvent(event),
-      signals: [],
       button: buttonForEvent(event),
       modifiers: modifiersForEvent(event),
       clickCount: event.detail,
@@ -759,7 +720,6 @@ class JsonRecordActionTool implements RecorderTool {
       ref,
       ariaSnapshot,
       position: positionForEvent(event),
-      signals: [],
       button: 'right',
       modifiers: modifiersForEvent(event),
       clickCount: 1,
@@ -776,7 +736,6 @@ class JsonRecordActionTool implements RecorderTool {
         selector,
         ref,
         ariaSnapshot,
-        signals: [],
         text: element.value,
       });
       return;
@@ -793,7 +752,6 @@ class JsonRecordActionTool implements RecorderTool {
         ref,
         selector,
         ariaSnapshot,
-        signals: [],
         text: element.isContentEditable ? element.innerText : (element as HTMLInputElement).value,
       });
       return;
@@ -807,7 +765,6 @@ class JsonRecordActionTool implements RecorderTool {
         ref,
         ariaSnapshot,
         options: [...selectElement.selectedOptions].map(option => option.value),
-        signals: []
       });
       return;
     }
@@ -829,7 +786,6 @@ class JsonRecordActionTool implements RecorderTool {
           selector,
           ref,
           ariaSnapshot,
-          signals: [],
         });
         return;
       }
@@ -840,7 +796,6 @@ class JsonRecordActionTool implements RecorderTool {
       selector,
       ref,
       ariaSnapshot,
-      signals: [],
       key: event.key,
       modifiers: modifiersForEvent(event),
     });
@@ -992,7 +947,6 @@ class TextAssertionTool implements RecorderTool {
         return {
           name: 'assertChecked',
           selector,
-          signals: [],
           // Interestingly, inputElement.checked is reversed inside this event handler.
           checked: !(target as HTMLInputElement).checked,
         };
@@ -1000,7 +954,6 @@ class TextAssertionTool implements RecorderTool {
         return {
           name: 'assertValue',
           selector,
-          signals: [],
           value: (target as (HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)).value,
         };
       }
@@ -1013,7 +966,6 @@ class TextAssertionTool implements RecorderTool {
       return {
         name: 'assertSnapshot',
         selector: this._hoverHighlight.selector,
-        signals: [],
         ariaSnapshot: this._recorder.injectedScript.ariaSnapshot(target, { mode: 'codegen' }),
       };
     } else {
@@ -1025,7 +977,6 @@ class TextAssertionTool implements RecorderTool {
       return {
         name: 'assertText',
         selector: this._hoverHighlight.selector,
-        signals: [],
         text: this._recorder.injectedScript.utils.elementText(this._textCache, target).normalized,
         substring: true,
       };

--- a/packages/isomorphic/codegen/actions.d.ts
+++ b/packages/isomorphic/codegen/actions.d.ts
@@ -36,7 +36,6 @@ export type ActionName =
 
 export type ActionBase = {
   name: ActionName,
-  signals: Signal[],
   ariaSnapshot?: string,
 };
 
@@ -166,12 +165,10 @@ export type Signal = NavigationSignal | PopupSignal | DownloadSignal | DialogSig
 export type ActionInContext = {
   pageGuid: string;
   action: Action;
-  startTime: number;
-  endTime?: number;
+  signals: Signal[];
 };
 
 export type SignalInContext = {
   pageGuid: string;
   signal: Signal;
-  timestamp: number;
 };

--- a/packages/isomorphic/codegen/csharp.ts
+++ b/packages/isomorphic/codegen/csharp.ts
@@ -91,7 +91,7 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
     }
 
     const subject = pageAlias;
-    const signals = toSignalMap(action);
+    const signals = toSignalMap(actionInContext);
 
     if (signals.dialog) {
       formatter.add(`    void ${pageAlias}_Dialog${signals.dialog.dialogAlias}_EventHandler(object sender, IDialog dialog)

--- a/packages/isomorphic/codegen/java.ts
+++ b/packages/isomorphic/codegen/java.ts
@@ -79,7 +79,7 @@ export class JavaLanguageGenerator implements LanguageGenerator {
     }
 
     const subject = pageAlias;
-    const signals = toSignalMap(action);
+    const signals = toSignalMap(actionInContext);
 
     if (signals.dialog) {
       formatter.add(`  ${pageAlias}.onceDialog(dialog -> {

--- a/packages/isomorphic/codegen/javascript.ts
+++ b/packages/isomorphic/codegen/javascript.ts
@@ -67,7 +67,7 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
     }
 
     const subject = pageAlias;
-    const signals = toSignalMap(action);
+    const signals = toSignalMap(actionInContext);
 
     if (signals.dialog) {
       formatter.add(`  ${pageAlias}.once('dialog', dialog => {

--- a/packages/isomorphic/codegen/jsonl.ts
+++ b/packages/isomorphic/codegen/jsonl.ts
@@ -33,12 +33,13 @@ export class JsonlLanguageGenerator implements LanguageGenerator {
     const locator = (actionInContext.action as any).selector ? JSON.parse(asLocator('jsonl', (actionInContext.action as any).selector)) : undefined;
     const entry = {
       ...actionInContext.action,
+      signals: actionInContext.signals,
       pageGuid: actionInContext.pageGuid,
       locator,
       ariaSnapshot: undefined,
     };
     const lines = [JSON.stringify(entry)];
-    const expect = toSignalMap(actionInContext.action).expect;
+    const expect = toSignalMap(actionInContext).expect;
     if (options.generateExpectSignal && expect)
       lines.push(this.generateAction(expectSignalAction(actionInContext, expect), options));
     return lines.join('\n');

--- a/packages/isomorphic/codegen/language.ts
+++ b/packages/isomorphic/codegen/language.ts
@@ -31,12 +31,10 @@ export function generateCode(actions: actions.ActionInContext[], languageGenerat
 export function expectSignalAction(actionInContext: actions.ActionInContext, signal: actions.ExpectSignal): actions.ActionInContext {
   return {
     pageGuid: actionInContext.pageGuid,
-    startTime: actionInContext.startTime,
-    endTime: actionInContext.startTime,
+    signals: [],
     action: {
       name: 'assertVisible',
       selector: signal.selector,
-      signals: [],
     },
   };
 }
@@ -51,12 +49,12 @@ export function sanitizeDeviceOptions(device: any, options: BrowserContextOption
   return cleanedOptions;
 }
 
-export function toSignalMap(action: actions.Action) {
+export function toSignalMap(actionInContext: actions.ActionInContext) {
   let popup: actions.PopupSignal | undefined;
   let download: actions.DownloadSignal | undefined;
   let dialog: actions.DialogSignal | undefined;
   let expect: actions.ExpectSignal | undefined;
-  for (const signal of action.signals) {
+  for (const signal of actionInContext.signals) {
     if (signal.name === 'popup')
       popup = signal;
     else if (signal.name === 'download')

--- a/packages/isomorphic/codegen/python.ts
+++ b/packages/isomorphic/codegen/python.ts
@@ -74,7 +74,7 @@ export class PythonLanguageGenerator implements LanguageGenerator {
     }
 
     const subject = pageAlias;
-    const signals = toSignalMap(action);
+    const signals = toSignalMap(actionInContext);
 
     if (signals.dialog)
       formatter.add(`  ${pageAlias}.once("dialog", lambda dialog: dialog.dismiss())`);

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -56,9 +56,8 @@ import type * as channels from './channels';
 import type * as actions from '@isomorphic/codegen/actions';
 
 interface RecorderEventSink {
-  actionAdded?(page: Page, actionInContext: actions.ActionInContext, code: string): void;
-  actionUpdated?(page: Page, actionInContext: actions.ActionInContext, code: string): void;
-  signalAdded?(page: Page, signal: actions.SignalInContext): void;
+  actionAdded?(page: Page, action: actions.Action, code: string): void;
+  signalAdded?(page: Page, signal: actions.Signal, code: string): void;
 }
 
 export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel> implements api.BrowserContext {
@@ -162,11 +161,9 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     this._channel.on('response', ({ response, page }) => this._onResponse(network.Response.from(response), Page.fromNullable(page)));
     this._channel.on('recorderEvent', ({ event, data, page, code }) => {
       if (event === 'actionAdded')
-        this._onRecorderEventSink?.actionAdded?.(Page.from(page), data as actions.ActionInContext, code);
-      else if (event === 'actionUpdated')
-        this._onRecorderEventSink?.actionUpdated?.(Page.from(page), data as actions.ActionInContext, code);
+        this._onRecorderEventSink?.actionAdded?.(Page.from(page), data as actions.Action, code);
       else if (event === 'signalAdded')
-        this._onRecorderEventSink?.signalAdded?.(Page.from(page), data as actions.SignalInContext);
+        this._onRecorderEventSink?.signalAdded?.(Page.from(page), data as actions.Signal, code);
     });
     this._closedPromise = new Promise(f => this.once(Events.BrowserContext.Close, f));
 

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -1360,7 +1360,7 @@ export type BrowserContextResponseEvent = {
   page?: PageChannel,
 };
 export type BrowserContextRecorderEventEvent = {
-  event: 'actionAdded' | 'actionUpdated' | 'signalAdded',
+  event: 'actionAdded' | 'signalAdded',
   data: any,
   page: PageChannel,
   code: string,

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -83,7 +83,7 @@ export type BrowserContextEventMap = {
   [BrowserContextEvent.RequestFulfilled]: [request: network.Request];
   [BrowserContextEvent.RequestContinued]: [request: network.Request];
   [BrowserContextEvent.BeforeClose]: [];
-  [BrowserContextEvent.RecorderEvent]: [event: { event: 'actionAdded' | 'actionUpdated' | 'signalAdded', data: any, page: Page, code: string }];
+  [BrowserContextEvent.RecorderEvent]: [event: { event: 'actionAdded' | 'signalAdded', data: any, page: Page, code: string }];
   [BrowserContextEvent.PageClosed]: [page: Page];
   [BrowserContextEvent.InternalFrameNavigatedToNewDocument]: [frame: frames.Frame];
   [BrowserContextEvent.FrameAttached]: [frame: frames.Frame];

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -1361,7 +1361,7 @@ export type BrowserContextResponseEvent = {
   page?: PageChannel,
 };
 export type BrowserContextRecorderEventEvent = {
-  event: 'actionAdded' | 'actionUpdated' | 'signalAdded',
+  event: 'actionAdded' | 'signalAdded',
   data: any,
   page: PageChannel,
   code: string,

--- a/packages/playwright-core/src/server/debugController.ts
+++ b/packages/playwright-core/src/server/debugController.ts
@@ -23,7 +23,6 @@ import { generateCode } from '@isomorphic/codegen/language';
 import { JavaScriptLanguageGenerator } from '@isomorphic/codegen/javascript';
 import { SdkObject, createInstrumentation } from './instrumentation';
 import { Recorder, RecorderEvent } from './recorder';
-import { collapseActions } from './recorder/recorderUtils';
 
 import type { Language } from '@isomorphic/locatorGenerators';
 import type { BrowserContext } from './browserContext';
@@ -188,8 +187,7 @@ function wireListeners(recorder: Recorder, debugController: DebugController) {
   const languageGenerator = new JavaScriptLanguageGenerator(/* isPlaywrightTest */true);
 
   const actionsChanged = () => {
-    const aa = collapseActions(actions);
-    const { header, footer, text, actionTexts } = generateCode(aa, languageGenerator, {
+    const { header, footer, text, actionTexts } = generateCode(actions, languageGenerator, {
       browserName: 'chromium',
       launchOptions: {},
       contextOptions: {},
@@ -215,7 +213,7 @@ function wireListeners(recorder: Recorder, debugController: DebugController) {
   recorder.on(RecorderEvent.SignalAdded, (signal: actions.SignalInContext) => {
     const lastAction = actions.findLast(a => a.pageGuid === signal.pageGuid);
     if (lastAction)
-      lastAction.action.signals.push(signal.signal);
+      lastAction.signals.push(signal.signal);
     actionsChanged();
   });
 }

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -193,7 +193,7 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
         page: PageDispatcher.fromNullable(this, request.frame()?._page.initializedOrUndefined()),
       });
     });
-    this.addObjectListener(BrowserContext.Events.RecorderEvent, ({ event, data, page, code }: { event: 'actionAdded' | 'actionUpdated' | 'signalAdded', data: any, page: Page, code: string }) => {
+    this.addObjectListener(BrowserContext.Events.RecorderEvent, ({ event, data, page, code }: { event: 'actionAdded' | 'signalAdded', data: any, page: Page, code: string }) => {
       this._dispatchEvent('recorderEvent', { event, data, code, page: PageDispatcher.from(this, page) });
     });
   }

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -22,7 +22,6 @@ import { stringifySelector } from '@isomorphic/selectorParser';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { isUnderTest } from '@utils/debug';
 import { eventsHelper } from '@utils/eventsHelper';
-import { monotonicTime } from '@isomorphic/time';
 import { BrowserContext } from './browserContext';
 import { Debugger } from './debugger';
 import { buildFullSelector, generateFrameSelector, metadataToCallLog } from './recorder/recorderUtils';
@@ -496,9 +495,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         pageGuid: page.guid,
         action: {
           name: 'closePage',
-          signals: [],
         },
-        startTime: monotonicTime()
+        signals: [],
       });
       this._filePrimaryURLChanged();
     });
@@ -518,9 +516,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         action: {
           name: 'openPage',
           url: page.mainFrame().url(),
-          signals: [],
         },
-        startTime: monotonicTime()
+        signals: [],
       });
     }
     this._filePrimaryURLChanged();
@@ -548,7 +545,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     const actionInContext: actions.ActionInContext = {
       pageGuid: frame._page.guid,
       action,
-      startTime: monotonicTime(),
+      signals: [],
     };
     return actionInContext;
   }

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -26,7 +26,6 @@ import { syncLocalStorageWithSettings } from '../launchApp';
 import { launchApp } from '../launchApp';
 import { nullProgress, ProgressController } from '../progress';
 import { ThrottledFile } from './throttledFile';
-import { collapseActions, shouldMergeAction } from './recorderUtils';
 import { Recorder, RecorderEvent } from '../recorder';
 import { BrowserContext } from '../browserContext';
 
@@ -290,7 +289,7 @@ export class RecorderApp {
   private _onSignalAdded(signal: actions.SignalInContext) {
     const lastAction = this._actions.findLast(a => a.pageGuid === signal.pageGuid);
     if (lastAction)
-      lastAction.action.signals.push(signal.signal);
+      lastAction.signals.push(signal.signal);
     this._updateActions();
   }
 
@@ -315,11 +314,9 @@ export class RecorderApp {
 
   private _updateActions(reveal?: 'reveal') {
     const recorderSources = [];
-    const actions = collapseActions(this._actions);
-
     let revealSourceId: string | undefined;
     for (const languageGenerator of languageSet()) {
-      const { header, footer, actionTexts, text } = generateCode(actions, languageGenerator, this._languageGeneratorOptions);
+      const { header, footer, actionTexts, text } = generateCode(this._actions, languageGenerator, this._languageGeneratorOptions);
       const source: Source = {
         isRecorded: true,
         label: languageGenerator.name,
@@ -357,7 +354,7 @@ function determinePrimaryGeneratorId(sdkLanguage: Language): string {
 
 export class ProgrammaticRecorderApp {
   static async run(inspectedContext: BrowserContext, recorder: Recorder, browserName: string, params: channels.BrowserContextEnableRecorderParams) {
-    let lastAction: actions.ActionInContext | null = null;
+    let lastAction: actions.ActionInContext | undefined;
     const languages = [...languageSet()];
 
     const languageGeneratorOptions = {
@@ -369,22 +366,23 @@ export class ProgrammaticRecorderApp {
     };
     const languageGenerator = languages.find(l => l.id === params.language) ?? languages.find(l => l.id === 'playwright-test')!;
 
-    recorder.on(RecorderEvent.ActionAdded, action => {
-      const page = findPageByGuid(inspectedContext, action.pageGuid);
+    recorder.on(RecorderEvent.ActionAdded, actionInContext => {
+      const page = findPageByGuid(inspectedContext, actionInContext.pageGuid);
       if (!page)
         return;
-      const code = languageGenerator.generateAction(action, languageGeneratorOptions);
-      if (!lastAction || !shouldMergeAction(action, lastAction))
-        inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'actionAdded', data: action, page, code });
-      else
-        inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'actionUpdated', data: action, page, code });
-      lastAction = action;
+      lastAction = actionInContext;
+      const code = languageGenerator.generateAction(actionInContext, languageGeneratorOptions);
+      inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'actionAdded', data: actionInContext.action, page, code });
     });
-    recorder.on(RecorderEvent.SignalAdded, signal => {
-      const page = findPageByGuid(inspectedContext, signal.pageGuid);
+    recorder.on(RecorderEvent.SignalAdded, signalInContext => {
+      const page = findPageByGuid(inspectedContext, signalInContext.pageGuid);
       if (!page)
         return;
-      inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'signalAdded', data: signal, page, code: '' });
+      // The signal belongs to the last action, so re-generate its code with the signal
+      // included (e.g. a popup or download wait around the action).
+      lastAction?.signals.push(signalInContext.signal);
+      const code = lastAction ? languageGenerator.generateAction(lastAction, languageGeneratorOptions) : '';
+      inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'signalAdded', data: signalInContext.signal, page, code });
     });
   }
 }

--- a/packages/playwright-core/src/server/recorder/recorderSignalProcessor.ts
+++ b/packages/playwright-core/src/server/recorder/recorderSignalProcessor.ts
@@ -26,81 +26,105 @@ export interface ProcessorDelegate {
   addSignal(signalInContext: actions.SignalInContext): void;
 }
 
-// How long a single click is held back, waiting for a double click to arrive and merge with it.
-const kClickBufferTimeout = 500;
+// How long an action is held back, waiting for a superseding action to merge with it:
+// a double click after a click, another keystroke after a fill, another navigation.
+const kActionBufferTimeout = 500;
 
 type BufferedSignal = { frame: Frame, signal: Signal, timestamp: number };
 
 export class RecorderSignalProcessor {
   private _delegate: ProcessorDelegate;
   private _lastAction: actions.ActionInContext | null = null;
-  private _bufferedClick: { actionInContext: actions.ActionInContext, signals: BufferedSignal[], timeout: NodeJS.Timeout } | undefined;
+  private _lastActionTimestamp = 0;
+  private _pendingAction: { actionInContext: actions.ActionInContext, receivedAt: number, signals: BufferedSignal[], timeout: NodeJS.Timeout } | undefined;
 
   constructor(actionSink: ProcessorDelegate) {
     this._delegate = actionSink;
   }
 
   addAction(actionInContext: actions.ActionInContext) {
-    if (this._bufferedClick) {
-      if (this._isDoubleClick(actionInContext, this._bufferedClick.actionInContext)) {
-        // A double click - merge it into the buffered single click and emit the result.
-        actionInContext.startTime = this._bufferedClick.actionInContext.startTime;
-        this._flushBufferedClick(actionInContext);
+    const timestamp = monotonicTime();
+    if (this._pendingAction) {
+      if (this._supersedes(actionInContext, this._pendingAction.actionInContext)) {
+        this._pendingAction.actionInContext = actionInContext;
+        this._pendingAction.receivedAt = timestamp;
+        this._resetPendingTimeout();
         return;
       }
-      // A different action - emit the buffered click before proceeding.
-      this._flushBufferedClick();
+      this._flushPendingAction();
     }
 
-    if (this._isBufferableClick(actionInContext)) {
-      this._bufferedClick = {
+    if (this._shouldBuffer(actionInContext)) {
+      this._pendingAction = {
         actionInContext,
+        receivedAt: timestamp,
         signals: [],
-        timeout: setTimeout(() => this._flushBufferedClick(), kClickBufferTimeout),
+        timeout: setTimeout(() => this._flushPendingAction(), kActionBufferTimeout),
       };
       return;
     }
 
-    this._emitAction(actionInContext);
+    this._emitAction(actionInContext, timestamp);
   }
 
   signal(frame: Frame, signal: Signal) {
     const timestamp = monotonicTime();
-    if (this._bufferedClick) {
-      this._bufferedClick.signals.push({ frame, signal, timestamp });
+    const isMainFrameNavigation = signal.name === 'navigation' && frame._page.mainFrame() === frame;
+    if (this._pendingAction?.actionInContext.action.name === 'navigate' && isMainFrameNavigation && this._pendingAction.actionInContext.pageGuid === frame._page.guid) {
+      this._pendingAction.actionInContext.action.url = frame.url();
+      this._resetPendingTimeout();
       return;
     }
-    this._processSignal(frame, signal, timestamp);
+    if (this._pendingAction)
+      this._pendingAction.signals.push({ frame, signal, timestamp });
+    else
+      this._processSignal(frame, signal, timestamp);
   }
 
-  private _isBufferableClick(actionInContext: actions.ActionInContext): boolean {
+  private _shouldBuffer(actionInContext: actions.ActionInContext): boolean {
     const action = actionInContext.action;
-    return action.name === 'click' && action.button === 'left' && action.clickCount === 1;
+    return (action.name === 'click' && action.button === 'left') || action.name === 'fill' || action.name === 'navigate';
   }
 
-  private _isDoubleClick(actionInContext: actions.ActionInContext, bufferedClick: actions.ActionInContext): boolean {
+  private _supersedes(actionInContext: actions.ActionInContext, pending: actions.ActionInContext): boolean {
     const action = actionInContext.action;
-    const buffered = bufferedClick.action;
-    return action.name === 'click' && buffered.name === 'click'
-      && actionInContext.pageGuid === bufferedClick.pageGuid
-      && action.selector === buffered.selector
-      && action.clickCount > buffered.clickCount;
+    const pendingAction = pending.action;
+    if (actionInContext.pageGuid !== pending.pageGuid)
+      return false;
+    // A higher click count on the same target is a double (or triple) click.
+    if (action.name === 'click' && pendingAction.name === 'click')
+      return action.selector === pendingAction.selector && action.clickCount > pendingAction.clickCount;
+    // Another keystroke into the same field supersedes the previous value.
+    if (action.name === 'fill' && pendingAction.name === 'fill')
+      return action.selector === pendingAction.selector;
+    // Another navigation on the same page supersedes the previous url.
+    if (action.name === 'navigate' && pendingAction.name === 'navigate')
+      return true;
+    return false;
   }
 
-  private _emitAction(actionInContext: actions.ActionInContext) {
+  private _resetPendingTimeout() {
+    if (!this._pendingAction)
+      return;
+    clearTimeout(this._pendingAction.timeout);
+    this._pendingAction.timeout = setTimeout(() => this._flushPendingAction(), kActionBufferTimeout);
+  }
+
+  private _emitAction(actionInContext: actions.ActionInContext, timestamp: number) {
     this._lastAction = actionInContext;
+    this._lastActionTimestamp = timestamp;
     this._delegate.addAction(actionInContext);
   }
 
-  private _flushBufferedClick(replacement?: actions.ActionInContext) {
-    const buffered = this._bufferedClick;
-    if (!buffered)
+  private _flushPendingAction() {
+    const pending = this._pendingAction;
+    if (!pending)
       return;
-    clearTimeout(buffered.timeout);
-    this._bufferedClick = undefined;
-    this._emitAction(replacement ?? buffered.actionInContext);
+    clearTimeout(pending.timeout);
+    this._pendingAction = undefined;
+    this._emitAction(pending.actionInContext, pending.receivedAt);
     // Replay the signals with their original timestamps, so that they attach to the emitted action.
-    for (const { frame, signal, timestamp } of buffered.signals)
+    for (const { frame, signal, timestamp } of pending.signals)
       this._processSignal(frame, signal, timestamp);
   }
 
@@ -114,19 +138,17 @@ export class RecorderSignalProcessor {
         generateGoto = true;
       else if (lastAction.action.name !== 'click' && lastAction.action.name !== 'press' && lastAction.action.name !== 'fill')
         generateGoto = true;
-      else if (timestamp - lastAction.startTime > signalThreshold)
+      else if (timestamp - this._lastActionTimestamp > signalThreshold)
         generateGoto = true;
 
       if (generateGoto) {
-        this._emitAction({
+        this.addAction({
           pageGuid: frame._page.guid,
           action: {
             name: 'navigate',
             url: frame.url(),
-            signals: [],
           },
-          startTime: timestamp,
-          endTime: timestamp,
+          signals: [],
         });
       }
       return;
@@ -135,7 +157,6 @@ export class RecorderSignalProcessor {
     this._delegate.addSignal({
       pageGuid: frame._page.guid,
       signal,
-      timestamp,
     });
   }
 }

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -21,7 +21,6 @@ import { quoteCSSAttributeValue } from '@isomorphic/stringUtils';
 import { Frame } from '../frames';
 
 import type { CallMetadata } from '../instrumentation';
-import type * as actions from '@isomorphic/codegen/actions';
 import type { CallLog, CallLogStatus } from '@recorder/recorderTypes';
 import type { Progress } from '../progress';
 
@@ -54,41 +53,6 @@ export function metadataToCallLog(metadata: CallMetadata, status: CallLogStatus)
   return callLog;
 }
 
-function isSameAction(a: actions.ActionInContext, b: actions.ActionInContext): boolean {
-  return a.action.name === b.action.name && a.pageGuid === b.pageGuid;
-}
-
-function isSameSelector(action: actions.ActionInContext, lastAction: actions.ActionInContext): boolean {
-  return 'selector' in action.action && 'selector' in lastAction.action && action.action.selector === lastAction.action.selector;
-}
-
-export function shouldMergeAction(action: actions.ActionInContext, lastAction: actions.ActionInContext | undefined): boolean {
-  if (!lastAction)
-    return false;
-  switch (action.action.name) {
-    case 'fill':
-      return isSameAction(action, lastAction) && isSameSelector(action, lastAction);
-    case 'navigate':
-      return isSameAction(action, lastAction);
-  }
-  return false;
-}
-
-export function collapseActions(actions: actions.ActionInContext[]): actions.ActionInContext[] {
-  const result: actions.ActionInContext[] = [];
-  for (const action of actions) {
-    const lastAction = result[result.length - 1];
-    const shouldMerge = shouldMergeAction(action, lastAction);
-    if (!shouldMerge) {
-      result.push(action);
-      continue;
-    }
-    const startTime = result[result.length - 1].startTime;
-    result[result.length - 1] = action;
-    result[result.length - 1].startTime = startTime;
-  }
-  return result;
-}
 
 export async function generateFrameSelector(progress: Progress, frame: Frame): Promise<string[]> {
   const selectorPromises: Promise<string>[] = [];

--- a/packages/protocol/spec/browserContext.yml
+++ b/packages/protocol/spec/browserContext.yml
@@ -449,7 +449,6 @@ BrowserContext:
           type: enum
           literals:
           - actionAdded
-          - actionUpdated
           - signalAdded
         data: json
         page: Page

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -732,7 +732,7 @@ scheme.BrowserContextResponseEvent = tObject({
   page: tOptional(tChannel(['Page'])),
 });
 scheme.BrowserContextRecorderEventEvent = tObject({
-  event: tEnum(['actionAdded', 'actionUpdated', 'signalAdded']),
+  event: tEnum(['actionAdded', 'signalAdded']),
   data: tAny,
   page: tChannel(['Page']),
   code: tString,

--- a/tests/library/inspector/recorder-api.spec.ts
+++ b/tests/library/inspector/recorder-api.spec.ts
@@ -20,14 +20,15 @@ import type { Page } from '@playwright/test';
 import type * as actions from '@isomorphic/codegen/actions';
 
 class RecorderLog {
-  actions: (actions.ActionInContext & { code: string })[] = [];
+  actions: { action: actions.Action, code: string }[] = [];
+  signals: { signal: actions.Signal, code: string }[] = [];
 
-  actionAdded(page: Page, actionInContext: actions.ActionInContext, code: string): void {
-    this.actions.push({ ...actionInContext, code });
+  actionAdded(page: Page, action: actions.Action, code: string): void {
+    this.actions.push({ action, code });
   }
 
-  actionUpdated(page: Page, actionInContext: actions.ActionInContext, code: string): void {
-    this.actions[this.actions.length - 1] = { ...actionInContext, code };
+  signalAdded(page: Page, signal: actions.Signal, code: string): void {
+    this.signals.push({ signal, code });
   }
 }
 
@@ -39,6 +40,7 @@ async function startRecording(context) {
   }, log);
   return {
     action: (name: string) => log.actions.filter(a => a.action.name === name),
+    signals: () => log.signals,
   };
 }
 
@@ -61,7 +63,6 @@ test('should click', async ({ context, browserName, platform, channel }) => {
         // Safari does not focus after a click: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#clicking_and_focus
         ariaSnapshot: (browserName === 'webkit' && (platform === 'darwin' || (platform === 'win32' && channel !== 'webkit-wsl'))) ? '- button "Submit" [ref=e2]' : '- button "Submit" [active] [ref=e2]',
       }),
-      startTime: expect.any(Number),
     })
   ]);
 
@@ -74,8 +75,7 @@ test('should double click', async ({ context, browserName, platform, channel }) 
   await page.setContent(`<button onclick="console.log('click')" ondblclick="console.log('dblclick')">Submit</button>`);
   await page.getByRole('button', { name: 'Submit' }).dblclick();
 
-  const clickActions = log.action('click');
-  expect(clickActions).toEqual([
+  await expect.poll(() => log.action('click')).toEqual([
     expect.objectContaining({
       action: expect.objectContaining({
         name: 'click',
@@ -85,11 +85,10 @@ test('should double click', async ({ context, browserName, platform, channel }) 
         // Safari does not focus after a click: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#clicking_and_focus
         ariaSnapshot: (browserName === 'webkit' && (platform === 'darwin' || (platform === 'win32' && channel !== 'webkit-wsl'))) ? '- button "Submit" [ref=e2]' : '- button "Submit" [active] [ref=e2]',
       }),
-      startTime: expect.any(Number),
     })
   ]);
 
-  expect(normalizeCode(clickActions[0].code)).toEqual(`await page.getByRole('button', { name: 'Submit' }).dblclick();`);
+  expect(normalizeCode(log.action('click')[0].code)).toEqual(`await page.getByRole('button', { name: 'Submit' }).dblclick();`);
 });
 
 test('should right click', async ({ context, browserName, platform, channel }) => {
@@ -109,11 +108,24 @@ test('should right click', async ({ context, browserName, platform, channel }) =
         // Safari does not focus after a click: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#clicking_and_focus
         ariaSnapshot: (browserName === 'webkit' && (platform === 'darwin' || (platform === 'win32' && channel !== 'webkit-wsl'))) ? '- button "Submit" [ref=e2]' : '- button "Submit" [active] [ref=e2]',
       }),
-      startTime: expect.any(Number),
     })
   ]);
 
   expect(normalizeCode(clickActions[0].code)).toEqual(`await page.getByRole('button', { name: 'Submit' }).click({ button: 'right' });`);
+});
+
+test('should send updated code with the signal', async ({ context, server }) => {
+  const recorder = await startRecording(context);
+  const page = await context.newPage();
+  await page.setContent(`<a target=_blank rel=noopener href="${server.EMPTY_PAGE}">link</a>`);
+  await page.getByRole('link', { name: 'link' }).click();
+
+  // The popup signal attaches to the click, so the click's code is re-generated to await it.
+  await expect.poll(() => recorder.signals().map(s => s.signal.name)).toContain('popup');
+  const code = recorder.signals().find(s => s.signal.name === 'popup')!.code;
+  expect(normalizeCode(code)).toContain(`const page1Promise = page.waitForEvent('popup');`);
+  expect(normalizeCode(code)).toContain(`await page.getByRole('link', { name: 'link' }).click();`);
+  expect(normalizeCode(code)).toContain(`const page1 = await page1Promise;`);
 });
 
 test('should type', async ({ context }) => {
@@ -123,8 +135,7 @@ test('should type', async ({ context }) => {
 
   await page.getByRole('textbox').pressSequentially('Hello');
 
-  const fillActions = log.action('fill');
-  expect(fillActions).toEqual([
+  await expect.poll(() => log.action('fill')).toEqual([
     expect.objectContaining({
       action: expect.objectContaining({
         name: 'fill',
@@ -132,11 +143,10 @@ test('should type', async ({ context }) => {
         ref: 'e2',
         ariaSnapshot: '- textbox [active] [ref=e2]: Hello',
       }),
-      startTime: expect.any(Number),
     })
   ]);
 
-  expect(normalizeCode(fillActions[0].code)).toEqual(`await page.getByRole('textbox').fill('Hello');`);
+  expect(normalizeCode(log.action('fill')[0].code)).toEqual(`await page.getByRole('textbox').fill('Hello');`);
 });
 
 test('should disable recorder', async ({ context }) => {


### PR DESCRIPTION
## Summary
- Derive double click from `event.detail` in `onClick` and drop `onDblClick`.
- Coalesce click/fill/navigate in the `RecorderSignalProcessor` so every action is emitted once; delete `collapseActions`/`shouldMergeAction` and the `actionUpdated` recorder event — actions are never updated or collapsed downstream.
- Move `signals` off `actions.Action` onto `ActionInContext`, and drop the now-unused action timestamps and `SignalInContext.timestamp`.
- The `recorderMode: 'api'` event sink now receives `Action`/`Signal` instead of the `*InContext` wrappers, and `signalAdded` carries the re-generated code for the action the signal attaches to.

Follow-up to #41902.