### PR TITLE
perf(test): avoid redundant stack capture

### DIFF
--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -343,6 +343,7 @@ function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: un
     apiName,
     title: longTitle,
     shortTitle,
+    location: stackFrames[0],
     params: args[0] ? { expected: args[0] } : undefined,
   };
   const step = testInfo?._addStep(stepData);

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -295,14 +295,13 @@ export class TestInfoImpl implements TestInfo {
         parentStep = this._parentStep();
     }
 
-    const filteredStack = filteredStackTrace(captureRawStack());
     let boxedStack = parentStep?.boxedStack;
     let location = data.location;
     if (!boxedStack && data.box) {
-      boxedStack = filteredStack.slice(1);
-      location = location || boxedStack[0];
+      boxedStack = filteredStackTrace(captureRawStack()).slice(1);
+      location ??= boxedStack[0];
     }
-    location = location || filteredStack[0];
+    location ??= filteredStackTrace(captureRawStack())[0];
 
     const step: TestStepInternal = {
       ...data,


### PR DESCRIPTION
Reuses already captured locations instead of taking a second stack trace.

Node 26, headless Chromium:

- `page.evaluate()`: 399 → 274 µs (**-31%**)
- polling expect: 568 → 493 µs (**-13%**)
- synchronous expect: 164 → 100 µs (**-39%**)