### PR TITLE
fix(chromium): reject --no-startup-window for persistent context

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiChromium.ts
+++ b/packages/playwright-core/src/server/bidi/bidiChromium.ts
@@ -91,10 +91,13 @@ export class BidiChromium extends BrowserType {
     const chromeArguments = this._innerDefaultArgs(options);
     chromeArguments.push(`--user-data-dir=${userDataDir}`);
     chromeArguments.push('--remote-debugging-port=0');
-    if (isPersistent)
+    if (isPersistent) {
+      if (options.args?.some(arg => arg === '--no-startup-window'))
+        throw new Error(`Cannot use '--no-startup-window' argument when launching a persistent context`);
       chromeArguments.push('about:blank');
-    else
+    } else {
       chromeArguments.push('--no-startup-window');
+    }
     return chromeArguments;
   }
 

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -355,10 +355,13 @@ export class Chromium extends BrowserType {
     const chromeArguments = this._innerDefaultArgs(options);
     chromeArguments.push(`--user-data-dir=${userDataDir}`);
     chromeArguments.push('--remote-debugging-pipe');
-    if (isPersistent)
+    if (isPersistent) {
+      if (options.args?.some(arg => arg === '--no-startup-window'))
+        throw new Error(`Cannot use '--no-startup-window' argument when launching a persistent context`);
       chromeArguments.push('about:blank');
-    else
+    } else {
       chromeArguments.push('--no-startup-window');
+    }
     return chromeArguments;
   }
 

--- a/tests/library/defaultbrowsercontext-2.spec.ts
+++ b/tests/library/defaultbrowsercontext-2.spec.ts
@@ -176,6 +176,14 @@ it('should throw if page argument is passed', async ({ browserType, server, crea
   expect(error.message).toContain('can not specify page');
 });
 
+it('should throw if --no-startup-window is passed as an argument', async ({ browserType, createUserDataDir, browserName }) => {
+  it.skip(browserName !== 'chromium');
+
+  const options = { args: ['--no-startup-window'] };
+  const error = await browserType.launchPersistentContext(await createUserDataDir(), options).catch(e => e);
+  expect(error.message).toContain(`Cannot use '--no-startup-window' argument when launching a persistent context`);
+});
+
 it('should have passed URL when launching with ignoreDefaultArgs: true', async ({ browserType, server, createUserDataDir, toImpl, browserName }) => {
   const userDataDir = await createUserDataDir();
   const args = (await toImpl(browserType).defaultArgs((browserType as any)._playwright._defaultLaunchOptions, 'persistent', userDataDir, 0)).filter(a => a !== 'about:blank');


### PR DESCRIPTION
`launchPersistentContext` hangs for the full timeout when `--no-startup-window` is passed in `args`. A persistent context waits for its initial page to open, but `--no-startup-window` tells Chromium not to open one, so the wait never resolves and the call times out after 180s.

This rejects the argument up front with a clear error, the same way a `--user-data-dir` argument is already rejected.

Fixes #42093
