### PR TITLE
fix(mcp): clear dialog modal state when dialog is closed out of band

### DIFF
--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -129,6 +129,7 @@ export class Tab extends EventEmitter<TabEventsInterface> {
         });
       }),
       eventsHelper.addEventListener(p, 'dialog', dialog => this._dialogShown(dialog)),
+      eventsHelper.addEventListener(p, 'dialogclosed', dialog => this._dialogClosed(dialog)),
       eventsHelper.addEventListener(p, 'download', download => {
         void this._downloadStarted(download);
       }),
@@ -205,6 +206,12 @@ export class Tab extends EventEmitter<TabEventsInterface> {
       dialog,
       clearedBy: { tool: handleDialog.schema.name, skill: 'dialog-accept or dialog-dismiss' }
     });
+  }
+
+  private _dialogClosed(dialog: playwright.Dialog) {
+    const modalState = this._modalStates.find(state => state.type === 'dialog' && state.dialog === dialog);
+    if (modalState)
+      this.clearModalState(modalState);
   }
 
   private async _downloadStarted(download: playwright.Download) {

--- a/tests/mcp/dialogs.spec.ts
+++ b/tests/mcp/dialogs.spec.ts
@@ -215,6 +215,51 @@ test('prompt dialog', async ({ client, server }) => {
   });
 });
 
+test('dialog closed out of band', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/41837' },
+}, async ({ cdpServer, startClient, server }) => {
+  server.setContent('/', `<title>Title</title><button onclick="alert('Alert')">Button</button>`, 'text/html');
+
+  const browserContext = await cdpServer.start();
+  const [page] = browserContext.pages();
+  // Subscribe to the dialog event to prevent this connection from auto-dismissing dialogs.
+  page.on('dialog', () => {});
+  // Establish the CDP session up front: creating one while a dialog is blocking the page hangs.
+  const cdpSession = await browserContext.newCDPSession(page);
+  await cdpSession.send('Page.enable');
+
+  const { client } = await startClient({ args: [`--cdp-endpoint=${cdpServer.endpoint}`] });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`- button "Button" [ref=e2]`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: {
+      element: 'Button',
+      target: 'e2',
+    },
+  })).toHaveResponse({
+    modalState: `- ["alert" dialog with message "Alert"]: can be handled by browser_handle_dialog`,
+  });
+
+  // Close the dialog through CDP as a side-channel, similar to the user closing it in the headed browser.
+  const closedPromise = page.waitForEvent('dialogclosed');
+  await cdpSession.send('Page.handleJavaScriptDialog', { accept: true });
+  await closedPromise;
+
+  expect(await client.callTool({
+    name: 'browser_snapshot',
+  })).toHaveResponse({
+    modalState: undefined,
+    inlineSnapshot: expect.stringContaining(`- button "Button"`),
+  });
+});
+
 test('alert dialog w/ race', async ({ client, server }) => {
   server.setContent('/', `<title>Title</title><button onclick="setTimeout(() => alert('Alert'), 100)">Button</button>`, 'text/html');
   expect(await client.callTool({

--- a/tests/mcp/dialogs.spec.ts
+++ b/tests/mcp/dialogs.spec.ts
@@ -252,7 +252,7 @@ test('dialog closed out of band', {
   await cdpSession.send('Page.handleJavaScriptDialog', { accept: true });
   await closedPromise;
 
-  expect(await client.callTool({
+  await expect.poll(() => client.callTool({
     name: 'browser_snapshot',
   })).toHaveResponse({
     modalState: undefined,


### PR DESCRIPTION
## Summary
- Listen to the new `dialogclosed` event in the MCP tab and clear the matching dialog modal state, so dialogs closed outside of `browser_handle_dialog` (e.g. manually by the user in a headed browser) no longer leave a phantom modal state behind.
- Add a test that closes the dialog through a CDP side-channel.

Fixes https://github.com/microsoft/playwright/issues/41837