### PR TITLE
fix(mcp): escape user input in codegen output

### DIFF
--- a/packages/playwright-core/src/tools/backend/cookies.ts
+++ b/packages/playwright-core/src/tools/backend/cookies.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool } from './tool';
 
 const cookieList = defineTool({
@@ -137,7 +138,7 @@ const cookieDelete = defineTool({
   handle: async (context, params, response) => {
     const browserContext = await context.ensureBrowserContext();
     await browserContext.clearCookies({ name: params.name });
-    response.addCode(`await page.context().clearCookies({ name: '${params.name}' });`);
+    response.addCode(`await page.context().clearCookies({ name: ${escapeWithQuotes(params.name)} });`);
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/keyboard.ts
+++ b/packages/playwright-core/src/tools/backend/keyboard.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTabTool } from './tool';
 import { elementSchema } from './snapshot';
 
@@ -33,7 +34,7 @@ const press = defineTabTool({
 
   handle: async (tab, params, response) => {
     response.addCode(`// Press ${params.key}`);
-    response.addCode(`await page.keyboard.press('${params.key}');`);
+    response.addCode(`await page.keyboard.press(${escapeWithQuotes(params.key)});`);
     if (params.key === 'Enter') {
       response.setIncludeSnapshot();
       await tab.waitForCompletion(async () => {
@@ -62,7 +63,7 @@ const pressSequentially = defineTabTool({
 
   handle: async (tab, params, response) => {
     response.addCode(`// Press ${params.text}`);
-    response.addCode(`await page.keyboard.type('${params.text}');`);
+    response.addCode(`await page.keyboard.type(${escapeWithQuotes(params.text)});`);
     await tab.page.keyboard.type(params.text);
     if (params.submit) {
       response.addCode(`await page.keyboard.press('Enter');`);
@@ -133,7 +134,7 @@ const keydown = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.addCode(`await page.keyboard.down('${params.key}');`);
+    response.addCode(`await page.keyboard.down(${escapeWithQuotes(params.key)});`);
     await tab.page.keyboard.down(params.key);
   },
 });
@@ -153,7 +154,7 @@ const keyup = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    response.addCode(`await page.keyboard.up('${params.key}');`);
+    response.addCode(`await page.keyboard.up(${escapeWithQuotes(params.key)});`);
     await tab.page.keyboard.up(params.key);
   },
 });

--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool, defineTabTool } from './tool';
 
 const navigate = defineTool({
@@ -35,7 +36,7 @@ const navigate = defineTool({
     const url = await tab.checkUrlAndNavigate(params.url);
 
     response.setIncludeSnapshot();
-    response.addCode(`await page.goto('${url}');`);
+    response.addCode(`await page.goto(${escapeWithQuotes(url)});`);
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/route.ts
+++ b/packages/playwright-core/src/tools/backend/route.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool } from './tool';
 
 import type * as playwright from '../../..';
@@ -81,7 +82,7 @@ const route = defineTool({
 
     await context.addRoute(entry);
     response.addTextResult(`Route added for pattern: ${params.pattern}`);
-    response.addCode(`await page.context().route('${params.pattern}', async route => { /* route handler */ });`);
+    response.addCode(`await page.context().route(${escapeWithQuotes(params.pattern)}, async route => { /* route handler */ });`);
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/storage.ts
+++ b/packages/playwright-core/src/tools/backend/storage.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool } from './tool';
 
 const storageState = defineTool({
@@ -35,7 +36,7 @@ const storageState = defineTool({
     const state = await browserContext.storageState();
     const serializedState = JSON.stringify(state, null, 2);
     const resolvedFile = await response.resolveClientFile({ prefix: 'storage-state', ext: 'json', suggestedFilename: params.filename }, 'Storage state');
-    response.addCode(`await page.context().storageState({ path: '${resolvedFile.relativeName}' });`);
+    response.addCode(`await page.context().storageState({ path: ${escapeWithQuotes(resolvedFile.relativeName)} });`);
     await response.addFileResult(resolvedFile, serializedState);
   },
 });
@@ -58,7 +59,7 @@ const setStorageState = defineTool({
     const resolvedFilename = await response.resolveClientFilename(params.filename);
     await browserContext.setStorageState(resolvedFilename);
     response.addTextResult(`Storage state restored from ${params.filename}`);
-    response.addCode(`await page.context().setStorageState('${params.filename}');`);
+    response.addCode(`await page.context().setStorageState(${escapeWithQuotes(params.filename)});`);
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 
@@ -44,7 +45,7 @@ const browserTabs = defineTool({
         if (params.url) {
           const url = await tab.checkUrlAndNavigate(params.url);
           response.setIncludeSnapshot();
-          response.addCode(`await page.goto('${url}');`);
+          response.addCode(`await page.goto(${escapeWithQuotes(url)});`);
         }
         break;
       }

--- a/packages/playwright-core/src/tools/backend/webstorage.ts
+++ b/packages/playwright-core/src/tools/backend/webstorage.ts
@@ -15,6 +15,7 @@
  */
 
 import * as z from 'zod';
+import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTabTool } from './tool';
 
 const localStorageList = defineTabTool({
@@ -59,7 +60,7 @@ const localStorageGet = defineTabTool({
       response.addTextResult(`localStorage key '${params.key}' not found`);
     else
       response.addTextResult(`${params.key}=${value}`);
-    response.addCode(`await page.localStorage.getItem('${params.key}');`);
+    response.addCode(`await page.localStorage.getItem(${escapeWithQuotes(params.key)});`);
   },
 });
 
@@ -79,7 +80,7 @@ const localStorageSet = defineTabTool({
 
   handle: async (tab, params, response) => {
     await tab.page.localStorage.setItem(params.key, params.value);
-    response.addCode(`await page.localStorage.setItem('${params.key}', '${params.value}');`);
+    response.addCode(`await page.localStorage.setItem(${escapeWithQuotes(params.key)}, ${escapeWithQuotes(params.value)});`);
   },
 });
 
@@ -98,7 +99,7 @@ const localStorageDelete = defineTabTool({
 
   handle: async (tab, params, response) => {
     await tab.page.localStorage.removeItem(params.key);
-    response.addCode(`await page.localStorage.removeItem('${params.key}');`);
+    response.addCode(`await page.localStorage.removeItem(${escapeWithQuotes(params.key)});`);
   },
 });
 
@@ -163,7 +164,7 @@ const sessionStorageGet = defineTabTool({
       response.addTextResult(`sessionStorage key '${params.key}' not found`);
     else
       response.addTextResult(`${params.key}=${value}`);
-    response.addCode(`await page.sessionStorage.getItem('${params.key}');`);
+    response.addCode(`await page.sessionStorage.getItem(${escapeWithQuotes(params.key)});`);
   },
 });
 
@@ -183,7 +184,7 @@ const sessionStorageSet = defineTabTool({
 
   handle: async (tab, params, response) => {
     await tab.page.sessionStorage.setItem(params.key, params.value);
-    response.addCode(`await page.sessionStorage.setItem('${params.key}', '${params.value}');`);
+    response.addCode(`await page.sessionStorage.setItem(${escapeWithQuotes(params.key)}, ${escapeWithQuotes(params.value)});`);
   },
 });
 
@@ -202,7 +203,7 @@ const sessionStorageDelete = defineTabTool({
 
   handle: async (tab, params, response) => {
     await tab.page.sessionStorage.removeItem(params.key);
-    response.addCode(`await page.sessionStorage.removeItem('${params.key}');`);
+    response.addCode(`await page.sessionStorage.removeItem(${escapeWithQuotes(params.key)});`);
   },
 });
 

--- a/tests/mcp/cli-core.spec.ts
+++ b/tests/mcp/cli-core.spec.ts
@@ -368,3 +368,10 @@ test('--raw on command without output', async ({ cli, server }) => {
   expect(output).not.toContain('### ');
   expect(output).not.toContain('Page URL');
 });
+
+test('codegen escapes single quotes in user input', async ({ cli, server }) => {
+  server.setContent('/', `<input type=text>`, 'text/html');
+  await cli('open', server.PREFIX);
+  const { output } = await cli('type', "it's working");
+  expect(output).toContain(`await page.keyboard.type('it\\'s working');`);
+});


### PR DESCRIPTION
## Rationale

`browser_type` escapes user input but `browser_press_sequentially` right below it doesn't. Something like "it's working" ends up producing invalid JS in the codegen. Looked around and a "few other tools" had the same gap while `evaluate.ts`, `form.ts`, `verify.ts` already handle it fine through `escapeWithQuotes()`. Figured it made sense to just bring the rest in line.