### PR TITLE
docs: fix playwright-cli skill link in triage skill

### DIFF
--- a/.claude/skills/playwright-triage/SKILL.md
+++ b/.claude/skills/playwright-triage/SKILL.md
@@ -58,7 +58,7 @@ result to report, not a non-finding.
    match. (A version ending in `-next`, e.g. `1.62.0-next`, is **not** an npm version — it means
    tip-of-tree, which is the `@next` build you already tried.)
 
-To step through a test interactively, use the [playwright-cli](../playwright-cli/SKILL.md) skill.
+To step through a test interactively, use the [playwright-cli](../../../packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md) skill.
 
 Reports sometimes target another part of the Playwright project — `@playwright/mcp` (its source is
 in this repo), `playwright-vscode`, `playwright-python`, `playwright-java`, `playwright-dotnet`.


### PR DESCRIPTION
The triage skill links `[playwright-cli](../playwright-cli/SKILL.md)`, which resolves to `.claude/skills/playwright-cli/SKILL.md`. That file does not exist — `.claude/skills/` holds only `playwright-dev`, `playwright-devops`, `playwright-test-results`, and `playwright-triage`.

The skill does exist, at `packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md`, so this repoints the link there. The `../../../` depth matches what `playwright-dev/SKILL.md` already uses for `CLAUDE.md`.

Verified the new relative path resolves to a real file from the triage skill directory. Documentation only, one line.