### PR TITLE
fix(fetch): do not crash on write ECONNRESET after early refusal

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -338,7 +338,7 @@ export abstract class APIRequestContext extends SdkObject {
 
     let destroyRequest: (() => void) | undefined;
     let requestSocket: net.Socket | undefined;
-    let handleConnectionError: ((error: Error) => void) | undefined;
+    let onConnectionError!: (error: Error) => void;
     progress.setAllowConcurrentOrNestedRaces(true);
     const resultPromise = new Promise<SendRequestResult>((fulfill, reject) => {
       const requestConstructor: ((url: URL, options: http.RequestOptions, callback?: (res: http.IncomingMessage) => void) => http.ClientRequest)
@@ -363,13 +363,8 @@ export abstract class APIRequestContext extends SdkObject {
 
       const listeners: RegisteredListener[] = [];
 
-      const onConnectionError = (error: Error) => {
-        // Write reset (ECONNRESET/EPIPE) can race with response headers when a server
-        // refuses the body without reading it. Buffer network errors and only reject on
-        // request close if no response arrived — so a late 413 can still win (Node fetch).
-        // Always attach a socket listener so keep-alive / IP Happy Eyeballs never leave an
-        // unhandled Socket 'error' that kills the process.
-        // See https://github.com/microsoft/playwright/issues/42074.
+      // Buffer write resets until request close so a racing response (e.g. 413) can win.
+      onConnectionError = (error: Error) => {
         if (isNetworkConnectionError(error)) {
           if (responseReceived)
             return;
@@ -378,7 +373,6 @@ export abstract class APIRequestContext extends SdkObject {
         }
         reject(error);
       };
-      handleConnectionError = onConnectionError;
 
       const request = requestConstructor(url, requestOptions as any, async response => {
         responseReceived = true;
@@ -592,7 +586,7 @@ export abstract class APIRequestContext extends SdkObject {
       );
       request.on('close', () => {
         eventsHelper.removeEventListeners(listeners);
-        // Reject buffered write-reset errors only after close, and only if headers never arrived.
+        // Reject buffered write reset only if no response headers arrived.
         if (!responseReceived && pendingConnectionError)
           reject(pendingConnectionError);
       });
@@ -613,8 +607,6 @@ export abstract class APIRequestContext extends SdkObject {
       };
 
       request.on('socket', socket => {
-        // Not tied to request 'close': Node can emit write EPIPE after 'close' on keep-alive.
-        // Removed in settleCleanup after the request promise settles.
         requestSocket = socket;
         socket.on('error', onConnectionError);
 
@@ -656,13 +648,12 @@ export abstract class APIRequestContext extends SdkObject {
     });
 
     const settleCleanup = () => {
-      // Defer so a late write reset in the same turn is still handled by handleConnectionError.
+      // Defer so a same-turn late write reset is still handled by onConnectionError.
       setImmediate(() => {
-        if (!requestSocket || !handleConnectionError)
+        if (!requestSocket)
           return;
-        requestSocket.removeListener('error', handleConnectionError);
-        // Shared one-shot sink for the keep-alive gap after our handler is removed.
-        // Reuse a named function so listeners do not stack across successful requests.
+        requestSocket.removeListener('error', onConnectionError);
+        // Keep-alive gap: absorb later reset without stacking per-request listeners.
         if (!requestSocket.destroyed) {
           requestSocket.removeListener('error', absorbSocketError);
           requestSocket.once('error', absorbSocketError);

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -337,6 +337,8 @@ export abstract class APIRequestContext extends SdkObject {
       throw new TargetClosedError(this._closeReason || 'Request context disposed.');
 
     let destroyRequest: (() => void) | undefined;
+    let requestSocket: net.Socket | undefined;
+    let handleConnectionError: ((error: Error) => void) | undefined;
     progress.setAllowConcurrentOrNestedRaces(true);
     const resultPromise = new Promise<SendRequestResult>((fulfill, reject) => {
       const requestConstructor: ((url: URL, options: http.RequestOptions, callback?: (res: http.IncomingMessage) => void) => http.ClientRequest)
@@ -356,10 +358,30 @@ export abstract class APIRequestContext extends SdkObject {
       let serverPort: number | undefined;
 
       let securityDetails: har.SecurityDetails | undefined;
+      let responseReceived = false;
+      let pendingConnectionError: Error | undefined;
 
       const listeners: RegisteredListener[] = [];
 
+      const onConnectionError = (error: Error) => {
+        // Write reset (ECONNRESET/EPIPE) can race with response headers when a server
+        // refuses the body without reading it. Buffer network errors and only reject on
+        // request close if no response arrived — so a late 413 can still win (Node fetch).
+        // Always attach a socket listener so keep-alive / IP Happy Eyeballs never leave an
+        // unhandled Socket 'error' that kills the process.
+        // See https://github.com/microsoft/playwright/issues/42074.
+        if (isNetworkConnectionError(error)) {
+          if (responseReceived)
+            return;
+          pendingConnectionError = error;
+          return;
+        }
+        reject(error);
+      };
+      handleConnectionError = onConnectionError;
+
       const request = requestConstructor(url, requestOptions as any, async response => {
+        responseReceived = true;
         const responseAt = monotonicTime();
 
         const notifyRequestFinished = (body?: Buffer) => {
@@ -559,7 +581,7 @@ export abstract class APIRequestContext extends SdkObject {
         body.on('data', chunk => chunks.push(chunk));
         body.on('end', notifyBodyFinished);
       });
-      request.on('error', reject);
+      request.on('error', onConnectionError);
       destroyRequest = () => request.destroy();
 
       listeners.push(
@@ -568,7 +590,12 @@ export abstract class APIRequestContext extends SdkObject {
             request.destroy();
           })
       );
-      request.on('close', () => eventsHelper.removeEventListeners(listeners));
+      request.on('close', () => {
+        eventsHelper.removeEventListeners(listeners);
+        // Reject buffered write-reset errors only after close, and only if headers never arrived.
+        if (!responseReceived && pendingConnectionError)
+          reject(pendingConnectionError);
+      });
 
       const captureSecurityDetails = (socket: net.Socket) => {
         if (!(socket instanceof TLSSocket))
@@ -586,6 +613,11 @@ export abstract class APIRequestContext extends SdkObject {
       };
 
       request.on('socket', socket => {
+        // Not tied to request 'close': Node can emit write EPIPE after 'close' on keep-alive.
+        // Removed in settleCleanup after the request promise settles.
+        requestSocket = socket;
+        socket.on('error', onConnectionError);
+
         serverIPAddress = socket.remoteAddress;
         serverPort = socket.remotePort;
 
@@ -623,10 +655,26 @@ export abstract class APIRequestContext extends SdkObject {
       request.end();
     });
 
+    const settleCleanup = () => {
+      // Defer so a late write reset in the same turn is still handled by handleConnectionError.
+      setImmediate(() => {
+        if (!requestSocket || !handleConnectionError)
+          return;
+        requestSocket.removeListener('error', handleConnectionError);
+        // Shared one-shot sink for the keep-alive gap after our handler is removed.
+        // Reuse a named function so listeners do not stack across successful requests.
+        if (!requestSocket.destroyed) {
+          requestSocket.removeListener('error', absorbSocketError);
+          requestSocket.once('error', absorbSocketError);
+        }
+      });
+    };
+
     return progress.race(resultPromise).catch(error => {
       destroyRequest?.();
       throw error;
     }).finally(() => {
+      settleCleanup();
       progress.setAllowConcurrentOrNestedRaces(false);
     });
   }
@@ -838,6 +886,10 @@ function isNetworkConnectionError(e: any): boolean {
   const code = e?.code;
   return code === 'ECONNRESET' || code === 'EPIPE' || code === 'ECONNABORTED';
 }
+
+// Shared keep-alive sink so settleCleanup does not stack per-request once() listeners.
+function absorbSocketError() {}
+
 
 function setBasicAuthorizationHeader(headers: { [name: string]: string }, credentials: HttpCredentials) {
   const { username, password } = credentials;

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1554,12 +1554,10 @@ it('should not crash when server resets while request body is still writing', {
   server.setRoute('/upload', (req, res) => {
     res.writeHead(413, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: 'too large' }));
-    // Body never read; cannot resynchronise — same as Cloudflare workerd.
     req.socket.destroy();
   });
-  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (IP Happy Eyeballs path) where the crash repros.
-  // TCP timing may reject the write or return 413 — either must be catchable (no process exit).
-  // If post() resolves, the body must still be readable (not the disposed-response failure mode).
+  // Either rejected or 413 - both catchable, never a process exit.
+  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (Happy Eyeballs IP path).
   const response = await context.request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
     data: 'x'.repeat(5 * 1024 * 1024),
     headers: { 'content-type': 'text/plain' },
@@ -1578,8 +1576,7 @@ it('should return 413 body when server refuses upload without reading it', {
   server.setRoute('/upload', (req, res) => {
     res.writeHead(413, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: 'too large' }));
-    // Drain unread body so the refusal is delivered without a flaky mid-write reset.
-    req.resume();
+    req.resume(); // Drain unread body so 413 arrives without a mid-write reset.
   });
   const response = await context.request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
     data: 'x'.repeat(5 * 1024 * 1024),

--- a/tests/library/browsercontext-fetch.spec.ts
+++ b/tests/library/browsercontext-fetch.spec.ts
@@ -1547,3 +1547,44 @@ it('should retry ECONNRESET mid-stream during gzip decompression', async ({ cont
   expect(await response.text()).toBe('midstream-retry-ok');
   expect(requestCount).toBe(3);
 });
+
+it('should not crash when server resets while request body is still writing', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ context, server }) => {
+  server.setRoute('/upload', (req, res) => {
+    res.writeHead(413, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'too large' }));
+    // Body never read; cannot resynchronise — same as Cloudflare workerd.
+    req.socket.destroy();
+  });
+  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (IP Happy Eyeballs path) where the crash repros.
+  // TCP timing may reject the write or return 413 — either must be catchable (no process exit).
+  // If post() resolves, the body must still be readable (not the disposed-response failure mode).
+  const response = await context.request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
+    data: 'x'.repeat(5 * 1024 * 1024),
+    headers: { 'content-type': 'text/plain' },
+  }).catch(e => e);
+  if (response instanceof Error) {
+    expect(response.message).toMatch(/EPIPE|ECONNRESET|ECONNABORTED/);
+    return;
+  }
+  expect(response.status()).toBe(413);
+  expect(await response.json()).toEqual({ error: 'too large' });
+});
+
+it('should return 413 body when server refuses upload without reading it', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ context, server }) => {
+  server.setRoute('/upload', (req, res) => {
+    res.writeHead(413, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'too large' }));
+    // Drain unread body so the refusal is delivered without a flaky mid-write reset.
+    req.resume();
+  });
+  const response = await context.request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
+    data: 'x'.repeat(5 * 1024 * 1024),
+    headers: { 'content-type': 'text/plain' },
+  });
+  expect(response.status()).toBe(413);
+  expect(await response.json()).toEqual({ error: 'too large' });
+});

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -714,12 +714,10 @@ it('should not crash when server resets while request body is still writing', {
   server.setRoute('/upload', (req, res) => {
     res.writeHead(413, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: 'too large' }));
-    // Body never read; cannot resynchronise — same as Cloudflare workerd.
     req.socket.destroy();
   });
-  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (IP Happy Eyeballs path) where the crash repros.
-  // TCP timing may reject the write or return 413 — either must be catchable (no process exit).
-  // If post() resolves, the body must still be readable (not the disposed-response failure mode).
+  // Either rejected or 413 - both catchable, never a process exit.
+  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (Happy Eyeballs IP path).
   const response = await request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
     data: 'x'.repeat(5 * 1024 * 1024),
     headers: { 'content-type': 'text/plain' },
@@ -741,8 +739,7 @@ it('should return 413 body when server refuses upload without reading it', {
   server.setRoute('/upload', (req, res) => {
     res.writeHead(413, { 'content-type': 'application/json' });
     res.end(JSON.stringify({ error: 'too large' }));
-    // Drain unread body so the refusal is delivered without a flaky mid-write reset.
-    req.resume();
+    req.resume(); // Drain unread body so 413 arrives without a mid-write reset.
   });
   const response = await request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
     data: 'x'.repeat(5 * 1024 * 1024),

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -707,6 +707,52 @@ it('should retry ECONNRESET', {
   await request.dispose();
 });
 
+it('should not crash when server resets while request body is still writing', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ playwright, server }) => {
+  const request = await playwright.request.newContext();
+  server.setRoute('/upload', (req, res) => {
+    res.writeHead(413, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'too large' }));
+    // Body never read; cannot resynchronise — same as Cloudflare workerd.
+    req.socket.destroy();
+  });
+  // CROSS_PROCESS_PREFIX uses 127.0.0.1 (IP Happy Eyeballs path) where the crash repros.
+  // TCP timing may reject the write or return 413 — either must be catchable (no process exit).
+  // If post() resolves, the body must still be readable (not the disposed-response failure mode).
+  const response = await request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
+    data: 'x'.repeat(5 * 1024 * 1024),
+    headers: { 'content-type': 'text/plain' },
+  }).catch(e => e);
+  if (response instanceof Error) {
+    expect(response.message).toMatch(/EPIPE|ECONNRESET|ECONNABORTED/);
+    await request.dispose();
+    return;
+  }
+  expect(response.status()).toBe(413);
+  expect(await response.json()).toEqual({ error: 'too large' });
+  await request.dispose();
+});
+
+it('should return 413 body when server refuses upload without reading it', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ playwright, server }) => {
+  const request = await playwright.request.newContext();
+  server.setRoute('/upload', (req, res) => {
+    res.writeHead(413, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'too large' }));
+    // Drain unread body so the refusal is delivered without a flaky mid-write reset.
+    req.resume();
+  });
+  const response = await request.post(server.CROSS_PROCESS_PREFIX + '/upload', {
+    data: 'x'.repeat(5 * 1024 * 1024),
+    headers: { 'content-type': 'text/plain' },
+  });
+  expect(response.status()).toBe(413);
+  expect(await response.json()).toEqual({ error: 'too large' });
+  await request.dispose();
+});
+
 it('should throw when failOnStatusCode is set to true inside APIRequest context options', async ({ playwright, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34204' });
   const request = await playwright.request.newContext({ failOnStatusCode: true });


### PR DESCRIPTION
## Summary
- Fix `APIRequestContext` killing the Node process when a server returns early (e.g. 413) without reading the POST body and resets the socket mid-write.
- Attach a Socket `'error'` listener, prefer an already-received response (Node `fetch` behavior), and otherwise reject cleanly on request close so `try/catch` works.
- Clean up the per-request socket handler after settle and leave a shared keep-alive error sink so late write resets cannot become unhandled.

Fixes #42074

## Test plan
- [x] `tests/library/browsercontext-fetch.spec.ts` — immediate destroy does not crash; resolve ⇒ 413+body or reject ⇒ EPIPE/ECONNRESET/ECONNABORTED
- [x] `tests/library/browsercontext-fetch.spec.ts` — drain unread body ⇒ deterministic 413 + JSON
- [x] Same coverage in `tests/library/global-fetch.spec.ts` for standalone `request.newContext()`
- [x] Existing ECONNRESET retry tests still pass