### PR TITLE
feat(webkit): roll to r2339

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -45,7 +45,7 @@
     },
     {
       "name": "webkit",
-      "revision": "2337",
+      "revision": "2339",
       "installByDefault": true,
       "revisionOverrides": {
         "mac14": "2251",

--- a/tests/library/capabilities.spec.ts
+++ b/tests/library/capabilities.spec.ts
@@ -142,21 +142,18 @@ it('should not crash on showDirectoryPicker', async ({ page, server, browserName
   await page.waitForTimeout(3_000);
 });
 
-it('should not crash on storage.getDirectory()', async ({ page, server, browserName, isMac }) => {
-  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18235' });
+it('should not crash on storage.getDirectory()', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18235' }
+}, async ({ page, server, browserName }) => {
   await page.goto(server.EMPTY_PAGE);
   const error = await page.evaluate(async () => {
     const dir = await navigator.storage.getDirectory();
     return dir.name;
   }).catch(e => e);
-  if (browserName === 'webkit') {
-    if (isMac)
-      expect(error.message).toContain('UnknownError: The operation failed for an unknown transient reason');
-    else
-      expect(error.message).toContain('TypeError: undefined is not an object');
-  } else {
+  if (browserName === 'webkit')
+    expect(error.message).toContain('UnknownError: The operation failed for an unknown transient reason');
+  else
     expect(error).toBeFalsy();
-  }
 });
 
 it('navigator.clipboard should be present', async ({ page, server }) => {

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -315,3 +315,17 @@ it('exposes browser', async ({ launchPersistent }) => {
   // Next line should not throw.
   await context.close();
 });
+
+it('should support storage.getDirectory()', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/18235' }
+}, async ({ launchPersistent, server }) => {
+  const { context } = await launchPersistent();
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  const name = await page.evaluate(async () => {
+    const dir = await navigator.storage.getDirectory();
+    return dir.name;
+  }).catch(e => e);
+  expect(name).toBe('');
+  await context.close();
+});


### PR DESCRIPTION
## Summary
- Roll WebKit to r2339, which includes the fix for `navigator.storage.getDirectory()` in persistent contexts
- Add a persistent context test for `storage.getDirectory()` and unify expectations in the existing default context test

Fixes https://github.com/microsoft/playwright/issues/18235