### PR TITLE
chore(test-runner): record videos via the screencast API instead of recordVideo

### DIFF
--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -70,6 +70,12 @@ If not specified the size will be equal to page viewport scaled down to fit into
 
 Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified in [`method: Screencast.start`]. Stopping after the page has been closed still saves the video recorded up to the moment the page was closed.
 
+### option: Screencast.stop.discard
+* since: v1.63
+- `discard` <[boolean]>
+
+Discard the recorded video instead of saving it to the [`option: Screencast.start.path`]. Defaults to `false`.
+
 ## async method: Screencast.showOverlay
 * since: v1.59
 - returns: <[Disposable]>

--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -68,7 +68,7 @@ If not specified the size will be equal to page viewport scaled down to fit into
 ## async method: Screencast.stop
 * since: v1.59
 
-Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified in [`method: Screencast.start`].
+Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified in [`method: Screencast.start`]. Stopping after the page has been closed still saves the video recorded up to the moment the page was closed.
 
 ## async method: Screencast.showOverlay
 * since: v1.59

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18262,7 +18262,8 @@ export interface Screencast {
 
   /**
    * Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
-   * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start).
+   * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start). Stopping after
+   * the page has been closed still saves the video recorded up to the moment the page was closed.
    */
   stop(): Promise<void>;
 }

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18264,8 +18264,15 @@ export interface Screencast {
    * Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
    * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start). Stopping after
    * the page has been closed still saves the video recorded up to the moment the page was closed.
+   * @param options
    */
