### PR TITLE
feat(test-runner): support fixture locks

### DIFF
--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -313,6 +313,27 @@ test('basic test', async ({ todoPage, page }) => {
 });
 ```
 
+## Fixture locks
+
+Test-scoped fixtures can declare named locks, and every test using the fixture will inherit those locks.
+
+```js title="my-test.ts"
+import { test as base } from '@playwright/test';
+import { testInbox } from './test-inbox';
+
+export const test = base.extend({
+  inbox: [
+    async ({}, use) => {
+      await testInbox.clear();
+      await use(testInbox);
+    },
+    { locks: ['test-inbox'] },
+  ],
+});
+```
+
+Learn more about [test locks](./test-parallel.md#test-locks).
+
 ## Overriding fixtures
 
 In addition to creating your own fixtures, you can also override existing fixtures to fit your needs. Consider the following example which overrides the `page` fixture by automatically navigating to the `baseURL`:

--- a/docs/src/test-fixtures-js.md
+++ b/docs/src/test-fixtures-js.md
@@ -316,18 +316,19 @@ test('basic test', async ({ todoPage, page }) => {
 ## Fixture locks
 
 Test-scoped fixtures can declare named locks, and every test using the fixture will inherit those locks.
+For example, tests that depend on specific server-wide settings must not run concurrently with other tests that change them.
 
 ```js title="my-test.ts"
 import { test as base } from '@playwright/test';
