### PR TITLE
fix(trace-viewer): remove speculative 1s isUnderTest startup delay

### DIFF
--- a/packages/trace-viewer/src/index.tsx
+++ b/packages/trace-viewer/src/index.tsx
@@ -26,8 +26,6 @@ import { LiveWorkbenchLoader } from './ui/liveWorkbenchLoader';
 
   applyTheme();
   if (window.location.protocol !== 'file:') {
-    if (queryParams.get('isUnderTest') === 'true')
-      await new Promise(f => setTimeout(f, 1000));
     if (!navigator.serviceWorker)
       throw new Error(`Service workers are not supported.\nMake sure to serve the Trace Viewer (${window.location}) via HTTPS or localhost.`);
     navigator.serviceWorker.register('sw.bundle.js');

--- a/packages/trace-viewer/src/uiMode.tsx
+++ b/packages/trace-viewer/src/uiMode.tsx
@@ -23,8 +23,6 @@ import { UIModeView } from './ui/uiModeView';
 (async () => {
   applyTheme();
   if (window.location.protocol !== 'file:') {
-    if (window.location.href.includes('isUnderTest=true'))
-      await new Promise(f => setTimeout(f, 1000));
     if (!navigator.serviceWorker)
       throw new Error(`Service workers are not supported.\nMake sure to serve the website (${window.location}) via HTTPS or localhost.`);
     navigator.serviceWorker.register('sw.bundle.js');


### PR DESCRIPTION
Removes the 1s `isUnderTest` sleep before service-worker registration in Trace Viewer and UI Mode.

It was added in 2022 as a speculative flake fix while SW registration was landing (#15330, then #15342), and later copied into UI Mode. It only runs under test, so every TV / UI Mode test was paying ~1s on first interaction. Looking at the history, there isn't a clear remaining reason for it.

Locally, full Trace Viewer and UI Mode suites pass without the delay. Opening as draft so CI can soak whether any of the original flakeiness comes back.
