### PR TITLE
fix(test-runner): resolve fixture lock option overrides

### DIFF
--- a/packages/playwright/src/common/fixtures.ts
+++ b/packages/playwright/src/common/fixtures.ts
@@ -54,8 +54,14 @@ export type FixtureRegistration = {
   super?: FixtureRegistration;
   // Whether this fixture is an option override value set from the config.
   optionOverride?: boolean;
+  // Whether project.use replaces this registration's dependencies.
+  depsReplacedByProjectUse: boolean;
   // Do not generate the step for this fixture, consider it internal.
   box?: boolean | 'self';
+};
+export type FixtureLockCandidate = {
+  lock: string;
+  invalidatedByProjectUse: string[];
 };
 export type LoadError = {
   message: string;
@@ -123,6 +129,7 @@ export class FixturePool {
       const name = entry[0];
       let value = entry[1];
       const previous = this._registrations.get(name);
+      const depsReplacedByProjectUse = !isOptionsOverride && (isFixtureOption(value) || (value === undefined && !!previous && isOptionFixture(previous)));
       let options: { auto: FixtureAuto, scope: FixtureScope, option?: boolean, locks: string[], timeout: number | undefined, customTitle?: string, box?: boolean | 'self' } | undefined;
       if (isFixtureTuple(value)) {
         const locks = value[1].locks ?? [];
@@ -190,7 +197,7 @@ export class FixturePool {
       }
 
       const deps = fixtureParameterNames(fn, location, e => this._onLoadError(e));
-      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, locks: options.locks, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride };
+      const registration: FixtureRegistration = { id: '', name, location, scope: options.scope, fn, auto: options.auto, option: !!options.option, locks: options.locks, timeout: options.timeout, customTitle: options.customTitle, box: options.box, deps, super: previous, optionOverride: isOptionsOverride, depsReplacedByProjectUse };
       registrationId(registration);
       this._registrations.set(name, registration);
     }
@@ -298,6 +305,40 @@ export class FixturePool {
         this.collectFixturesInSetupOrder(dependency, collector);
     }
     collector.add(registration);
+  }
+
+  lockCandidatesForFunction(fn: Function, location: Location): FixtureLockCandidate[] {
+    const result: FixtureLockCandidate[] = [];
+    for (const name of fixtureParameterNames(fn, location, e => this._onLoadError(e))) {
+      const registration = this.resolve(name);
+      if (registration)
+        this._collectLockCandidates(registration, [], new Set(), result);
+    }
+    return result;
+  }
+
+  lockCandidatesForAutoFixtures(): FixtureLockCandidate[] {
+    const result: FixtureLockCandidate[] = [];
+    for (const registration of this.autoFixtures())
+      this._collectLockCandidates(registration, [], new Set(), result);
+    return result;
+  }
+
+  private _collectLockCandidates(registration: FixtureRegistration, invalidatedByProjectUse: string[], path: Set<FixtureRegistration>, result: FixtureLockCandidate[]) {
+    if (path.has(registration))
+      return;
+    path.add(registration);
+    for (const lock of registration.locks)
+      result.push({ lock, invalidatedByProjectUse });
+    let dependencyInvalidators = invalidatedByProjectUse;
+    if (registration.depsReplacedByProjectUse && !invalidatedByProjectUse.includes(registration.name))
+      dependencyInvalidators = [...invalidatedByProjectUse, registration.name];
+    for (const name of registration.deps) {
+      const dependency = this.resolve(name, registration);
+      if (dependency)
+        this._collectLockCandidates(dependency, dependencyInvalidators, path, result);
+    }
+    path.delete(registration);
   }
 
   private _addLoadError(message: string, location: Location) {

--- a/packages/playwright/src/common/poolBuilder.ts
+++ b/packages/playwright/src/common/poolBuilder.ts
@@ -17,7 +17,7 @@
 import { FixturePool } from './fixtures';
 import { formatLocation } from '../util';
 
-import type { FixtureRegistration, LoadError } from './fixtures';
+import type { LoadError } from './fixtures';
 import type { FullProjectInternal } from './config';
 import type { Suite, TestCase } from './test';
 import type { TestTypeImpl } from './testType';
@@ -70,22 +70,19 @@ export class PoolBuilder {
 
     pool.validateFunction(test.fn, 'Test', test.location);
     if (this._type === 'loader')
-      this._setFixtureLocksForTest(test, pool, parents);
+      this._collectLockCandidatesForTest(test, pool, parents);
     return pool;
   }
 
-  private _setFixtureLocksForTest(test: TestCase, pool: FixturePool, parents: Suite[]) {
-    const collector = new Set<FixtureRegistration>();
-    for (const registration of pool.autoFixtures())
-      pool.collectFixturesInSetupOrder(registration, collector);
+  private _collectLockCandidatesForTest(test: TestCase, pool: FixturePool, parents: Suite[]) {
+    test._lockCandidates.push(...pool.lockCandidatesForAutoFixtures());
     for (const parent of parents) {
       for (const hook of parent._hooks)
-        pool.collectFixturesForFunction(hook.fn, hook.location, collector);
+        test._lockCandidates.push(...pool.lockCandidatesForFunction(hook.fn, hook.location));
       for (const modifier of parent._modifiers)
-        pool.collectFixturesForFunction(modifier.fn, modifier.location, collector);
+        test._lockCandidates.push(...pool.lockCandidatesForFunction(modifier.fn, modifier.location));
     }
-    pool.collectFixturesForFunction(test.fn, test.location, collector);
-    test._locks.push(...[...collector].flatMap(registration => registration.locks));
+    test._lockCandidates.push(...pool.lockCandidatesForFunction(test.fn, test.location));
   }
 
   private _buildTestTypePool(testType: TestTypeImpl, testErrors?: TestError[]): FixturePool {

--- a/packages/playwright/src/common/suiteUtils.ts
+++ b/packages/playwright/src/common/suiteUtils.ts
@@ -36,6 +36,11 @@ export function filterTestsRemoveEmptySuites(suite: Suite, filter: TestCaseFilte
 export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suite): Suite {
   const relativeFile = path.relative(project.project.testDir, suite.location!.file);
   const fileId = calculateSha1(toPosixPath(relativeFile)).slice(0, 20);
+  const overriddenFixtureOptions = new Set<string>();
+  for (const [name, value] of Object.entries(project.project.use)) {
+    if (value !== undefined)
+      overriddenFixtureOptions.add(name);
+  }
 
   // Clone suite.
   const result = suite._deepClone();
@@ -50,6 +55,10 @@ export function bindFileSuiteToProject(project: FullProjectInternal, suite: Suit
     const testId = fileId + '-' + calculateSha1(testIdExpression).slice(0, 20);
     test.id = testId;
     test._projectId = project.id;
+    for (const candidate of test._lockCandidates) {
+      if (!candidate.invalidatedByProjectUse.some(name => overriddenFixtureOptions.has(name)))
+        test._locks.push(candidate.lock);
+    }
 
     // Inherit properties from parent suites.
     let inheritedRetries: number | undefined;

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -17,7 +17,7 @@
 import { rootTestType } from './testType';
 import { computeTestCaseOutcome } from '../isomorphic/teleReceiver';
 import type { FixturesWithLocation, FullProjectInternal } from './config';
-import type { FixturePool } from './fixtures';
+import type { FixtureLockCandidate, FixturePool } from './fixtures';
 import type { TestTypeImpl } from './testType';
 import type { TestAnnotation } from '../../types/test';
 import type * as reporterTypes from '../../types/testReporter';
@@ -287,6 +287,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   // Explicitly declared tags that are not a part of the title.
   _tags: string[] = [];
   _locks: string[] = [];
+  _lockCandidates: FixtureLockCandidate[] = [];
   _planAnnotations: TestAnnotation[] = [];
 
   constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {
@@ -347,6 +348,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
       annotations: this.annotations.slice(),
       tags: this._tags.slice(),
       locks: this._locks.slice(),
+      lockCandidates: this._lockCandidates,
       projectId: this._projectId,
     };
   }
@@ -364,6 +366,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
     test.annotations = data.annotations;
     test._tags = data.tags;
     test._locks = data.locks;
+    test._lockCandidates = data.lockCandidates;
     test._projectId = data.projectId;
     return test;
   }

--- a/tests/playwright-test/test-locks.spec.ts
+++ b/tests/playwright-test/test-locks.spec.ts
@@ -352,8 +352,6 @@ test('should resolve fixture locks through project option overrides', async ({ r
           await use('default');
         }, { option: true, locks: ['account'] }],
       });
-      test.use({ account: undefined });
-
       test('account one', async ({ account }) => {
         console.log('\\n%%begin:account-one:' + account);
         fs.writeFileSync(test.info().project.outputDir + '/account', '');
@@ -427,7 +425,37 @@ test('should resolve fixture locks through suite option overrides', async ({ run
   expect(result.passed).toBe(3);
   expect(result.outputLines).toContain('begin:account-one:override');
   expect(conflictingOverlaps(result.outputLines, [['account-one', 'database']])).toHaveLength(1);
-  expect(conflictingOverlaps(result.outputLines, [['account-one', 'account-two']])).toEqual([]);
+  expect(conflictingOverlaps(result.outputLines, [['account-one', 'account-two']])).toHaveLength(1);
+});
+
+test('should not inherit locks when resetting an option with test.use(undefined)', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const test = base.extend<{ account: string }>({
+        account: ['default', { option: true, locks: ['account'] }],
+      });
+      test.use({ account: undefined });
+
+      test('option', async ({ account }) => {
+        console.log('\\n%%begin:option:' + account);
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:option');
+      });
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('direct', 500, 'account')}
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.outputLines).toContain('begin:option:default');
+  expect(conflictingOverlaps(result.outputLines, [['option', 'direct']])).toHaveLength(1);
 });
 
 test('should preserve fixture locks reachable outside an overridden option', async ({ runInlineTest }) => {

--- a/tests/playwright-test/test-locks.spec.ts
+++ b/tests/playwright-test/test-locks.spec.ts
@@ -334,7 +334,103 @@ test('should collect locks from automatic fixtures, hooks and modifiers', async 
   ])).toEqual([]);
 });
 
