### PR TITLE
feat(mcp): support python, java and csharp in --codegen

### DIFF
--- a/packages/isomorphic/codegen/python.ts
+++ b/packages/isomorphic/codegen/python.ts
@@ -146,7 +146,7 @@ export class PythonLanguageGenerator implements LanguageGenerator {
         return `expect(${subject}.${this._asLocator(action.selector)}).to_be_visible()`;
       case 'assertValue': {
         const assertion = action.value ? `to_have_value(${quote(action.value)})` : `to_be_empty()`;
-        return `expect(${subject}.${this._asLocator(action.selector)}).${assertion};`;
+        return `expect(${subject}.${this._asLocator(action.selector)}).${assertion}`;
       }
       case 'assertSnapshot':
         return `expect(${subject}.${this._asLocator(action.selector)}).to_match_aria_snapshot(${quote(action.ariaSnapshot)})`;

--- a/packages/playwright-core/src/tools/backend/codegen.ts
+++ b/packages/playwright-core/src/tools/backend/codegen.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CSharpLanguageGenerator } from '@isomorphic/codegen/csharp';
+import { JavaLanguageGenerator } from '@isomorphic/codegen/java';
+import { JavaScriptLanguageGenerator } from '@isomorphic/codegen/javascript';
+import { PythonLanguageGenerator } from '@isomorphic/codegen/python';
+
+import type * as actions from '@isomorphic/codegen/actions';
+import type { LanguageGenerator } from '@isomorphic/codegen/types';
+
+export type CodegenLanguage = 'typescript' | 'python' | 'java' | 'csharp';
+
+export type CodeItem = string | actions.ActionInContext;
+
+export function actionInContext(action: actions.Action): actions.ActionInContext {
+  return { pageGuid: 'page', action, signals: [] };
+}
+
+export function renderCode(items: CodeItem[], language: CodegenLanguage): string[] {
+  const generator = createGenerator(language);
+  generator.reset();
+  const options = { browserName: 'chromium', launchOptions: {}, contextOptions: {} };
+  const lines: string[] = [];
+  for (const item of items) {
+    if (typeof item === 'string') {
+      lines.push(item);
+      continue;
+    }
+    const text = generator.generateAction(item, options);
+    if (text)
+      lines.push(...dedent(text).split('\n'));
+  }
+  return lines;
+}
+
+export function secretCode(language: CodegenLanguage, secretName: string): string {
+  switch (language) {
+    case 'typescript': return `process.env['${secretName}']`;
+    case 'python': return `os.environ["${secretName}"]`;
+    case 'java': return `System.getenv("${secretName}")`;
+    case 'csharp': return `Environment.GetEnvironmentVariable("${secretName}")`;
+    default: return `"SECRET_${secretName}"`;
+  }
+}
+
+export function substituteSecrets(lines: string[], language: CodegenLanguage, secretNames: string[]): string[] {
+  if (!secretNames.length)
+    return lines;
+  return lines.map(line => {
+    for (const name of secretNames) {
+      for (const quote of [`'`, `"`])
+        line = line.replaceAll(`${quote}SECRET_${name}${quote}`, secretCode(language, name));
+    }
+    return line;
+  });
+}
+
+function createGenerator(language: CodegenLanguage): LanguageGenerator {
+  switch (language) {
+    case 'typescript': return new JavaScriptLanguageGenerator(/* isTest */ true);
+    case 'python': return new PythonLanguageGenerator(/* isAsync */ false, /* isPyTest */ false);
+    case 'java': return new JavaLanguageGenerator('library');
+    case 'csharp': return new CSharpLanguageGenerator('library');
+  }
+}
+
+function dedent(text: string): string {
+  const lines = text.split('\n');
+  const indents = lines.filter(line => line.trim()).map(line => line.length - line.trimStart().length);
+  const indent = indents.length ? Math.min(...indents) : 0;
+  return lines.map(line => line.substring(indent)).join('\n');
+}

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -25,6 +25,7 @@ import { eventsHelper } from '@utils/eventsHelper';
 import { isPathInside, isSystemDirectory, isWritable } from '@utils/fileUtils';
 import { playwright } from '../../inprocess';
 
