### PR TITLE
fix(types): preserve branded primitives in evaluate Unboxed

### DIFF
--- a/packages/playwright-core/types/structs.d.ts
+++ b/packages/playwright-core/types/structs.d.ts
@@ -26,10 +26,13 @@ export type Serializable = any;
 export type EvaluationArgument = {};
 
 type CallbackResult<T> = T extends PromiseLike<infer U> ? Promise<Unboxed<U>> : Promise<Unboxed<T>>;
-export type NoHandles<Arg> = Arg extends JSHandle ? never : (Arg extends Function ? never : (Arg extends object ? { [Key in keyof Arg]: NoHandles<Arg[Key]> } : Arg));
+// Primitive guard must come before `object` / `Function` so branded primitives like
+// `string & { [brand]: ... }` stay themselves instead of being mapped over String.prototype.
+export type NoHandles<Arg> = Arg extends JSHandle ? never : (Arg extends string | number | boolean | bigint | symbol ? Arg : (Arg extends Function ? never : (Arg extends object ? { [Key in keyof Arg]: NoHandles<Arg[Key]> } : Arg)));
 export type Unboxed<Arg> =
   Arg extends ElementHandle<infer T> ? T :
   Arg extends JSHandle<infer T> ? T :
+  Arg extends string | number | boolean | bigint | symbol | null | undefined ? Arg :
   Arg extends (...args: infer T) => infer R ? (...args: T) => CallbackResult<R> :
   Arg extends NoHandles<Arg> ? Arg :
   Arg extends [infer A0] ? [Unboxed<A0>] :

--- a/utils/generate_types/test/test.ts
+++ b/utils/generate_types/test/test.ts
@@ -19,6 +19,11 @@ import * as playwright from 'playwright';
 type AssertType<T, S> = S extends T ? AssertNotAny<S> : false;
 type AssertNotAny<S> = {notRealProperty: number} extends S ? false : true;
 
+declare const __brand: unique symbol;
+type Branded<T, B> = T & { [__brand]: B };
+type IsoDate = Branded<string, 'IsoDate'>;
+type UserId = Branded<number, 'UserId'>;
+
 // Examples taken from README
 (async () => {
   const browser = await playwright.chromium.launch();
@@ -456,6 +461,36 @@ playwright.chromium.launch().then(async browser => {
       const assertion: AssertType<Promise<{ double: number, add: number }>, typeof value> = true;
     }, { cb: func });
   }
+  await browser.close();
+})();
+
+// branded primitive args must stay branded through Unboxed (https://github.com/microsoft/playwright/issues/42000)
+(async () => {
+  const browser = await playwright.chromium.launch();
+  const page = await browser.newPage();
+
+  function takesIsoDate(date: IsoDate): void { void date; }
+  function takesUserId(id: UserId): void { void id; }
+
+  const date = '2026-01-15' as IsoDate;
+  const userId = 42 as UserId;
+
+  {
+    await page.evaluate((d: IsoDate) => void d, date);
+  }
+  {
+    await page.evaluate(d => takesIsoDate(d), date);
+  }
+  {
+    await page.evaluate(({ d }) => takesIsoDate(d), { d: date });
+  }
+  {
+    await page.evaluate(id => takesUserId(id), userId);
+  }
+  {
+    await page.evaluate(({ id }) => takesUserId(id), { id: userId });
+  }
+
   await browser.close();
 })();
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/42000

## Summary
Branded primitives (`string & { brand }`, etc.) were treated as objects by `NoHandles`/`Unboxed` after callback support landed in 1.62, so `String.prototype` methods were rewritten to return promises and `page.evaluate` args no longer type-checked.

Guard primitives before the `object`/`Function` branches so branded values stay themselves, and add type tests covering the issue repro (plus branded `number`).

## Test plan
- [x] `tsc -p utils/generate_types/test/tsconfig.json` (via `npm run test-types`) passes with the new branded-primitive cases