### PR TITLE
fix(mcp): reconnect to the browser after disconnect

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -27,6 +27,8 @@ import type { Tool } from './tool';
 import type * as mcpServer from '../utils/mcp/server';
 import type { ClientInfo, ServerBackend } from '../utils/mcp/server';
 
+const backendDebug = debug('pw:mcp:backend');
+
 export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [] }> implements ServerBackend {
   private _tools: Tool[];
   private _context: Context | undefined;
@@ -35,9 +37,9 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [
   private _disconnected = false;
   private _disposed = false;
   private _browserContext: playwright.BrowserContext;
-  private _disposeCallback: (() => Promise<void>) | undefined;
+  private _disposeCallback: ((disconnected: boolean) => Promise<void>) | undefined;
 
-  constructor(config: ContextConfig, browserContext: playwright.BrowserContext, tools: Tool[], disposeCallback?: () => Promise<void>) {
+  constructor(config: ContextConfig, browserContext: playwright.BrowserContext, tools: Tool[], disposeCallback?: (disconnected: boolean) => Promise<void>) {
     super();
     this._config = config;
     this._tools = tools;
@@ -46,6 +48,7 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [
     const markDisconnected = () => {
       if (this._disconnected)
         return;
+      backendDebug('browser disconnected');
       this._disconnected = true;
       this.emit('disconnected');
     };
@@ -67,7 +70,7 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [
       return;
     this._disposed = true;
     await this._context?.dispose().catch(e => debug('pw:tools:error')(e));
-    await this._disposeCallback?.().catch(e => debug('pw:tools:error')(e));
+    await this._disposeCallback?.(this._disconnected).catch(e => debug('pw:tools:error')(e));
     this.emit('disposed');
   }
 

--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -29,7 +29,7 @@ import type { ClientInfo, ServerBackend } from '../utils/mcp/server';
 
 const backendDebug = debug('pw:mcp:backend');
 
-export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [] }> implements ServerBackend {
+export class BrowserBackend extends EventEmitter<{ disconnected: [] }> implements ServerBackend {
   private _tools: Tool[];
   private _context: Context | undefined;
   private _sessionLog: SessionLog | undefined;
@@ -37,9 +37,9 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [
   private _disconnected = false;
   private _disposed = false;
   private _browserContext: playwright.BrowserContext;
-  private _disposeCallback: ((disconnected: boolean) => Promise<void>) | undefined;
+  private _disposeCallback: (() => Promise<void>) | undefined;
 
-  constructor(config: ContextConfig, browserContext: playwright.BrowserContext, tools: Tool[], disposeCallback?: (disconnected: boolean) => Promise<void>) {
+  constructor(config: ContextConfig, browserContext: playwright.BrowserContext, tools: Tool[], disposeCallback?: () => Promise<void>) {
     super();
     this._config = config;
     this._tools = tools;
@@ -70,8 +70,7 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [], disposed: [
       return;
     this._disposed = true;
     await this._context?.dispose().catch(e => debug('pw:tools:error')(e));
-    await this._disposeCallback?.(this._disconnected).catch(e => debug('pw:tools:error')(e));
-    this.emit('disposed');
+    await this._disposeCallback?.().catch(e => debug('pw:tools:error')(e));
   }
 
   async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}, signal?: AbortSignal): Promise<mcpServer.CallToolResult> {

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -58,6 +58,7 @@ type CDPCommand = {
 type CDPResponse = CDPMessage;
 
 export class CDPRelayServer {
+  private _httpServer: http.Server;
   private _wsHost: string;
   private _browserChannel: string;
   private _executablePath?: string;
@@ -72,6 +73,7 @@ export class CDPRelayServer {
   private _extensionConnectionPromise = new ManualPromise<void>();
 
   constructor(server: http.Server, browserChannel: string, executablePath?: string, userDataDir?: string) {
+    this._httpServer = server;
     this._wsHost = addressToString(server.address(), { protocol: 'ws' });
     this._browserChannel = browserChannel;
     this._executablePath = executablePath;
@@ -160,6 +162,7 @@ export class CDPRelayServer {
   stop(): void {
     this._closeConnections('Server stopped');
     this._wss.close();
+    this._httpServer.close();
   }
 
   private _closeConnections(reason: string) {

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -41,10 +41,11 @@ export async function createExtensionBrowser(channel: string, executablePath: st
 
   try {
     await relay.establishExtensionConnection(clientName);
-    return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0 });
+    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0 });
+    browser.on('disconnected', () => relay.stop());
+    return browser;
   } catch (error) {
     relay.stop();
-    httpServer.close();
     throw error;
   }
 }

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -110,41 +110,59 @@ export function decorateMCPCommand(command: Command) {
           toolSchemas: tools.map(tool => tool.schema),
           create: async (clientInfo: ClientInfo) => {
             if (useSharedBrowser && !sharedBrowserPromise) {
-              sharedBrowserPromise = (async () => {
+              const promise = (async () => {
                 const { browser, canBind } = await createBrowserWithInfo(config, clientInfo, options);
                 if (canBind)
                   await browser.bind(clientInfo.clientName, { workspaceDir: clientInfo.cwd });
+                // Drop the dead browser, the next client will create a fresh
+                // one. The identity check avoids clobbering a replacement.
+                browser.once('disconnected', () => {
+                  if (sharedBrowserPromise === promise)
+                    sharedBrowserPromise = undefined;
+                });
                 return browser;
               })().catch(error => {
-                sharedBrowserPromise = undefined;
+                if (sharedBrowserPromise === promise)
+                  sharedBrowserPromise = undefined;
                 throw error;
               });
+              sharedBrowserPromise = promise;
             }
             clientCount++;
-            const { browser, canBind } = sharedBrowserPromise ? { browser: await sharedBrowserPromise, canBind: false } : await createBrowserWithInfo(config, clientInfo, options);
-            if (canBind) {
-              const count = (clientNameCounters.get(clientInfo.clientName) ?? 0) + 1;
-              clientNameCounters.set(clientInfo.clientName, count);
-              const sessionName = count > 1 ? `${clientInfo.clientName} (${count})` : clientInfo.clientName;
-              await browser.bind(sessionName, { workspaceDir: clientInfo.cwd });
-            }
-            const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
-            return new BrowserBackend(config, browserContext, tools, async () => {
-              clientCount--;
-
-              if (sharedBrowserPromise && clientCount > 0) {
-                if (config.browser.isolated) {
-                  testDebug('close context');
-                  await browserContext.close().catch(() => { });
-                }
-                return;
+            try {
+              const promise = sharedBrowserPromise;
+              const { browser, canBind } = promise ? { browser: await promise, canBind: false } : await createBrowserWithInfo(config, clientInfo, options);
+              if (canBind) {
+                const count = (clientNameCounters.get(clientInfo.clientName) ?? 0) + 1;
+                clientNameCounters.set(clientInfo.clientName, count);
+                const sessionName = count > 1 ? `${clientInfo.clientName} (${count})` : clientInfo.clientName;
+                await browser.bind(sessionName, { workspaceDir: clientInfo.cwd });
               }
+              const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
+              return new BrowserBackend(config, browserContext, tools, async disconnected => {
+                clientCount--;
 
-              testDebug('close browser');
-              sharedBrowserPromise = undefined;
-              await browserContext.close().catch(() => { });
-              await browserContext.browser()?.close().catch(() => { });
-            });
+                if (clientCount > 0 && !disconnected) {
+                  if (config.browser.isolated) {
+                    testDebug('close context');
+                    await browserContext.close().catch(() => { });
+                  }
+                  return;
+                }
+
+                if (!disconnected)
+                  testDebug('close browser');
+                if (sharedBrowserPromise === promise)
+                  sharedBrowserPromise = undefined;
+                await browserContext.close().catch(() => { });
+                await browser.close().catch(() => { });
+              });
+            } catch (error) {
+              // The dispose callback will not run for a failed create — undo
+              // the count.
+              clientCount--;
+              throw error;
+            }
           },
         };
         await mcpServer.start(factory, config.server);

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -114,8 +114,6 @@ export function decorateMCPCommand(command: Command) {
                 const { browser, canBind } = await createBrowserWithInfo(config, clientInfo, options);
                 if (canBind)
                   await browser.bind(clientInfo.clientName, { workspaceDir: clientInfo.cwd });
-                // Drop the dead browser, the next client will create a fresh
-                // one. The identity check avoids clobbering a replacement.
                 browser.once('disconnected', () => {
                   if (sharedBrowserPromise === promise)
                     sharedBrowserPromise = undefined;
@@ -157,8 +155,7 @@ export function decorateMCPCommand(command: Command) {
                 await browser.close().catch(() => { });
               });
             } catch (error) {
-              // The dispose callback will not run for a failed create — undo
-              // the count.
+              // The dispose callback never runs for a failed create.
               clientCount--;
               throw error;
             }

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -139,10 +139,10 @@ export function decorateMCPCommand(command: Command) {
                 await browser.bind(sessionName, { workspaceDir: clientInfo.cwd });
               }
               const browserContext = config.browser.isolated ? await browser.newContext(config.browser.contextOptions) : browser.contexts()[0];
-              return new BrowserBackend(config, browserContext, tools, async disconnected => {
+              return new BrowserBackend(config, browserContext, tools, async () => {
                 clientCount--;
 
-                if (clientCount > 0 && !disconnected) {
+                if (sharedBrowserPromise && clientCount > 0) {
                   if (config.browser.isolated) {
                     testDebug('close context');
                     await browserContext.close().catch(() => { });
@@ -150,8 +150,7 @@ export function decorateMCPCommand(command: Command) {
                   return;
                 }
 
-                if (!disconnected)
-                  testDebug('close browser');
+                testDebug('close browser');
                 if (sharedBrowserPromise === promise)
                   sharedBrowserPromise = undefined;
                 await browserContext.close().catch(() => { });

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -42,7 +42,7 @@ export interface ServerBackend {
   initialize?(clientInfo: ClientInfo): Promise<void>;
   callTool(name: string, args: CallToolRequest['params']['arguments'], signal: AbortSignal): Promise<CallToolResult>;
   dispose?(): Promise<void>;
-  once(event: 'disposed', listener: () => void): void;
+  once(event: 'disposed' | 'disconnected', listener: () => void): void;
 }
 
 export type ServerBackendFactory = {
@@ -80,13 +80,26 @@ export function createServer(name: string, version: string, factory: ServerBacke
 
     try {
       if (!backendPromise) {
-        backendPromise = initializeServer(server, factory, transportInitialized, runHeartbeat).then(backend => {
-          backend.once('disposed', () => { backendPromise = undefined; });
+        const promise = initializeServer(server, factory, transportInitialized, runHeartbeat).then(backend => {
+          const reset = () => {
+            // A concurrent call may have already replaced the backend.
+            if (backendPromise === promise)
+              backendPromise = undefined;
+          };
+          backend.once('disposed', reset);
+          // The browser disconnected between tool calls — dispose the backend
+          // right away, so that the next call runs against a live browser.
+          backend.once('disconnected', () => {
+            reset();
+            void backend.dispose?.().catch(serverDebug);
+          });
           return backend;
         }).catch(e => {
-          backendPromise = undefined;
+          if (backendPromise === promise)
+            backendPromise = undefined;
           throw e;
         });
+        backendPromise = promise;
       }
 
       const backend = await backendPromise;

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -42,7 +42,7 @@ export interface ServerBackend {
   initialize?(clientInfo: ClientInfo): Promise<void>;
   callTool(name: string, args: CallToolRequest['params']['arguments'], signal: AbortSignal): Promise<CallToolResult>;
   dispose?(): Promise<void>;
-  once(event: 'disposed' | 'disconnected', listener: () => void): void;
+  once(event: 'disconnected', listener: () => void): void;
 }
 
 export type ServerBackendFactory = {
@@ -81,16 +81,9 @@ export function createServer(name: string, version: string, factory: ServerBacke
     try {
       if (!backendPromise) {
         const promise = initializeServer(server, factory, transportInitialized, runHeartbeat).then(backend => {
-          const reset = () => {
-            // A concurrent call may have already replaced the backend.
+          backend.once('disconnected', () => {
             if (backendPromise === promise)
               backendPromise = undefined;
-          };
-          backend.once('disposed', reset);
-          // The browser disconnected between tool calls — dispose the backend
-          // right away, so that the next call runs against a live browser.
-          backend.once('disconnected', () => {
-            reset();
             void backend.dispose?.().catch(serverDebug);
           });
           return backend;

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -197,6 +197,15 @@ export async function startWithExtensionFlag(browserWithExtension: BrowserWithEx
   return client;
 }
 
+export async function readExtensionToken(browserContext: BrowserContext): Promise<string> {
+  const page = await browserContext.newPage();
+  await page.goto(`chrome-extension://${extensionId}/status.html`);
+  const token = await page.locator('.auth-token-code').textContent();
+  await page.close();
+  const [, value] = token?.split('=') || [];
+  return value;
+}
+
 // The connect page closes itself once a different tab is selected, which races
 // with the click — the request reaches the background while the page is being
 // torn down. Swallow the resulting "Target closed" error.

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -17,7 +17,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, connectAndNavigate, startWithExtensionFlag } from './extension-fixtures';
+import { test, testWithOldExtensionVersion, expect, extensionId, clickAllowAndSelect, connectAndNavigate, readExtensionToken, startWithExtensionFlag } from './extension-fixtures';
 import { utils } from '../../packages/playwright-core/lib/coreBundle';
 
 const { defaultUserDataDirForChannel } = utils;
@@ -342,18 +342,14 @@ test(`browser_cookie_list and browser_cookie_set work in extension mode`, {
 
 test(`bypass connection dialog with token`, async ({ browserWithExtension, startClient, server }) => {
   const browserContext = await browserWithExtension.launch();
-
-  const page = await browserContext.newPage();
-  await page.goto(`chrome-extension://${extensionId}/status.html`);
-  const token = await page.locator('.auth-token-code').textContent();
-  const [, value] = token?.split('=') || [];
+  const token = await readExtensionToken(browserContext);
 
   const clientName = 'token-bypass-client';
   const { client } = await startClient({
     clientName,
     args: [`--extension`],
     env: {
-      PLAYWRIGHT_MCP_EXTENSION_TOKEN: value,
+      PLAYWRIGHT_MCP_EXTENSION_TOKEN: token,
       PWTEST_EXTENSION_USER_DATA_DIR: browserWithExtension.userDataDir,
     },
   });
@@ -367,6 +363,45 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
     snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
   });
 
+  const page = await browserContext.newPage();
   await page.goto(`chrome-extension://${extensionId}/status.html`);
   await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
+});
+
+test(`reconnects after the extension connection drops`, {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41874' },
+}, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+  const token = await readExtensionToken(browserContext);
+
+  const { client, stderr } = await startClient({
+    args: [`--extension`],
+    env: {
+      DEBUG: 'pw:mcp:backend',
+      PLAYWRIGHT_MCP_EXTENSION_TOKEN: token,
+      PWTEST_EXTENSION_USER_DATA_DIR: browserWithExtension.userDataDir,
+    },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+
+  // Closing the last controlled tab drops the relay WebSocket, like the MV3
+  // service worker idle timeout would.
+  await browserContext.pages().find(page => page.url() === server.HELLO_WORLD)!.close();
+
+  // Wait for the MCP server to observe the disconnect.
+  await expect.poll(() => stderr()).toContain('browser disconnected');
+
+  // The next tool call reconnects transparently; the token bypasses the dialog.
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
 });

--- a/tests/mcp/cdp.spec.ts
+++ b/tests/mcp/cdp.spec.ts
@@ -130,6 +130,33 @@ test('auto-recover when remote browser disconnects mid-session', async ({ cdpSer
   });
 });
 
+test('transparently reconnects when the remote browser is restarted', async ({ cdpServer, startClient, server }) => {
+  const browserContext = await cdpServer.start();
+  const { client, stderr } = await startClient({
+    args: [`--cdp-endpoint=${cdpServer.endpoint}`],
+    env: { DEBUG: 'pw:mcp:backend' },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+
+  await browserContext.close();
+  await expect.poll(() => stderr()).toContain('browser disconnected');
+  await cdpServer.start();
+
+  // The very next tool call must reconnect, with no failed call in between.
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+});
+
 test('does not support --device', async () => {
   const result = spawnSync('node', [
     ...mcpServerPath, '--device=Pixel 5', '--cdp-endpoint=http://localhost:1234',

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -159,6 +159,7 @@ test('http transport browser sigint', async ({ serverEndpoint, server }) => {
     'create context': 1,
     'create http session': 1,
     'gracefully closing 1': 1,
+    'close browser': 1,
   });
 });
 
@@ -287,14 +288,14 @@ test('http transport isolated multiclient relaunches a crashed shared browser', 
   await transport2.terminateSession();
   await client2.close();
 
-  await expect.poll(() => formatLog(stderr())).toEqual({
+  await expect.poll(() => formatLog(stderr())).toEqual(({
     'create http session': 2,
     'delete http session': 2,
     'create browser (isolated)': 2,
     'create context': 4,
-    'close context': 1,
-    'close browser': 1,
-  });
+    'close browser': 2,
+    'close context': 2,
+  }));
 });
 
 test('http transport isolated closes the browser despite an earlier failed backend creation', async ({ serverEndpoint, server }, testInfo) => {

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import dns from 'dns';
 
 import { ChildProcess, spawn } from 'child_process';
+import { chromium } from 'playwright';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { test as baseTest, expect, mcpServerPath, formatLog } from './fixtures';
@@ -231,6 +232,103 @@ test('http transport browser lifecycle (isolated, concurrent clients)', { annota
     'create context': 3,
     'create browser (isolated)': 1,
     'close context': 2,
+    'close browser': 1,
+  });
+});
+
+test('http transport isolated multiclient relaunches a crashed shared browser', async ({ serverEndpoint, server }, testInfo) => {
+  // The CDP port lets the test kill the browser from the outside.
+  const port = 9400 + testInfo.workerIndex;
+  const configFile = testInfo.outputPath('config.json');
+  await fs.promises.writeFile(configFile, JSON.stringify({
+    browser: { launchOptions: { args: [`--remote-debugging-port=${port}`] } },
+  }));
+  const { url, stderr } = await serverEndpoint({
+    args: ['--isolated', `--config=${configFile}`],
+    env: { DEBUG: 'pw:mcp:test,pw:mcp:backend' },
+  });
+
+  const transport1 = new StreamableHTTPClientTransport(new URL('/mcp', url));
+  const client1 = new Client({ name: 'test', version: '1.0.0' });
+  await client1.connect(transport1);
+  await client1.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  const transport2 = new StreamableHTTPClientTransport(new URL('/mcp', url));
+  const client2 = new Client({ name: 'test', version: '1.0.0' });
+  await client2.connect(transport2);
+  await client2.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  // Kill the shared browser, as if it crashed, and wait for both backends
+  // to observe the disconnect.
+  const cdpBrowser = await chromium.connectOverCDP(`http://localhost:${port}`);
+  const session = await cdpBrowser.newBrowserCDPSession();
+  await session.send('Browser.close').catch(() => {});
+  await expect.poll(() => stderr().match(/browser disconnected/g)?.length).toBe(2);
+
+  // Each client transparently migrates to a fresh shared browser on its
+  // next tool call.
+  for (const client of [client1, client2]) {
+    expect(await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.HELLO_WORLD },
+    })).toHaveResponse({
+      snapshot: expect.stringContaining(`Hello, world!`),
+    });
+  }
+
+  await transport1.terminateSession();
+  await client1.close();
+  await transport2.terminateSession();
+  await client2.close();
+
+  await expect.poll(() => formatLog(stderr())).toEqual({
+    'create http session': 2,
+    'delete http session': 2,
+    'create browser (isolated)': 2,
+    'create context': 4,
+    'close context': 1,
+    'close browser': 1,
+  });
+});
+
+test('http transport isolated closes the browser despite an earlier failed backend creation', async ({ serverEndpoint, server }, testInfo) => {
+  // A failed backend creation must not leak the client count, otherwise the
+  // browser is never closed once the last client disconnects.
+  const storageStatePath = testInfo.outputPath('storage-state.json');
+  const { url, stderr } = await serverEndpoint({ args: ['--isolated', `--storage-state=${storageStatePath}`] });
+
+  const transport = new StreamableHTTPClientTransport(new URL('/mcp', url));
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(transport);
+
+  // The browser launches, but context creation fails on the missing file.
+  expect((await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).isError).toBe(true);
+
+  await fs.promises.writeFile(storageStatePath, JSON.stringify({ origins: [] }));
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+
+  await transport.terminateSession();
+  await client.close();
+
+  await expect.poll(() => formatLog(stderr())).toEqual({
+    'create http session': 1,
+    'delete http session': 1,
+    'create browser (isolated)': 1,
+    'create context': 1,
     'close browser': 1,
   });
 });

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -16,6 +16,8 @@
 
 import fs from 'fs';
 
+import { chromium } from 'playwright';
+
 import { test, expect, formatLog } from './fixtures';
 
 test('test reopen browser', async ({ startClient, server }) => {
@@ -156,6 +158,40 @@ test('isolated context', async ({ startClient, server }) => {
     arguments: { url: server.PREFIX },
   })).toHaveResponse({
     snapshot: expect.stringContaining(`Storage: NO`),
+  });
+});
+
+test('isolated context relaunches the browser after it dies', async ({ startClient, server, mcpBrowser }, testInfo) => {
+  test.skip(!['chrome', 'msedge', 'chromium'].includes(mcpBrowser!), 'The test kills the browser over CDP');
+
+  // The CDP port lets the test kill the browser from the outside.
+  const port = 9300 + testInfo.workerIndex;
+  const { client, stderr } = await startClient({
+    args: [`--isolated`],
+    config: { browser: { launchOptions: { args: [`--remote-debugging-port=${port}`] } } },
+    env: { DEBUG: 'pw:mcp:backend' },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+
+  // Kill the browser, as if it crashed.
+  const cdpBrowser = await chromium.connectOverCDP(`http://localhost:${port}`);
+  const session = await cdpBrowser.newBrowserCDPSession();
+  await session.send('Browser.close').catch(() => {});
+  await expect.poll(() => stderr()).toContain('browser disconnected');
+
+  // The very next tool call must relaunch the browser, with no failed call
+  // in between.
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
   });
 });
 


### PR DESCRIPTION
## Summary
- Recreate the MCP backend when its browser disconnected between tool calls, so the next call transparently reconnects: `--extension` reopens `connect.html` (silent with token bypass), cdp mode reconnects to the endpoint, persistent/isolated modes relaunch the browser.
- Stop the single-shot extension relay and its http server once the browser connection drops.
- Relaunch a crashed shared browser (`--isolated`/`--shared-browser-context` with multiple HTTP clients) instead of caching the dead one until all clients disconnect.

Fixes https://github.com/microsoft/playwright/issues/41874