### PR TITLE
fix(network): return null securityDetails for non-HTTPS on Chromium/Firefox

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -419,13 +419,20 @@ export class CRNetworkManager {
     } else {
       response._serverAddrFinished();
     }
-    response._securityDetailsFinished({
-      protocol: responsePayload?.securityDetails?.protocol,
-      subjectName: responsePayload?.securityDetails?.subjectName,
-      issuer: responsePayload?.securityDetails?.issuer,
-      validFrom: responsePayload?.securityDetails?.validFrom,
-      validTo: responsePayload?.securityDetails?.validTo,
-    });
+    // Only surface details when the browser provided them (HTTPS). Passing an
+    // all-undefined object is truthy and makes securityDetails() return {} on
+    // plain HTTP; WebKit correctly resolves null instead.
+    if (responsePayload?.securityDetails) {
+      response._securityDetailsFinished({
+        protocol: responsePayload.securityDetails.protocol,
+        subjectName: responsePayload.securityDetails.subjectName,
+        issuer: responsePayload.securityDetails.issuer,
+        validFrom: responsePayload.securityDetails.validFrom,
+        validTo: responsePayload.securityDetails.validTo,
+      });
+    } else {
+      response._securityDetailsFinished();
+    }
     this._responseExtraInfoTracker.processResponse(request._requestId, response, hasExtraInfo);
     return response;
   }

--- a/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
+++ b/packages/playwright-core/src/server/firefox/ffNetworkManager.ts
@@ -124,13 +124,18 @@ export class FFNetworkManager {
     } else {
       response._serverAddrFinished();
     }
-    response._securityDetailsFinished({
-      protocol: event?.securityDetails?.protocol,
-      subjectName: event?.securityDetails?.subjectName,
-      issuer: event?.securityDetails?.issuer,
-      validFrom: event?.securityDetails?.validFrom,
-      validTo: event?.securityDetails?.validTo,
-    });
+    // Match Chromium/WebKit: no security details for non-HTTPS responses.
+    if (event?.securityDetails) {
+      response._securityDetailsFinished({
+        protocol: event.securityDetails.protocol,
+        subjectName: event.securityDetails.subjectName,
+        issuer: event.securityDetails.issuer,
+        validFrom: event.securityDetails.validFrom,
+        validTo: event.securityDetails.validTo,
+      });
+    } else {
+      response._securityDetailsFinished();
+    }
     // "raw" headers are the same as "provisional" headers in Firefox.
     response.setRawResponseHeaders(null);
     // Headers size are not available in Firefox.

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -32,6 +32,12 @@ it('should work @smoke', async ({ page, server }) => {
   expect((await response.allHeaders())['BaZ']).toBe(undefined);
 });
 
+it('should return null securityDetails for HTTP', async ({ page, server }) => {
+  const response = await page.goto(server.EMPTY_PAGE);
+  expect(response).toBeTruthy();
+  expect(await response!.securityDetails()).toBeNull();
+});
+
 it('should return multiple header value', async ({ page, server, browserName, platform }) => {
   it.skip(browserName === 'webkit' && platform === 'win32', 'libcurl does not support non-set-cookie multivalue headers');
 


### PR DESCRIPTION
## Summary

For plain HTTP responses, Chromium and Firefox called
`_securityDetailsFinished` with an object whose fields were all
`undefined`. That object is truthy, so `response.securityDetails()`
returned `{}` instead of `null`.

WebKit already resolves with no argument when there are no details.
Only pass a details object when the browser protocol provided
`securityDetails`.

## Public repro

```js
const response = await page.goto("http://example.com");
console.log(await response.securityDetails()); // was {}, now null
```

## Evidence

- Red: `chromium-page` test received `{}`
- Green: `toBeNull()` after the fix
- Aligns Chromium/Firefox with WebKit

## Test

- `tests/page/page-network-response.spec.ts`: `should return null securityDetails for HTTP`