### PR TITLE
fix(cli): exit with non-zero code when the tool result is an error

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -295,6 +295,8 @@ async function runInSession(entry: SessionFile, clientInfo: ClientInfo, args: Mi
     delete args[globalOption];
   const session = new Session(entry);
   const result = await session.run(clientInfo, args, { raw, json: output.json });
+  if (result.isError)
+    process.exitCode = 1;
   return result.text;
 }
 

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -42,7 +42,7 @@ export class Session {
     return compareSemver(clientInfo.version, this.config.version) >= 0;
   }
 
-  async run(clientInfo: ClientInfo, args: MinimistArgs, options?: { raw?: boolean, json?: boolean }): Promise<{ text: string }> {
+  async run(clientInfo: ClientInfo, args: MinimistArgs, options?: { raw?: boolean, json?: boolean }): Promise<{ text: string, isError?: boolean }> {
     if (!this.isCompatible(clientInfo))
       throw new Error(`Client is v${clientInfo.version}, session '${this.name}' is v${this.config.version}. Run\n\n  playwright-cli${this.name !== 'default' ? ` -s=${this.name}` : ''} open\n\nto restart the browser session.`);
 

--- a/tests/mcp/cli-core.spec.ts
+++ b/tests/mcp/cli-core.spec.ts
@@ -369,6 +369,18 @@ test('--raw on command without output', async ({ cli, server }) => {
   expect(output).not.toContain('Page URL');
 });
 
+test('tool error exits with non-zero code', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42028' } }, async ({ cli, server }) => {
+  await cli('open', server.HELLO_WORLD);
+
+  const { output, exitCode } = await cli('click', 'e999');
+  expect(output).toContain('Ref e999 not found in the current page snapshot.');
+  expect(exitCode).toBe(1);
+
+  const { output: jsonOutput, exitCode: jsonExitCode } = await cli('--json', 'click', 'e999');
+  expect(JSON.parse(jsonOutput).isError).toBe(true);
+  expect(jsonExitCode).toBe(1);
+});
+
 test('codegen escapes single quotes in user input', async ({ cli, server }) => {
   server.setContent('/', `<input type=text>`, 'text/html');
   await cli('open', server.PREFIX);


### PR DESCRIPTION
## Summary
- Propagate `isError` from the daemon's tool result to the process exit code, in both text and `--json` output modes.

Fixes https://github.com/microsoft/playwright/issues/42028