-  stop(): Promise<void>;
+  stop(options?: {
+    /**
+     * Discard the recorded video instead of saving it to the
+     * [`path`](https://playwright.dev/docs/api/class-screencast#screencast-start-option-path). Defaults to `false`.
+     */
+    discard?: boolean;
+  }): Promise<void>;
 }
 
 type DeviceDescriptor = {

--- a/packages/playwright-core/src/client/artifact.ts
+++ b/packages/playwright-core/src/client/artifact.ts
@@ -35,13 +35,13 @@ export class Artifact extends ChannelOwner<channels.ArtifactChannel> {
     return (await this._channel.pathAfterFinished({}, kNoTimeout)).value;
   }
 
-  async saveAs(path: string): Promise<void> {
+  async saveAs(path: string, options: { dispose?: boolean } = {}): Promise<void> {
     if (!this._connection.isRemote()) {
-      await this._channel.saveAs({ path }, kNoTimeout);
+      await this._channel.saveAs({ path, dispose: options.dispose }, kNoTimeout);
       return;
     }
 
-    const result = await this._channel.saveAsStream({}, kNoTimeout);
+    const result = await this._channel.saveAsStream({ dispose: options.dispose }, kNoTimeout);
     const stream = Stream.from(result.stream);
     await mkdirIfNeeded(path);
     await new Promise((resolve, reject) => {

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -690,13 +690,18 @@ export type ArtifactPathAfterFinishedResult = {
 };
 export type ArtifactSaveAsParams = {
   path: string,
+  dispose?: boolean,
 };
 export type ArtifactSaveAsOptions = {
-
+  dispose?: boolean,
 };
 export type ArtifactSaveAsResult = void;
-export type ArtifactSaveAsStreamParams = {};
-export type ArtifactSaveAsStreamOptions = {};
+export type ArtifactSaveAsStreamParams = {
+  dispose?: boolean,
+};
+export type ArtifactSaveAsStreamOptions = {
+  dispose?: boolean,
+};
 export type ArtifactSaveAsStreamResult = {
   stream: StreamChannel,
 };

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -16,6 +16,7 @@
 
 import { Artifact } from './artifact';
 import { DisposableStub } from './disposable';
+import { isTargetClosedError } from './errors';
 import { kNoTimeout } from './timeoutSettings';
 
 import type * as api from '../../types/types';
@@ -62,11 +63,19 @@ export class Screencast implements api.Screencast {
     await this._page._wrapApiCall(async () => {
       this._started = false;
       this._onFrame = null;
-      await this._page._channel.screencastStop({}, kNoTimeout);
-      if (this._savePath)
-        await this._artifact?.saveAs(this._savePath);
+      const artifact = this._artifact;
+      const savePath = this._savePath;
       this._artifact = undefined;
       this._savePath = undefined;
+      try {
+        await this._page._channel.screencastStop({}, kNoTimeout);
+      } catch (e) {
+        // Closing the page stops the screencast server-side, and the video can still be saved.
+        if (!isTargetClosedError(e))
+          throw e;
+      }
+      if (artifact && savePath)
+        await artifact.saveAs(savePath, { dispose: true });
     });
   }
 

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -59,7 +59,7 @@ export class Screencast implements api.Screencast {
     return new DisposableStub(() => this.stop());
   }
 
-  async stop(): Promise<void> {
+  async stop(options: { discard?: boolean } = {}): Promise<void> {
     await this._page._wrapApiCall(async () => {
       this._started = false;
       this._onFrame = null;
@@ -74,7 +74,11 @@ export class Screencast implements api.Screencast {
         if (!isTargetClosedError(e))
           throw e;
       }
-      if (artifact && savePath)
+      if (!artifact || !savePath)
+        return;
+      if (options.discard)
+        await artifact.delete();
+      else
         await artifact.saveAs(savePath, { dispose: true });
     });
   }

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -691,13 +691,18 @@ export type ArtifactPathAfterFinishedResult = {
 };
 export type ArtifactSaveAsParams = {
   path: string,
+  dispose?: boolean,
 };
 export type ArtifactSaveAsOptions = {
-
+  dispose?: boolean,
 };
 export type ArtifactSaveAsResult = void;
-export type ArtifactSaveAsStreamParams = {};
-export type ArtifactSaveAsStreamOptions = {};
+export type ArtifactSaveAsStreamParams = {
+  dispose?: boolean,
+};
+export type ArtifactSaveAsStreamOptions = {
+  dispose?: boolean,
+};
 export type ArtifactSaveAsStreamResult = {
   stream: StreamChannel,
 };

--- a/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/artifactDispatcher.ts
@@ -51,7 +51,7 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
   }
 
   async saveAs(params: channels.ArtifactSaveAsParams, progress: Progress): Promise<channels.ArtifactSaveAsResult> {
-    return await progress.race(new Promise((resolve, reject) => {
+    await progress.race(new Promise<void>((resolve, reject) => {
       this._object.saveAs(progress, async (localPath, error) => {
         if (error) {
           reject(error);
@@ -66,6 +66,8 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
         }
       });
     }));
+    if (params.dispose)
+      this._dispose();
   }
 
   async saveAsStream(params: channels.ArtifactSaveAsStreamParams, progress: Progress): Promise<channels.ArtifactSaveAsStreamResult> {
@@ -77,7 +79,7 @@ export class ArtifactDispatcher extends Dispatcher<Artifact, channels.ArtifactCh
         }
         try {
           const readable = fs.createReadStream(localPath, { highWaterMark: 1024 * 1024 });
-          const stream = new StreamDispatcher(this, readable);
+          const stream = new StreamDispatcher(this, readable, { onClose: params.dispose ? () => this._dispose() : undefined });
           // Resolve with a stream, so that client starts saving the data.
           resolve({ stream });
           // Block the Artifact until the stream is consumed.

--- a/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/streamDispatcher.ts
@@ -35,12 +35,14 @@ class StreamSdkObject extends SdkObject {
 export class StreamDispatcher extends Dispatcher<StreamSdkObject, channels.StreamChannel, ArtifactDispatcher> implements channels.StreamChannel {
   _type_Stream = true;
   private _ended: boolean = false;
+  private _onClose: (() => void) | undefined;
 
-  constructor(scope: ArtifactDispatcher, stream: stream.Readable) {
+  constructor(scope: ArtifactDispatcher, stream: stream.Readable, options: { onClose?: () => void } = {}) {
     super(scope, new StreamSdkObject(scope._object, stream), 'Stream', {});
     // In Node v12.9.0+ we can use readableEnded.
     stream.once('end', () => this._ended =  true);
     stream.once('error', () => this._ended =  true);
+    this._onClose = options.onClose;
   }
 
   async read(params: channels.StreamReadParams, progress: Progress): Promise<channels.StreamReadResult> {
@@ -71,5 +73,6 @@ export class StreamDispatcher extends Dispatcher<StreamSdkObject, channels.Strea
 
   async close(params: channels.StreamCloseParams, progress: Progress): Promise<void> {
     this._object.stream.destroy();
+    this._onClose?.();
   }
 }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18262,7 +18262,8 @@ export interface Screencast {
 
   /**
    * Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
-   * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start).
+   * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start). Stopping after
+   * the page has been closed still saves the video recorded up to the moment the page was closed.
    */
   stop(): Promise<void>;
 }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18264,8 +18264,15 @@ export interface Screencast {
    * Stops the screencast and video recording if active. If a video was being recorded, saves it to the path specified
    * in [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start). Stopping after
    * the page has been closed still saves the video recorded up to the moment the page was closed.
+   * @param options
    */
-  stop(): Promise<void>;
+  stop(options?: {
+    /**
+     * Discard the recorded video instead of saving it to the
+     * [`path`](https://playwright.dev/docs/api/class-screencast#screencast-start-option-path). Defaults to `false`.
+     */
+    discard?: boolean;
+  }): Promise<void>;
 }
 
 type DeviceDescriptor = {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -41,7 +41,7 @@ import type { BrowserContext as BrowserContextImpl } from '../../playwright-core
 import type { APIRequestContext as APIRequestContextImpl, NewContextOptions as APIRequestContextOptions } from '../../playwright-core/src/client/fetch';
 import type { ChannelOwner } from '../../playwright-core/src/client/channelOwner';
 import type { Page as PageImpl } from '../../playwright-core/src/client/page';
-import type { BrowserContext, BrowserContextOptions, Disposable, LaunchOptions, Page, Tracing } from 'playwright-core';
+import type { BrowserContext, BrowserContextOptions, LaunchOptions, Page, Tracing } from 'playwright-core';
 
 export { expect } from './matchers/expect';
 export const _baseTest: TestType<{}, {}> = testType.rootTestType.test;
@@ -75,22 +75,23 @@ type WorkerFixtures = PlaywrightWorkerArgs & PlaywrightWorkerOptions & {
 
 // Note: utility fixtures and _utilityTest are reused in electron package. Be mindful when changing them.
 type UtilityTestFixtures = Pick<TestFixtures, 'testIdAttribute' | 'request' | '_combinedContextOptions' | '_setupArtifacts'>;
-type UtilityWorkerFixtures = Pick<WorkerFixtures, 'playwright' | 'screenshot' | 'trace'>;
+type UtilityWorkerFixtures = Pick<WorkerFixtures, 'playwright' | 'screenshot' | 'trace' | 'video'>;
 const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
   playwright: [async ({}, use) => {
     await use(require('playwright-core'));
   }, { scope: 'worker', box: true }],
   screenshot: ['off', { scope: 'worker', option: true, box: true }],
   trace: ['off', { scope: 'worker', option: true, box: true }],
+  video: ['off', { scope: 'worker', option: true, box: true }],
   testIdAttribute: ['data-testid', { option: true, box: true }],
   _combinedContextOptions: [{}, { box: true }],
-  _setupArtifacts: [async ({ playwright, screenshot, _combinedContextOptions }, use, testInfo) => {
+  _setupArtifacts: [async ({ playwright, screenshot, video, _combinedContextOptions }, use, testInfo) => {
     // This fixture has a separate zero-timeout slot to ensure that artifact collection
     // happens even after some fixtures or hooks time out.
     // Now that default test timeout is known, we can replace zero with an actual value.
     testInfo.setTimeout(testInfo.project.timeout);
 
-    const artifactsRecorder = new ArtifactsRecorder(playwright, tracing().artifactsDir(), screenshot);
+    const artifactsRecorder = new ArtifactsRecorder(playwright, tracing().artifactsDir(), screenshot, video);
     await artifactsRecorder.willStartTest(testInfo as TestInfoImpl);
 
     const tracingGroupSteps: TestStepInternal[] = [];
@@ -225,7 +226,6 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
   connectOptions: [async ({ _optionConnectOptions }, use) => {
     await use(connectOptionsFromEnv() || _optionConnectOptions);
   }, { scope: 'worker', option: true, box: true }],
-  video: ['off', { scope: 'worker', option: true, box: true }],
 
   _browserOptions: [async ({ playwright, headless, channel, launchOptions }, use) => {
     const options: LaunchOptions = {
@@ -390,13 +390,9 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
     playwright._defaultContextNavigationTimeout = undefined;
   }, { auto: 'all-hooks-included',  title: 'context configuration', box: true } as any],
 
-  _contextFactory: [async ({ browser, video, _reuseContext, _combinedContextOptions /** mitigate dep-via-auto lack of traceability */ }, use, testInfo) => {
+  _contextFactory: [async ({ browser, _combinedContextOptions /** mitigate dep-via-auto lack of traceability */ }, use, testInfo) => {
     const testInfoImpl = testInfo as TestInfoImpl;
-    const videoMode = normalizeVideoMode(video);
-    const captureVideo = shouldCaptureVideo(videoMode, testInfo) && !_reuseContext;
-    type VideoRecording = { savedPath: string, disposablePromise: Promise<Disposable | null> };
-    const contexts = new Map<BrowserContext, { close: () => Promise<void>, videos: VideoRecording[] }>();
-    let counter = 0;
+    const closeCallbacks: (() => Promise<void>)[] = [];
 
     await use(async options => {
       const hook = testInfoImpl._currentHookType();
@@ -407,8 +403,6 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
           `If you would like to configure your page before each test, do that in beforeEach hook instead.`,
         ].join('\n'));
       }
-      const show = typeof video === 'string' ? undefined : video.show;
-      const size = typeof video === 'string' ? undefined : video.size;
       const context = await browser.newContext(options) as BrowserContextImpl;
 
       let closed = false;
@@ -418,43 +412,12 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         closed = true;
         const closeReason = testInfo.status === 'timedOut' ? 'Test timeout of ' + testInfo.timeout + 'ms exceeded.' : 'Test ended.';
         await context.close({ reason: closeReason });
-        const preserveVideo = captureVideo && shouldPreserveVideo(videoMode, testInfo);
-        if (preserveVideo) {
-          const { videos } = contexts.get(context)!;
-          await Promise.all(videos.map(async ({ savedPath, disposablePromise }) => {
-            try {
-              const disposable = await disposablePromise;
-              if (!disposable)
-                return;
-              await disposable.dispose();
-              if (await existsAsync(savedPath))
-                testInfo.attachments.push({ name: 'video', path: savedPath, contentType: 'video/webm' });
-            } catch (e) {
-              // Silent catch empty videos.
-            }
-          }));
-        }
       };
-
-      const contextData = { close, videos: [] as VideoRecording[] };
-      if (captureVideo) {
-        context.on('page', page => {
-          // Note: outputPath() would create the output directory, do not use it here.
-          const savedPath = testInfoImpl._getOutputPath(`video${counter ? '-' + counter : ''}.webm`);
-          ++counter;
-          if (show?.actions)
-            void page.screencast.showActions(show.actions).catch(() => {});
-          contextData.videos.push({
-            savedPath,
-            disposablePromise: page.screencast.start({ path: savedPath, size }).catch(() => null),
-          });
-        });
-      }
-      contexts.set(context, contextData);
+      closeCallbacks.push(close);
       return { context, close };
     });
 
-    await Promise.all([...contexts.values()].map(data => data.close()));
+    await Promise.all(closeCallbacks.map(close => close()));
   }, { scope: 'test',  title: 'context', box: true }],
 
   _optionContextReuseMode: ['none', { scope: 'worker', option: true, box: true }],
@@ -462,12 +425,11 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
 
   reuseContext: [false, { scope: 'worker', option: true, box: true }],
 
-  _reuseContext: [async ({ video, _optionContextReuseMode, reuseContext }, use) => {
+  _reuseContext: [async ({ _optionContextReuseMode, reuseContext }, use) => {
     let mode = _optionContextReuseMode;
     if (process.env.PW_TEST_REUSE_CONTEXT || reuseContext)
       mode = 'when-possible';
-    const reuse = mode === 'when-possible' && normalizeVideoMode(video) === 'off';
-    await use(reuse);
+    await use(mode === 'when-possible');
   }, { scope: 'worker',  title: 'context', box: true }],
 
   context: async ({ browser, video, _reuseContext, _contextFactory }, use, testInfoPublic) => {
@@ -533,6 +495,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
 });
 
 type ScreenshotOption = PlaywrightWorkerOptions['screenshot'] | undefined;
+type VideoOption = PlaywrightWorkerOptions['video'] | undefined;
+type VideoRecording = { page: PageImpl, savedPath: string, startPromise: Promise<boolean> };
 
 function normalizeVideoMode(video: VideoMode | 'retry-with-video' | { mode: VideoMode } | undefined): VideoMode {
   if (!video)
@@ -726,9 +690,14 @@ class ArtifactsRecorder {
   private _screenshotRecorder: SnapshotRecorder;
   private _pageSnapshot: string | undefined;
 
-  constructor(playwright: PlaywrightImpl, artifactsDir: string, screenshot: ScreenshotOption) {
+  private _video: VideoOption;
+  private _videoRecordings = new Map<BrowserContextImpl, { listener: (page: Page) => void, recordings: VideoRecording[] }>();
+  private _videoCounter = 0;
+
+  constructor(playwright: PlaywrightImpl, artifactsDir: string, screenshot: ScreenshotOption, video: VideoOption) {
     this._playwright = playwright;
     this._artifactsDir = artifactsDir;
+    this._video = video;
     const screenshotOptions = typeof screenshot === 'string' ? undefined : screenshot;
     this._startedCollectingArtifacts = Symbol('startedCollectingArtifacts');
 
@@ -753,10 +722,12 @@ class ArtifactsRecorder {
 
   async didCreateBrowserContext(context: BrowserContextImpl) {
     await this._startTraceChunkOnContextCreation(context, context.tracing);
+    await this._startVideoRecording(context);
   }
 
   async willCloseBrowserContext(context: BrowserContextImpl) {
     await this._stopTracing(context, context.tracing);
+    await this._stopVideoRecording(context);
     await this._screenshotRecorder.captureTemporary(context);
     await this._takePageSnapshot(context);
   }
@@ -809,6 +780,7 @@ class ArtifactsRecorder {
       await this._stopTracing(context, context.tracing);
     })));
 
+    await Promise.all([...this._videoRecordings.keys()].map(context => this._stopVideoRecording(context)));
     await this._screenshotRecorder.persistTemporary();
 
     const context = leftoverContexts[0];
@@ -833,6 +805,50 @@ class ArtifactsRecorder {
         }, undefined);
       }
     }
+  }
+
+  private async _startVideoRecording(context: BrowserContextImpl) {
+    if (!shouldCaptureVideo(normalizeVideoMode(this._video), this._testInfo) || this._videoRecordings.has(context))
+      return;
+    const show = typeof this._video === 'string' ? undefined : this._video?.show;
+    const size = typeof this._video === 'string' ? undefined : this._video?.size;
+    const recordings: VideoRecording[] = [];
+    const startOnPage = (page: Page) => {
+      // Note: outputPath() would create the output directory, do not use it here.
+      const savedPath = this._testInfo._getOutputPath(`video${this._videoCounter ? '-' + this._videoCounter : ''}.webm`);
+      ++this._videoCounter;
+      const startPromise = (page as PageImpl)._wrapApiCall(async () => {
+        if (show?.actions)
+          void page.screencast.showActions(show.actions).catch(() => {});
+        await page.screencast.start({ path: savedPath, size });
+      }, { internal: true }).then(() => true, () => false);
+      recordings.push({ page: page as PageImpl, savedPath, startPromise });
+      return startPromise;
+    };
+    const listener = (page: Page) => void startOnPage(page);
+    this._videoRecordings.set(context, { listener, recordings });
+    context.on('page', listener);
+    await Promise.all(context.pages().map(startOnPage));
+  }
+
+  private async _stopVideoRecording(context: BrowserContextImpl) {
+    const entry = this._videoRecordings.get(context);
+    if (!entry)
+      return;
+    this._videoRecordings.delete(context);
+    context.off('page', entry.listener);
+    const preserve = shouldPreserveVideo(normalizeVideoMode(this._video), this._testInfo);
+    await Promise.all(entry.recordings.map(async ({ page, savedPath, startPromise }) => {
+      if (!await startPromise)
+        return;
+      try {
+        await page._wrapApiCall(() => page.screencast.stop({ discard: !preserve }), { internal: true });
+        if (preserve && await existsAsync(savedPath))
+          this._testInfo.attachments.push({ name: 'video', path: savedPath, contentType: 'video/webm' });
+      } catch (e) {
+        // Silently ignore failed videos.
+      }
+    }));
   }
 
   private async _startTraceChunkOnContextCreation(channelOwner: ChannelOwner, tracing: Tracing) {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -25,6 +25,7 @@ import { jsonStringifyForceASCII } from '@utils/ascii';
 import { createGuid } from '@utils/crypto';
 import { debugMode } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
+import { existsAsync } from '@utils/fileUtils';
 import { currentZone } from '@utils/zones';
 import { buildErrorContext } from './errorContext';
 import { config, testType } from './common';
@@ -40,7 +41,7 @@ import type { BrowserContext as BrowserContextImpl } from '../../playwright-core
 import type { APIRequestContext as APIRequestContextImpl, NewContextOptions as APIRequestContextOptions } from '../../playwright-core/src/client/fetch';
 import type { ChannelOwner } from '../../playwright-core/src/client/channelOwner';
 import type { Page as PageImpl } from '../../playwright-core/src/client/page';
-import type { BrowserContext, BrowserContextOptions, LaunchOptions, Page, Tracing } from 'playwright-core';
+import type { BrowserContext, BrowserContextOptions, Disposable, LaunchOptions, Page, Tracing } from 'playwright-core';
 
 export { expect } from './matchers/expect';
 export const _baseTest: TestType<{}, {}> = testType.rootTestType.test;
@@ -393,7 +394,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
     const testInfoImpl = testInfo as TestInfoImpl;
     const videoMode = normalizeVideoMode(video);
     const captureVideo = shouldCaptureVideo(videoMode, testInfo) && !_reuseContext;
-    const contexts = new Map<BrowserContext, { close: () => Promise<void>, pagesWithVideo: Page[] }>();
+    type VideoRecording = { savedPath: string, disposablePromise: Promise<Disposable | null> };
+    const contexts = new Map<BrowserContext, { close: () => Promise<void>, videos: VideoRecording[] }>();
     let counter = 0;
 
     await use(async options => {
@@ -406,14 +408,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         ].join('\n'));
       }
       const show = typeof video === 'string' ? undefined : video.show;
-      const videoOptions: BrowserContextOptions = captureVideo ? {
-        recordVideo: {
-          dir: tracing().artifactsDir(),
-          size: typeof video === 'string' ? undefined : video.size,
-          showActions: show?.actions,
-        }
-      } : {};
-      const context = await browser.newContext({ ...videoOptions, ...options }) as BrowserContextImpl;
+      const size = typeof video === 'string' ? undefined : video.size;
+      const context = await browser.newContext(options) as BrowserContextImpl;
 
       let closed = false;
       const close = async () => {
@@ -424,14 +420,15 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         await context.close({ reason: closeReason });
         const preserveVideo = captureVideo && shouldPreserveVideo(videoMode, testInfo);
         if (preserveVideo) {
-          const { pagesWithVideo: pagesForVideo } = contexts.get(context)!;
-          const videos = pagesForVideo.map(p => p.video()).filter(video => !!video);
-          await Promise.all(videos.map(async v => {
+          const { videos } = contexts.get(context)!;
+          await Promise.all(videos.map(async ({ savedPath, disposablePromise }) => {
             try {
-              const savedPath = testInfo.outputPath(`video${counter ? '-' + counter : ''}.webm`);
-              ++counter;
-              await v.saveAs(savedPath);
-              testInfo.attachments.push({ name: 'video', path: savedPath, contentType: 'video/webm' });
+              const disposable = await disposablePromise;
+              if (!disposable)
+                return;
+              await disposable.dispose();
+              if (await existsAsync(savedPath))
+                testInfo.attachments.push({ name: 'video', path: savedPath, contentType: 'video/webm' });
             } catch (e) {
               // Silent catch empty videos.
             }
@@ -439,9 +436,20 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
         }
       };
 
-      const contextData = { close, pagesWithVideo: [] as Page[] };
-      if (captureVideo)
-        context.on('page', page => contextData.pagesWithVideo.push(page));
+      const contextData = { close, videos: [] as VideoRecording[] };
+      if (captureVideo) {
+        context.on('page', page => {
+          // Note: outputPath() would create the output directory, do not use it here.
+          const savedPath = testInfoImpl._getOutputPath(`video${counter ? '-' + counter : ''}.webm`);
+          ++counter;
+          if (show?.actions)
+            void page.screencast.showActions(show.actions).catch(() => {});
+          contextData.videos.push({
+            savedPath,
+            disposablePromise: page.screencast.start({ path: savedPath, size }).catch(() => null),
+          });
+        });
+      }
       contexts.set(context, contextData);
       return { context, close };
     });

--- a/packages/protocol/spec/artifact.yml
+++ b/packages/protocol/spec/artifact.yml
@@ -30,10 +30,13 @@ Artifact:
       internal: true
       parameters:
         path: string
+        dispose: boolean?
 
     # Blocks path/failure/delete/context.close until the stream is closed.
     saveAsStream:
       internal: true
+      parameters:
+        dispose: boolean?
       returns:
         stream: Stream
 

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -362,9 +362,12 @@ scheme.ArtifactPathAfterFinishedResult = tObject({
 });
 scheme.ArtifactSaveAsParams = tObject({
   path: tString,
+  dispose: tOptional(tBoolean),
 });
 scheme.ArtifactSaveAsResult = tOptional(tObject({}));
-scheme.ArtifactSaveAsStreamParams = tOptional(tObject({}));
+scheme.ArtifactSaveAsStreamParams = tObject({
+  dispose: tOptional(tBoolean),
+});
 scheme.ArtifactSaveAsStreamResult = tObject({
   stream: tChannel(['Stream']),
 });

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -262,6 +262,35 @@ test('stop should not fail after page is closed', async ({ browser }) => {
   await context.close();
 });
 
+test('stop should discard video', async ({ browserType }, testInfo) => {
+  const artifactsDir = testInfo.outputPath('artifacts');
+  const browser = await browserType.launch({ artifactsDir });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const videoPath = testInfo.outputPath('video.webm');
+  await page.screencast.start({ path: videoPath });
+  await ensureSomeFrames(page);
+  await page.screencast.stop({ discard: true });
+  expect(fs.existsSync(videoPath)).toBe(false);
+  expect(fs.readdirSync(artifactsDir).filter(f => f.endsWith('.webm'))).toHaveLength(0);
+  await browser.close();
+});
+
+test('stop should discard video after page is closed', async ({ browserType }, testInfo) => {
+  const artifactsDir = testInfo.outputPath('artifacts');
+  const browser = await browserType.launch({ artifactsDir });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const videoPath = testInfo.outputPath('video.webm');
+  await page.screencast.start({ path: videoPath });
+  await ensureSomeFrames(page);
+  await page.close();
+  await page.screencast.stop({ discard: true });
+  expect(fs.existsSync(videoPath)).toBe(false);
+  expect(fs.readdirSync(artifactsDir).filter(f => f.endsWith('.webm'))).toHaveLength(0);
+  await browser.close();
+});
+
 test('empty video', async ({ browser }, testInfo) => {
   const size = { width: 800, height: 800 };
   const context = await browser.newContext({ viewport: size });

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -18,7 +18,6 @@ import fs from 'fs';
 import path from 'path';
 import { expect, browserTest as test } from '../config/browserTest';
 import { ensureSomeFrames } from '../config/utils';
-import { kTargetClosedErrorMessage } from '../config/errors';
 import { VideoPlayer } from './videoPlayer';
 
 test.skip(({ mode }) => mode !== 'default', 'screencast is not available in remote mode');
@@ -240,16 +239,26 @@ test('stop should not fail when no recording is in progress', async ({ browser }
   await context.close();
 });
 
-test('start should finish when page is closed', async ({ browser }, testInfo) => {
-  const context = await browser.newContext();
+test('stop should save video after page is closed', async ({ browser }, testInfo) => {
+  const size = { width: 800, height: 800 };
+  const context = await browser.newContext({ viewport: size });
   const page = await context.newPage();
   const videoPath = testInfo.outputPath('video.webm');
-  await page.screencast.start({ path: videoPath, size: { width: 800, height: 800 } });
+  await page.screencast.start({ path: videoPath, size });
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
   await ensureSomeFrames(page);
   await page.close();
-  const error = await page.screencast.stop().catch(e => e);
-  expect(error.message).toContain(kTargetClosedErrorMessage);
+  await page.screencast.stop();
+  expectRedFrames(videoPath, size);
+  await context.close();
+});
+
+test('stop should not fail after page is closed', async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.screencast.start({ onFrame: () => {} });
+  await page.close();
+  await page.screencast.stop();
   await context.close();
 });
 

--- a/tests/playwright-test/playwright.reuse.spec.ts
+++ b/tests/playwright-test/playwright.reuse.spec.ts
@@ -63,7 +63,7 @@ test('should reuse context', async ({ runInlineTest }) => {
   expect(result.passed).toBe(5);
 });
 
-test('should not reuse context with video if mode=when-possible', async ({ runInlineTest }, testInfo) => {
+test('should reuse context with video if mode=when-possible', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest(withReuseContext({
     'playwright.config.ts': `
       export default {
@@ -74,20 +74,22 @@ test('should not reuse context with video if mode=when-possible', async ({ runIn
       import { test, expect } from '@playwright/test';
       let lastContextGuid;
 
-      test('one', async ({ context }) => {
+      test('one', async ({ page, context }) => {
         lastContextGuid = context._guid;
+        await page.setContent('<div>ONE</div>');
       });
 
-      test('two', async ({ context }) => {
-        expect(context._guid).not.toBe(lastContextGuid);
+      test('two', async ({ page, context }) => {
+        expect(context._guid).toBe(lastContextGuid);
+        await page.setContent('<div>TWO</div>');
       });
     `,
   }), { workers: 1 });
 
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(2);
-  expect(fs.existsSync(testInfo.outputPath('test-results', 'reuse-one', 'video.webm'))).toBeFalsy();
-  expect(fs.existsSync(testInfo.outputPath('test-results', 'reuse-two', 'video.webm'))).toBeFalsy();
+  expect(fs.existsSync(testInfo.outputPath('test-results', 'src-reuse-one', 'video.webm'))).toBeTruthy();
+  expect(fs.existsSync(testInfo.outputPath('test-results', 'src-reuse-two', 'video.webm'))).toBeTruthy();
 });
 
 test('should reuse context with trace if mode=when-possible', async ({ runInlineTest }, testInfo) => {

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -644,20 +644,50 @@ test('should work with video size', async ({ runInlineTest }) => {
   expect(videoPlayer.videoHeight).toBe(110);
 });
 
+test('should record video for contexts created by the test', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      module.exports = {
+        use: { video: 'on' },
+        name: 'chromium',
+      };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({ browser }) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.setContent('<div>PASS</div>');
+        await page.waitForTimeout(3000);
+        await context.close();
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  const dir = testInfo.outputPath(`test-results/a-pass-chromium/`);
+  const video = fs.readdirSync(dir).find(file => file.endsWith('webm'));
+  expect(video).toBe('video.webm');
+  expect(result.report.suites[0].specs[0].tests[0].results[0].attachments).toEqual([{
+    name: 'video',
+    contentType: 'video/webm',
+    path: path.join(dir, video!),
+  }]);
+});
+
 test('should save video when the page is closed before the test ends', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.js': `
       module.exports = {
-        use: { video: { mode: 'on' } },
+        use: { video: 'on' },
         name: 'chromium',
-        preserveOutput: 'always',
       };
     `,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('pass', async ({ page }) => {
         await page.setContent('<div>PASS</div>');
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(3000);
         await page.close();
       });
     `,
@@ -672,6 +702,39 @@ test('should save video when the page is closed before the test ends', async ({ 
     contentType: 'video/webm',
     path: path.join(dir, video!),
   }]);
+});
+
+test('should record video for pages created before the test', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'playwright.config.js': `
+      module.exports = {
+        use: { video: 'on' },
+        name: 'chromium',
+      };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      let page;
+      test.beforeAll(async ({ browser }) => {
+        const context = await browser.newContext();
+        page = await context.newPage();
+      });
+      test('one', async () => {
+        await page.setContent('<div>ONE</div>');
+        await page.waitForTimeout(3000);
+      });
+      test('two', async () => {
+        await page.setContent('<div>TWO</div>');
+        await page.waitForTimeout(3000);
+      });
+    `,
+  }, { workers: 1 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  for (const dir of ['a-one-chromium', 'a-two-chromium']) {
+    const video = fs.readdirSync(testInfo.outputPath('test-results', dir)).find(file => file.endsWith('webm'));
+    expect(video, dir).toBe('video.webm');
+  }
 });
 
 test('should pass fixture defaults to tests', async ({ runInlineTest }) => {

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -644,8 +644,7 @@ test('should work with video size', async ({ runInlineTest }) => {
   expect(videoPlayer.videoHeight).toBe(110);
 });
 
-test('should work with video.path() throwing', async ({ runInlineTest }, testInfo) => {
-  // When running remotely, video.path() is not available, so we must not use it.
+test('should save video when the page is closed before the test ends', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.js': `
       module.exports = {
@@ -657,9 +656,9 @@ test('should work with video.path() throwing', async ({ runInlineTest }, testInf
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('pass', async ({ page }) => {
-        page.video().path = () => { throw new Error('No-no!'); };
         await page.setContent('<div>PASS</div>');
-        await page.waitForTimeout(3000);
+        await page.waitForTimeout(1000);
+        await page.close();
       });
     `,
   }, { workers: 1 });
@@ -667,7 +666,12 @@ test('should work with video.path() throwing', async ({ runInlineTest }, testInf
   expect(result.passed).toBe(1);
   const dir = testInfo.outputPath(`test-results/a-pass-chromium/`);
   const video = fs.readdirSync(dir).find(file => file.endsWith('webm'));
-  expect(video).toBeTruthy();
+  expect(video).toBe('video.webm');
+  expect(result.report.suites[0].specs[0].tests[0].results[0].attachments).toEqual([{
+    name: 'video',
+    contentType: 'video/webm',
+    path: path.join(dir, video!),
+  }]);
 });
 
 test('should pass fixture defaults to tests', async ({ runInlineTest }) => {


### PR DESCRIPTION
## Summary
- Record fixture videos through `page.screencast.start()`/`stop()` instead of the `recordVideo` context option.
- Move video recording into `ArtifactsRecorder`, symmetric with trace recording: starts on context creation (including contexts created by the test and pages that exist before the test), stops on context close.
- Add a `dispose` option to `Artifact.saveAs()` and a `discard` option to `Screencast.stop()`; non-preserved videos are deleted server-side instead of accumulating in the artifacts dir.
- Allow context reuse with video recording enabled.