### PR TITLE
fix(aria): keep icon-only clickable elements in ai snapshots

### DIFF
--- a/packages/injected/src/ariaSnapshotDistiller.ts
+++ b/packages/injected/src/ariaSnapshotDistiller.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { hasPointerCursor } from '@isomorphic/ariaSnapshot';
 import { normalizeWhiteSpace } from '@isomorphic/stringUtils';
 
 import type * as aria from '@isomorphic/ariaSnapshot';
@@ -102,6 +103,11 @@ function isLeafGeneric(node: aria.AriaNode): boolean {
   return node.role === 'generic' && node.children.every(child => typeof child === 'string');
 }
 
+// Removing the click target root would hide an actionable element from the snapshot.
+function isClickTargetRoot(node: aria.AriaNode, ctx: DistillerContext): boolean {
+  return !!node.ref && hasPointerCursor(node) && !ctx.ancestors.some(ancestor => !!ancestor.ref && hasPointerCursor(ancestor));
+}
+
 // The tree builder emits raw text tokens - text nodes, CSS content, block spacing markers - as
 // string children. Coalesce the adjacent ones, normalize whitespace and drop the empties, then
 // drop a lone text child that merely repeats the node's accessible name. Runs on `exit`, so the
@@ -137,22 +143,27 @@ const mergeStringChildren: DistillerPlugin = {
 // Only unwrap a generic that encloses at most one element, logical grouping still makes sense,
 // even if it is not ref-able. The decision is made on `exit` - whether the node encloses a single
 // ref-bearing child is only known after its own descendants were unwrapped - so nested wrappers
-// collapse bottom-up.
+// collapse bottom-up. A generic emptied by the other plugins is dropped, unless it is the
+// click target root, for example an icon-only button.
 const unwrapSingleChildGenerics: DistillerPlugin = {
   name: 'unwrapSingleChildGenerics',
-  exit(node: aria.AriaNode): 'unwrap' | void {
-    if (node.role === 'generic' && !node.name && node.children.length <= 1 && node.children.every(child => typeof child !== 'string' && !!child.ref))
-      return 'unwrap';
+  exit(node: aria.AriaNode, ctx: DistillerContext): 'unwrap' | void {
+    if (node.role !== 'generic' || node.name || node.children.length > 1 || !node.children.every(child => typeof child !== 'string' && !!child.ref))
+      return;
+    if (!node.children.length && isClickTargetRoot(node, ctx))
+      return;
+    return 'unwrap';
   },
 };
 
 // A decorative image - role `img` with no accessible name and no content - carries no
 // information. The decision is made on `exit` - whether the node has content is only known after
-// `mergeStringChildren` dropped the empty text tokens.
+// `mergeStringChildren` dropped the empty text tokens. A clickable image outside of any clickable
+// container is not decorative though - e.g. a bare svg icon acting as a button - and is kept.
 const removeNamelessImages: DistillerPlugin = {
   name: 'removeNamelessImages',
-  exit(node: aria.AriaNode): 'remove' | void {
-    if (node.role === 'img' && !node.name && !node.children.length)
+  exit(node: aria.AriaNode, ctx: DistillerContext): 'remove' | void {
+    if (node.role === 'img' && !node.name && !node.children.length && !isClickTargetRoot(node, ctx))
       return 'remove';
   },
 };

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -440,13 +440,13 @@ it('should omit images without an accessible name', async ({ page }) => {
   `);
 
   const snapshot = await snapshotForAI(page);
-  // A nameless image carries no information and is omitted, whether or not it is clickable. Only
-  // the named image is kept - and the body wrapper, left with a single child, is unwrapped.
+  // A nameless image that cannot be clicked carries no information and is omitted.
   expect(snapshot).toContainYaml(`
-    - img "A cat" [ref=e3]
+    - generic [active] [ref=e1]:
+      - img "A cat" [ref=e3]
+      - img [ref=e4] [cursor=pointer]
   `);
   expect(snapshot).not.toContain('[ref=e2]');
-  expect(snapshot).not.toContain('[ref=e4]');
 });
 
 it('should omit a nameless image nested inside a link', async ({ page }) => {
@@ -461,6 +461,27 @@ it('should omit a nameless image nested inside a link', async ({ page }) => {
       - /url: /issue/1
   `);
   expect(snapshot).not.toContain('img');
+});
+
+it('should keep icon-only clickable elements', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42013' },
+}, async ({ page }) => {
+  const icon = `<svg viewBox="0 0 1024 1024"><use xlink:href="#icon"></use></svg>`;
+  await page.setContent(`
+    <div style="cursor: pointer" aria-haspopup="true"><i>${icon}</i></div>
+    <img style="cursor: pointer" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=">
+    <a style="cursor: pointer" href="/target">${icon}</a>
+    <div onclick="void 0">${icon}</div>
+  `);
+
+  const snapshot = await snapshotForAI(page);
+  expect(snapshot).toContainYaml(`
+    - generic [active] [ref=e1]:
+      - generic [ref=e2] [cursor=pointer]
+      - img [ref=e5] [cursor=pointer]
+      - link [ref=e6] [cursor=pointer]:
+        - /url: /target
+  `);
 });
 
 it('should omit leaf generic whose text is already in an ancestor name', async ({ page }) => {


### PR DESCRIPTION
## Summary
- The ai snapshot distiller removed nameless images and emptied generic wrappers even when they were the only handle for a click surface, hiding icon-only buttons from the snapshot entirely.
- Keep a nameless image or an emptied generic that is clickable (has a ref and a pointer cursor) when no clickable ancestor represents its click surface.

Fixes https://github.com/microsoft/playwright/issues/42013