-test('should preserve fixture locks through project option overrides', async ({ runInlineTest }) => {
+test('should resolve fixture locks through project option overrides', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        fullyParallel: true,
+        use: { account: 'override' },
+      };
+    `,
+    'a.test.ts': `
+      import { expect, test as base } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void, account: string }>({
+        database: [undefined, { locks: ['database'] }],
+        account: [async ({ database }, use) => {
+          await use('default');
+        }, { option: true, locks: ['account'] }],
+      });
+      test.use({ account: undefined });
+
+      test('account one', async ({ account }) => {
+        console.log('\\n%%begin:account-one:' + account);
+        fs.writeFileSync(test.info().project.outputDir + '/account', '');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/database')).toBe(true);
+        console.log('\\n%%end:account-one');
+      });
+
+      test('account two', async ({ account }) => {
+        console.log('\\n%%begin:account-two:' + account);
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:account-two');
+      });
+
+      test('database', async ({ database }) => {
+        console.log('\\n%%begin:database');
+        fs.writeFileSync(test.info().project.outputDir + '/database', '');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/account')).toBe(true);
+        console.log('\\n%%end:database');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(result.outputLines).toContain('begin:account-one:override');
+  expect(conflictingOverlaps(result.outputLines, [['account-one', 'database']])).toHaveLength(1);
+  expect(conflictingOverlaps(result.outputLines, [['account-one', 'account-two']])).toEqual([]);
+});
+
+test('should resolve fixture locks through suite option overrides', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { expect, test as base } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void, account: string }>({
+        database: [undefined, { locks: ['database'] }],
+        account: [async ({ database }, use) => {
+          await use('default');
+        }, { option: true, locks: ['account'] }],
+      });
+
+      test.describe('overridden', () => {
+        test.use({ account: 'override' });
+
+        test('account one', async ({ account }) => {
+          console.log('\\n%%begin:account-one:' + account);
+          fs.writeFileSync(test.info().project.outputDir + '/account', '');
+          await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/database')).toBe(true);
+          console.log('\\n%%end:account-one');
+        });
+
+        test('account two', async ({ account }) => {
+          console.log('\\n%%begin:account-two:' + account);
+          await new Promise(f => setTimeout(f, 500));
+          console.log('\\n%%end:account-two');
+        });
+      });
+
+      test('database', async ({ database }) => {
+        console.log('\\n%%begin:database');
+        fs.writeFileSync(test.info().project.outputDir + '/database', '');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/account')).toBe(true);
+        console.log('\\n%%end:database');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(result.outputLines).toContain('begin:account-one:override');
+  expect(conflictingOverlaps(result.outputLines, [['account-one', 'database']])).toHaveLength(1);
+  expect(conflictingOverlaps(result.outputLines, [['account-one', 'account-two']])).toEqual([]);
+});
+
+test('should preserve fixture locks reachable outside an overridden option', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
       module.exports = {
@@ -345,23 +441,74 @@ test('should preserve fixture locks through project option overrides', async ({ 
     'a.test.ts': `
       import { test as base } from '@playwright/test';
 
-      type Options = { account: string };
-      const test = base.extend<Options>({
-        account: ['default', { option: true, locks: ['account'] }],
+      const test = base.extend<{ database: void, account: string, audit: void }>({
+        database: [undefined, { locks: ['database'] }],
+        account: [async ({ database }, use) => {
+          await use('default');
+        }, { option: true }],
+        audit: async ({ database }, use) => {
+          await use();
+        },
       });
 
-      for (const name of ['one', 'two']) {
-        test(name, async ({ account }) => {
-          void account;
-          console.log('\\n%%begin:' + name);
-          await new Promise(f => setTimeout(f, 500));
-          console.log('\\n%%end:' + name);
-        });
-      }
+      test('one', async ({ account, audit }) => {
+        console.log('\\n%%begin:one:' + account);
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:one');
+      });
+
+      test('two', async ({ database }) => {
+        console.log('\\n%%begin:two');
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:two');
+      });
     `,
   }, { workers: 2 });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(2);
+  expect(result.outputLines).toContain('begin:one:override');
+  expect(conflictingOverlaps(result.outputLines, [['one', 'two']])).toEqual([]);
+});
+
+test('should preserve dependency locks added after an option declaration', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = {
+        fullyParallel: true,
+        use: { account: 'override' },
+      };
+    `,
+    'a.test.ts': `
+      import { test as base } from '@playwright/test';
+
+      const baseWithOption = base.extend<{ database: void, account: string }>({
+        database: [undefined, { locks: ['database'] }],
+        account: [async ({}, use) => {
+          await use('default');
+        }, { option: true }],
+      });
+      const test = baseWithOption.extend({
+        account: async ({ account, database }, use) => {
+          await use(account);
+        },
+      });
+
+      test('one', async ({ account }) => {
+        console.log('\\n%%begin:one:' + account);
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:one');
+      });
+
+      test('two', async ({ database }) => {
+        console.log('\\n%%begin:two');
+        await new Promise(f => setTimeout(f, 500));
+        console.log('\\n%%end:two');
+      });
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.outputLines).toContain('begin:one:override');
   expect(conflictingOverlaps(result.outputLines, [['one', 'two']])).toEqual([]);
 });
 