-import { testInbox } from './test-inbox';
 
 export const test = base.extend({
-  inbox: [
-    async ({}, use) => {
-      await testInbox.clear();
-      await use(testInbox);
+  smtpSettings: [
+    async ({ request }, use) => {
+      const updateSettings = settings =>
+        request.put('/api/admin/smtp-settings', { data: settings });
+      await use(updateSettings);
     },
-    { locks: ['test-inbox'] },
+    { locks: ['smtp-settings'] },
   ],
 });
 ```

--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -155,6 +155,8 @@ test('reset the database', { lock: ['database', 'external-api'] }, async () => {
 });
 ```
 
+Test-scoped [fixtures](./test-fixtures.md#fixture-locks) can also contribute locks to a test. Playwright combines them with locks declared in the test details before scheduling the test.
+
 Playwright acquires all the locks of a test before the test starts and releases them when it finishes.
 
 :::note

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -281,32 +281,23 @@ export class FixturePool {
     return [...this._registrations.values()].filter(r => r.auto !== false);
   }
 
-  locksForFunction(fn: Function, location: Location): string[] {
-    const collector = new Set<FixtureRegistration>();
+  collectFixturesForFunction(fn: Function, location: Location, collector: Set<FixtureRegistration>) {
     for (const name of fixtureParameterNames(fn, location, e => this._onLoadError(e))) {
       const registration = this.resolve(name);
       if (registration)
-        this._collectRegistrations(registration, collector);
+        this.collectFixturesInSetupOrder(registration, collector);
     }
-    return [...collector].flatMap(registration => registration.locks);
   }
 
-  locksForAutoFixtures(): string[] {
-    const collector = new Set<FixtureRegistration>();
-    for (const registration of this.autoFixtures())
-      this._collectRegistrations(registration, collector);
-    return [...collector].flatMap(registration => registration.locks);
-  }
-
-  private _collectRegistrations(registration: FixtureRegistration, collector: Set<FixtureRegistration>) {
+  collectFixturesInSetupOrder(registration: FixtureRegistration, collector: Set<FixtureRegistration>) {
     if (collector.has(registration))
       return;
-    collector.add(registration);
     for (const name of registration.deps) {
       const dependency = this.resolve(name, registration);
       if (dependency)
-        this._collectRegistrations(dependency, collector);
+        this.collectFixturesInSetupOrder(dependency, collector);
     }
+    collector.add(registration);
   }
 
   private _addLoadError(message: string, location: Location) {

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -26,7 +26,7 @@ import type { Location } from '../../types/testReporter';
 export type FixtureScope = 'test' | 'worker';
 type FixtureAuto = boolean | 'all-hooks-included';
 const kScopeOrder: FixtureScope[] = ['test', 'worker'];
-type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' };
+type FixtureOptions = { auto?: FixtureAuto, scope?: FixtureScope, option?: boolean, locks?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' };
 type FixtureTuple = [ value: any, options: FixtureOptions ];
 export type FixtureRegistration = {
   // Fixture registration location.
@@ -46,6 +46,8 @@ export type FixtureRegistration = {
   timeout?: number;
   // Names of the dependencies, comes from the declaration "({ foo, bar }) => {...}"
   deps: string[];
+  // Named locks required by this test-scoped fixture.
+  locks: string[];
   // Unique id, to differentiate between fixtures with the same name.
   id: string;
   // A fixture override can use the previous version of the fixture.
@@ -120,12 +122,25 @@ export class FixturePool {
     for (const entry of Object.entries(fixtures)) {
       const name = entry[0];
       let value = entry[1];
-      let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
+      const previous = this._registrations.get(name);
+      let locksSpecified = false;
+      let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, locks: string[], timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
       if (isFixtureTuple(value)) {
+        locksSpecified = value[1].locks !== undefined;
+        const locks = value[1].locks ?? previous?.locks ?? [];
+        if (!Array.isArray(locks)) {
+          this._addLoadError(`Fixture "${name}" option "locks" must be an array.`, location);
+          continue;
+        }
+        if (locks.some(lock => typeof lock !== 'string')) {
+          this._addLoadError(`Fixture "${name}" option "locks" must contain only strings.`, location);
+          continue;
+        }
         options = {
           auto: value[1].auto ?? false,
           scope: value[1].scope || 'test',
           option: value[1].option,
+          locks: [...locks],
           timeout: value[1].timeout,
           customTitle: value[1].title,
           box: value[1].box,
@@ -134,7 +149,6 @@ export class FixturePool {
       }
       let fn = value as (Function | any);
 
-      const previous = this._registrations.get(name);
       if (previous && options) {
         if (previous.scope !== options.scope) {
           this._addLoadError(`Fixture "${name}" has already been registered as a { scope: '${previous.scope}' } fixture defined in ${formatLocation(previous.location)}.`, location);
@@ -150,9 +164,9 @@ export class FixturePool {
         }
       } else if (previous) {
         // Note: deliberately not inheriting "options.box" so that fixture override is visible by default.
-        options = { auto: previous.auto, scope: previous.scope, option: previous.option, timeout: previous.timeout, customTitle: previous.customTitle };
+        options = { auto: previous.auto, scope: previous.scope, option: previous.option, locks: previous.locks, timeout: previous.timeout, customTitle: previous.customTitle };
       } else if (!options) {
-        options = { auto: false, scope: 'test', option: false, timeout: undefined };
+        options = { auto: false, scope: 'test', option: false, locks: [], timeout: undefined };
       }
 
       if (!kScopeOrder.includes(options.scope)) {
@@ -161,6 +175,10 @@ export class FixturePool {
       }
       if (options.scope === 'worker' && disallowWorkerFixtures) {
         this._addLoadError(`Cannot use({ ${name} }) in a describe group, because it forces a new worker.\nMake it top-level in the test file or put in the configuration file.`, location);
+        continue;
+      }
+      if (options.scope === 'worker' && locksSpecified) {
+        this._addLoadError(`Fixture "${name}" cannot specify locks because it has worker scope.`, location);
         continue;
       }
 
@@ -174,7 +192,7 @@ export class FixturePool {
       }
 
       const deps = fixtureParameterNames(fn, location, e => this._onLoadError(e));
-      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
+      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, locks: options.locks, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
       registrationId(registration);
       this._registrations.set(name, registration);
     }
@@ -263,6 +281,34 @@ export class FixturePool {
 
   autoFixtures() {
     return [...this._registrations.values()].filter(r => r.auto !== false);
+  }
+
+  locksForFunction(fn: Function, location: Location): string[] {
+    const collector = new Set<FixtureRegistration>();
+    for (const name of fixtureParameterNames(fn, location, e => this._onLoadError(e))) {
+      const registration = this.resolve(name);
+      if (registration)
+        this._collectRegistrations(registration, collector);
+    }
+    return [...collector].flatMap(registration => registration.locks);
+  }
+
+  locksForAutoFixtures(): string[] {
+    const collector = new Set<FixtureRegistration>();
+    for (const registration of this.autoFixtures())
+      this._collectRegistrations(registration, collector);
+    return [...collector].flatMap(registration => registration.locks);
+  }
+
+  private _collectRegistrations(registration: FixtureRegistration, collector: Set<FixtureRegistration>) {
+    if (collector.has(registration))
+      return;
+    collector.add(registration);
+    for (const name of registration.deps) {
+      const dependency = this.resolve(name, registration);
+      if (dependency)
+        this._collectRegistrations(dependency, collector);
+    }
   }
 
   private _addLoadError(message: string, location: Location) {

--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -123,11 +123,9 @@ export class FixturePool {
       const name = entry[0];
       let value = entry[1];
       const previous = this._registrations.get(name);
-      let locksSpecified = false;
       let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, locks: string[], timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
       if (isFixtureTuple(value)) {
-        locksSpecified = value[1].locks !== undefined;
-        const locks = value[1].locks ?? previous?.locks ?? [];
+        const locks = value[1].locks ?? [];
         if (!Array.isArray(locks)) {
           this._addLoadError(`Fixture "${name}" option "locks" must be an array.`, location);
           continue;
@@ -164,7 +162,7 @@ export class FixturePool {
         }
       } else if (previous) {
         // Note: deliberately not inheriting "options.box" so that fixture override is visible by default.
-        options = { auto: previous.auto, scope: previous.scope, option: previous.option, locks: previous.locks, timeout: previous.timeout, customTitle: previous.customTitle };
+        options = { auto: previous.auto, scope: previous.scope, option: previous.option, locks: [], timeout: previous.timeout, customTitle: previous.customTitle };
       } else if (!options) {
         options = { auto: false, scope: 'test', option: false, locks: [], timeout: undefined };
       }
@@ -177,7 +175,7 @@ export class FixturePool {
         this._addLoadError(`Cannot use({ ${name} }) in a describe group, because it forces a new worker.\nMake it top-level in the test file or put in the configuration file.`, location);
         continue;
       }
-      if (options.scope === 'worker' && locksSpecified) {
+      if (options.scope === 'worker' && options.locks.length) {
         this._addLoadError(`Fixture "${name}" cannot specify locks because it has worker scope.`, location);
         continue;
       }

--- a/packages/playwright/src/common/poolBuilder.ts
+++ b/packages/playwright/src/common/poolBuilder.ts
@@ -17,8 +17,8 @@
 import { FixturePool } from './fixtures';
 import { formatLocation } from '../util';
 
+import type { FixtureRegistration, LoadError } from './fixtures';
 import type { FullProjectInternal } from './config';
-import type { LoadError } from './fixtures';
 import type { Suite, TestCase } from './test';
 import type { TestTypeImpl } from './testType';
 import type { TestError } from '../../types/testReporter';
@@ -75,14 +75,17 @@ export class PoolBuilder {
   }
 
   private _setFixtureLocksForTest(test: TestCase, pool: FixturePool, parents: Suite[]) {
-    test._locks.push(...pool.locksForAutoFixtures());
+    const collector = new Set<FixtureRegistration>();
+    for (const registration of pool.autoFixtures())
+      pool.collectFixturesInSetupOrder(registration, collector);
     for (const parent of parents) {
       for (const hook of parent._hooks)
-        test._locks.push(...pool.locksForFunction(hook.fn, hook.location));
+        pool.collectFixturesForFunction(hook.fn, hook.location, collector);
       for (const modifier of parent._modifiers)
-        test._locks.push(...pool.locksForFunction(modifier.fn, modifier.location));
+        pool.collectFixturesForFunction(modifier.fn, modifier.location, collector);
     }
-    test._locks.push(...pool.locksForFunction(test.fn, test.location));
+    pool.collectFixturesForFunction(test.fn, test.location, collector);
+    test._locks.push(...[...collector].flatMap(registration => registration.locks));
   }
 
   private _buildTestTypePool(testType: TestTypeImpl, testErrors?: TestError[]): FixturePool {

--- a/packages/playwright/src/common/poolBuilder.ts
+++ b/packages/playwright/src/common/poolBuilder.ts
@@ -69,7 +69,20 @@ export class PoolBuilder {
     }
 
     pool.validateFunction(test.fn, 'Test', test.location);
+    if (this._type === 'loader')
+      this._setFixtureLocksForTest(test, pool, parents);
     return pool;
+  }
+
+  private _setFixtureLocksForTest(test: TestCase, pool: FixturePool, parents: Suite[]) {
+    test._locks.push(...pool.locksForAutoFixtures());
+    for (const parent of parents) {
+      for (const hook of parent._hooks)
+        test._locks.push(...pool.locksForFunction(hook.fn, hook.location));
+      for (const modifier of parent._modifiers)
+        test._locks.push(...pool.locksForFunction(modifier.fn, modifier.location));
+    }
+    test._locks.push(...pool.locksForFunction(test.fn, test.location));
   }
 
   private _buildTestTypePool(testType: TestTypeImpl, testErrors?: TestError[]): FixturePool {

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -199,16 +199,6 @@ export class FixtureRunner {
     this.pool = pool;
   }
 
-  private _collectFixturesInSetupOrder(registration: fixtures.FixtureRegistration, collector: Set<fixtures.FixtureRegistration>) {
-    if (collector.has(registration))
-      return;
-    for (const name of registration.deps) {
-      const dep = this.pool!.resolve(name, registration)!;
-      this._collectFixturesInSetupOrder(dep, collector);
-    }
-    collector.add(registration);
-  }
-
   async teardownScope(scope: fixtures.FixtureScope, testInfo: TestInfoImpl, runnable: RunnableDescription) {
     // Teardown fixtures in the reverse order.
     const allFixtures = Array.from(this.instanceForId.values()).reverse();
@@ -245,12 +235,12 @@ export class FixtureRunner {
     }
     auto.sort((r1, r2) => (r1.scope === 'worker' ? 0 : 1) - (r2.scope === 'worker' ? 0 : 1));
     for (const registration of auto)
-      this._collectFixturesInSetupOrder(registration, collector);
+      this.pool!.collectFixturesInSetupOrder(registration, collector);
 
     // Collect used fixtures.
     const names = getRequiredFixtureNames(fn);
     for (const name of names)
-      this._collectFixturesInSetupOrder(this.pool!.resolve(name)!, collector);
+      this.pool!.collectFixturesInSetupOrder(this.pool!.resolve(name)!, collector);
 
     // Setup fixtures.
     for (const registration of collector)

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -6863,11 +6863,11 @@ type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixtu
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', locks?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
   [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, locks?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';

--- a/tests/playwright-test/test-locks.spec.ts
+++ b/tests/playwright-test/test-locks.spec.ts
@@ -163,6 +163,124 @@ test('should support multiple locks on a single test', async ({ runInlineTest })
   expect(conflictingOverlaps(result.outputLines, [['test1', 'test2'], ['test1', 'test3']])).toEqual([]);
 });
 
+test('should collect locks from the used fixture graph', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ outer: void, inner: void, unused: void }>({
+        outer: [undefined, { locks: ['shared'] }],
+        inner: async ({ outer }, use) => {
+          void outer;
+          await use();
+        },
+        unused: [undefined, { locks: ['shared'] }],
+      });
+
+      test('fixture', async ({ inner }) => {
+        void inner;
+        console.log('\\n%%begin:fixture');
+        fs.writeFileSync('fixture.ready', '');
+        await expect.poll(() => fs.existsSync('unused.ready')).toBe(true);
+        console.log('\\n%%end:fixture');
+      });
+      test('unused', async () => {
+        console.log('\\n%%begin:unused');
+        fs.writeFileSync('unused.ready', '');
+        await expect.poll(() => fs.existsSync('fixture.ready')).toBe(true);
+        console.log('\\n%%end:unused');
+      });
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('direct', 500, 'shared')}
+    `,
+  }, { workers: 3 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(conflictingOverlaps(result.outputLines, [['fixture', 'direct']])).toEqual([]);
+  expect(conflictingOverlaps(result.outputLines, [['fixture', 'unused']])).toEqual([['fixture', 'unused']]);
+});
+
+test('should collect locks from automatic fixtures, hooks and modifiers', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a-auto.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const test = base.extend<{ automatic: void }>({
+        automatic: [undefined, { auto: true, locks: ['shared'] }],
+      });
+      ${lockedTest('automatic', 500)}
+    `,
+    'b-hook.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const test = base.extend<{ hooked: void }>({
+        hooked: [undefined, { locks: ['shared'] }],
+      });
+      test.beforeEach(async ({ hooked }) => void hooked);
+      ${lockedTest('hook', 500)}
+    `,
+    'c-modifier.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const test = base.extend<{ modified: void }>({
+        modified: [undefined, { locks: ['shared'] }],
+      });
+      test.skip(({ modified }) => {
+        void modified;
+        return false;
+      });
+      ${lockedTest('modifier', 500)}
+    `,
+  }, { workers: 3 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(conflictingOverlaps(result.outputLines, [
+    ['automatic', 'hook'],
+    ['automatic', 'modifier'],
+    ['hook', 'modifier'],
+  ])).toEqual([]);
+});
+
+test('should preserve fixture locks through project option overrides', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        fullyParallel: true,
+        use: { account: 'override' },
+      };
+    `,
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      type Options = { account: string };
+      const test = base.extend<Options>({
+        account: ['default', { option: true, locks: ['account'] }],
+      });
+
+      for (const name of ['one', 'two']) {
+        test(name, async ({ account }) => {
+          void account;
+          console.log('\\n%%begin:' + name);
+          await new Promise(f => setTimeout(f, 500));
+          console.log('\\n%%end:' + name);
+        });
+      }
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(conflictingOverlaps(result.outputLines, [['one', 'two']])).toEqual([]);
+});
+
 test('should hold the lock for the whole file group in default mode', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'a.test.ts': `
@@ -235,4 +353,42 @@ test('should validate lock in test details', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('details.lock');
+});
+
+test('should validate fixture locks', async ({ runInlineTest }) => {
+  const worker = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { scope: 'worker', locks: ['shared'] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(worker.exitCode).toBe(1);
+  expect(worker.output).toContain('cannot specify locks because it has worker scope');
+
+  const nonArray = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { locks: 'shared' }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(nonArray.exitCode).toBe(1);
+  expect(nonArray.output).toContain('option "locks" must be an array');
+
+  const nonString = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { locks: [42] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(nonString.exitCode).toBe(1);
+  expect(nonString.output).toContain('option "locks" must contain only strings');
 });

--- a/tests/playwright-test/test-locks.spec.ts
+++ b/tests/playwright-test/test-locks.spec.ts
@@ -206,6 +206,90 @@ test('should collect locks from the used fixture graph', async ({ runInlineTest 
   expect(conflictingOverlaps(result.outputLines, [['fixture', 'unused']])).toEqual([['fixture', 'unused']]);
 });
 
+test('should not inherit locks when replacing a fixture', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'helper.ts': `
+      import fs from 'fs';
+      import path from 'path';
+      export async function signalAndWait(signal: string, waitFor: string) {
+        fs.mkdirSync(process.env.SIGNAL_DIR, { recursive: true });
+        fs.writeFileSync(path.join(process.env.SIGNAL_DIR, signal), '');
+        while (!fs.existsSync(path.join(process.env.SIGNAL_DIR, waitFor)))
+          await new Promise(f => setTimeout(f, 100));
+      }
+    `,
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+      import { signalAndWait } from './helper';
+
+      const withLockedFixture = base.extend<{ resource: void }>({
+        resource: [undefined, { locks: ['shared'] }],
+      });
+      const test = withLockedFixture.extend({
+        resource: async ({}, use) => use(),
+      });
+
+      test('replacement', async ({ resource }) => {
+        void resource;
+        console.log('\\n%%begin:replacement');
+        await signalAndWait('replacement', 'direct');
+        console.log('\\n%%end:replacement');
+      });
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      import { signalAndWait } from './helper';
+
+      test('direct', { lock: 'shared' }, async () => {
+        console.log('\\n%%begin:direct');
+        await signalAndWait('direct', 'replacement');
+        console.log('\\n%%end:direct');
+      });
+    `,
+  }, { workers: 2 }, { SIGNAL_DIR: test.info().outputDir });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(conflictingOverlaps(result.outputLines, [['replacement', 'direct']])).toEqual([['replacement', 'direct']]);
+});
+
+test('should collect locks when an overriding fixture uses its base implementation', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const withLockedFixture = base.extend<{ resource: void }>({
+        resource: [undefined, { locks: ['shared'] }],
+      });
+      const test = withLockedFixture.extend({
+        resource: async ({ resource }, use) => {
+          void resource;
+          await use();
+        },
+      });
+
+      test('fixture', async ({ resource }) => {
+        void resource;
+        console.log('\\n%%begin:fixture');
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:fixture');
+      });
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('direct', 500, 'shared')}
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(conflictingOverlaps(result.outputLines, [['fixture', 'direct']])).toEqual([]);
+});
+
 test('should collect locks from automatic fixtures, hooks and modifiers', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
@@ -367,6 +451,18 @@ test('should validate fixture locks', async ({ runInlineTest }) => {
   });
   expect(worker.exitCode).toBe(1);
   expect(worker.output).toContain('cannot specify locks because it has worker scope');
+
+  const emptyWorker = await runInlineTest({
+    'a.test.js': `
+      const { test: base } = require('@playwright/test');
+      const test = base.extend({
+        fixture: [undefined, { scope: 'worker', locks: [] }],
+      });
+      test('test', async ({ fixture }) => {});
+    `,
+  });
+  expect(emptyWorker.exitCode).toBe(0);
+  expect(emptyWorker.passed).toBe(1);
 
   const nonArray = await runInlineTest({
     'a.test.js': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -210,11 +210,11 @@ type WorkerFixtureValue<R, Args extends {}> = Exclude<R, Function> | WorkerFixtu
 export type Fixtures<T extends {} = {}, W extends {} = {}, PT extends {} = {}, PW extends {} = {}> = {
   [K in keyof PW]?: WorkerFixtureValue<PW[K], W & PW> | [WorkerFixtureValue<PW[K], W & PW>, { scope: 'worker', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in keyof PT]?: TestFixtureValue<PT[K], T & W & PT & PW> | [TestFixtureValue<PT[K], T & W & PT & PW>, { scope: 'test', locks?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
   [K in Exclude<keyof W, keyof PW | keyof PT>]?: [WorkerFixtureValue<W[K], W & PW>, { scope: 'worker', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 } & {
-  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
+  [K in Exclude<keyof T, keyof PW | keyof PT>]?: TestFixtureValue<T[K], T & W & PT & PW> | [TestFixtureValue<T[K], T & W & PT & PW>, { scope?: 'test', auto?: boolean, option?: boolean, locks?: string[], timeout?: number | undefined, title?: string, box?: boolean | 'self' }];
 };
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';


### PR DESCRIPTION
Adds named locks to test-scoped fixture declarations. Tests inherit locks from the fixtures, hooks, modifiers and automatic fixtures they use; worker-scoped declarations are rejected.