### PR TITLE
fix(client): report a failed BrowserContext.close() instead of resolving

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -82,6 +82,7 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
 
   readonly _serviceWorkers = new Set<Worker>();
   private _closingStatus: 'none' | 'closing' | 'closed' = 'none';
+  private _closeFailure: Error | undefined;
   private _closeReason: string | undefined;
   private _harRouters: HarRouter[] = [];
   private _onRecorderEventSink: RecorderEventSink | undefined;
@@ -521,15 +522,25 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
   }
 
   async close(options: { reason?: string } = {}): Promise<void> {
-    if (this.isClosed())
+    if (this._closingStatus === 'closed')
       return;
+    if (this._closeFailure)
+      throw this._closeFailure;
     this._closeReason = options.reason;
     this._closingStatus = 'closing';
-    await this.request.dispose(options);
-    await this._instrumentation.runBeforeCloseBrowserContext(this);
-    await this.tracing._exportAllHars();
-    await this._channel.close(options, kNoTimeout);
-    await this._closedPromise;
+    try {
+      await this.request.dispose(options);
+      await this._instrumentation.runBeforeCloseBrowserContext(this);
+      await this.tracing._exportAllHars();
+      await this._channel.close(options, kNoTimeout);
+      await this._closedPromise;
+    } catch (error) {
+      this._closeFailure = error;
+      // The context did not close, so isClosed() must not claim otherwise.
+      if (this._closingStatus === 'closing')
+        this._closingStatus = 'none';
+      throw error;
+    }
   }
 
   async _enableRecorder(params: channels.BrowserContextEnableRecorderParams, eventSink?: RecorderEventSink) {

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -17,6 +17,7 @@
 
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { browserTest as it, expect } from '../config/browserTest';
+import os from 'os';
 import { attachFrame, verifyViewport } from '../config/utils';
 import type { Page } from '@playwright/test';
 
@@ -210,6 +211,20 @@ it('close() should be callable twice', async ({ browser }) => {
   const context = await browser.newContext();
   await context.close();
   await context.close();
+});
+
+it('close() should report a failure instead of silently succeeding', async ({ browserType }) => {
+  const browser = await browserType.launch();
+  // Writing the HAR into a directory fails, which makes close() reject.
+  const context = await browser.newContext({ recordHar: { path: os.tmpdir() } });
+  await context.newPage();
+  const firstError = await context.close().catch(e => e);
+  expect(firstError).toBeInstanceOf(Error);
+  // The context is still alive, so it must not report itself as closed.
+  expect(context.isClosed()).toBe(false);
+  const secondError = await context.close().catch(e => e);
+  expect(secondError).toBeInstanceOf(Error);
+  await browser.close();
 });
 
 it('should pass self to close event', async ({ browser }) => {


### PR DESCRIPTION
Fixes #42069.

### The problem

`BrowserContext.close()` sets `_closingStatus = 'closing'` before its first `await` and never restores it if one of the four awaited steps throws. Since `isClosed()` reports `'closing'` as closed, the entry guard becomes permanent: after one failed close the context can never be closed again, and every later `close()` — from anywhere in the process — resolves as success while doing nothing.

The context stays fully usable meanwhile (navigates, screenshots, opens new pages) and keeps being listed in `browser.contexts()`, so nothing in the public API tells the caller it is still there.

Reproduction (public API only, no monkey-patching):

```js
const context = await browser.newContext({ recordHar: { path: os.tmpdir() } }); // unwritable HAR path
await (await context.newPage()).goto('about:blank');
await context.close().catch(e => console.log('rejected:', e.message));  // rejected: EISDIR ...
console.log(context.isClosed());          // true  ← wrong, the context is live
console.log(browser.contexts().length);   // 1
await context.close();                    // resolves, closes nothing — forever
```

### The change

Remember the failure, restore the status so `isClosed()` stays truthful, and rethrow it on subsequent calls, so `close()` never claims success for a context it did not close.

| | before | after |
|---|---|---|
| first `close()` | rejected | rejected (unchanged) |
| `isClosed()` after the failure | `true` | `false` |
| later `close()` calls | resolved, closed nothing | rejected with the original error |
| healthy context: `close()` twice | ok, no-op | ok, no-op (unchanged) |
| `browser.close()` afterwards | ok | ok |

The added test in `browsercontext-basic.spec.ts` covers the first three rows; the existing `close() should be callable twice` covers the fourth.

### Why the failure is cached rather than retried

I first tried the smaller change of only restoring `_closingStatus`, letting every call retry the close for real. The first two attempts then rejected correctly, but the **third never settled** (still pending after 60 s), so the server-side close path does not appear to survive repeated attempts once a HAR export has failed. Caching the failure keeps the client honest without depending on that.

If you would rather have real retries — which is the nicer semantic — the server side likely needs a fix underneath, and I am happy to look into that instead; just let me know which direction you prefer.