+import { secretCode } from './codegen';
 import { Tab } from './tab';
 
 import type * as playwrightTypes from '../../..';
@@ -37,7 +38,7 @@ const testDebug = debug('pw:mcp:test');
 export type ContextConfig = {
   allowUnrestrictedFileAccess?: boolean;
   capabilities?: ToolCapability[];
-  codegen?: 'typescript' | 'none';
+  codegen?: 'typescript' | 'python' | 'java' | 'csharp' | 'none';
   console?: { level?: 'error' | 'warning' | 'info' | 'debug' };
   imageResponses?: 'allow' | 'omit';
   network?: {
@@ -348,12 +349,14 @@ export class Context {
       throw new Error(`Access to "file:" protocol is blocked. Attempted URL: "${url}"`);
   }
 
-  lookupSecret(secretName: string): { value: string, code: string } {
+  lookupSecret(secretName: string): { value: string, code: string, isSecret: boolean } {
     if (!this.config.secrets?.[secretName])
-      return { value: secretName, code: escapeWithQuotes(secretName, '\'') };
+      return { value: secretName, code: escapeWithQuotes(secretName, '\''), isSecret: false };
+    const codegen = this.config.codegen ?? 'typescript';
     return {
       value: this.config.secrets[secretName]!,
-      code: `process.env['${secretName}']`,
+      code: secretCode(codegen === 'none' ? 'typescript' : codegen, secretName),
+      isSecret: true,
     };
   }
 

--- a/packages/playwright-core/src/tools/backend/form.ts
+++ b/packages/playwright-core/src/tools/backend/form.ts
@@ -15,7 +15,6 @@
  */
 
 import * as z from 'zod';
-import { escapeWithQuotes } from '@isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';
 import { elementSchema } from './snapshot';
@@ -39,18 +38,17 @@ const fillForm = defineTabTool({
 
   handle: async (tab, params, response) => {
     for (const field of params.fields) {
-      const { locator, resolved } = await tab.targetLocator({ element: field.name, target: field.target });
-      const locatorSource = `await page.${resolved}`;
+      const { locator, selector } = await tab.targetLocator({ element: field.name, target: field.target });
       if (field.type === 'textbox' || field.type === 'slider') {
         const secret = tab.context.lookupSecret(field.value);
         await locator.fill(secret.value, tab.actionTimeoutOptions);
-        response.addCode(`${locatorSource}.fill(${secret.code});`);
+        response.addAction({ name: 'fill', selector, text: secret.isSecret ? `SECRET_${field.value}` : field.value });
       } else if (field.type === 'checkbox' || field.type === 'radio') {
         await locator.setChecked(field.value === 'true', tab.actionTimeoutOptions);
-        response.addCode(`${locatorSource}.setChecked(${field.value});`);
+        response.addAction({ name: field.value === 'true' ? 'check' : 'uncheck', selector });
       } else if (field.type === 'combobox') {
         await locator.selectOption({ label: field.value }, tab.actionTimeoutOptions);
-        response.addCode(`${locatorSource}.selectOption(${escapeWithQuotes(field.value)});`);
+        response.addAction({ name: 'select', selector, options: [field.value] });
       }
     }
   },

--- a/packages/playwright-core/src/tools/backend/keyboard.ts
+++ b/packages/playwright-core/src/tools/backend/keyboard.ts
@@ -92,7 +92,7 @@ const type = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const { locator, resolved } = await tab.targetLocator(params);
+    const { locator, resolved, selector } = await tab.targetLocator(params);
     const secret = tab.context.lookupSecret(params.text);
 
     const action = async () => {
@@ -101,13 +101,13 @@ const type = defineTabTool({
         response.addCode(`await page.${resolved}.pressSequentially(${secret.code});`);
         await locator.pressSequentially(secret.value, tab.actionTimeoutOptions);
       } else {
-        response.addCode(`await page.${resolved}.fill(${secret.code});`);
+        response.addAction({ name: 'fill', selector, text: secret.isSecret ? `SECRET_${params.text}` : params.text });
         await locator.fill(secret.value, tab.actionTimeoutOptions);
       }
 
       if (params.submit) {
         response.setIncludeSnapshot();
-        response.addCode(`await page.${resolved}.press('Enter');`);
+        response.addAction({ name: 'press', selector, key: 'Enter', modifiers: 0 });
         await locator.press('Enter', tab.actionTimeoutOptions);
       }
     };

--- a/packages/playwright-core/src/tools/backend/navigate.ts
+++ b/packages/playwright-core/src/tools/backend/navigate.ts
@@ -15,7 +15,6 @@
  */
 
 import * as z from 'zod';
-import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool, defineTabTool } from './tool';
 
 const navigate = defineTool({
@@ -36,7 +35,7 @@ const navigate = defineTool({
     const url = await tab.checkUrlAndNavigate(params.url);
 
     response.setIncludeSnapshot();
-    response.addCode(`await page.goto(${escapeWithQuotes(url)});`);
+    response.addAction({ name: 'navigate', url });
   },
 });
 

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -18,12 +18,15 @@ import fs from 'fs';
 import path from 'path';
 
 import debug from 'debug';
+import { actionInContext, renderCode, substituteSecrets } from './codegen';
 import { renderModalStates } from './tab';
 import { scaleImageToFitMessage } from './screenshot';
 
 import { outputDir as resolveOutputDir } from './context';
 
 import type * as playwright from '../../..';
+import type * as actions from '@isomorphic/codegen/actions';
+import type { CodeItem } from './codegen';
 import type { TabHeader } from './tab';
 import type { CallToolResult, ImageContent, TextContent } from '@modelcontextprotocol/sdk/types.js';
 import type { Context, FilenameTemplate } from './context';
@@ -42,13 +45,13 @@ type Section = {
   title: string;
   content: SectionContent;
   isError?: boolean;
-  codeframe?: 'yaml' | 'js' | 'json';
+  codeframe?: 'yaml' | 'js' | 'json' | 'python' | 'java' | 'csharp';
 };
 
 export class Response {
   private _results: string[] = [];
   private _errors: string[] = [];
-  private _code: string[] = [];
+  private _code: CodeItem[] = [];
   private _context: Context;
   private _includeSnapshot: 'none' | 'full' | 'explicit' = 'none';
   private _includeSnapshotFileName: string | undefined;
@@ -143,6 +146,10 @@ export class Response {
 
   addCode(code: string) {
     this._code.push(code);
+  }
+
+  addAction(action: actions.Action) {
+    this._code.push(actionInContext(action));
   }
 
   setIncludeSnapshot() {
@@ -262,7 +269,7 @@ export class Response {
 
   private async _build(): Promise<Section[]> {
     const sections: Section[] = [];
-    const addSection = (title: string, content: SectionContent, codeframe?: 'yaml' | 'js' | 'json') => {
+    const addSection = (title: string, content: SectionContent, codeframe?: Section['codeframe']) => {
       const section = { title, content, isError: title === 'Error', codeframe };
       sections.push(section);
       return content;
@@ -275,8 +282,11 @@ export class Response {
       addSection('Result', this._results);
 
     // Code
-    if (this._context.config.codegen !== 'none' && this._code.length)
-      addSection('Ran Playwright code', this._code, 'js');
+    const codegen = this._context.config.codegen ?? 'typescript';
+    if (codegen !== 'none' && this._code.length) {
+      const code = substituteSecrets(renderCode(this._code, codegen), codegen, Object.keys(this._context.config.secrets ?? {}));
+      addSection('Ran Playwright code', code, codegen === 'typescript' ? 'js' : codegen);
+    }
 
     // Render tab titles upon changes or when more than one tab.
     const snapshotToFile = this._includeSnapshot !== 'explicit' || !!this._includeSnapshotFileName;
@@ -411,7 +421,7 @@ export function parseResponse(response: CallToolResult, cwd?: string) {
   const events = sections.get('Events');
   const modalState = sections.get('Modal state');
   const paused = sections.get('Paused');
-  const codeNoFrame = code?.replace(/^```js\n/, '').replace(/\n```$/, '');
+  const codeNoFrame = code?.replace(/^```(?:js|python|java|csharp)\n/, '').replace(/\n```$/, '');
   const isError = response.isError;
   const attachments = response.content.length > 1 ? response.content.slice(1) : undefined;
 

--- a/packages/playwright-core/src/tools/backend/snapshot.ts
+++ b/packages/playwright-core/src/tools/backend/snapshot.ts
@@ -15,7 +15,7 @@
  */
 
 import * as z from 'zod';
-import { formatObject, formatObjectOrVoid } from '@isomorphic/stringUtils';
+import { fromKeyboardModifiers } from '@isomorphic/codegen/language';
 import { defineTabTool } from './tool';
 
 import type * as playwright from '../../..';
@@ -74,18 +74,19 @@ const click = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
-    const { locator, resolved } = await tab.targetLocator(params);
+    const { locator, selector } = await tab.targetLocator(params);
     const options = {
       button: params.button,
       modifiers: params.modifiers,
       ...tab.actionTimeoutOptions,
     };
-    const optionsArg = formatObjectOrVoid(options);
-
-    if (params.doubleClick)
-      response.addCode(`await page.${resolved}.dblclick(${optionsArg});`);
-    else
-      response.addCode(`await page.${resolved}.click(${optionsArg});`);
+    response.addAction({
+      name: 'click',
+      selector,
+      button: params.button ?? 'left',
+      modifiers: fromKeyboardModifiers(params.modifiers),
+      clickCount: params.doubleClick ? 2 : 1,
+    });
 
     await tab.waitForCompletion(async () => {
       if (params.doubleClick)
@@ -140,8 +141,8 @@ const hover = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
-    const { locator, resolved } = await tab.targetLocator(params);
-    response.addCode(`await page.${resolved}.hover();`);
+    const { locator, selector } = await tab.targetLocator(params);
+    response.addAction({ name: 'hover', selector });
 
     await locator.hover(tab.actionTimeoutOptions);
   },
@@ -164,8 +165,8 @@ const selectOption = defineTabTool({
   handle: async (tab, params, response) => {
     response.setIncludeSnapshot();
 
-    const { locator, resolved } = await tab.targetLocator(params);
-    response.addCode(`await page.${resolved}.selectOption(${formatObject(params.values)});`);
+    const { locator, selector } = await tab.targetLocator(params);
+    response.addAction({ name: 'select', selector, options: params.values });
 
     await locator.selectOption(params.values, tab.actionTimeoutOptions);
   },
@@ -200,8 +201,8 @@ const check = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const { locator, resolved } = await tab.targetLocator(params);
-    response.addCode(`await page.${resolved}.check();`);
+    const { locator, selector } = await tab.targetLocator(params);
+    response.addAction({ name: 'check', selector });
     await locator.check(tab.actionTimeoutOptions);
   },
 });
@@ -218,8 +219,8 @@ const uncheck = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const { locator, resolved } = await tab.targetLocator(params);
-    response.addCode(`await page.${resolved}.uncheck();`);
+    const { locator, selector } = await tab.targetLocator(params);
+    response.addAction({ name: 'uncheck', selector });
     await locator.uncheck(tab.actionTimeoutOptions);
   },
 });

--- a/packages/playwright-core/src/tools/backend/tab.ts
+++ b/packages/playwright-core/src/tools/backend/tab.ts
@@ -488,12 +488,12 @@ export class Tab extends EventEmitter<TabEventsInterface> {
     await this._raceAgainstModalStates(() => waitForCompletion(this, callback));
   }
 
-  async targetLocator(params: { element?: string, target: string }): Promise<{ locator: playwright.Locator, resolved: string }> {
+  async targetLocator(params: { element?: string, target: string }): Promise<{ locator: playwright.Locator, resolved: string, selector: string }> {
     await this._initializedPromise;
     return (await this.targetLocators([params]))[0];
   }
 
-  async targetLocators(params: { element?: string, target: string }[]): Promise<{ locator: playwright.Locator, resolved: string }[]> {
+  async targetLocators(params: { element?: string, target: string }[]): Promise<{ locator: playwright.Locator, resolved: string, selector: string }[]> {
     await this._initializedPromise;
     return Promise.all(params.map(async param => {
       if (!param.target.match(/^(f\d+)?e\d+$/)) {
@@ -502,14 +502,14 @@ export class Tab extends EventEmitter<TabEventsInterface> {
         if (!handle)
           throw new Error(`"${param.target}" does not match any elements.`);
         handle.dispose().catch(() => {});
-        return { locator: this.page.locator(selector), resolved: asLocator('javascript', selector) };
+        return { locator: this.page.locator(selector), resolved: asLocator('javascript', selector), selector };
       } else {
         try {
           let locator = this.page.locator(`aria-ref=${param.target}`);
           if (param.element)
             locator = locator.describe(param.element);
           const resolved = await locator.normalize();
-          return { locator, resolved: resolved.toString() };
+          return { locator, resolved: resolved.toString(), selector: locatorSelector(resolved) };
         } catch (e) {
           throw new Error(`Ref ${param.target} not found in the current page snapshot. Try capturing new snapshot.`);
         }
@@ -533,6 +533,10 @@ export type ConsoleMessage = {
   text: string;
   toString(): string;
 };
+
+export function locatorSelector(locator: playwright.Locator): string {
+  return (locator as unknown as { _selector: string })._selector;
+}
 
 function messageToConsoleMessage(message: playwright.ConsoleMessage): ConsoleMessage {
   return {

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -15,7 +15,6 @@
  */
 
 import * as z from 'zod';
-import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
 
@@ -45,7 +44,7 @@ const browserTabs = defineTool({
         if (params.url) {
           const url = await tab.checkUrlAndNavigate(params.url);
           response.setIncludeSnapshot();
-          response.addCode(`await page.goto(${escapeWithQuotes(url)});`);
+          response.addAction({ name: 'navigate', url });
         }
         break;
       }

--- a/packages/playwright-core/src/tools/backend/verify.ts
+++ b/packages/playwright-core/src/tools/backend/verify.ts
@@ -18,6 +18,7 @@ import * as z from 'zod';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
 
 import { defineTabTool } from './tool';
+import { locatorSelector } from './tab';
 import type * as playwright from '../../..';
 
 const verifyElement = defineTabTool({
@@ -38,7 +39,7 @@ const verifyElement = defineTabTool({
       const locator = frame.getByRole(params.role as Parameters<playwright.Frame['getByRole']>[0], { name: params.accessibleName });
       if (await locator.count() > 0) {
         const resolved = await locator.normalize();
-        response.addCode(`await expect(page.${resolved}).toBeVisible();`);
+        response.addAction({ name: 'assertVisible', selector: locatorSelector(resolved) });
         response.addTextResult('Done');
         return;
       }
@@ -64,7 +65,7 @@ const verifyText = defineTabTool({
       const locator = frame.getByText(params.text).filter({ visible: true });
       if (await locator.count() > 0) {
         const resolved = await locator.normalize();
-        response.addCode(`await expect(page.${resolved}).toBeVisible();`);
+        response.addAction({ name: 'assertVisible', selector: locatorSelector(resolved) });
         response.addTextResult('Done');
         return;
       }
@@ -98,11 +99,9 @@ const verifyList = defineTabTool({
       }
       itemTexts.push((await itemLocator.textContent(tab.expectTimeoutOptions))!);
     }
-    const ariaSnapshot = `\`
-- list:
-${itemTexts.map(t => `  - listitem: ${escapeWithQuotes(t, '"')}`).join('\n')}
-\``;
-    response.addCode(`await expect(page.locator('body')).toMatchAriaSnapshot(${ariaSnapshot});`);
+    const ariaSnapshot = `- list:
+${itemTexts.map(t => `  - listitem: ${escapeWithQuotes(t, '"')}`).join('\n')}`;
+    response.addAction({ name: 'assertSnapshot', selector: 'body', ariaSnapshot });
     response.addTextResult('Done');
   },
 });
@@ -123,23 +122,21 @@ const verifyValue = defineTabTool({
   },
 
   handle: async (tab, params, response) => {
-    const { locator, resolved } = await tab.targetLocator(params);
-    const locatorSource = `page.${resolved}`;
+    const { locator, selector } = await tab.targetLocator(params);
     if (params.type === 'textbox' || params.type === 'slider' || params.type === 'combobox') {
       const value = await locator.inputValue(tab.expectTimeoutOptions);
       if (value !== params.value) {
         response.addError(`Expected value "${params.value}", but got "${value}"`);
         return;
       }
-      response.addCode(`await expect(${locatorSource}).toHaveValue(${escapeWithQuotes(params.value)});`);
+      response.addAction({ name: 'assertValue', selector, value: params.value });
     } else if (params.type === 'checkbox' || params.type === 'radio') {
       const value = await locator.isChecked(tab.expectTimeoutOptions);
       if (value !== (params.value === 'true')) {
         response.addError(`Expected value "${params.value}", but got "${value}"`);
         return;
       }
-      const matcher = value ? 'toBeChecked' : 'not.toBeChecked';
-      response.addCode(`await expect(${locatorSource}).${matcher}();`);
+      response.addAction({ name: 'assertChecked', selector, checked: value });
     }
     response.addTextResult('Done');
   },

--- a/packages/playwright-core/src/tools/mcp/config.d.ts
+++ b/packages/playwright-core/src/tools/mcp/config.d.ts
@@ -246,5 +246,5 @@ export type Config = {
   /**
    * Specify the language to use for code generation.
    */
-  codegen?: 'typescript' | 'none';
+  codegen?: 'typescript' | 'python' | 'java' | 'csharp' | 'none';
 };

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -43,7 +43,7 @@ export type CLIOptions = {
   cdpEndpoint?: string;
   cdpHeader?: Record<string, string>;
   cdpTimeout?: number;
-  codegen?: 'typescript' | 'none';
+  codegen?: 'typescript' | 'python' | 'java' | 'csharp' | 'none';
   config?: string;
   consoleLevel?: 'error' | 'warning' | 'info' | 'debug';
   device?: string;

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -42,7 +42,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
       .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
-      .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript']))
+      .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "python", "java", "csharp", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript', 'python', 'java', 'csharp']))
       .option('--config <path>', 'path to the configuration file.')
       .option('--console-level <level>', 'level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.', enumParser.bind(null, '--console-level', ['error', 'warning', 'info', 'debug']))
       .option('--device <device>', 'device to emulate, for example: "iPhone 15"')

--- a/tests/mcp/cli-core.spec.ts
+++ b/tests/mcp/cli-core.spec.ts
@@ -79,10 +79,10 @@ test('click with --modifiers', { annotation: { type: 'issue', description: 'http
   await cli('open', server.PREFIX);
 
   const single = await cli('click', 'e2', '--modifiers', 'Control');
-  expect(single.output).toContain(`await page.getByRole('button', { name: 'Submit' }).click({\n  modifiers: ['Control']\n});`);
+  expect(single.output).toContain(`await page.getByRole('button', { name: 'Submit' }).click({\n  modifiers: ['ControlOrMeta']\n});`);
 
   const repeated = await cli('click', 'e2', '--modifiers', 'Control', '--modifiers', 'Shift');
-  expect(repeated.output).toContain(`await page.getByRole('button', { name: 'Submit' }).click({\n  modifiers: ['Control', 'Shift']\n});`);
+  expect(repeated.output).toContain(`await page.getByRole('button', { name: 'Submit' }).click({\n  modifiers: ['ControlOrMeta', 'Shift']\n});`);
 });
 
 test('type', async ({ cli, server }) => {

--- a/tests/mcp/click.spec.ts
+++ b/tests/mcp/click.spec.ts
@@ -136,7 +136,7 @@ test('browser_click (modifiers)', async ({ client, server, mcpBrowser }) => {
     })).toHaveResponse({
       code: [
         `await page.getByRole('button', { name: 'Submit' }).click({`,
-        `  modifiers: ['Control']`,
+        `  modifiers: ['ControlOrMeta']`,
         `});`
       ].join('\n'),
       snapshot: expect.stringContaining(`generic [ref=e3]: ctrlKey:true metaKey:false shiftKey:false altKey:false`),
@@ -169,7 +169,7 @@ test('browser_click (modifiers)', async ({ client, server, mcpBrowser }) => {
   })).toHaveResponse({
     code: [
       `await page.getByRole('button', { name: 'Submit' }).click({`,
-      `  modifiers: ['Shift', 'Alt']`,
+      `  modifiers: ['Alt', 'Shift']`,
       `});`
     ].join('\n'),
     snapshot: expect.stringContaining(`generic [ref=e3]: ctrlKey:false metaKey:false shiftKey:true altKey:true`),

--- a/tests/mcp/codegen.spec.ts
+++ b/tests/mcp/codegen.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import { test, expect } from './fixtures';
+
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+async function navigateToForm(client: Client, server: any) {
+  server.setContent('/', `
+    <title>Title</title>
+    <button>Submit</button>
+    <input type="text">
+  `, 'text/html');
+  return await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.PREFIX },
+  });
+}
+
+test('codegen python', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: ['--codegen=python'] });
+  expect(await navigateToForm(client, server)).toHaveResponse({
+    code: `page.goto("${server.PREFIX}")`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Submit button', target: 'e2' },
+  })).toHaveResponse({
+    code: `page.get_by_role("button", name="Submit").click()`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Submit button', target: 'e2', modifiers: ['Control'] },
+  })).toHaveResponse({
+    code: `page.get_by_role("button", name="Submit").click(modifiers=["ControlOrMeta"])`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_type',
+    arguments: { element: 'textbox', target: 'e3', text: `it's a secret`, submit: true },
+  })).toHaveResponse({
+    code: `page.get_by_role("textbox").fill("it's a secret")\npage.get_by_role("textbox").press("Enter")`,
+  });
+
+  // Page-level keyboard input has no action equivalent and stays as JavaScript.
+  expect(await client.callTool({
+    name: 'browser_press_key',
+    arguments: { key: 'Escape' },
+  })).toHaveResponse({
+    code: `// Press Escape\nawait page.keyboard.press('Escape');`,
+  });
+});
+
+test('codegen java', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: ['--codegen=java'] });
+  expect(await navigateToForm(client, server)).toHaveResponse({
+    code: `page.navigate("${server.PREFIX}");`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Submit button', target: 'e2' },
+  })).toHaveResponse({
+    code: `page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Submit")).click();`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_type',
+    arguments: { element: 'textbox', target: 'e3', text: 'hello', submit: false },
+  })).toHaveResponse({
+    code: `page.getByRole(AriaRole.TEXTBOX).fill("hello");`,
+  });
+});
+
+test('codegen csharp', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: ['--codegen=csharp'] });
+  expect(await navigateToForm(client, server)).toHaveResponse({
+    code: `await page.GotoAsync("${server.PREFIX}");`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Submit button', target: 'e2' },
+  })).toHaveResponse({
+    code: `await page.GetByRole(AriaRole.Button, new() { Name = "Submit" }).ClickAsync();`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_type',
+    arguments: { element: 'textbox', target: 'e3', text: 'hello', submit: false },
+  })).toHaveResponse({
+    code: `await page.GetByRole(AriaRole.Textbox).FillAsync("hello");`,
+  });
+});
+
+test('codegen verify tools', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: ['--codegen=python', '--caps=testing'] });
+  await navigateToForm(client, server);
+  await client.callTool({
+    name: 'browser_type',
+    arguments: { element: 'textbox', target: 'e3', text: 'hello', submit: false },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_verify_value',
+    arguments: { type: 'textbox', element: 'textbox', target: 'e3', value: 'hello' },
+  })).toHaveResponse({
+    code: `expect(page.get_by_role("textbox")).to_have_value("hello")`,
+  });
+});
+
+test('codegen renders secrets as environment lookups', async ({ startClient, server }) => {
+  const secretsFile = test.info().outputPath('secrets.env');
+  await fs.promises.writeFile(secretsFile, 'X-PASSWORD=password123');
+
+  for (const [language, code] of [
+    ['typescript', `await page.getByRole('textbox').fill(process.env['X-PASSWORD']);`],
+    ['python', `page.get_by_role("textbox").fill(os.environ["X-PASSWORD"])`],
+    ['java', `page.getByRole(AriaRole.TEXTBOX).fill(System.getenv("X-PASSWORD"));`],
+    ['csharp', `await page.GetByRole(AriaRole.Textbox).FillAsync(Environment.GetEnvironmentVariable("X-PASSWORD"));`],
+  ] as const) {
+    const { client } = await startClient({ args: [`--codegen=${language}`, '--secrets', secretsFile] });
+    await navigateToForm(client, server);
+    expect(await client.callTool({
+      name: 'browser_type',
+      arguments: { element: 'textbox', target: 'e3', text: 'X-PASSWORD', submit: false },
+    })).toHaveResponse({ code });
+    await client.close();
+  }
+});
+
+test('codegen falls back to JavaScript for scripted lines', async ({ startClient, server }) => {
+  const { client } = await startClient({ args: ['--codegen=python'] });
+  await navigateToForm(client, server);
+
+  expect(await client.callTool({
+    name: 'browser_evaluate',
+    arguments: { function: '() => document.title' },
+  })).toHaveResponse({
+    code: `await page.evaluate('() => document.title');`,
+  });
+});

--- a/tests/mcp/form.spec.ts
+++ b/tests/mcp/form.spec.ts
@@ -97,7 +97,7 @@ test('browser_fill_form (textbox)', async ({ client, server }) => {
 await page.getByRole('textbox', { name: 'Email' }).fill('john.doe@example.com');
 await page.getByRole('slider', { name: 'Age' }).fill('25');
 await page.getByLabel('Choose a country United').selectOption('United States');
-await page.getByRole('checkbox', { name: 'Subscribe to newsletter' }).setChecked(true);`,
+await page.getByRole('checkbox', { name: 'Subscribe to newsletter' }).check();`,
   });
 
   const response = await client.callTool({

--- a/tests/mcp/verify.spec.ts
+++ b/tests/mcp/verify.spec.ts
@@ -261,11 +261,11 @@ test('browser_verify_list_visible', async ({ client, server }) => {
   })).toHaveResponse({
     result: 'Done',
     code: expect.stringContaining(`await expect(page.locator('body')).toMatchAriaSnapshot(\`
-- list:
-  - listitem: "Apple"
-  - listitem: "Banana"
-  - listitem: "Cherry"
-\`);`),
+  - list:
+    - listitem: "Apple"
+    - listitem: "Banana"
+    - listitem: "Cherry"
+  \`);`),
   });
 });
 
@@ -295,10 +295,10 @@ test('browser_verify_list_visible (partial items)', async ({ client, server }) =
   })).toHaveResponse({
     result: 'Done',
     code: expect.stringContaining(`await expect(page.locator('body')).toMatchAriaSnapshot(\`
-- list:
-  - listitem: "Apple"
-  - listitem: "Cherry"
-\`);`),
+  - list:
+    - listitem: "Apple"
+    - listitem: "Cherry"
+  \`);`),
   });
 });
 


### PR DESCRIPTION
## Summary
- `--codegen` now accepts `python`, `java` and `csharp` in addition to `typescript` and `none`
- tools emit structured actions (`@isomorphic/codegen/actions`) rendered with the recorder language generators when serializing the response; operations without an action representation keep their JavaScript snippets
- secrets render as idiomatic environment lookups per language (`process.env[...]`, `os.environ[...]`, `System.getenv(...)`, `Environment.GetEnvironmentVariable(...)`), with a `SECRET_<NAME>` placeholder fallback

Fixes https://github.com/microsoft/playwright-mcp/issues/1696