### PR TITLE
chore: remove firefox-beta and chromium-tip-of-tree channels

### DIFF
--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -16,32 +16,11 @@
       "title": "Chrome Headless Shell"
     },
     {
-      "name": "chromium-tip-of-tree",
-      "revision": "1433",
-      "installByDefault": false,
-      "browserVersion": "151.0.7893.0",
-      "title": "Chrome Canary for Testing"
-    },
-    {
-      "name": "chromium-tip-of-tree-headless-shell",
-      "revision": "1433",
-      "installByDefault": false,
-      "browserVersion": "151.0.7893.0",
-      "title": "Chrome Canary Headless Shell"
-    },
-    {
       "name": "firefox",
       "revision": "1539",
       "installByDefault": true,
       "browserVersion": "153.0",
       "title": "Firefox"
-    },
-    {
-      "name": "firefox-beta",
-      "revision": "1526",
-      "installByDefault": false,
-      "browserVersion": "152.0b1",
-      "title": "Firefox Beta"
     },
     {
       "name": "webkit",

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -417,8 +417,6 @@ export class Chromium extends BrowserType {
   override getExecutableName(options: types.LaunchOptions): string {
     if (options.channel && registry.isChromiumAlias(options.channel))
       return 'chromium';
-    if (options.channel === 'chromium-tip-of-tree')
-      return options.headless ? 'chromium-tip-of-tree-headless-shell' : 'chromium-tip-of-tree';
     if (options.channel)
       return options.channel;
     return options.headless ? 'chromium-headless-shell' : 'chromium';

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -78,22 +78,6 @@ const EXECUTABLE_PATHS = {
     'mac-arm64': ['chrome-headless-shell-mac-arm64', 'chrome-headless-shell'],
     'win-x64': ['chrome-headless-shell-win64', 'chrome-headless-shell.exe'],
   },
-  'chromium-tip-of-tree': {
-    '<unknown>': undefined,
-    'linux-x64': ['chrome-linux64', 'chrome'],
-    'linux-arm64': ['chrome-linux', 'chrome'],  // non-cft build
-    'mac-x64': ['chrome-mac-x64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing'],
-    'mac-arm64': ['chrome-mac-arm64', 'Google Chrome for Testing.app', 'Contents', 'MacOS', 'Google Chrome for Testing'],
-    'win-x64': ['chrome-win64', 'chrome.exe'],
-  },
-  'chromium-tip-of-tree-headless-shell': {
-    '<unknown>': undefined,
-    'linux-x64': ['chrome-headless-shell-linux64', 'chrome-headless-shell'],
-    'linux-arm64': ['chrome-linux', 'headless_shell'],  // non-cft build
-    'mac-x64': ['chrome-headless-shell-mac-x64', 'chrome-headless-shell'],
-    'mac-arm64': ['chrome-headless-shell-mac-arm64', 'chrome-headless-shell'],
-    'win-x64': ['chrome-headless-shell-win64', 'chrome-headless-shell.exe'],
-  },
   'firefox': {
     '<unknown>': undefined,
     'linux-x64': ['firefox', 'firefox'],
@@ -213,76 +197,6 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac26-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
     'win64': cftUrl('win64/chrome-headless-shell-win64.zip'),
   },
-  'chromium-tip-of-tree': {
-    '<unknown>': undefined,
-    'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': undefined,
-    'ubuntu22.04-x64': cftUrl('linux64/chrome-linux64.zip'),
-    'ubuntu24.04-x64': cftUrl('linux64/chrome-linux64.zip'),
-    'ubuntu26.04-x64': cftUrl('linux64/chrome-linux64.zip'),
-    'ubuntu18.04-arm64': undefined,
-    'ubuntu20.04-arm64': undefined,
-    'ubuntu22.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'ubuntu24.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'ubuntu26.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'debian11-x64': undefined,
-    'debian11-arm64': undefined,
-    'debian12-x64': cftUrl('linux64/chrome-linux64.zip'),
-    'debian12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'debian13-x64': cftUrl('linux64/chrome-linux64.zip'),
-    'debian13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'mac10.13': undefined,
-    'mac10.14': undefined,
-    'mac10.15': undefined,
-    'mac11': undefined,
-    'mac11-arm64': undefined,
-    'mac12': undefined,
-    'mac12-arm64': undefined,
-    'mac13': undefined,
-    'mac13-arm64': undefined,
-    'mac14': cftUrl('mac-x64/chrome-mac-x64.zip'),
-    'mac14-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
-    'mac15': cftUrl('mac-x64/chrome-mac-x64.zip'),
-    'mac15-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
-    'mac26': cftUrl('mac-x64/chrome-mac-x64.zip'),
-    'mac26-arm64': cftUrl('mac-arm64/chrome-mac-arm64.zip'),
-    'win64': cftUrl('win64/chrome-win64.zip'),
-  },
-  'chromium-tip-of-tree-headless-shell': {
-    '<unknown>': undefined,
-    'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': undefined,
-    'ubuntu22.04-x64': cftUrl('linux64/chrome-headless-shell-linux64.zip'),
-    'ubuntu24.04-x64': cftUrl('linux64/chrome-headless-shell-linux64.zip'),
-    'ubuntu26.04-x64': cftUrl('linux64/chrome-headless-shell-linux64.zip'),
-    'ubuntu18.04-arm64': undefined,
-    'ubuntu20.04-arm64': undefined,
-    'ubuntu22.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'ubuntu24.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'ubuntu26.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'debian11-x64': undefined,
-    'debian11-arm64': undefined,
-    'debian12-x64': cftUrl('linux64/chrome-headless-shell-linux64.zip'),
-    'debian12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'debian13-x64': cftUrl('linux64/chrome-headless-shell-linux64.zip'),
-    'debian13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'mac10.13': undefined,
-    'mac10.14': undefined,
-    'mac10.15': undefined,
-    'mac11': undefined,
-    'mac11-arm64': undefined,
-    'mac12': undefined,
-    'mac12-arm64': undefined,
-    'mac13': undefined,
-    'mac13-arm64': undefined,
-    'mac14': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
-    'mac14-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
-    'mac15': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
-    'mac15-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
-    'mac26': cftUrl('mac-x64/chrome-headless-shell-mac-x64.zip'),
-    'mac26-arm64': cftUrl('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
-    'win64': cftUrl('win64/chrome-headless-shell-win64.zip'),
-  },
   'firefox': {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
@@ -317,41 +231,6 @@ const DOWNLOAD_PATHS: Record<string, DownloadPaths> = {
     'mac26': 'builds/firefox/%s/firefox-mac.zip',
     'mac26-arm64': 'builds/firefox/%s/firefox-mac-arm64.zip',
     'win64': 'builds/firefox/%s/firefox-win64.zip',
-  },
-  'firefox-beta': {
-    '<unknown>': undefined,
-    'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': undefined,
-    'ubuntu22.04-x64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-22.04.zip',
-    'ubuntu24.04-x64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-24.04.zip',
-    'ubuntu26.04-x64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-24.04.zip',
-    'ubuntu18.04-arm64': undefined,
-    'ubuntu20.04-arm64': undefined,
-    'ubuntu22.04-arm64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-22.04-arm64.zip',
-    'ubuntu24.04-arm64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-24.04-arm64.zip',
-    'ubuntu26.04-arm64': 'builds/firefox-beta/%s/firefox-beta-ubuntu-24.04-arm64.zip',
-    'debian11-x64': undefined,
-    'debian11-arm64': undefined,
-    'debian12-x64': 'builds/firefox-beta/%s/firefox-beta-debian-12.zip',
-    'debian12-arm64': 'builds/firefox-beta/%s/firefox-beta-debian-12-arm64.zip',
-    'debian13-x64': 'builds/firefox-beta/%s/firefox-beta-debian-12.zip',
-    'debian13-arm64': 'builds/firefox-beta/%s/firefox-beta-debian-12-arm64.zip',
-    'mac10.13': undefined,
-    'mac10.14': undefined,
-    'mac10.15': undefined,
-    'mac11': undefined,
-    'mac11-arm64': undefined,
-    'mac12': undefined,
-    'mac12-arm64': undefined,
-    'mac13': undefined,
-    'mac13-arm64': undefined,
-    'mac14': 'builds/firefox-beta/%s/firefox-beta-mac.zip',
-    'mac14-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
-    'mac15': 'builds/firefox-beta/%s/firefox-beta-mac.zip',
-    'mac15-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
-    'mac26': 'builds/firefox-beta/%s/firefox-beta-mac.zip',
-    'mac26-arm64': 'builds/firefox-beta/%s/firefox-beta-mac-arm64.zip',
-    'win64': 'builds/firefox-beta/%s/firefox-beta-win64.zip',
   },
   'webkit': {
     '<unknown>': undefined,
@@ -717,44 +596,6 @@ export class Registry {
       _isHermeticInstallation: true,
     });
 
-    const chromiumTipOfTreeHeadlessShell = descriptors.find(d => d.name === 'chromium-tip-of-tree-headless-shell')!;
-    const chromiumTipOfTreeHeadlessShellExecutable = findExecutablePath(chromiumTipOfTreeHeadlessShell.dir, 'chromium-tip-of-tree-headless-shell');
-    this._executables.push({
-      name: 'chromium-tip-of-tree-headless-shell',
-      browserName: 'chromium',
-      directory: chromiumTipOfTreeHeadlessShell.dir,
-      executablePath: () => chromiumTipOfTreeHeadlessShellExecutable,
-      executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium', chromiumTipOfTreeHeadlessShellExecutable, chromiumTipOfTreeHeadlessShell.installByDefault, sdkLanguage),
-      installType: chromiumTipOfTreeHeadlessShell.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTreeHeadlessShell.dir, ['chrome-linux'], [], ['chrome-win']),
-      downloadURLs: this._downloadURLs(chromiumTipOfTreeHeadlessShell),
-      title: chromiumTipOfTreeHeadlessShell.title,
-      revision: chromiumTipOfTreeHeadlessShell.revision,
-      browserVersion: chromiumTipOfTreeHeadlessShell.browserVersion,
-      _install: force => this._downloadExecutable(chromiumTipOfTreeHeadlessShell, force, chromiumTipOfTreeHeadlessShellExecutable),
-      _dependencyGroup: 'chromium',
-      _isHermeticInstallation: true,
-    });
-
-    const chromiumTipOfTree = descriptors.find(d => d.name === 'chromium-tip-of-tree')!;
-    const chromiumTipOfTreeExecutable = findExecutablePath(chromiumTipOfTree.dir, 'chromium-tip-of-tree');
-    this._executables.push({
-      name: 'chromium-tip-of-tree',
-      browserName: 'chromium',
-      directory: chromiumTipOfTree.dir,
-      executablePath: () => chromiumTipOfTreeExecutable,
-      executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('chromium-tip-of-tree', chromiumTipOfTreeExecutable, chromiumTipOfTree.installByDefault, sdkLanguage),
-      installType: chromiumTipOfTree.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, chromiumTipOfTree.dir, ['chrome-linux'], [], ['chrome-win']),
-      downloadURLs: this._downloadURLs(chromiumTipOfTree),
-      title: chromiumTipOfTree.title,
-      revision: chromiumTipOfTree.revision,
-      browserVersion: chromiumTipOfTree.browserVersion,
-      _install: force => this._downloadExecutable(chromiumTipOfTree, force, chromiumTipOfTreeExecutable),
-      _dependencyGroup: 'chromium',
-      _isHermeticInstallation: true,
-    });
-
     this._executables.push(this._createChromiumChannel('chrome', {
       'linux': '/opt/google/chrome/chrome',
       'darwin': '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
@@ -854,25 +695,6 @@ export class Registry {
       revision: firefox.revision,
       browserVersion: firefox.browserVersion,
       _install: force => this._downloadExecutable(firefox, force, firefoxExecutable),
-      _dependencyGroup: 'firefox',
-      _isHermeticInstallation: true,
-    });
-
-    const firefoxBeta = descriptors.find(d => d.name === 'firefox-beta')!;
-    const firefoxBetaExecutable = findExecutablePath(firefoxBeta.dir, 'firefox');
-    this._executables.push({
-      name: 'firefox-beta',
-      browserName: 'firefox',
-      directory: firefoxBeta.dir,
-      executablePath: () => firefoxBetaExecutable,
-      executablePathOrDie: (sdkLanguage: string) => executablePathOrDie('firefox-beta', firefoxBetaExecutable, firefoxBeta.installByDefault, sdkLanguage),
-      installType: firefoxBeta.installByDefault ? 'download-by-default' : 'download-on-demand',
-      _validateHostRequirements: (sdkLanguage: string) => this._validateHostRequirements(sdkLanguage, firefoxBeta.dir, ['firefox'], [], ['firefox']),
-      downloadURLs: this._downloadURLs(firefoxBeta),
-      title: firefoxBeta.title,
-      revision: firefoxBeta.revision,
-      browserVersion: firefoxBeta.browserVersion,
-      _install: force => this._downloadExecutable(firefoxBeta, force, firefoxBetaExecutable),
       _dependencyGroup: 'firefox',
       _isHermeticInstallation: true,
     });
@@ -1439,9 +1261,9 @@ export class Registry {
   private _defaultBrowsersToInstall(options: { shell?: 'no' | 'only' }): Executable[] {
     let executables = this.defaultExecutables();
     if (options.shell === 'no')
-      executables = executables.filter(e => e.name !== 'chromium-headless-shell' && e.name !== 'chromium-tip-of-tree-headless-shell');
+      executables = executables.filter(e => e.name !== 'chromium-headless-shell');
     if (options.shell === 'only')
-      executables = executables.filter(e => e.name !== 'chromium' && e.name !== 'chromium-tip-of-tree');
+      executables = executables.filter(e => e.name !== 'chromium');
     return executables;
   }
 
@@ -1477,11 +1299,6 @@ export class Registry {
           handleArgument('chromium');
         if (options.shell !== 'no')
           handleArgument('chromium-headless-shell');
-      } else if (alias === 'chromium-tip-of-tree') {
-        if (options.shell !== 'only')
-          handleArgument('chromium-tip-of-tree');
-        if (options.shell !== 'no')
-          handleArgument('chromium-tip-of-tree-headless-shell');
       } else {
         handleArgument(alias);
       }

--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -99,8 +99,7 @@ const test = baseTest.extend<BrowserTestTestFixtures & { _contextFactory: Contex
 
   isHeadlessShell: [async ({ browserName, channel, headless }, use) => {
     const isShell = channel === 'chromium-headless-shell' || (!channel && headless);
-    const isToTShell = channel === 'chromium-tip-of-tree-headless-shell' || (channel === 'chromium-tip-of-tree' && headless);
-    await use(browserName === 'chromium' && (isShell || isToTShell));
+    await use(browserName === 'chromium' && isShell);
   }, { scope: 'worker' }],
 
   isFrozenWebkit: [async ({ browserName, isMac, macVersion }, use) => {

--- a/tests/library/browsercontext-cookies.spec.ts
+++ b/tests/library/browsercontext-cookies.spec.ts
@@ -356,7 +356,6 @@ it('should add cookies with an expiration', async ({ context }) => {
 it('should support requestStorageAccess', async ({ page, server, channel, browserName, isMac, isLinux, isWindows, macVersion }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/17285' });
   it.skip(browserName === 'chromium', 'requestStorageAccess API is not available in Chromium');
-  it.skip(channel === 'firefox-beta', 'hasStorageAccess returns true, but no cookie is sent');
 
   server.setRoute('/set-cookie.html', (req, res) => {
     res.setHeader('Set-Cookie', 'name=value; Path=/');

--- a/tests/library/headful.spec.ts
+++ b/tests/library/headful.spec.ts
@@ -21,7 +21,7 @@ import { expect, playwrightTest as it } from '../config/browserTest';
 const { compare } = utils;
 
 it.skip(({ headless }) => headless, 'avoid popping windows in headless mode');
-it.skip(({ channel }) => channel === 'chromium-headless-shell' || channel === 'chromium-tip-of-tree-headless-shell', 'shell is never headed');
+it.skip(({ channel }) => channel === 'chromium-headless-shell', 'shell is never headed');
 
 it('should have default url when launching browser @smoke', async ({ launchPersistent }) => {
   const { context } = await launchPersistent();

--- a/tests/library/launcher.spec.ts
+++ b/tests/library/launcher.spec.ts
@@ -45,7 +45,6 @@ it('should kill browser process on timeout after close', async ({ browserType, m
 it('should throw a friendly error if its headed and there is no xserver on linux running', async ({ mode, browserType, platform, channel }) => {
   it.skip(platform !== 'linux');
   it.skip(channel === 'chromium-headless-shell', 'shell is never headed');
-  it.skip(channel === 'chromium-tip-of-tree-headless-shell', 'shell is never headed');
 
   const error: Error = await browserType.launch({
     headless: false,

--- a/utils/roll_browser.js
+++ b/utils/roll_browser.js
@@ -32,9 +32,9 @@ usage: ${SCRIPT_NAME} <browser> <revision> [version]
 
 Roll the <browser> to a specific <revision> and generate new protocol.
 Version is required for chromium-based browsers.
-Supported browsers: chromium, firefox, webkit, ffmpeg, firefox-beta.
+Supported browsers: chromium, firefox, webkit, ffmpeg.
 
-Rolling firefox or firefox-beta requires a playwright-browsers checkout
+Rolling firefox requires a playwright-browsers checkout
 next to the playwright checkout, to roll browser patches from upstream.
 Set PW_BROWSERS_CHECKOUT to point to a checkout in a custom location.
 
@@ -63,7 +63,6 @@ Example:
   const browserName = {
     'cr': 'chromium',
     'ff': 'firefox',
-    'ff-beta': 'firefox-beta',
     'wk': 'webkit',
   }[args[0].toLowerCase()] ?? args[0].toLowerCase();
   const browserTypeName = browserName.split('-')[0];


### PR DESCRIPTION
## Summary
- Remove `firefox-beta`, `chromium-tip-of-tree` and `chromium-tip-of-tree-headless-shell` from the registry, `browsers.json` and install aliases.
- Remove the tip-of-tree headless shell mapping in `getExecutableName` and related test skips.
- Remove `firefox-beta` support from `utils/roll_browser.js`.

The `moz-firefox-beta` channel (system-installed Firefox Beta) and `allDownloadableDirectoriesThatEverExisted` are intentionally untouched.