### PR TITLE
chore(bidi): add support for the local-network-access permission

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiBrowser.ts
+++ b/packages/playwright-core/src/server/bidi/bidiBrowser.ts
@@ -331,8 +331,11 @@ export class BidiBrowserContext extends BrowserContext {
   async doGrantPermissions(origin: string, permissions: string[]) {
     if (origin === 'null')
       return;
+    const protocolPermissions = permissions.flatMap(
+        permission => permission === 'local-network-access' ? ['local-network', 'loopback-network'] : permission
+    );
     const currentPermissions = this._originToPermissions.get(origin) || [];
-    const toGrant = permissions.filter(permission => !currentPermissions.includes(permission));
+    const toGrant = protocolPermissions.filter(permission => !currentPermissions.includes(permission));
     this._originToPermissions.set(origin, [...currentPermissions, ...toGrant]);
     if (origin === '*') {
       await Promise.all(this._bidiPages().flatMap(page =>

--- a/tests/bidi/expectations/moz-firefox-nightly-library.txt
+++ b/tests/bidi/expectations/moz-firefox-nightly-library.txt
@@ -155,7 +155,6 @@ library/page-event-crash.spec.ts › should cancel navigation when page crashes 
 library/page-event-crash.spec.ts › should cancel waitForEvent when page crashes [timeout]
 library/page-event-crash.spec.ts › should emit crash event when page crashes [timeout]
 library/page-event-crash.spec.ts › should throw on any action after page crashes [timeout]
-library/permissions.spec.ts › local network request is allowed from public origin [timeout]
 library/permissions.spec.ts › permissions › should deny permission when not listed [fail]
 library/permissions.spec.ts › permissions › should fail when bad permission is given [fail]
 library/permissions.spec.ts › permissions › should isolate permissions between browser contexts [fail]


### PR DESCRIPTION
Fixes the test "local network request is allowed from public origin" in both Firefox and Chrome.