--- a/tests/playwright-test/test-server.spec.ts
+++ b/tests/playwright-test/test-server.spec.ts
@@ -177,6 +177,51 @@ test('stdio interception', async ({ startTestServer, writeFiles }) => {
   ]));
 });
 
+test('fixture locks survive loader process serialization', async ({ startTestServer, writeFiles }) => {
+  await writeFiles({
+    'playwright.config.ts': `
+      module.exports = {
+        fullyParallel: true,
+        workers: 2,
+        use: { account: 'override' },
+      };
+    `,
+    'a.test.ts': `
+      import { expect, test as base } from '@playwright/test';
+      import fs from 'fs';
+
+      const test = base.extend<{ database: void, account: string }>({
+        database: [undefined, { locks: ['database'] }],
+        account: [async ({ database }, use) => {
+          await use('default');
+        }, { option: true, locks: ['account'] }],
+      });
+      test.use({ account: undefined });
+
+      test('account one', async ({ account }) => {
+        expect(account).toBe('override');
+        fs.writeFileSync(test.info().project.outputDir + '/account-started', '');
+        fs.writeFileSync(test.info().project.outputDir + '/account-active', '');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/database')).toBe(true);
+        fs.unlinkSync(test.info().project.outputDir + '/account-active');
+      });
+
+      test('account two', async ({ account }) => {
+        expect(account).toBe('override');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/account-started')).toBe(true);
+        expect(fs.existsSync(test.info().project.outputDir + '/account-active')).toBe(false);
+      });
+
+      test('database', async ({ database }) => {
+        fs.writeFileSync(test.info().project.outputDir + '/database', '');
+        await expect.poll(() => fs.existsSync(test.info().project.outputDir + '/account-started')).toBe(true);
+      });
+    `,
+  });
+  const testServerConnection = await startTestServer();
+  expect(await testServerConnection.runTests({ locations: [] })).toEqual({ status: 'passed' });
+});
+
 test('find related test files errors', async ({ startTestServer, writeFiles }) => {
   await writeFiles({
     'a.spec.ts': `

--- a/tests/playwright-test/test-server.spec.ts
+++ b/tests/playwright-test/test-server.spec.ts
@@ -196,8 +196,6 @@ test('fixture locks survive loader process serialization', async ({ startTestSer
           await use('default');
         }, { option: true, locks: ['account'] }],
       });
-      test.use({ account: undefined });
-
       test('account one', async ({ account }) => {
         expect(account).toBe('override');
         fs.writeFileSync(test.info().project.outputDir + '/account-started', '');


### PR DESCRIPTION
## Summary
- resolve fixture-lock candidates through project and suite option overrides
- preserve locks reachable through unaffected dependency paths

Depends on #42064.