### PR TITLE
cherry-pick(#42040): docs(release-notes): mention the isolated headless clipboard in 1.62

### DIFF
--- a/docs/src/release-notes-js.md
+++ b/docs/src/release-notes-js.md
@@ -124,6 +124,7 @@ export default defineConfig({
 
 ### Announcements
 
+* 📋 The clipboard is now isolated from the operating system in headless mode, so tests that use `navigator.clipboard` no longer read or overwrite the clipboard of the machine running them.
 * ⚠️ Debian 11 is not supported anymore.
 
 ### Browser Versions


### PR DESCRIPTION
headless browsers keep the clipboard to themselves instead of sharing the clipboard of the operating system, which WebKit on macOS started doing in build `2334`

announce it in the 1.62 release notes so that anyone who relied on the clipboard of the machine being involved knows what changed