### PR TITLE
feat(extension): isolate concurrent automation tasks

### DIFF
--- a/.claude/plan/session-isolated-extension.md
+++ b/.claude/plan/session-isolated-extension.md
@@ -1,0 +1,23 @@
+# Session-isolated Playwright extension
+
+## Goal
+
+Make the local Playwright Chrome extension safe for concurrent CLI/MCP tasks without taking browser focus or deleting user-owned tabs.
+
+## Implementation
+
+- [x] Propagate the CLI session name or explicit `PLAYWRIGHT_MCP_TASK_ID` through the MCP relay URL.
+- [x] Replace the extension's single active connection with independent connection records and unique tab groups.
+- [x] Create automation tabs in the background and remove focus-changing calls.
+- [x] Track task-created tabs separately from user-selected tabs and clean only owned resources on disconnect, cancellation, timeout, or service-worker recovery.
+- [x] Preserve CLI/MCP protocol compatibility and document low-token batch workflows.
+- [x] Add targeted regressions for concurrent sessions, focus preservation, and ownership-safe cleanup.
+
+## Acceptance criteria
+
+- Two extension clients remain connected simultaneously and receive different group identities.
+- Opening or selecting task tabs does not activate a tab or focus a Chrome window.
+- Closing either task removes only tabs created by that task and leaves the other task and user tabs intact.
+- Existing extension MCP and CLI session tests continue to pass.
+- Extension build, repository type checking, lint for touched files, and targeted tests pass.
+- The result is committed; push/draft PR is attempted only after rebasing on current `upstream/main`.

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -1,70 +1,82 @@
-# Playwright Chrome Extension
+# Playwright Chrome Extension (Task Isolated)
 
-## Introduction
+This local fork of the Playwright Chrome extension keeps every CLI or MCP task in a separately owned tab group. It is intended for running concurrent automation against an existing Chrome profile without replacing the official extension or interrupting the user's active tab.
 
-The Playwright Chrome Extension allows you to connect to pages in your existing browser and leverage the state of your default user profile. This means the AI assistant can interact with websites where you're already logged in, using your existing cookies, sessions, and browser state, providing a seamless experience without requiring separate authentication or setup.
+## Behavior
 
-## Prerequisites
+- Each CLI session name, explicit `PLAYWRIGHT_MCP_TASK_ID`, or generated MCP connection ID gets a unique tab group.
+- Background approval creates an inactive task-owned blank tab. New tabs and popups created by the task stay owned by that task.
+- Playwright's logical `bringToFront` command does not activate a Chrome tab. The only path that activates a selected target is the explicit **Allow & select** button.
+- Disconnect, success, failure, cancellation, timeout, transport loss, and stale service-worker recovery close only tabs recorded as task-owned. User tabs that were explicitly shared or dragged into the group are only ungrouped.
+- Multiple connections can coexist; the extension status page can disconnect them individually.
 
-- Chrome/Edge/Chromium browser
+## Build and install alongside the official extension
 
-## Installation Steps
+Prerequisites: Node.js, npm, and Chrome/Edge/Chromium.
 
-### Install the Extension
-
-Install [Playwright Extension](https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm) from the Chrome Web Store.
-
-### Configure Playwright MCP server
-
-Configure Playwright MCP server to connect to the browser using the extension by passing the `--extension` option when running the MCP server:
-
-```json
-{
-  "mcpServers": {
-    "playwright-extension": {
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@latest",
-        "--extension"
-      ]
-    }
-  }
-}
+```bash
+git clone https://github.com/WitMiao/playwright.git
+cd playwright
+git checkout codex/session-isolated-extension
+npm ci
+npm run build
 ```
 
-## Usage
+Then open `chrome://extensions`:
 
-### Browser Tab Selection
+1. Enable **Developer mode**.
+2. Choose **Load unpacked**.
+3. Select `packages/extension/dist` from this checkout.
+4. Verify the displayed ID is `mmblklcefccekjbfjehkpmeibpjlanca`.
 
-When the LLM interacts with the browser for the first time, it will load a page where you can select which browser tab the LLM will connect to. This allows you to control which specific page the AI assistant will interact with during the session.
+The fork uses a separate pinned extension ID, so the Chrome Web Store version can remain installed. Do not disable or uninstall the official extension. Use the CLI/MCP entry points from this checkout because they are pinned to the local extension ID.
 
-### Bypassing the Connection Approval Dialog
+## CLI usage
 
-By default, you'll need to approve each connection when the MCP server tries to connect to your browser. To bypass this approval dialog and allow automatic connections, you can use an authentication token.
+Use a distinct session name for every concurrent task. That name becomes the readable ownership label and allows subsequent commands or generated scripts to reuse the same daemon session.
 
-#### Using Your Unique Authentication Token
+```bash
+npm run playwright-cli -- -s=invoice-audit attach --extension=chrome
+npm run playwright-cli -- -s=invoice-audit tab-new https://example.com
+npm run playwright-cli -- -s=invoice-audit run-code --filename=automation.js
+npm run playwright-cli -- -s=invoice-audit detach
+```
 
-1. After installing the extension, click on the extension icon or navigate to the extension's status page
-2. Copy the `PLAYWRIGHT_MCP_EXTENSION_TOKEN` value displayed in the extension UI
-3. Add it to your MCP server configuration:
+`detach` ends the task connection and triggers extension cleanup. `close` is also supported. Keep unrelated concurrent work on a different `-s=<name>`.
+
+## MCP usage
+
+Run the MCP entry point built by this checkout and provide an explicit task ID when the caller can identify the job:
 
 ```json
 {
   "mcpServers": {
-    "playwright-extension": {
-      "command": "npx",
+    "playwright-isolated": {
+      "command": "node",
       "args": [
-        "@playwright/mcp@latest",
-        "--extension"
+        "/absolute/path/to/playwright/packages/playwright-core/lib/entry/mcp.js",
+        "--extension",
+        "--snapshot-mode=none"
       ],
       "env": {
-        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "your-token-here"
+        "PLAYWRIGHT_MCP_TASK_ID": "replace-with-one-id-per-task"
       }
     }
   }
 }
 ```
 
-This token is unique to your browser profile and provides secure authentication between the MCP server and the extension. Once configured, you won't need to manually approve connections each time.
+If `PLAYWRIGHT_MCP_TASK_ID` is omitted, the server generates a unique ID. Never reuse one explicit task ID for concurrently running jobs.
 
+The optional authentication token shown by the extension can skip the approval page. Treat it as a secret: provide it only through the `PLAYWRIGHT_MCP_EXTENSION_TOKEN` environment variable and never commit or log it.
 
+## Lower-token workflow
+
+- Prefer one named CLI session plus `run-code --filename=...` for a complete multi-step flow instead of many one-command round trips.
+- For MCP jobs that do not need element references in every response, use `--snapshot-mode=none` and request a snapshot only when needed.
+- Reuse generated scripts and session names; avoid repeated full snapshots, console dumps, network logs, traces, and screenshots unless they answer a specific diagnostic question.
+- Give every parallel task its own session/task ID so retries never inherit another job's resources.
+
+## Focus limitation
+
+Extension-created tabs are inactive and Playwright tab selection is kept logical. However, when Chrome is launched or asked by the operating system to open the extension's `connect.html` URL, Chrome itself may briefly foreground that connection page before extension JavaScript runs. Chrome does not expose an extension API that can retroactively guarantee the original application focus in this startup path. Token-based approval avoids the interactive page after Chrome has already received the URL, but cannot eliminate this browser/OS startup limitation.

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 3,
-  "name": "Playwright Extension",
-  "version": "0.2.1",
-  "description": "Connect your browser to AI agents through Playwright MCP server and CLI. Enables AI-driven web testing, debugging, and automation.",
+  "name": "Playwright Extension (Task Isolated)",
+  "version": "0.2.2",
+  "description": "Local Playwright bridge with task-isolated tabs, background authorization, and ownership-safe cleanup.",
   "permissions": [
     "debugger",
     "activeTab",
+    "storage",
     "tabs",
     "tabGroups"
   ],
