### PR TITLE
fix(chromium): refuse WebUI navigations that crash the browser

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -49,11 +49,10 @@ import type * as channels from '../channels';
 
 export type WindowBounds = { top?: number, left?: number, width?: number, height?: number };
 
-// Chromium does not allow these WebUI hosts in off-the-record profiles, and instead redirects them
-// to a normal window in the original profile. That redirect crashes the browser process when the
-// profile was created over CDP, as it is for every non-persistent context. Refuse the navigation
-// rather than lose the whole browser. See https://github.com/microsoft/playwright/issues/41935.
-const kWebUIHostsUnavailableOffTheRecord = new Set([
+// Chromium disallows these WebUI hosts in off-the-record profiles and redirects them to the original
+// profile, which crashes browsers launched over CDP.
+// See https://github.com/microsoft/playwright/issues/41935.
+const kCrashingWebUIHosts = new Set([
   'apps',
   'extensions',
   'help',
@@ -61,6 +60,14 @@ const kWebUIHostsUnavailableOffTheRecord = new Set([
   'password-manager',
   'settings',
 ]);
+
+// Chromium canonicalizes WebUI urls as standard ones, so "VIEW-SOURCE:Chrome:Settings" ends up
+// being "chrome://settings/".
+function webUIHost(url: string): string {
+  const match = /^(?:view-source:)?(?:chrome|edge):\/*([^/?#]+)/i.exec(url);
+  const authority = match ? `http://${match[1]}` : '';
+  return URL.canParse(authority) ? new URL(authority).hostname : '';
+}
 
 export class CRPage implements PageDelegate {
   readonly utilityWorldName: string;
@@ -172,13 +179,8 @@ export class CRPage implements PageDelegate {
   private _assertNavigationDoesNotCrashBrowser(url: string) {
     if (this._browserContext.isPersistentContext())
       return;
-    if (!URL.canParse(url))
-      return;
-    // "chrome:" is not a special scheme, so the URL parser leaves the host case alone
-    // while Chromium resolves it case-insensitively.
-    const { protocol, hostname } = new URL(url);
-    if (protocol === 'chrome:' && kWebUIHostsUnavailableOffTheRecord.has(hostname.toLowerCase()))
-      throw new Error(`Cannot navigate to "${url}": Chromium does not allow this page in an isolated browser context, and opening it crashes the browser. Use browserType.launchPersistentContext() instead.`);
+    if (kCrashingWebUIHosts.has(webUIHost(url)))
+      throw new Error(`Cannot navigate to "${url}": this page is not available in an isolated browser context, and opening it crashes the browser. Use browserType.launchPersistentContext() instead.`);
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -49,17 +49,13 @@ import type * as channels from '../channels';
 
 export type WindowBounds = { top?: number, left?: number, width?: number, height?: number };
 
-// Chromium disallows these WebUI hosts in off-the-record profiles and redirects them to the original
-// profile, which crashes browsers launched over CDP.
+// Browsers disallow these WebUI hosts in off-the-record profiles and redirect them to the original
+// profile, which crashes when the profile was created over CDP. Edge allows most of them in InPrivate.
 // See https://github.com/microsoft/playwright/issues/41935.
-const kCrashingWebUIHosts = new Set([
-  'apps',
-  'extensions',
-  'help',
-  'history',
-  'password-manager',
-  'settings',
-]);
+const kCrashingWebUIHosts = {
+  chromium: new Set(['apps', 'extensions', 'help', 'history', 'password-manager', 'settings']),
+  edge: new Set(['history']),
+};
 
 // Chromium canonicalizes WebUI urls as standard ones, so "VIEW-SOURCE:Chrome:Settings" ends up
 // being "chrome://settings/".
@@ -179,7 +175,8 @@ export class CRPage implements PageDelegate {
   private _assertNavigationDoesNotCrashBrowser(url: string) {
     if (this._browserContext.isPersistentContext())
       return;
-    if (kCrashingWebUIHosts.has(webUIHost(url)))
+    const isEdge = this._browserContext._browser.userAgent().includes('Edg/');
+    if ((isEdge ? kCrashingWebUIHosts.edge : kCrashingWebUIHosts.chromium).has(webUIHost(url)))
       throw new Error(`Cannot navigate to "${url}": this page is not available in an isolated browser context, and opening it crashes the browser. Use browserType.launchPersistentContext() instead.`);
   }
 

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -49,6 +49,19 @@ import type * as channels from '../channels';
 
 export type WindowBounds = { top?: number, left?: number, width?: number, height?: number };
 
+// Chromium does not allow these WebUI hosts in off-the-record profiles, and instead redirects them
+// to a normal window in the original profile. That redirect crashes the browser process when the
+// profile was created over CDP, as it is for every non-persistent context. Refuse the navigation
+// rather than lose the whole browser. See https://github.com/microsoft/playwright/issues/41935.
+const kWebUIHostsUnavailableOffTheRecord = new Set([
+  'apps',
+  'extensions',
+  'help',
+  'history',
+  'password-manager',
+  'settings',
+]);
+
 export class CRPage implements PageDelegate {
   readonly utilityWorldName: string;
   readonly _mainFrameSession: FrameSession;
@@ -152,7 +165,20 @@ export class CRPage implements PageDelegate {
   }
 
   async navigateFrame(frame: frames.Frame, url: string, referrer: string | undefined): Promise<frames.GotoResult> {
+    this._assertNavigationDoesNotCrashBrowser(url);
     return this._sessionForFrame(frame)._navigate(frame, url, referrer);
+  }
+
+  private _assertNavigationDoesNotCrashBrowser(url: string) {
+    if (this._browserContext.isPersistentContext())
+      return;
+    if (!URL.canParse(url))
+      return;
+    // "chrome:" is not a special scheme, so the URL parser leaves the host case alone
+    // while Chromium resolves it case-insensitively.
+    const { protocol, hostname } = new URL(url);
+    if (protocol === 'chrome:' && kWebUIHostsUnavailableOffTheRecord.has(hostname.toLowerCase()))
+      throw new Error(`Cannot navigate to "${url}": Chromium does not allow this page in an isolated browser context, and opening it crashes the browser. Use browserType.launchPersistentContext() instead.`);
   }
 
   async updateExtraHTTPHeaders(): Promise<void> {

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -18,6 +18,8 @@
 import { contextTest as test, expect } from '../../config/browserTest';
 import { playwrightTest } from '../../config/browserTest';
 
+import type { Page } from 'playwright-core';
+
 test('should create a worker from a service worker', async ({ page, server }) => {
   const [worker] = await Promise.all([
     page.context().waitForEvent('serviceworker'),
@@ -748,28 +750,30 @@ test('should capture console.log from ServiceWorker start', async ({ context, pa
 });
 
 test.describe('WebUI navigation', () => {
-  const crashingHosts = ['apps', 'extensions', 'help', 'history', 'password-manager', 'settings'];
-  const crashingUrls = [
-    ...crashingHosts.map(host => `chrome://${host}`),
-    'chrome://extensions/',
-    'chrome://settings/help',
-    'chrome://SETTINGS',
-    'chrome:settings',
-    'chrome:///settings',
-    'view-source:chrome://settings',
-    'edge://settings',
-  ];
+  const isEdge = (channel: string | undefined) => !!channel?.startsWith('msedge');
+  const gotoError = (page: Page, url: string) => page.goto(url).then(() => '', e => e.message);
 
-  test('should refuse WebUI pages that crash the browser in an isolated context', async ({ browser, page }) => {
+  test('should refuse WebUI pages that crash the browser in an isolated context', async ({ browser, page, channel }) => {
     test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41935' });
+    test.skip(isEdge(channel), 'Edge only disallows chrome://history');
 
-    for (const url of crashingUrls) {
-      const error = await page.goto(url).catch(e => e);
-      expect(error.message).toContain(`Cannot navigate to "${url}"`);
-    }
+    const hosts = ['apps', 'extensions', 'help', 'history', 'password-manager', 'settings'];
+    for (const url of [...hosts.map(host => `chrome://${host}`), 'chrome://extensions/', 'chrome://settings/help', 'chrome://SETTINGS', 'chrome:settings', 'chrome:///settings', 'view-source:chrome://settings'])
+      expect(await gotoError(page, url)).toContain(`Cannot navigate to "${url}"`);
     // The refusal only matters because it keeps the browser process alive.
     expect(browser.isConnected()).toBe(true);
     expect(await page.evaluate(() => 1 + 1)).toBe(2);
+  });
+
+  test('should refuse WebUI pages that crash Edge in an isolated context', async ({ browser, page, channel }) => {
+    test.skip(!isEdge(channel), 'Edge has its own list of pages disallowed in InPrivate');
+
+    for (const url of ['edge://history', 'chrome://history', 'view-source:edge://history'])
+      expect(await gotoError(page, url)).toContain(`Cannot navigate to "${url}"`);
+    // Edge does allow these in InPrivate, so they must not be refused.
+    for (const url of ['edge://settings', 'edge://extensions'])
+      expect(await gotoError(page, url)).not.toContain('Cannot navigate to');
+    expect(browser.isConnected()).toBe(true);
   });
 
   test('should navigate to WebUI pages that work in an isolated context', async ({ page, headless }) => {

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -747,14 +747,23 @@ test('should capture console.log from ServiceWorker start', async ({ context, pa
   expect(consoleMessage.type()).toBe('log');
 });
 
-test.describe('chrome:// navigation', () => {
-  // Chromium disallows these WebUI hosts in off-the-record profiles.
-  const unavailableHosts = ['apps', 'extensions', 'help', 'history', 'password-manager', 'settings'];
+test.describe('WebUI navigation', () => {
+  const crashingHosts = ['apps', 'extensions', 'help', 'history', 'password-manager', 'settings'];
+  const crashingUrls = [
+    ...crashingHosts.map(host => `chrome://${host}`),
+    'chrome://extensions/',
+    'chrome://settings/help',
+    'chrome://SETTINGS',
+    'chrome:settings',
+    'chrome:///settings',
+    'view-source:chrome://settings',
+    'edge://settings',
+  ];
 
   test('should refuse WebUI pages that crash the browser in an isolated context', async ({ browser, page }) => {
     test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41935' });
 
-    for (const url of [...unavailableHosts.map(host => `chrome://${host}`), 'chrome://extensions/', 'chrome://settings/help', 'chrome://SETTINGS']) {
+    for (const url of crashingUrls) {
       const error = await page.goto(url).catch(e => e);
       expect(error.message).toContain(`Cannot navigate to "${url}"`);
     }

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -747,6 +747,44 @@ test('should capture console.log from ServiceWorker start', async ({ context, pa
   expect(consoleMessage.type()).toBe('log');
 });
 
+test.describe('chrome:// navigation', () => {
+  // Chromium disallows these WebUI hosts in off-the-record profiles.
+  const unavailableHosts = ['apps', 'extensions', 'help', 'history', 'password-manager', 'settings'];
+
+  test('should refuse WebUI pages that crash the browser in an isolated context', async ({ browser, page }) => {
+    test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41935' });
+
+    for (const url of [...unavailableHosts.map(host => `chrome://${host}`), 'chrome://extensions/', 'chrome://settings/help', 'chrome://SETTINGS']) {
+      const error = await page.goto(url).catch(e => e);
+      expect(error.message).toContain(`Cannot navigate to "${url}"`);
+    }
+    // The refusal only matters because it keeps the browser process alive.
+    expect(browser.isConnected()).toBe(true);
+    expect(await page.evaluate(() => 1 + 1)).toBe(2);
+  });
+
+  test('should navigate to WebUI pages that work in an isolated context', async ({ page, headless }) => {
+    test.skip(headless, 'WebUI pages are not available in headless');
+
+    const response = await page.goto('chrome://version');
+    expect(response.status()).toBe(200);
+  });
+
+  test('should navigate to any WebUI page in a persistent context', async ({ browserType, createUserDataDir, headless }) => {
+    test.skip(headless, 'WebUI pages are not available in headless');
+
+    const context = await browserType.launchPersistentContext(await createUserDataDir());
+    try {
+      const page = await context.newPage();
+      // Committing the navigation is all this asserts - waiting for the WebUI to load is slow and beside the point.
+      const response = await page.goto('chrome://extensions', { waitUntil: 'commit' });
+      expect(response.status()).toBe(200);
+    } finally {
+      await context.close();
+    }
+  });
+});
+
 test('should fire dialogclosed event when dialog is closed out of band', async ({ page }) => {
   // Establish the CDP session up front: creating one while a dialog is blocking the page hangs.
   const client = await page.context().newCDPSession(page);


### PR DESCRIPTION
## Summary

- `page.goto('chrome://extensions')` segfaults the Chromium browser process. The trigger is navigating inside a **CDP-created off-the-record browser context** — every non-persistent context — to one of the WebUIs Chromium disallows in incognito (`IsURLAllowedInIncognito`). Those redirect to a normal window in the original profile, and that path null-derefs.
- Reproducible with raw CDP and none of Playwright's launch switches, so this is upstream; the same navigation works in a regular profile, in real incognito, over `connectOverCDP`, and in `launchPersistentContext`.
- Refuses the six affected hosts (`apps`, `extensions`, `help`, `history`, `password-manager`, `settings`) in non-persistent contexts with an error pointing at `launchPersistentContext()`. Hosts that do work (`version`, `gpu`, `bookmarks`, `downloads`, `flags`, `policy`, …) are untouched, as is `chrome://crash`.
- Guards the `page.goto` path only — a click or `window.location` still reaches Chromium directly. Measurements and the raw-CDP repro are in https://github.com/microsoft/playwright/issues/41935#issuecomment-5077984297.

Fixes https://github.com/microsoft/playwright/issues/41935