### PR TITLE
feat(runner): add --delete-unused-snapshots option

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -82,6 +82,7 @@ npx playwright test --ui
 | `--add-reporter <reporter>` | Reporter to add on top of the reporters configured in the config file, comma-separated. Can be a built-in reporter name or a path to a custom reporter file. Unlike `--reporter`, this keeps the configured reporters instead of replacing them. |
 | `-c <file>` or `--config <file>` | Configuration file, or a test directory with optional "playwright.config.&#123;m,c&#125;?&#123;js,ts&#125;". Defaults to `playwright.config.ts` or `playwright.config.js` in the current directory. |
 | `--debug` | Run tests with Playwright Inspector. Shortcut for `PWDEBUG=1` environment variable and `--timeout=0 --max-failures=1 --headed --workers=1` options. |
+| `--delete-unused-snapshots` | After a successful test run, delete snapshot files that were not used by any test. Only deletes inside directories that contain snapshots used in this run, and keeps snapshots for other platforms and projects. Cannot be combined with test filtering options. |
 | `--fail-on-flaky-tests` | Fail if any test is flagged as flaky (default: false). |
 | `--forbid-only` | Fail if `test.only` is called (default: false). Useful on CI. |
 | `--fully-parallel` | Run all tests in parallel (default: false). |

--- a/packages/playwright/src/cli/testActions.ts
+++ b/packages/playwright/src/cli/testActions.ts
@@ -44,7 +44,33 @@ export async function runTests(args: string[], opts: { [key: string]: any }) {
     testList: opts.testList ? path.resolve(process.cwd(), opts.testList) : undefined,
     testListInvert: opts.testListInvert ? path.resolve(process.cwd(), opts.testListInvert) : undefined,
     shardWeights: resolveShardWeightsOption(),
+    deleteUnusedSnapshots: !!opts.deleteUnusedSnapshots,
   };