@@ -17,7 +18,7 @@
     "type": "module"
   },
   "action": {
-    "default_title": "Playwright Extension",
+    "default_title": "Playwright Extension (Task Isolated)",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",
@@ -31,5 +32,5 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwRsUUO4mmbCi4JpmrIoIw31iVW9+xUJRZ6nSzya17PQkaUPDxe1IpgM+vpd/xB6mJWlJSyE1Lj95c0sbomGfVY1M0zUeKbaRVcAb+/a6m59gNR+ubFlmTX0nK9/8fE2FpRB9D+4N5jyeIPQuASW/0oswI2/ijK7hH5NTRX8gWc/ROMSgUj7rKhTAgBrICt/NsStgDPsxRTPPJnhJ/ViJtM1P5KsSYswE987DPoFnpmkFpq8g1ae0eYbQfXy55ieaacC4QWyJPj3daU2kMfBQw7MXnnk0H/WDxouMOIHnd8MlQxpEMqAihj7KpuONH+MUhuj9HEQo4df6bSaIuQ0b4QIDAQAB"
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmf/uFlhrk6mLM2TbJU29fjbpGvXkEBQ3CxhF77CQImtgtC9WRhqW0r1e7bRTMcxFuRMNQoWRy/tWS1Kg26mrdh5WySAemgykscVmPkHrEggS/PTn1MEVkOwmbCOVSPefCqVrz+vkraR7I66FGCjoQn/0U/4hNbQNzE10IQgsyl2EVNswq50B4+eL6gy7VTh1Xg/bo/PSCNSG5wMUjl8iPo2vlpVHTtWzMZ7taLKMjOCN3kX0lKBboaeXk5mJ1Whg+ZP31SIZNIr92zzfiO+uT/YytoWu5jkrQ2Gj7I+u4lWd1dgvCharzwnrEJngO0e0CXOkxa43QxKsZjmCzovbjQIDAQAB"
 }

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -16,11 +16,14 @@
 
 import { debugLog } from './relayConnection';
 import { PendingConnections } from './pendingConnection';
