### PR TITLE
fix(mcp extension): look for extension profile in default user data dir

### DIFF
--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -34,7 +34,7 @@ import ws, { WebSocketServer as wsServer } from 'ws';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { registry } from '../../server/registry/index';
 
-import { findPlaywrightExtensionProfile, playwrightExtensionId } from '../utils/extension';
+import { defaultUserDataDir, findPlaywrightExtensionProfile, playwrightExtensionId } from '../utils/extension';
 import { addressToString } from '../utils/mcp/http';
 import { logUnhandledError } from './log';
 import { ExtensionProtocolV2 } from './cdpRelayV2';
@@ -142,7 +142,7 @@ export class CDPRelayServer {
     const testUserDataDir = process.env.PWTEST_EXTENSION_USER_DATA_DIR;
     if (testUserDataDir)
       args.push(`--user-data-dir=${testUserDataDir}`);
-    const userDataDir = testUserDataDir ?? this._userDataDir;
+    const userDataDir = testUserDataDir ?? this._userDataDir ?? defaultUserDataDir(channel);
     const profileDirectory = userDataDir ? await findPlaywrightExtensionProfile(userDataDir) : undefined;
     if (profileDirectory)
       args.push(`--profile-directory=${profileDirectory}`);

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -15,12 +15,41 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 // Also pinned via the "key" field in packages/extension/manifest.json.
 export const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
 
 export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-extension/${playwrightExtensionId}`;
+
+export function defaultUserDataDir(channel: string): string | undefined {
+  const home = os.homedir();
+  switch (os.platform()) {
+    case 'win32': {
+      const localAppData = process.env.LOCALAPPDATA;
+      if (!localAppData)
+        return undefined;
+      if (channel === 'chrome')
+        return path.join(localAppData, 'Google', 'Chrome', 'User Data');
+      if (channel === 'msedge')
+        return path.join(localAppData, 'Microsoft', 'Edge', 'User Data');
+      return undefined;
+    }
+    case 'darwin':
+      if (channel === 'chrome')
+        return path.join(home, 'Library', 'Application Support', 'Google', 'Chrome');
+      if (channel === 'msedge')
+        return path.join(home, 'Library', 'Application Support', 'Microsoft Edge');
+      return undefined;
+    default:
+      if (channel === 'chrome')
+        return path.join(home, '.config', 'google-chrome');
+      if (channel === 'msedge')
+        return path.join(home, '.config', 'microsoft-edge');
+      return undefined;
+  }
+}
 
 export async function findPlaywrightExtensionProfile(userDataDir: string): Promise<string | undefined> {
   const profiles = await listProfileDirectories(userDataDir);


### PR DESCRIPTION
fixes the silent hang from microsoft/playwright-mcp#1571

running with `--extension` and no `--user-data-dir`, the relay spawns chrome without `--profile-directory`, so connect.html opens in the last used profile. if the extension lives in a different profile the page never loads and `establishExtensionConnection()` waits forever with no error.

this adds a `defaultUserDataDir(channel)` helper returning the standard chrome/edge user data folder per OS, used as fallback so the existing profile lookup actually runs on default setups. no behavior change if you pass your own dir. unknown channels fall back to old behavior.