+
+  if (opts.deleteUnusedSnapshots) {
+    const conflicting: [string, any][] = [
+      ['--grep', opts.grep],
+      ['--grep-invert', opts.grepInvert],
+      ['--shard', opts.shard],
+      ['--last-failed', opts.lastFailed],
+      ['--only-changed', opts.onlyChanged],
+      ['--test-list', opts.testList],
+      ['--test-list-invert', opts.testListInvert],
+      ['--list', opts.list],
+      ['--ignore-snapshots', opts.ignoreSnapshots],
+      ['--ui', opts.ui || opts.uiHost || opts.uiPort],
+      ['watch mode', process.env.PWTEST_WATCH],
+    ];
+    for (const [name, value] of conflicting) {
+      if (value)
+        throw new Error(`--delete-unused-snapshots cannot be used with ${name}`);
+    }
+    // Allow whole test files as arguments, but not individual test locations like "foo.spec.ts:42".
+    for (const arg of args) {
+      if (/:\d+$/.test(arg))
+        throw new Error(`--delete-unused-snapshots cannot be used with individual test locations like "${arg}", pass whole test files instead`);
+    }
+  }
 
   // Evaluate project filters against config before starting execution. This enables a consistent error message across run modes
   projectUtils.filterProjects(config.projects, options.projectFilter);

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -119,6 +119,13 @@ export type TestEndPayload = {
   expectedStatus: TestStatus;
   annotations: TestAnnotation[];
   timeout: number;
+  usedSnapshots: UsedSnapshotPayload[];
+};
+
+export type UsedSnapshotPayload = {
+  path: string;
+  // Path prefix shared by all platform/project flavors of this snapshot.
+  prefix: string;
 };
 
 export type StepBeginPayload = {

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -210,6 +210,7 @@ const testOptions: [string, { description: string, choices?: string[], preset?: 
   /* deprecated */ ['--browser <browser>', { description: `Browser to use for tests, one of "all", "chromium", "firefox" or "webkit" (default: "chromium")` }],
   ['-c, --config <file>', { description: `Configuration file, or a test directory with optional "playwright.config.{m,c}?{js,ts}"` }],
   ['--debug [mode]', { description: `Run tests with Playwright Inspector. Shortcut for "PWDEBUG=1" environment variable and "--timeout=0 --max-failures=1 --headed --workers=1" options`, choices: ['inspector', 'cli'], preset: 'inspector' }],
+  ['--delete-unused-snapshots', { description: `After a successful test run, delete snapshot files that were not used by any test. Only deletes inside directories that contain snapshots used in this run, and keeps snapshots for other platforms and projects. Cannot be combined with test filtering options.` }],
   ['--fail-on-flaky-tests', { description: `Fail if any test is flagged as flaky (default: false)` }],
   ['--forbid-only', { description: `Fail if test.only is called (default: false)` }],
   ['--fully-parallel', { description: `Run all tests in parallel (default: false)` }],

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -372,6 +372,8 @@ class JobDispatcher {
     test.annotations = [...params.annotations]; // last test result wins
     test.expectedStatus = params.expectedStatus;
     test.timeout = params.timeout;
+    if (this._testRun.options.deleteUnusedSnapshots)
+      this._testRun.usedSnapshots.push(...params.usedSnapshots.map(snapshot => ({ ...snapshot, testFile: test.location.file })));
     const isFailure = result.status !== 'skipped' && result.status !== test.expectedStatus;
     if (isFailure)
       this._failedTests.add(test);

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -27,6 +27,7 @@ import { Dispatcher  } from './dispatcher';
 import { collectProjectsAndTestFiles, createRootSuite, loadFileSuites, loadGlobalHook, loadTestList } from './loadUtils';
 import { buildDependentProjects, buildTeardownToSetupsMap, filterProjects } from './projectUtils';
 import { applySuggestedRebaselines, clearSuggestedRebaselines } from './rebase';
+import { deleteUnusedSnapshots } from './unusedSnapshots';
 import { TaskRunner } from './taskRunner';
 import { detectChangedTestFiles } from './vcs';
 import { cc, config as commonConfig, FullConfigInternal, suiteUtils, test as testNs } from '../common';
@@ -39,6 +40,7 @@ import type { TestRunnerPluginRegistration } from '../plugins';
 import type { Task } from './taskRunner';
 import type { FullResult, TestError } from '../../types/testReporter';
 import type { Matcher, TestCaseFilter } from '../util';
+import type { UsedSnapshot } from './unusedSnapshots';
 import type { InternalReporter } from '../reporters/internalReporter';
 
 const readDirAsync = promisify(fs.readdir);
@@ -72,6 +74,7 @@ export type TestRunOptions = {
   onTestPaused?: (params: TestPausedParams) => void;
   preserveOutputDir?: boolean;
   shardWeights?: number[];
+  deleteUnusedSnapshots?: boolean;
 };
 
 export type TestPausedParams = {
@@ -94,6 +97,7 @@ export class TestRun {
   readonly loadFileFilters: Matcher[] = [];
   readonly preOnlyTestFilters: TestCaseFilter[] = [];
   readonly postShardTestFilters: TestCaseFilter[] = [];
+  readonly usedSnapshots: UsedSnapshot[] = [];
 
   constructor(config: FullConfigInternal, reporter: InternalReporter, options?: TestRunOptions) {
     this.config = config;
@@ -367,6 +371,18 @@ export function createLoadTask(mode: 'out-of-process' | 'in-process', options: {
         }
         throw new Error(`No tests found`);
       }
+    },
+  };
+}
+
+export function createDeleteUnusedSnapshotsTask(): Task<TestRun> {
+  // This task must come after the "test suite" task, so that its setup runs
+  // when all the tests have finished, but is skipped when the test run
+  // was interrupted or a preceding task failed.
+  return {
+    title: 'delete unused snapshots',
+    setup: async testRun => {
+      await deleteUnusedSnapshots(testRun);
     },
   };
 }

--- a/packages/playwright/src/runner/testRunner.ts
+++ b/packages/playwright/src/runner/testRunner.ts
@@ -33,7 +33,7 @@ import { internalScreen } from '../reporters/base';
 import { InternalReporter } from '../reporters/internalReporter';
 import { serializeError } from '../util';
 import { createErrorCollectingReporter, createReporters } from './reporters';
-import { TestRun, createApplyRebaselinesTask, createClearCacheTask, createGlobalSetupTasks, createListFilesTask, createLoadTask, createPluginSetupTasks, createReportBeginTask, createRunTestsTasks, runTasks, runTasksDeferCleanup } from './tasks';
+import { TestRun, createApplyRebaselinesTask, createClearCacheTask, createDeleteUnusedSnapshotsTask, createGlobalSetupTasks, createListFilesTask, createLoadTask, createPluginSetupTasks, createReportBeginTask, createRunTestsTasks, runTasks, runTasksDeferCleanup } from './tasks';
 import { LastRunReporter } from './lastRun';
 import { filterProjects } from './projectUtils';
 
@@ -468,6 +468,7 @@ export async function runAllTestsWithConfig(config: FullConfigInternal, options:
     ...createGlobalSetupTasks(config),
     createLoadTask('in-process', { filterOnly: true, failOnLoadErrors: true }),
     ...createRunTestsTasks(config),
+    ...(options.deleteUnusedSnapshots ? [createDeleteUnusedSnapshotsTask()] : []),
   ];
 
   const testRun = new TestRun(config, reporter, { ...options, pauseAtEnd: config.configCLIOverrides.pause, pauseOnError: config.configCLIOverrides.pause });

--- a/packages/playwright/src/runner/unusedSnapshots.ts
+++ b/packages/playwright/src/runner/unusedSnapshots.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import colors from 'colors/safe';
+
+import type { UsedSnapshotPayload } from '../common/ipc';
+import type { TestRun } from './tasks';
+
+export type UsedSnapshot = UsedSnapshotPayload & { testFile: string };
+
+export async function deleteUnusedSnapshots(testRun: TestRun) {
+  // Deleting baselines of tests that did not run would lose data, so only proceed
+  // when every test has actually finished successfully.
+  if (testRun.result() !== 'passed')
+    return;
+
+  // Snapshots of skipped tests are never reported as used. Do not clean up snapshot
+  // directories used by files that contain skipped tests.
+  const filesWithSkippedTests = new Set<string>();
+  for (const test of testRun.rootSuite?.allTests() || []) {
+    if (test.outcome() === 'skipped')
+      filesWithSkippedTests.add(test.location.file);
+  }
+
+  // Only ever delete inside directories that contain at least one used snapshot.
+  // Everything outside of them, e.g. snapshots of test files filtered out on the
+  // command line, is left untouched.
+  const dirs = new Set<string>();
+  const skippedDirs = new Set<string>();
+  for (const snapshot of testRun.usedSnapshots) {
+    const dir = path.dirname(snapshot.path);
+    dirs.add(dir);
+    // A custom snapshotPathTemplate may map multiple test files to the same
+    // directory, so mark the whole directory as excluded rather than skipping
+    // this snapshot's entry.
+    if (filesWithSkippedTests.has(snapshot.testFile))
+      skippedDirs.add(dir);
+  }
+
+  // Paths on disk may differ in case from the resolved snapshot paths on
+  // case-insensitive file systems.
+  const caseInsensitive = process.platform === 'win32' || process.platform === 'darwin';
+  const normalize = (p: string) => caseInsensitive ? p.toLowerCase() : p;
+  const usedPrefixes = [...new Set(testRun.usedSnapshots.map(snapshot => normalize(snapshot.prefix)))];
+
+  const deleted: string[] = [];
+  for (const dir of dirs) {
+    if (skippedDirs.has(dir))
+      continue;
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    // Every used path is covered by its own prefix, so prefixes alone determine
+    // which files to keep.
+    const dirWithSep = normalize(dir + path.sep);
+    const dirPrefixes = usedPrefixes.filter(prefix => prefix.startsWith(dirWithSep) || dirWithSep.startsWith(prefix));
+    for (const entry of entries) {
+      if (!entry.isFile())
+        continue;
+      const filePath = path.join(dir, entry.name);
+      const normalized = normalize(filePath);
+      if (dirPrefixes.some(prefix => normalized.startsWith(prefix)))
+        continue;
+      try {
+        await fs.promises.unlink(filePath);
+        deleted.push(filePath);
+      } catch {
+      }
+    }
+  }
+
+  if (deleted.length) {
+    const fileList = deleted.sort().map(file => '  ' + colors.dim(path.relative(process.cwd(), file))).join('\n');
+    testRun.reporter.onStdErr(`\nDeleted unused snapshots:\n\n${fileList}\n`);
+  }
+}

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -87,6 +87,8 @@ export class TestInfoImpl implements TestInfo {
   private _callbacks: TestInfoCallbacks;
   private _snapshotNames: SnapshotNames = { lastAnonymousSnapshotIndex: 0, lastNamedSnapshotIndex: {} };
   private _ariaSnapshotNames: SnapshotNames = { lastAnonymousSnapshotIndex: 0, lastNamedSnapshotIndex: {} };
+  // Snapshot path => path prefix shared by all platform/project flavors of this snapshot.
+  readonly _usedSnapshots = new Map<string, string>();
   readonly _timeoutManager: TimeoutManager;
   readonly _startTime: number;
   readonly _startWallTime: number;
@@ -616,10 +618,29 @@ export class TestInfoImpl implements TestInfo {
 
     const nameArgument = path.join(path.dirname(subPath), path.basename(subPath, ext));
     const absoluteSnapshotPath = this._applyPathTemplate(template, nameArgument, ext);
+    this._trackUsedSnapshot(template, nameArgument, ext, absoluteSnapshotPath);
     return { absoluteSnapshotPath, relativeOutputPath };
   }
 
-  _applyPathTemplate(template: string, nameArgument: string, ext: string) {
+  private _trackUsedSnapshot(template: string, nameArgument: string, ext: string, absoluteSnapshotPath: string) {
+    if (this._usedSnapshots.has(absoluteSnapshotPath))
+      return;
+    // Resolve the template with platform/project-specific tokens erased and compute the common
+    // path prefix with the actual snapshot path. Any file sharing this prefix is considered
+    // a flavor of the same snapshot for another platform/project and is never deleted
+    // by --delete-unused-snapshots. For templates where these tokens do not directly precede
+    // the varying part, the prefix degrades towards the directory path, which errs on the side
+    // of keeping files.
+    let strippedPath = this._applyPathTemplate(template, nameArgument, ext, 'eraseFlavorTokens');
+    if (ext && strippedPath.endsWith(ext))
+      strippedPath = strippedPath.substring(0, strippedPath.length - ext.length);
+    let commonLength = 0;
+    while (commonLength < absoluteSnapshotPath.length && commonLength < strippedPath.length && absoluteSnapshotPath[commonLength] === strippedPath[commonLength])
+      ++commonLength;
+    this._usedSnapshots.set(absoluteSnapshotPath, absoluteSnapshotPath.substring(0, commonLength));
+  }
+
+  _applyPathTemplate(template: string, nameArgument: string, ext: string, eraseFlavorTokens?: 'eraseFlavorTokens') {
     const relativeTestFilePath = path.relative(this.project.testDir, this._requireFile);
     const parsedRelativeTestFilePath = path.parse(relativeTestFilePath);
     const projectNamePathSegment = sanitizeForFilePath(this.project.name);
@@ -627,10 +648,10 @@ export class TestInfoImpl implements TestInfo {
     const snapshotPath = template
         .replace(/\{(.)?testDir\}/g, '$1' + this.project.testDir)
         .replace(/\{(.)?snapshotDir\}/g, '$1' + this.project.snapshotDir)
-        .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix ? '$1' + this.snapshotSuffix : '')
+        .replace(/\{(.)?snapshotSuffix\}/g, this.snapshotSuffix && !eraseFlavorTokens ? '$1' + this.snapshotSuffix : '')
         .replace(/\{(.)?testFileDir\}/g, '$1' + parsedRelativeTestFilePath.dir)
-        .replace(/\{(.)?platform\}/g, '$1' + process.platform)
-        .replace(/\{(.)?projectName\}/g, projectNamePathSegment ? '$1' + projectNamePathSegment : '')
+        .replace(/\{(.)?platform\}/g, eraseFlavorTokens ? '' : '$1' + process.platform)
+        .replace(/\{(.)?projectName\}/g, projectNamePathSegment && !eraseFlavorTokens ? '$1' + projectNamePathSegment : '')
         .replace(/\{(.)?testName\}/g, '$1' + this._fsSanitizedTestName())
         .replace(/\{(.)?testFileBaseName\}/g, '$1' + parsedRelativeTestFilePath.name)
         .replace(/\{(.)?testFileName\}/g, '$1' + parsedRelativeTestFilePath.base)

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -657,6 +657,7 @@ function buildTestEndPayload(testInfo: TestInfoImpl): ipc.TestEndPayload {
     expectedStatus: testInfo.expectedStatus,
     annotations: testInfo.annotations,
     timeout: testInfo.timeout,
+    usedSnapshots: [...testInfo._usedSnapshots].map(([path, prefix]) => ({ path, prefix })),
   };
 }
 

--- a/tests/playwright-test/delete-unused-snapshots.spec.ts
+++ b/tests/playwright-test/delete-unused-snapshots.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs';
+import { test, expect } from './playwright-test-fixtures';
+
+const platformSuffix = '-' + process.platform;
+
+const files = {
+  'a.spec.js': `
+    const { test, expect } = require('@playwright/test');
+    test('is a test', ({}) => {
+      expect('Hello world').toMatchSnapshot('snapshot.txt');
+    });
+  `,
+};
+
+const snapshotFiles = {
+  [`a.spec.js-snapshots/snapshot${platformSuffix}.txt`]: `Hello world`,
+  [`a.spec.js-snapshots/stale${platformSuffix}.txt`]: `Stale`,
+};
+
+test('should delete unused snapshots in used snapshot directories only', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...files,
+    ...snapshotFiles,
+    [`b.spec.js-snapshots/old${platformSuffix}.txt`]: `Old`,
+    'b.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('does not use snapshots', ({}) => {
+        expect(1).toBe(1);
+      });
+    `,
+  }, { 'delete-unused-snapshots': true });
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('Deleted unused snapshots:');
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `snapshot${platformSuffix}.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(false);
+  // Directory not used by any snapshot in this run is left untouched.
+  expect(fs.existsSync(testInfo.outputPath('b.spec.js-snapshots', `old${platformSuffix}.txt`))).toBe(true);
+});
+
+test('should keep snapshots for other platforms and projects', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...files,
+    ...snapshotFiles,
+    'a.spec.js-snapshots/snapshot-otherplatform.txt': `Hello world`,
+    [`a.spec.js-snapshots/snapshot-otherproject${platformSuffix}.txt`]: `Hello world`,
+  }, { 'delete-unused-snapshots': true });
+  expect(result.exitCode).toBe(0);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `snapshot${platformSuffix}.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `snapshot-otherplatform.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `snapshot-otherproject${platformSuffix}.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(false);
+});
+
+test('should not delete snapshots without the flag', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...files,
+    ...snapshotFiles,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(true);
+});
+
+test('should not delete snapshots when a test fails', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...snapshotFiles,
+    'a.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('is a test', ({}) => {
+        expect('Hello world').toMatchSnapshot('snapshot.txt');
+      });
+      test('fails', ({}) => {
+        expect(1).toBe(2);
+      });
+    `,
+  }, { 'delete-unused-snapshots': true });
+  expect(result.exitCode).toBe(1);
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(true);
+});
+
+test('should not delete snapshots in directories used by files with skipped tests', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...snapshotFiles,
+    [`b.spec.js-snapshots/snapshot${platformSuffix}.txt`]: `Hello world`,
+    [`b.spec.js-snapshots/stale${platformSuffix}.txt`]: `Stale`,
+    'a.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('is a test', ({}) => {
+        expect('Hello world').toMatchSnapshot('snapshot.txt');
+      });
+      test.fixme('skipped test', ({}) => {
+        expect('Stale').toMatchSnapshot('stale.txt');
+      });
+    `,
+    'b.spec.js': `
+      const { test, expect } = require('@playwright/test');
+      test('is a test', ({}) => {
+        expect('Hello world').toMatchSnapshot('snapshot.txt');
+      });
+    `,
+  }, { 'delete-unused-snapshots': true });
+  expect(result.exitCode).toBe(0);
+  // a.spec.js has a skipped test, so its snapshot directory is not cleaned up.
+  expect(fs.existsSync(testInfo.outputPath('a.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(true);
+  // b.spec.js has no skipped tests, so its snapshot directory is cleaned up.
+  expect(fs.existsSync(testInfo.outputPath('b.spec.js-snapshots', `stale${platformSuffix}.txt`))).toBe(false);
+});
+
+test('should work with custom snapshotPathTemplate', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    ...files,
+    'playwright.config.js': `
+      module.exports = { snapshotPathTemplate: '__snapshots__/{testFilePath}/{arg}{-snapshotSuffix}{ext}' };
+    `,
+    [`__snapshots__/a.spec.js/snapshot${platformSuffix}.txt`]: `Hello world`,
+    '__snapshots__/a.spec.js/snapshot-otherplatform.txt': `Hello world`,
+    [`__snapshots__/a.spec.js/stale${platformSuffix}.txt`]: `Stale`,
+  }, { 'delete-unused-snapshots': true });
+  expect(result.exitCode).toBe(0);
+  expect(fs.existsSync(testInfo.outputPath('__snapshots__', 'a.spec.js', `snapshot${platformSuffix}.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('__snapshots__', 'a.spec.js', `snapshot-otherplatform.txt`))).toBe(true);
+  expect(fs.existsSync(testInfo.outputPath('__snapshots__', 'a.spec.js', `stale${platformSuffix}.txt`))).toBe(false);
+});
+
+test('should require running without test filters', async ({ runInlineTest }) => {
+  {
+    const result = await runInlineTest(files, { 'delete-unused-snapshots': true, 'grep': 'test' });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('--delete-unused-snapshots cannot be used with --grep');
+  }
+  {
+    const result = await runInlineTest(files, { 'delete-unused-snapshots': true, 'shard': '1/2' });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('--delete-unused-snapshots cannot be used with --shard');
+  }
+  {
+    const result = await runInlineTest(files, { 'delete-unused-snapshots': true, 'last-failed': true });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('--delete-unused-snapshots cannot be used with --last-failed');
+  }
+  {
+    const result = await runInlineTest(files, { 'delete-unused-snapshots': true }, {}, { additionalArgs: ['a.spec.js:4'] });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.output).toContain('--delete-unused-snapshots cannot be used with individual test locations');
+  }
+  {
+    // Whole test files are allowed.
+    const result = await runInlineTest(files, { 'delete-unused-snapshots': true, 'update-snapshots': 'all' }, {}, { additionalArgs: ['a.spec.js'] });
+    expect(result.exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
After a successful unfiltered test run, delete snapshot files that were not used by any test. Only cleans up directories containing snapshots used in this run, keeps snapshots for other platforms/projects sharing the same path prefix, and skips directories used by files with skipped tests. Errors out when combined with test filtering options.

Fixes: https://github.com/microsoft/playwright/issues/16582