-import { ConnectedTabGroup, cleanupStalePlaywrightGroups, isNonDebuggableUrl } from './connectedTabGroup';
+import { ConnectedTabGroup, isNonDebuggableUrl } from './connectedTabGroup';
+import { cleanupStalePlaywrightGroups } from './taskResources';
 
 type PageMessage = {
   type: 'connectionRequested';
   mcpRelayUrl: string;
+  connectionId?: string;
+  taskId?: string;
 } | {
   type: 'getTabs';
 } | {
@@ -33,13 +36,17 @@ type PageMessage = {
   type: 'getConnectionStatus';
 } | {
   type: 'disconnect';
+  connectionId?: string;
 } | {
   type: 'keepalive';
 };
 
 class PlaywrightExtension {
-  private _activeGroup: ConnectedTabGroup | undefined;
-  private _activeClientName: string | undefined;
+  private _activeConnections = new Map<string, {
+    group: ConnectedTabGroup;
+    clientName?: string;
+    taskId: string;
+  }>();
   private _pendingConnections = new PendingConnections();
   // Service worker restarts lose all connection state, so any existing
   // Playwright groups are stale. Connections wait on this before reconciling.
@@ -55,7 +62,11 @@ class PlaywrightExtension {
   private _onMessage(message: PageMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: any) => void) {
     switch (message.type) {
       case 'connectionRequested':
-        this._pendingConnections.create(sender.tab!.id!, message.mcpRelayUrl);
+        this._pendingConnections.create(sender.tab!.id!, {
+          mcpRelayUrl: message.mcpRelayUrl,
+          connectionId: message.connectionId || crypto.randomUUID(),
+          taskId: message.taskId || 'Playwright',
+        });
         sendResponse({ success: true });
         return false;
       case 'getTabs':
@@ -64,25 +75,24 @@ class PlaywrightExtension {
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true;
       case 'connectToTab': {
-        // Token-bypass (no specific pick) falls back to the connect page itself
-        // so `ConnectedTabGroup` always has a concrete tab to start from. Both
-        // sender.tab and UI-supplied tabs come from chrome.tabs.query / runtime
-        // message sender, where `id` is always defined.
-        const selectedTab = (message.tab ?? sender.tab!) as chrome.tabs.Tab & { id: number };
-        this._connectTab(sender.tab!.id!, selectedTab, message.clientName).then(
+        this._connectTab(sender.tab!.id!, sender.tab!.windowId, message.tab, message.clientName).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true; // Return true to indicate that the response will be sent asynchronously
       }
       case 'getConnectionStatus':
         sendResponse({
-          connectedTabIds: this._activeGroup?.connectedTabIds() ?? [],
-          clientName: this._activeClientName,
+          connections: [...this._activeConnections].map(([connectionId, connection]) => ({
+            connectionId,
+            clientName: connection.clientName,
+            taskId: connection.taskId,
+            connectedTabIds: connection.group.connectedTabIds(),
+          })),
         });
         return false;
       case 'disconnect':
         try {
-          this._disconnect('User disconnected');
+          this._disconnect(message.connectionId, 'User disconnected');
           sendResponse({ success: true });
         } catch (error: any) {
           sendResponse({ success: false, error: error.message });
@@ -95,41 +105,56 @@ class PlaywrightExtension {
     }
   }
 
-  private async _connectTab(selectorTabId: number, tab: chrome.tabs.Tab & { id: number }, clientName: string | undefined): Promise<void> {
+  private async _connectTab(selectorTabId: number, selectorWindowId: number, tab: chrome.tabs.Tab | undefined, clientName: string | undefined): Promise<void> {
     try {
       await this._cleanupPromise;
-      this._disconnect('Another connection is requested');
 
-      const connection = await this._pendingConnections.take(selectorTabId);
-      if (!connection)
+      const pending = await this._pendingConnections.take(selectorTabId);
+      if (!pending)
         throw new Error('Pending client connection closed');
+      if (this._activeConnections.has(pending.connectionId)) {
+        pending.connection.close('Duplicate connection id');
+        throw new Error('Connection id is already active');
+      }
+      const selectedTab = tab ?? await chrome.tabs.create({
+        url: 'about:blank',
+        active: false,
+        index: 0,
+        windowId: selectorWindowId,
+      });
+      if (selectedTab.id === undefined) {
+        pending.connection.close('Failed to create a background task tab');
+        throw new Error('Failed to create a background task tab');
+      }
 
-      const group = new ConnectedTabGroup(connection, tab);
+      const group = new ConnectedTabGroup(
+          pending.connection,
+          selectedTab,
+          pending.connectionId,
+          pending.taskId,
+          !tab);
       group.onclose = () => {
-        if (this._activeGroup === group) {
-          this._activeGroup = undefined;
-          this._activeClientName = undefined;
-        }
+        if (this._activeConnections.get(pending.connectionId)?.group === group)
+          this._activeConnections.delete(pending.connectionId);
       };
-      this._activeGroup = group;
-      this._activeClientName = clientName;
+      this._activeConnections.set(pending.connectionId, { group, clientName, taskId: pending.taskId });
 
-      await Promise.all([
-        chrome.tabs.update(tab.id, { active: true }),
-        chrome.windows.update(tab.windowId, { focused: true }),
-      ]).catch(() => {});
-
-      if (tab.id !== selectorTabId)
-        await chrome.tabs.remove(selectorTabId).catch(() => {});
+      // Activating a target is reserved for the user's explicit
+      // "Allow & select" click. Background/token authorization never enters
+      // this branch and never changes the active tab.
+      if (tab)
+        await chrome.tabs.update(selectedTab.id, { active: true }).catch(() => {});
+      await chrome.tabs.remove(selectorTabId).catch(() => {});
     } catch (error: any) {
-      debugLog(`Failed to connect tab ${tab.id}:`, error.message);
+      debugLog(`Failed to connect task tab:`, error.message);
       throw error;
     }
   }
 
   private async _getTabs(): Promise<chrome.tabs.Tab[]> {
     const tabs = await chrome.tabs.query({});
-    return tabs.filter(tab => !isNonDebuggableUrl(tab.url));
+    const connectedTabIds = new Set([...this._activeConnections.values()].flatMap(connection => connection.group.connectedTabIds()));
+    return tabs.filter(tab => !isNonDebuggableUrl(tab.url) && (tab.id === undefined || !connectedTabIds.has(tab.id)));
   }
 
   private async _onActionClicked(): Promise<void> {
@@ -139,12 +164,16 @@ class PlaywrightExtension {
     });
   }
 
-  // Closes the active group's connection if any. ConnectedTabGroup's onclose
-  // handles state cleanup (connectedTabIds, badges, reconcile).
-  private _disconnect(reason: string) {
-    this._activeGroup?.close(reason);
-    this._activeGroup = undefined;
-    this._activeClientName = undefined;
+  // Closes one connection, or every connection for backwards-compatible
+  // callers that omit a connection id. Each ConnectedTabGroup owns its own
+  // resource cleanup.
+  private _disconnect(connectionId: string | undefined, reason: string) {
+    if (connectionId) {
+      this._activeConnections.get(connectionId)?.group.close(reason);
+      return;
+    }
+    for (const connection of this._activeConnections.values())
+      connection.group.close(reason);
   }
 }
 

--- a/packages/extension/src/connectedTabGroup.ts
+++ b/packages/extension/src/connectedTabGroup.ts
@@ -15,27 +15,14 @@
  */
 
 import { RelayConnection, debugLog } from './relayConnection';
+import { groupTitleForTask, removeTaskResources, storeTaskResources } from './taskResources';
 
-const PLAYWRIGHT_GROUP_TITLE = 'Playwright';
 const PLAYWRIGHT_GROUP_COLOR = 'green';
-const NON_DEBUGGABLE_SCHEMES = ['chrome:', 'edge:', 'devtools:'];
+const NON_DEBUGGABLE_SCHEMES = ['chrome:', 'chrome-extension:', 'edge:', 'devtools:'];
 const CONNECTED_BADGE = { text: '✓', color: '#4CAF50', title: 'Connected to Playwright client' };
 
 export function isNonDebuggableUrl(url: string | undefined): boolean {
   return !!url && NON_DEBUGGABLE_SCHEMES.some(s => url.startsWith(s));
-}
-
-// Ungroups any Playwright-titled groups left behind by a prior service worker.
-export async function cleanupStalePlaywrightGroups(): Promise<void> {
-  try {
-    const groups = await chrome.tabGroups.query({ title: PLAYWRIGHT_GROUP_TITLE });
-    const tabsPerGroup = await Promise.all(groups.map(g => chrome.tabs.query({ groupId: g.id })));
-    const tabIds = tabsPerGroup.flat().map(t => t.id).filter((id): id is number => id !== undefined);
-    if (tabIds.length)
-      await chrome.tabs.ungroup(tabIds);
-  } catch (error: any) {
-    debugLog('Error cleaning up stale groups:', error);
-  }
 }
 
 // The Playwright tab group for an active RelayConnection. The Chrome tab group
@@ -48,22 +35,35 @@ export async function cleanupStalePlaywrightGroups(): Promise<void> {
 // in `_onTabUpdated` stay synchronous.
 export class ConnectedTabGroup {
   private _connection: RelayConnection;
+  private _connectionId: string;
+  private _groupTitle: string;
   private _groupId: number | null = null;
   private _groupTabIds: Set<number> = new Set();
-  private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
+  private _ownedTabIds: Set<number> = new Set();
+  private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.OnUpdatedInfo, tab: chrome.tabs.Tab) => void;
+  private _onTabCreatedListener: (tab: chrome.tabs.Tab) => void;
   private _onTabRemovedListener: (tabId: number) => void;
+  private _resourceUpdate = Promise.resolve();
+  private _closed = false;
 
   onclose?: () => void;
 
-  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab) {
+  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab, connectionId: string, taskId: string, selectedTabOwned: boolean) {
     this._connection = connection;
+    this._connectionId = connectionId;
+    this._groupTitle = groupTitleForTask(taskId, connectionId);
     this._connection.onclose = () => this._onConnectionClose();
     this._connection.ontabattached = (tabId: number) => this._onTabAttached(tabId);
     this._connection.ontabdetached = (tabId: number) => this._onTabDetached(tabId);
+    this._connection.onownedtabcreated = (tabId: number) => this._onOwnedTabCreated(tabId);
     this._onTabUpdatedListener = this._onTabUpdated.bind(this);
+    this._onTabCreatedListener = this._onTabCreated.bind(this);
     this._onTabRemovedListener = this._onTabRemoved.bind(this);
     chrome.tabs.onUpdated.addListener(this._onTabUpdatedListener);
+    chrome.tabs.onCreated.addListener(this._onTabCreatedListener);
     chrome.tabs.onRemoved.addListener(this._onTabRemovedListener);
+    if (selectedTabOwned)
+      this._ownedTabIds.add(selectedTab.id!);
     // Seed the relay with the user-selected tab, then close out the initial
     // handshake. The relay holds Playwright-side CDP traffic until
     // `didInitialize` arrives, so it sees a fully populated tab model by the
@@ -76,11 +76,17 @@ export class ConnectedTabGroup {
     return [...this._groupTabIds];
   }
 
+  groupId(): number | null {
+    return this._groupId;
+  }
+
   close(reason: string): void {
     this._connection.close(reason);
   }
 
-  private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab): void {
+  private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.OnUpdatedInfo, tab: chrome.tabs.Tab): void {
+    if (this._closed)
+      return;
     if (changeInfo.groupId !== undefined)
       this._onTabGroupChanged(tabId, tab);
     if (changeInfo.url === undefined)
@@ -97,6 +103,8 @@ export class ConnectedTabGroup {
   // detaches on exit; a chrome:// tab stays in the group until it navigates
   // (handled in _onTabUpdated).
   private _onTabGroupChanged(tabId: number, tab: chrome.tabs.Tab): void {
+    if (this._closed)
+      return;
     const inOurGroup = this._groupId !== null && tab.groupId === this._groupId;
     const wasInGroup = this._groupTabIds.has(tabId);
     if (inOurGroup === wasInGroup)
@@ -107,18 +115,46 @@ export class ConnectedTabGroup {
         this._connection.attachTab(tab);
     } else {
       this._groupTabIds.delete(tabId);
+      this._ownedTabIds.delete(tabId);
       if (this._connection.attachedTabs.has(tabId))
         this._connection.detachTab(tabId);
     }
+    this._persistResources();
   }
 
   private _onTabRemoved(tabId: number): void {
     this._groupTabIds.delete(tabId);
+    this._ownedTabIds.delete(tabId);
+    this._persistResources();
+  }
+
+  // Chrome creates popups and modifier-click tabs directly inside the opener's
+  // group. They never emit a groupId transition, so observe creation itself.
+  // A tab born inside the task group is task-owned; dragging it out later
+  // relinquishes ownership through _onTabGroupChanged.
+  private _onTabCreated(tab: chrome.tabs.Tab): void {
+    if (this._closed || this._groupId === null || tab.groupId !== this._groupId || tab.id === undefined)
+      return;
+    this._ownedTabIds.add(tab.id);
+    this._groupTabIds.add(tab.id);
+    if (!isNonDebuggableUrl(tab.url))
+      this._connection.attachTab(tab);
+    this._persistResources();
   }
 
   private _onTabAttached(tabId: number): void {
+    if (this._closed)
+      return;
     void this._updateBadge(tabId, CONNECTED_BADGE);
     void this._addTabToGroup(tabId);
+  }
+
+  private _onOwnedTabCreated(tabId: number): void {
+    if (this._closed) {
+      void chrome.tabs.remove(tabId).catch(() => {});
+      return;
+    }
+    this._ownedTabIds.add(tabId);
   }
 
   // The debugger detached (drag-out, tab close, or external action). Clear the
@@ -129,16 +165,32 @@ export class ConnectedTabGroup {
   }
 
   private _onConnectionClose(): void {
+    if (this._closed)
+      return;
+    this._closed = true;
     chrome.tabs.onUpdated.removeListener(this._onTabUpdatedListener);
+    chrome.tabs.onCreated.removeListener(this._onTabCreatedListener);
     chrome.tabs.onRemoved.removeListener(this._onTabRemovedListener);
-    const groupTabs = [...this._groupTabIds];
+    const ownedTabs = [...this._ownedTabIds];
+    const borrowedTabs = [...this._groupTabIds].filter(tabId => !this._ownedTabIds.has(tabId));
     this._groupTabIds.clear();
-    if (groupTabs.length) {
-      this._retryOnDrag(() => chrome.tabs.ungroup(groupTabs)).catch(error => {
-        debugLog('Error ungrouping tabs on close:', error);
+    this._ownedTabIds.clear();
+    void this._cleanupResources(ownedTabs, borrowedTabs);
+    this.onclose?.();
+  }
+
+  private async _cleanupResources(ownedTabs: number[], borrowedTabs: number[]): Promise<void> {
+    await this._resourceUpdate;
+    if (ownedTabs.length)
+      await chrome.tabs.remove(ownedTabs).catch(error => debugLog('Error closing owned tabs on close:', error));
+    if (borrowedTabs.length) {
+      const [firstBorrowedTab, ...otherBorrowedTabs] = borrowedTabs;
+      const tabIds = otherBorrowedTabs.length ? [firstBorrowedTab, ...otherBorrowedTabs] as [number, ...number[]] : firstBorrowedTab;
+      await this._retryOnDrag(() => chrome.tabs.ungroup(tabIds)).catch(error => {
+        debugLog('Error ungrouping borrowed tabs on close:', error);
       });
     }
-    this.onclose?.();
+    await removeTaskResources(this._connectionId).catch(error => debugLog('Error removing task resource record:', error));
   }
 
   private async _updateBadge(tabId: number, { text, color, title }: { text: string; color?: string, title?: string }): Promise<void> {
@@ -158,21 +210,45 @@ export class ConnectedTabGroup {
   // that arrives concurrently (`_groupId` still null, wasInGroup still false)
   // becomes a harmless no-op rather than taking the drag-out branch.
   private async _addTabToGroup(tabId: number): Promise<void> {
-    if (this._groupTabIds.has(tabId))
+    if (this._closed || this._groupTabIds.has(tabId))
       return;
     try {
       await this._retryOnDrag(async () => {
         if (this._groupId === null) {
           this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
-          await chrome.tabGroups.update(this._groupId, { color: PLAYWRIGHT_GROUP_COLOR, title: PLAYWRIGHT_GROUP_TITLE });
+          await chrome.tabGroups.update(this._groupId, { color: PLAYWRIGHT_GROUP_COLOR, title: this._groupTitle });
         } else {
           await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
         }
       });
+      if (this._closed) {
+        if (this._ownedTabIds.has(tabId))
+          await chrome.tabs.remove(tabId).catch(() => {});
+        else
+          await chrome.tabs.ungroup(tabId).catch(() => {});
+        return;
+      }
       this._groupTabIds.add(tabId);
+      this._persistResources();
     } catch (error: any) {
       debugLog('Error adding tab to group:', error);
     }
+  }
+
+  private _persistResources(): void {
+    if (this._closed || this._groupId === null)
+      return;
+    const resources = {
+      version: 1 as const,
+      connectionId: this._connectionId,
+      groupId: this._groupId,
+      groupTitle: this._groupTitle,
+      tabIds: [...this._groupTabIds],
+      ownedTabIds: [...this._ownedTabIds].filter(tabId => this._groupTabIds.has(tabId)),
+    };
+    this._resourceUpdate = this._resourceUpdate
+        .then(() => storeTaskResources(resources))
+        .catch(error => debugLog('Error storing task resources:', error));
   }
 
   // Chrome throws "user may be dragging a tab" while a drag is in progress.

--- a/packages/extension/src/pendingConnection.ts
+++ b/packages/extension/src/pendingConnection.ts
@@ -16,25 +16,39 @@
 
 import { RelayConnection, debugLog } from './relayConnection';
 
+export type PendingConnection = {
+  connection: RelayConnection;
+  connectionId: string;
+  taskId: string;
+};
+
+type PendingConnectionRequest = Omit<PendingConnection, 'connection'> & {
+  mcpRelayUrl: string;
+};
+
 // Relay URLs recorded by `connectionRequested`, keyed by the connect page tab
 // id. The relay WebSocket opens lazily in `take` once the user clicks Allow.
 export class PendingConnections {
-  private _map = new Map<number, string>();
+  private _map = new Map<number, PendingConnectionRequest>();
 
   constructor() {
     chrome.tabs.onRemoved.addListener(tabId => this._map.delete(tabId));
   }
 
-  create(selectorTabId: number, mcpRelayUrl: string): void {
-    this._map.set(selectorTabId, mcpRelayUrl);
+  create(selectorTabId: number, request: PendingConnectionRequest): void {
+    this._map.set(selectorTabId, request);
   }
 
-  async take(selectorTabId: number): Promise<RelayConnection | undefined> {
-    const mcpRelayUrl = this._map.get(selectorTabId);
-    if (mcpRelayUrl === undefined)
+  async take(selectorTabId: number): Promise<PendingConnection | undefined> {
+    const request = this._map.get(selectorTabId);
+    if (!request)
       return undefined;
     this._map.delete(selectorTabId);
-    return openRelayConnection(mcpRelayUrl);
+    return {
+      connection: await openRelayConnection(request.mcpRelayUrl),
+      connectionId: request.connectionId,
+      taskId: request.taskId,
+    };
   }
 }
 

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -58,6 +58,8 @@ export class RelayConnection {
   private _ws: WebSocket;
   // Tabs whose debugger we have explicitly attached for this connection.
   private _attachedTabs = new Set<number>();
+  // Tabs already reported to the relay but not attached by chrome.debugger yet.
+  private _pendingTabs = new Set<number>();
   // Once we've attached at least one tab, detaching the last one closes the connection.
   private _hasEverAttached = false;
   private _eventListeners: Array<{ remove: () => void }> = [];
@@ -66,6 +68,7 @@ export class RelayConnection {
   onclose?: () => void;
   ontabattached?: (tabId: number) => void;
   ontabdetached?: (tabId: number) => void;
+  onownedtabcreated?: (tabId: number) => void;
 
   get attachedTabs(): ReadonlySet<number> {
     return this._attachedTabs;
@@ -99,8 +102,9 @@ export class RelayConnection {
   // chrome.debugger.attach, which flows through _handleCommand and fires
   // ontabattached.
   attachTab(tab: chrome.tabs.Tab): void {
-    if (this._closed || this._attachedTabs.has(tab.id!))
+    if (this._closed || this._attachedTabs.has(tab.id!) || this._pendingTabs.has(tab.id!))
       return;
+    this._pendingTabs.add(tab.id!);
     this._sendMessage({ method: 'chrome.tabs.onCreated', params: [tab] });
   }
 
@@ -123,12 +127,14 @@ export class RelayConnection {
   }
 
   private _notifyTabAttached(tabId: number): void {
+    this._pendingTabs.delete(tabId);
     this._attachedTabs.add(tabId);
     this._hasEverAttached = true;
     this.ontabattached?.(tabId);
   }
 
   private _notifyTabDetached(tabId: number): void {
+    this._pendingTabs.delete(tabId);
     this._attachedTabs.delete(tabId);
     this.ontabdetached?.(tabId);
   }
@@ -155,6 +161,7 @@ export class RelayConnection {
       chrome.debugger.detach({ tabId }).catch(() => {});
       this._notifyTabDetached(tabId);
     }
+    this._pendingTabs.clear();
     this.onclose?.();
   }
 
@@ -166,6 +173,15 @@ export class RelayConnection {
   // Forwards chrome.* events concerning attached tabs to the relay, then runs
   // shared detach bookkeeping.
   private _onChromeEvent(fullMethod: string, args: any[]): void {
+    if (fullMethod === 'chrome.tabs.onCreated') {
+      const tab = args[0] as chrome.tabs.Tab;
+      if (tab.openerTabId === undefined || !this._attachedTabs.has(tab.openerTabId) || tab.id === undefined || this._attachedTabs.has(tab.id) || this._pendingTabs.has(tab.id))
+        return;
+      this._pendingTabs.add(tab.id);
+      this.onownedtabcreated?.(tab.id);
+      this._sendMessage({ method: fullMethod, params: args });
+      return;
+    }
     const tabId = this._tabIdForEventArgs(fullMethod, args);
     if (tabId === undefined || !this._attachedTabs.has(tabId))
       return;
@@ -215,6 +231,11 @@ export class RelayConnection {
     try {
       response.result = await this._handleCommand(message);
     } catch (error: any) {
+      if (message.method === 'chrome.debugger.attach') {
+        const target = (message.params as any[] | undefined)?.[0] as chrome.debugger.Debuggee | undefined;
+        if (target?.tabId !== undefined)
+          this._pendingTabs.delete(target.tabId);
+      }
       debugLog(`Error handling command ${JSON.stringify(message)}:`, error);
       response.error = error.message;
     }
@@ -225,12 +246,23 @@ export class RelayConnection {
     if (!ALLOWED_CHROME_COMMANDS.has(message.method))
       throw new Error(`Unknown method: ${message.method}`);
     const args = (message.params ?? []) as any[];
+    if (message.method === 'chrome.tabs.create')
+      args[0] = { ...args[0], active: false };
+    // Playwright uses Page.bringToFront when changing its logical current tab.
+    // In extension mode that must not change the user's active Chrome tab.
+    if (message.method === 'chrome.debugger.sendCommand' && args[1] === 'Page.bringToFront')
+      return {};
     const result = await invokeChromeMethod(message.method, args);
     // Attach bookkeeping; detach flows through the chrome.debugger.onDetach event.
     if (message.method === 'chrome.debugger.attach') {
       const target = args[0] as chrome.debugger.Debuggee | undefined;
       if (target?.tabId !== undefined)
         this._notifyTabAttached(target.tabId);
+    }
+    if (message.method === 'chrome.tabs.create') {
+      const tabId = (result as chrome.tabs.Tab | undefined)?.id;
+      if (tabId !== undefined)
+        this.onownedtabcreated?.(tabId);
     }
     return result ?? {};
   }

--- a/packages/extension/src/taskResources.ts
+++ b/packages/extension/src/taskResources.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { debugLog } from './relayConnection';
+
+export const PLAYWRIGHT_GROUP_TITLE_PREFIX = 'Playwright · ';
+
+const STORAGE_KEY_PREFIX = 'playwright.taskResources.';
+
+export type StoredTaskResources = {
+  version: 1;
+  connectionId: string;
+  groupId: number;
+  groupTitle: string;
+  tabIds: number[];
+  ownedTabIds: number[];
+};
+
+export function groupTitleForTask(taskId: string, connectionId: string): string {
+  const taskLabel = taskId.trim().replace(/\s+/g, ' ').slice(0, 48) || 'task';
+  const connectionLabel = connectionId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 8) || 'local';
+  return `${PLAYWRIGHT_GROUP_TITLE_PREFIX}${taskLabel} · ${connectionLabel}`;
+}
+
+export async function storeTaskResources(resources: StoredTaskResources): Promise<void> {
+  await chrome.storage.local.set({ [storageKey(resources.connectionId)]: resources });
+}
+
+export async function removeTaskResources(connectionId: string): Promise<void> {
+  await chrome.storage.local.remove(storageKey(connectionId));
+}
+
+// A service-worker restart drops every relay WebSocket. Reconcile resources
+// recorded before the restart, then conservatively ungroup any marked group
+// for which storage is unavailable. Tabs are closed only when both the stored
+// ownership record and the exact group title still match.
+export async function cleanupStalePlaywrightGroups(): Promise<void> {
+  try {
+    const storage = await chrome.storage.local.get(null);
+    const records = Object.entries(storage)
+        .filter(([key]) => key.startsWith(STORAGE_KEY_PREFIX))
+        .map(([, value]) => value as StoredTaskResources);
+    for (const record of records) {
+      try {
+        await cleanupRecord(record);
+      } finally {
+        await removeTaskResources(record.connectionId);
+      }
+    }
+  } catch (error: any) {
+    debugLog('Error cleaning recorded task resources:', error);
+  }
+
+  try {
+    const groups = await chrome.tabGroups.query({});
+    for (const group of groups) {
+      if (!group.title?.startsWith(PLAYWRIGHT_GROUP_TITLE_PREFIX))
+        continue;
+      const tabs = await chrome.tabs.query({ groupId: group.id });
+      await ungroupTabs(tabs.flatMap(tab => tab.id ?? []));
+    }
+  } catch (error: any) {
+    debugLog('Error cleaning unrecorded Playwright groups:', error);
+  }
+}
+
+async function cleanupRecord(record: StoredTaskResources): Promise<void> {
+  let group: chrome.tabGroups.TabGroup;
+  try {
+    group = await chrome.tabGroups.get(record.groupId);
+  } catch {
+    return;
+  }
+  if (group.title !== record.groupTitle)
+    return;
+
+  const tabs = await chrome.tabs.query({ groupId: record.groupId });
+  const currentTabIds = tabs.flatMap(tab => tab.id ?? []);
+  const ownedTabIds = record.ownedTabIds.filter(tabId => currentTabIds.includes(tabId));
+  const borrowedTabIds = currentTabIds.filter(tabId => !ownedTabIds.includes(tabId));
+  await clearBadges(currentTabIds);
+  if (ownedTabIds.length)
+    await chrome.tabs.remove(ownedTabIds).catch(error => debugLog('Error closing stale task tabs:', error));
+  await ungroupTabs(borrowedTabIds);
+}
+
+async function clearBadges(tabIds: number[]): Promise<void> {
+  await Promise.all(tabIds.map(tabId => Promise.all([
+    chrome.action.setBadgeText({ tabId, text: '' }),
+    chrome.action.setTitle({ tabId, title: '' }),
+  ]).catch(() => {})));
+}
+
+async function ungroupTabs(tabIds: number[]): Promise<void> {
+  if (!tabIds.length)
+    return;
+  const [firstTabId, ...otherTabIds] = tabIds;
+  await chrome.tabs.ungroup(otherTabIds.length ? [firstTabId, ...otherTabIds] : firstTabId)
+      .catch(error => debugLog('Error ungrouping stale task tabs:', error));
+}
+
+function storageKey(connectionId: string): string {
+  return STORAGE_KEY_PREFIX + connectionId;
+}

--- a/packages/extension/src/ui/connect.css
+++ b/packages/extension/src/ui/connect.css
@@ -108,6 +108,11 @@ body {
   min-width: 90px;
 }
 
+.button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
 .button.primary {
   background-color: #f8f9fa;
   color: #3c4043;
@@ -153,6 +158,21 @@ body {
 .client-info {
   font-size: 14px;
   color: #1f2328;
+  min-width: 0;
+}
+
+.connection-section + .connection-section {
+  border-top: 1px solid #d8dee4;
+  padding-top: 16px;
+  margin-top: 16px;
+}
+
+.task-info {
+  max-width: 420px;
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Tab selection */

--- a/packages/extension/src/ui/connect.tsx
+++ b/packages/extension/src/ui/connect.tsx
@@ -36,6 +36,16 @@ const clientInfo = (() => {
   }
 })();
 
+const connectionInfo = (() => {
+  const params = new URLSearchParams(window.location.search);
+  const relayUrl = params.get('mcpRelayUrl') ?? '';
+  const fallbackConnectionId = relayUrl.split('/').filter(Boolean).at(-1) || crypto.randomUUID();
+  return {
+    connectionId: params.get('connectionId') || fallbackConnectionId,
+    taskId: params.get('taskId') || clientInfo,
+  };
+})();
+
 const ConnectApp: React.FC = () => {
   const [tabs, setTabs] = useState<chrome.tabs.Tab[]>([]);
   const [status, setStatus] = useState<Status | null>(null);
@@ -91,7 +101,11 @@ const ConnectApp: React.FC = () => {
       }
       // The background only records the relay URL; the WS to the relay opens
       // once the user clicks Allow.
-      await chrome.runtime.sendMessage({ type: 'connectionRequested', mcpRelayUrl: relayUrl });
+      await chrome.runtime.sendMessage({
+        type: 'connectionRequested',
+        mcpRelayUrl: relayUrl,
+        ...connectionInfo,
+      });
 
       const expectedToken = getOrCreateAuthToken();
       const token = params.get('token');
@@ -176,11 +190,19 @@ const ConnectApp: React.FC = () => {
           <AuthTokenSection />
         )}
 
+        {status?.type === 'connecting' && (
+          <div className='button-container'>
+            <Button variant='primary' onClick={() => handleConnectToTab()}>
+              Allow in background
+            </Button>
+          </div>
+        )}
+
         {showTabList && (
           <div>
             <div className='tab-section-title'>
               You can drag tabs into the Playwright group later to make them accessible to the client.
-              Optionally, select a tab to allow and immediately switch to it:
+              Only choose a tab below if you explicitly want to authorize and switch to it:
             </div>
             <div>
               {tabs.map(tab => (
@@ -203,13 +225,12 @@ const ConnectApp: React.FC = () => {
 };
 
 const VersionMismatchError: React.FC<{ extensionVersion: string }> = ({ extensionVersion }) => {
-  const readmeUrl = 'https://github.com/microsoft/playwright/blob/main/packages/extension/README.md';
-  const chromeWebStoreUrl = 'https://chromewebstore.google.com/detail/playwright-extension/mmlmfjhmonkocbjadbfplnigmagldckm';
+  const readmeUrl = 'https://github.com/WitMiao/playwright/blob/codex/session-isolated-extension/packages/extension/README.md';
   return (
     <div>
       Playwright client trying to connect requires newer extension version (current version: {extensionVersion}).{' '}
-      Update <a href={chromeWebStoreUrl} target='_blank' rel='noopener noreferrer'>Playwright Extension</a> from the Chrome Web Store to the latest version.{' '}
-      See <a href={readmeUrl} target='_blank' rel='noopener noreferrer'>installation instructions</a> for more details.
+      Rebuild and reload the local extension.{' '}
+      See <a href={readmeUrl} target='_blank' rel='noopener noreferrer'>local installation instructions</a> for details.
     </div>
   );
 };

--- a/packages/extension/src/ui/status.tsx
+++ b/packages/extension/src/ui/status.tsx
@@ -19,19 +19,35 @@ import { createRoot } from 'react-dom/client';
 import { Button, TabItem  } from './tabItem';
 import { AuthTokenSection } from './authToken';
 
+type ConnectionStatus = {
+  connectionId: string;
+  clientName?: string;
+  taskId: string;
+  connectedTabIds: number[];
+};
+
+type ConnectionView = Omit<ConnectionStatus, 'connectedTabIds'> & {
+  tabs: chrome.tabs.Tab[];
+};
+
 const StatusApp: React.FC = () => {
-  const [connectedTabs, setConnectedTabs] = useState<chrome.tabs.Tab[]>([]);
-  const [clientName, setClientName] = useState<string | undefined>(undefined);
+  const [connections, setConnections] = useState<ConnectionView[]>([]);
+  const [disconnecting, setDisconnecting] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     void loadStatus();
   }, []);
 
   const loadStatus = async () => {
-    const { connectedTabIds, clientName } = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
-    const tabs = await Promise.all((connectedTabIds as number[] ?? []).map(tabId => chrome.tabs.get(tabId)));
-    setConnectedTabs(tabs);
-    setClientName(clientName);
+    const response = await chrome.runtime.sendMessage({ type: 'getConnectionStatus' });
+    const views = await Promise.all((response.connections as ConnectionStatus[] ?? []).map(async connection => ({
+      connectionId: connection.connectionId,
+      clientName: connection.clientName,
+      taskId: connection.taskId,
+      tabs: (await Promise.all(connection.connectedTabIds.map(tabId => chrome.tabs.get(tabId).catch(() => undefined))))
+          .filter((tab): tab is chrome.tabs.Tab => !!tab),
+    })));
+    setConnections(views);
   };
 
   const openTab = async (tabId: number) => {
@@ -39,36 +55,55 @@ const StatusApp: React.FC = () => {
     window.close();
   };
 
-  const disconnect = async () => {
-    await chrome.runtime.sendMessage({ type: 'disconnect' });
-    window.close();
+  const disconnect = async (connectionId: string) => {
+    setDisconnecting(current => new Set(current).add(connectionId));
+    try {
+      await chrome.runtime.sendMessage({ type: 'disconnect', connectionId });
+      await loadStatus();
+    } finally {
+      setDisconnecting(current => {
+        const next = new Set(current);
+        next.delete(connectionId);
+        return next;
+      });
+    }
   };
 
   return (
     <div className='app-container'>
       <div className='content-wrapper'>
-        {connectedTabs.length > 0 ? (
+        {connections.length > 0 ? (
           <div>
-            <div className='connection-header'>
-              <div className='client-info'>
-                Connected to <strong>"{clientName || 'unknown'}"</strong>
-              </div>
-              <Button variant='primary' onClick={disconnect}>
-                Disconnect
-              </Button>
-            </div>
-            <div className='tab-section-title'>
-              {connectedTabs.length === 1 ? 'Accessible page:' : 'Accessible pages:'}
-            </div>
-            <div>
-              {connectedTabs.map(tab => (
-                <TabItem
-                  key={tab.id}
-                  tab={tab}
-                  onClick={() => openTab(tab.id!)}
-                />
-              ))}
-            </div>
+            {connections.map(connection => (
+              <section className='connection-section' key={connection.connectionId}>
+                <div className='connection-header'>
+                  <div className='client-info'>
+                    <div>Connected client: <strong>"{connection.clientName || 'unknown'}"</strong></div>
+                    <div className='task-info' title={connection.taskId}>Task: <strong>{connection.taskId}</strong></div>
+                  </div>
+                  <Button
+                    variant='primary'
+                    onClick={() => disconnect(connection.connectionId)}
+                    disabled={disconnecting.has(connection.connectionId)}
+                    ariaLabel={`Disconnect ${connection.clientName || 'unknown'} task ${connection.taskId}`}
+                  >
+                    {disconnecting.has(connection.connectionId) ? 'Disconnecting…' : 'Disconnect'}
+                  </Button>
+                </div>
+                <div className='tab-section-title'>
+                  {connection.tabs.length === 0 ? 'No accessible pages.' : connection.tabs.length === 1 ? 'Accessible page:' : 'Accessible pages:'}
+                </div>
+                <div>
+                  {connection.tabs.map(tab => (
+                    <TabItem
+                      key={tab.id}
+                      tab={tab}
+                      onClick={() => openTab(tab.id!)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
           </div>
         ) : (
           <div className='status-banner'>

--- a/packages/extension/src/ui/tabItem.tsx
+++ b/packages/extension/src/ui/tabItem.tsx
@@ -16,13 +16,15 @@
 
 import React from 'react';
 
-export const Button: React.FC<{ variant: 'primary' | 'default' | 'reject'; onClick: () => void; children: React.ReactNode }> = ({
+export const Button: React.FC<{ variant: 'primary' | 'default' | 'reject'; onClick: () => void; children: React.ReactNode; disabled?: boolean; ariaLabel?: string }> = ({
   variant,
   onClick,
-  children
+  children,
+  disabled,
+  ariaLabel,
 }) => {
   return (
-    <button className={`button ${variant}`} onClick={onClick}>
+    <button className={`button ${variant}`} onClick={onClick} disabled={disabled} aria-label={ariaLabel}>
       {children}
     </button>
   );

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -58,6 +58,7 @@ export function decorateProgram(program: Command) {
         const mcpClientInfo = {
           cwd: process.cwd(),
           clientName: guessClientName(),
+          taskId: sessionName,
         };
 
         try {

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -36,7 +36,7 @@ import type { Playwright } from '../../client/playwright';
 import type * as playwrightTypes from '../../..';
 import type { BrowserInfo } from '../../serverRegistry';
 
-type BrowserWithInfo = {
+export type BrowserWithInfo = {
   browser: playwrightTypes.Browser,
   browserInfo: BrowserInfo,
   canBind: boolean,
@@ -60,7 +60,7 @@ export async function createBrowserWithInfo(config: FullConfig, clientInfo: Clie
     ownership = 'own';
   } else if (config.extension) {
     const { channel, executablePath } = resolveExtensionOptions(cliOptions);
-    browser = await createExtensionBrowser(channel, executablePath, clientInfo.clientName);
+    browser = await createExtensionBrowser(channel, executablePath, clientInfo.clientName, clientInfo.taskId);
     ownership = 'attached';
   } else {
     browser = await createPersistentBrowser(config, clientInfo);

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -60,6 +60,8 @@ type CDPResponse = CDPMessage;
 export class CDPRelayServer {
   private _wsHost: string;
   private _browserChannel: string;
+  private _taskId: string;
+  private _connectionId: string;
   private _executablePath?: string;
   private _userDataDir?: string;
   private _cdpPath: string;
@@ -71,9 +73,10 @@ export class CDPRelayServer {
   private _handler: ExtensionProtocolV2;
   private _extensionConnectionPromise = new ManualPromise<void>();
 
-  constructor(server: http.Server, browserChannel: string, executablePath?: string, userDataDir?: string) {
+  constructor(server: http.Server, browserChannel: string, executablePath?: string, userDataDir?: string, taskId = 'Playwright MCP') {
     this._wsHost = addressToString(server.address(), { protocol: 'ws' });
     this._browserChannel = browserChannel;
+    this._taskId = taskId;
     this._executablePath = executablePath;
     this._userDataDir = userDataDir;
     this._protocolVersion = parseInt(process.env.PLAYWRIGHT_EXTENSION_PROTOCOL ?? protocol.VERSION.toString(), 10);
@@ -85,9 +88,9 @@ export class CDPRelayServer {
     };
     this._handler = new ExtensionProtocolV2(sendCommand);
 
-    const uuid = crypto.randomUUID();
-    this._cdpPath = `/cdp/${uuid}`;
-    this._extensionPath = `/extension/${uuid}`;
+    this._connectionId = crypto.randomUUID();
+    this._cdpPath = `/cdp/${this._connectionId}`;
+    this._extensionPath = `/extension/${this._connectionId}`;
 
     void this._extensionConnectionPromise.catch(logUnhandledError);
     this._wss = new wsServer({ server });
@@ -115,6 +118,8 @@ export class CDPRelayServer {
     const mcpRelayEndpoint = `${this._wsHost}${this._extensionPath}`;
     const url = new URL(`chrome-extension://${playwrightExtensionId}/connect.html`);
     url.searchParams.set('mcpRelayUrl', mcpRelayEndpoint);
+    url.searchParams.set('taskId', this._taskId);
+    url.searchParams.set('connectionId', this._connectionId);
     const client = {
       name: clientName,
       // Not used anymore.

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -25,7 +25,7 @@ import type * as playwrightTypes from '../../..';
 
 const debugLogger = debug('pw:mcp:relay');
 
-export async function createExtensionBrowser(channel: string, executablePath: string | undefined, clientName: string): Promise<playwrightTypes.Browser> {
+export async function createExtensionBrowser(channel: string, executablePath: string | undefined, clientName: string, taskId?: string): Promise<playwrightTypes.Browser> {
   // Custom executablePath may target a browser in a different filesystem (e.g. Windows chrome.exe from WSL2), so the local profile path is not meaningful.
   let userDataDir: string | undefined;
   if (!executablePath) {
@@ -36,12 +36,17 @@ export async function createExtensionBrowser(channel: string, executablePath: st
 
   const httpServer = createHttpServer();
   await startHttpServer(httpServer, {});
-  const relay = new CDPRelayServer(httpServer, channel, executablePath, userDataDir);
+  const relay = new CDPRelayServer(httpServer, channel, executablePath, userDataDir, taskId ?? clientName);
   debugLogger(`CDP relay server started, extension endpoint: ${relay.extensionEndpoint()}.`);
 
   try {
     await relay.establishExtensionConnection(clientName);
-    return await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0 });
+    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0 });
+    // Extension mode attaches to the user's browser. Browser.close() must tear
+    // down only this Playwright connection, not forward Browser.close over CDP.
+    // eslint-disable-next-line no-restricted-syntax
+    (browser as any)._shouldCloseConnectionOnClose = true;
+    return browser;
   } catch (error) {
     relay.stop();
     httpServer.close();

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -26,7 +26,7 @@ import { packageJSON } from '../../package';
 
 import type { Command } from 'commander';
 import type { ClientInfo } from '../utils/mcp/server';
-import type * as playwright from '../../..';
+import type { BrowserWithInfo } from './browserFactory';
 
 const version = packageJSON.version;
 
@@ -99,7 +99,7 @@ export function decorateMCPCommand(command: Command) {
         const config = await resolveCLIConfigForMCP(options);
         const tools = filteredTools(config);
         const useSharedBrowser = config.sharedBrowserContext || config.browser.isolated;
-        let sharedBrowserPromise: Promise<playwright.Browser> | undefined;
+        let sharedBrowserPromise: Promise<BrowserWithInfo> | undefined;
         let clientCount = 0;
         const clientNameCounters = new Map<string, number>();
 
@@ -111,17 +111,17 @@ export function decorateMCPCommand(command: Command) {
           create: async (clientInfo: ClientInfo) => {
             if (useSharedBrowser && !sharedBrowserPromise) {
               sharedBrowserPromise = (async () => {
-                const { browser, canBind } = await createBrowserWithInfo(config, clientInfo, options);
-                if (canBind)
-                  await browser.bind(clientInfo.clientName, { workspaceDir: clientInfo.cwd });
-                return browser;
+                const browserWithInfo = await createBrowserWithInfo(config, clientInfo, options);
+                if (browserWithInfo.canBind)
+                  await browserWithInfo.browser.bind(clientInfo.clientName, { workspaceDir: clientInfo.cwd });
+                return browserWithInfo;
               })().catch(error => {
                 sharedBrowserPromise = undefined;
                 throw error;
               });
             }
             clientCount++;
-            const { browser, canBind } = sharedBrowserPromise ? { browser: await sharedBrowserPromise, canBind: false } : await createBrowserWithInfo(config, clientInfo, options);
+            const { browser, canBind, ownership } = sharedBrowserPromise ? { ...await sharedBrowserPromise, canBind: false } : await createBrowserWithInfo(config, clientInfo, options);
             if (canBind) {
               const count = (clientNameCounters.get(clientInfo.clientName) ?? 0) + 1;
               clientNameCounters.set(clientInfo.clientName, count);
@@ -137,6 +137,13 @@ export function decorateMCPCommand(command: Command) {
                   testDebug('close context');
                   await browserContext.close().catch(() => { });
                 }
+                return;
+              }
+
+              if (ownership === 'attached') {
+                testDebug('disconnect attached browser');
+                sharedBrowserPromise = undefined;
+                await browser.close().catch(() => { });
                 return;
               }
 

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -18,9 +18,9 @@ import fs from 'fs';
 import path from 'path';
 
 // Also pinned via the "key" field in packages/extension/manifest.json.
-export const playwrightExtensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
+export const playwrightExtensionId = 'mmblklcefccekjbfjehkpmeibpjlanca';
 
-export const playwrightExtensionInstallUrl = `https://chromewebstore.google.com/detail/playwright-extension/${playwrightExtensionId}`;
+export const playwrightExtensionInstallUrl = 'https://github.com/WitMiao/playwright/tree/codex/session-isolated-extension/packages/extension';
 
 export async function findPlaywrightExtensionProfile(userDataDir: string): Promise<string | undefined> {
   const profiles = await listProfileDirectories(userDataDir);

--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -15,6 +15,7 @@
  */
 
 import { fileURLToPath } from 'url';
+import crypto from 'crypto';
 
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import debug from 'debug';
@@ -36,6 +37,7 @@ const serverDebugResponse = debug('pw:mcp:server:response');
 export type ClientInfo = {
   cwd: string;
   clientName: string;
+  taskId?: string;
 };
 
 export interface ServerBackend {
@@ -119,6 +121,7 @@ const initializeServer = async (server: ServerType, factory: ServerBackendFactor
   const clientInfo: ClientInfo = {
     cwd: firstRootPath(clientRoots),
     clientName: server.getClientVersion()?.name ?? 'Playwright MCP',
+    taskId: process.env.PLAYWRIGHT_MCP_TASK_ID || crypto.randomUUID(),
   };
 
   const backend = await factory.create(clientInfo);

--- a/tests/extension/cli.spec.ts
+++ b/tests/extension/cli.spec.ts
@@ -44,9 +44,14 @@ test('attach <url> --extension', async ({ startAttach, cli, server }) => {
   {
     const { output } = await cliPromise;
     expect(output).toContain(`### Page`);
-    expect(output).toContain(`- Page URL: chrome-extension://${extensionId}/connect.html?`);
-    expect(output).toContain(`- Page Title: Welcome`);
+    expect(output).toContain(`- Page URL: about:blank`);
   }
+
+  const [serviceWorker] = confirmationPage.context().serviceWorkers();
+  await expect.poll(() => serviceWorker.evaluate(async () => {
+    const chrome = (globalThis as any).chrome;
+    return (await chrome.tabGroups.query({})).map((group: any) => group.title);
+  })).toContainEqual(expect.stringMatching(/^Playwright · chromium · /));
 
   {
     const { output } = await cli(['-s=chromium', 'goto', server.HELLO_WORLD]);

--- a/tests/extension/extension-fixtures.ts
+++ b/tests/extension/extension-fixtures.ts
@@ -43,7 +43,7 @@ export type TestFixtures = {
   cli: (args: string[], options?: { env?: Record<string, string> }) => Promise<CliResult>;
 };
 
-export const extensionId = 'mmlmfjhmonkocbjadbfplnigmagldckm';
+export const extensionId = 'mmblklcefccekjbfjehkpmeibpjlanca';
 
 export const test = base.extend<TestFixtures>({
   pathToExtension: async ({}, use, testInfo) => {
@@ -77,7 +77,6 @@ export const test = base.extend<TestFixtures>({
             `--load-extension=${pathToExtension}`,
           ],
         });
-
         // MV3 service workers start lazily; wait for the extension's
         // background to be ready so tests can reach `chrome.*` via it.
         if (!browserContext.serviceWorkers().length)
@@ -201,7 +200,11 @@ export async function startWithExtensionFlag(browserWithExtension: BrowserWithEx
 // with the click — the request reaches the background while the page is being
 // torn down. Swallow the resulting "Target closed" error.
 export async function clickAllowAndSelect(connectPage: Page, tabTitle: RegExp | string): Promise<void> {
-  await connectPage.locator('.tab-item', { hasText: tabTitle }).getByRole('button', { name: 'Allow & select' }).click().catch(e => {
+  const matchingTab = connectPage.locator('.tab-item', { hasText: tabTitle });
+  const button = await matchingTab.count()
+    ? matchingTab.getByRole('button', { name: 'Allow & select' })
+    : connectPage.getByRole('button', { name: 'Allow in background' });
+  await button.click().catch(e => {
     if (!e?.message?.includes(kTargetClosedErrorMessage))
       throw e;
   });

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -38,8 +38,82 @@ test(`navigate with extension`, async ({ startExtensionClient, server }) => {
   await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
+});
+
+test(`parallel extension tasks isolate groups, preserve focus, and clean owned tabs`, async ({ browserWithExtension, startClient, server }) => {
+  const browserContext = await browserWithExtension.launch();
+  const statusPage = await browserContext.newPage();
+  await statusPage.goto(`chrome-extension://${extensionId}/status.html`);
+  const token = await statusPage.locator('.auth-token-code').textContent();
+  const [, tokenValue] = token?.split('=') || [];
+
+  const userPage = await browserContext.newPage();
+  await userPage.setContent('<title>User-owned A</title><body>User-owned A</body>');
+
+  const { client: clientA } = await startClient({
+    clientName: 'parallel-a',
+    args: [`--extension`],
+    env: {
+      PLAYWRIGHT_MCP_TASK_ID: 'task-a',
+      PWTEST_EXTENSION_USER_DATA_DIR: browserWithExtension.userDataDir,
+    },
+  });
+  const confirmationPagePromise = browserContext.waitForEvent('page', page =>
+    page.url().startsWith(`chrome-extension://${extensionId}/connect.html`)
+  );
+  const snapshotPromise = clientA.callTool({ name: 'browser_snapshot', arguments: {} });
+  await clickAllowAndSelect(await confirmationPagePromise, 'User-owned A');
+  await snapshotPromise;
+
+  const { client: clientB } = await startClient({
+    clientName: 'parallel-b',
+    args: [`--extension`],
+    env: {
+      PLAYWRIGHT_MCP_EXTENSION_TOKEN: tokenValue,
+      PLAYWRIGHT_MCP_TASK_ID: 'task-b',
+      PWTEST_EXTENSION_USER_DATA_DIR: browserWithExtension.userDataDir,
+    },
+  });
+  await clientB.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } });
+
+  const groupTitles = () => statusPage.evaluate(async () =>
+    (await chrome.tabGroups.query({})).map(group => group.title || '').filter(title => title.startsWith('Playwright · ')).sort()
+  );
+  await expect.poll(groupTitles).toEqual([
+    expect.stringMatching(/^Playwright · task-a · /),
+    expect.stringMatching(/^Playwright · task-b · /),
+  ]);
+
+  await statusPage.bringToFront();
+  const ownedUrl = server.PREFIX + '/owned-by-task-b';
+  await clientB.callTool({ name: 'browser_tabs', arguments: { action: 'new', url: ownedUrl } });
+  await expect.poll(() => statusPage.evaluate(async url => {
+    const [taskTab] = await chrome.tabs.query({ url });
+    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    return { taskTabActive: taskTab?.active, activeTabUrl: activeTab?.url };
+  }, ownedUrl)).toEqual({ taskTabActive: false, activeTabUrl: statusPage.url() });
+  await clientB.callTool({ name: 'browser_tabs', arguments: { action: 'select', index: 0 } });
+  expect(await statusPage.evaluate(async () => (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.url)).toBe(statusPage.url());
+
+  await clientA.close();
+  await expect.poll(groupTitles).toEqual([
+    expect.stringMatching(/^Playwright · task-b · /),
+  ]);
+  await expect(userPage).toHaveTitle('User-owned A');
+  expect(await statusPage.evaluate(async () => {
+    const [tab] = await chrome.tabs.query({ title: 'User-owned A' });
+    return tab?.groupId === chrome.tabs.TAB_ID_NONE;
+  })).toBe(true);
+
+  expect(await clientB.callTool({ name: 'browser_tabs', arguments: { action: 'list' } })).toHaveResponse({
+    result: expect.stringContaining(ownedUrl),
+  });
+
+  await clientB.close();
+  await expect.poll(groupTitles).toEqual([]);
+  await expect.poll(() => statusPage.evaluate(async url => (await chrome.tabs.query({ url })).length, ownedUrl)).toBe(0);
 });
 
 test(`connect.html requests protocol version 2`, async ({ startExtensionClient, server }) => {
@@ -188,7 +262,7 @@ testWithOldExtensionVersion(`works with old extension version`, async ({ startEx
   await clickAllowAndSelect(selectorPage, 'Welcome');
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
 });
 
@@ -364,9 +438,9 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   });
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
 
   await page.goto(`chrome-extension://${extensionId}/status.html`);
-  await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
+  await expect(page.locator('.client-info')).toContainText(`Connected client: "${clientName}"`);
 });

--- a/tests/extension/tab-grouping.spec.ts
+++ b/tests/extension/tab-grouping.spec.ts
@@ -74,7 +74,7 @@ test('connected tab is in green Playwright group, connect page is closed', async
       const g = await chrome.tabGroups.get(connectedTab.groupId);
       return { color: g.color, title: g.title };
     });
-  }).toEqual({ color: 'green', title: 'Playwright' });
+  }).toEqual({ color: 'green', title: expect.stringMatching(/^Playwright · .+ · /) });
 });
 
 test('tab added to group gets auto-attached', async ({ browserWithExtension, startClient, server }) => {
@@ -337,5 +337,5 @@ test('tab is re-added to Playwright group after reconnecting', async ({ browserW
       const g = await chrome.tabGroups.get(tab.groupId);
       return { color: g.color, title: g.title };
     });
-  }).toEqual({ color: 'green', title: 'Playwright' });
+  }).toEqual({ color: 'green', title: expect.stringMatching(/^Playwright · .+ · /) });
 });

--- a/tests/extension/tab-management.spec.ts
+++ b/tests/extension/tab-management.spec.ts
@@ -22,7 +22,7 @@ test(`browser_tabs new creates a new tab`, async ({ startExtensionClient, server
 
   const navigateResponse = await connectAndNavigate(browserContext, client, server.HELLO_WORLD);
   expect(navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`- generic [active] [ref=e1]: Hello, world!`),
   });
 
   const newTabResponse = await client.callTool({
@@ -115,7 +115,7 @@ test(`cmd+click opens new tab visible in tab list`, async ({ startExtensionClien
 
   await client.callTool({
     name: 'browser_click',
-    arguments: { element: 'click me', target: 'f1e2', modifiers: ['ControlOrMeta'] },
+    arguments: { element: 'click me', target: 'e2', modifiers: ['ControlOrMeta'] },
   });
 
   await expect.poll(async () => {
@@ -147,7 +147,7 @@ test(`window.open from tracked tab auto-attaches new tab`, async ({ startExtensi
 
   await client.callTool({
     name: 'browser_click',
-    arguments: { element: 'open', target: 'f1e2' },
+    arguments: { element: 'open', target: 'e2' },
   });
 
   await expect.poll(async () => {


### PR DESCRIPTION
## Summary

- derive unique tab-group and resource ownership from CLI sessions or explicit MCP task ids
- authorize in the background by default, suppress focus-changing automation paths, and reserve tab activation for the explicit Allow & select action
- close only task-owned tabs on disconnect while preserving user tabs and concurrent tasks
- pin a separate local extension id so this fork can be loaded alongside the Chrome Web Store extension
- document local installation and lower-token CLI/MCP workflows

## Validation

- npm run build
- npx tsc -p . --noEmit
- npx tsc -p packages/extension/tsconfig.json --noEmit
- npx tsc -p packages/extension/tsconfig.ui.json --noEmit
- targeted ESLint on all changed TypeScript files
- env -u PLAYWRIGHT_MCP_EXTENSION_TOKEN npm run test-extension -- --timeout=60000 (27 passed)

## Known browser boundary

Chrome or the operating system may briefly foreground connect.html when it opens the extension URL before extension JavaScript runs. Extension-created automation tabs and logical Playwright tab selection remain background-only.