### PR TITLE
test(websocket): cover `setExtraHTTPHeaders` and `locale` on the handshake request

### DIFF
--- a/tests/library/browsercontext-locale.spec.ts
+++ b/tests/library/browsercontext-locale.spec.ts
@@ -227,12 +227,32 @@ it('should send Accept-Language header on WebSocket handshake', {
   annotation: [{ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23732' }],
 }, async ({ browser, server, browserName, browserMajorVersion, isBidi }) => {
   it.fixme(browserName === 'firefox' && !isBidi, 'Firefox/Juggler does not send Accept-Language on WebSocket handshake');
-  it.fixme(browserName === 'chromium' && browserMajorVersion === 150, 'Chromium 150 sends the browser Accept-Language instead of the emulated locale on WebSocket handshake, https://github.com/microsoft/playwright/issues/23732');
+  it.fixme(browserName === 'chromium' && browserMajorVersion < 151, 'Chromium before 151 sends the browser Accept-Language instead of the emulated locale on WebSocket handshake');
+
   const context = await browser.newContext({ locale: 'en-GB' });
   const page = await context.newPage();
   await page.goto(server.EMPTY_PAGE);
   const reqPromise = server.waitForWebSocketConnectionRequest();
   await page.evaluate(port => { new WebSocket(`ws://localhost:${port}/ws`); }, server.PORT);
+  const req = await reqPromise;
+  expect(req.headers['accept-language']).toContain('en-GB');
+  await context.close();
+});
+
+it('should send Accept-Language header on WebSocket handshake from a worker', {
+  annotation: [{ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/13919' }],
+}, async ({ browser, server, browserName, browserMajorVersion }) => {
+  it.fixme(browserName === 'firefox', 'Firefox does not associate a WebSocket opened inside a worker with its browsing context');
+  it.fixme(browserName === 'chromium' && browserMajorVersion < 151, 'Chromium before 151 sends the browser Accept-Language instead of the emulated locale on WebSocket handshake');
+
+  const context = await browser.newContext({ locale: 'en-GB' });
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  const reqPromise = server.waitForWebSocketConnectionRequest();
+  await page.evaluate(port => {
+    const code = `new WebSocket(${JSON.stringify(`ws://localhost:${port}/ws`)});`;
+    new Worker(URL.createObjectURL(new Blob([code], { type: 'text/javascript' })));
+  }, server.PORT);
   const req = await reqPromise;
   expect(req.headers['accept-language']).toContain('en-GB');
   await context.close();

--- a/tests/library/web-socket.spec.ts
+++ b/tests/library/web-socket.spec.ts
@@ -243,3 +243,33 @@ it('should turn off when offline', async ({ page }) => {
   expect(await result).toBe('successfully closed');
   await new Promise(x => webSocketServer.close(x));
 });
+
+it('should send extra HTTP headers on WebSocket handshake', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28948' },
+}, async ({ page, server, browserName, browserMajorVersion }) => {
+  it.fixme(browserName === 'chromium' && browserMajorVersion < 151, 'Chromium before 151 does not send extra HTTP headers on WebSocket handshake');
+
+  await page.setExtraHTTPHeaders({ foo: 'bar' });
+  await page.goto(server.EMPTY_PAGE);
+  const reqPromise = server.waitForWebSocketConnectionRequest();
+  await page.evaluate(host => { new WebSocket(`ws://${host}/ws`); }, server.HOST);
+  const req = await reqPromise;
+  expect(req.headers['foo']).toBe('bar');
+});
+
+it('should send extra HTTP headers on WebSocket handshake from a worker', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/28948' },
+}, async ({ page, server, browserName, browserMajorVersion }) => {
+  it.fixme(browserName === 'chromium' && browserMajorVersion < 151, 'Chromium before 151 does not send extra HTTP headers on WebSocket handshake');
+  it.fixme(browserName === 'firefox', 'Firefox does not associate a WebSocket opened inside a worker with its browsing context');
+
+  await page.setExtraHTTPHeaders({ foo: 'bar' });
+  await page.goto(server.EMPTY_PAGE);
+  const reqPromise = server.waitForWebSocketConnectionRequest();
+  await page.evaluate(host => {
+    const code = `new WebSocket(${JSON.stringify('ws://' + host + '/ws')});`;
+    new Worker(URL.createObjectURL(new Blob([code], { type: 'text/javascript' })));
+  }, server.HOST);
+  const req = await reqPromise;
+  expect(req.headers['foo']).toBe('bar');
+});


### PR DESCRIPTION
`Network.setExtraHTTPHeaders` and an emulated `locale` now reach the `WebSocket` handshake request, but nothing exercised either from the page or from inside a `Worker`

Chromium:
- <https://chromium-review.googlesource.com/c/chromium/src/+/7950740> (Network.setExtraHTTPHeaders should affect WebSocket handshake requests)
- <https://chromium-review.googlesource.com/c/chromium/src/+/8000530> (Network.setExtraHTTPHeaders should affect WebSocket requests in a Worker)

WebKit:
- <https://github.com/WebKit/WebKit/pull/67097> (Web Inspector: Network.setExtraHTTPHeaders does not affect WebSocket)

Chrome Stable and Edge Stable are both still on 150, which predates that Chromium work, so widen the existing guard to `browserMajorVersion < 151` and reuse it on the new cases

Firefox drops the browsing context association when it opens the handshake channel, so the `Worker` cases stay `it.fixme` there until the bundled Firefox picks up <https://phabricator.services.mozilla.com/D310690>

fixes <https://github.com/microsoft/playwright/issues/13919>
fixes <https://github.com/microsoft/playwright/issues/28948>