### PR TITLE
fix(aria): preserve names from collapsed text contributors

### DIFF
--- a/packages/injected/src/ariaSnapshotDistiller.ts
+++ b/packages/injected/src/ariaSnapshotDistiller.ts
@@ -195,8 +195,9 @@ const removeRedundantNames: DistillerPlugin = {
 // name - that repeats the parent's accessible name adds no information, so it removes itself.
 // `inlineTextIntoGeneric` runs first, bubbling text up through nameless wrappers, so by the time
 // a wrapper exits its text faces the real parent - no need to look further up the ancestor chain.
-// Whenever the node is the source of that name, `removeRedundantNames` keeps the name - the node
-// is a leaf generic - so the text is never lost.
+// The removed text then only survives through the names derived from it, so the node's ref is
+// marked pending again - it may have been cleared on enter, before the node's other children
+// (e.g. a decorative image) were distilled away - and `removeRedundantNames` keeps those names.
 const removeNameRepeatingChild: DistillerPlugin = {
   name: 'removeNameRepeatingChild',
   exit(node: aria.AriaNode, ctx: DistillerContext): 'remove' | void {
@@ -205,8 +206,11 @@ const removeNameRepeatingChild: DistillerPlugin = {
       return;
     const singleTextChild = node.children.length === 1 && typeof node.children[0] === 'string' ? node.children[0] : undefined;
     const text = node.name ? (node.children.length ? undefined : node.name) : singleTextChild;
-    if (text && text === parent.name)
+    if (text && text === parent.name) {
+      if (node.ref)
+        ctx.pendingContentRefs.add(node.ref);
       return 'remove';
+    }
   },
 };
 

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -395,6 +395,30 @@ it('should omit redundant name when a contributor is a skipped leaf generic', as
   `);
 });
 
+it('should keep the name when the contributing wrapper collapses into repeating text', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41985' });
+  // The outer span is marked as represented while it still wraps the icon. Once the nameless
+  // image is dropped, the span collapses into a lone text repeating the button's name and removes
+  // itself, so the button must keep the name derived from it.
+  await page.setContent(`
+    <button>
+      <span>
+        <span>
+          <svg focusable="false" tabindex="-1" aria-hidden="true" viewBox="0 0 448 512">
+            <path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"/>
+          </svg>
+        </span>
+        <span>Add New Item</span>
+      </span>
+    </button>
+  `);
+
+  const snapshot = await snapshotForAI(page);
+  expect(snapshot).toContainYaml(`
+    - button "Add New Item" [ref=e2]
+  `);
+});
+
 it('should keep names not derived from printed nodes', async ({ page }) => {
   await page.setContent(`
     <h3 aria-label="Clipboard API issue"><a style="cursor: pointer" href="/issues/1">Clipboard API</a></h3>


### PR DESCRIPTION
## Summary

Preserves AI-mode ARIA snapshot names when a text-contributing wrapper is removed during distillation.

## Why

In AI snapshot mode, `removeRedundantNames` can mark a name contributor as represented before later distillation removes that same contributor.

For markup such as a button containing nested spans and an aria-hidden SVG, this caused both the visible text and the button name to disappear from the final snapshot:

```yaml
- button [ref=e2]
```

even though the accessible name is correctly computed as `Add New Item`.

## Change

When `removeNameRepeatingChild` removes a node whose text repeats the parent name, it marks that node’s ref as pending again. This preserves the ancestor name derived from that text while still allowing aria-hidden content to remain ignored.

## Tests

* `npm run ctest tests/page/page-aria-snapshot-ai.spec.ts -- --grep "contributing wrapper collapses"`

Fixes https://github.com/microsoft/playwright/issues/41985
