### PR TITLE
fix(fetch): do not crash on a late request-socket error

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -100,6 +100,8 @@ type SendRequestResult = {
   response: Omit<channels.APIResponse, 'fetchUid'>,
 };
 
+const socketsWithSwallowedErrors = new WeakSet<net.Socket>();
+
 export abstract class APIRequestContext extends SdkObject {
   static Events = {
     Dispose: 'dispose',
@@ -588,6 +590,15 @@ export abstract class APIRequestContext extends SdkObject {
       request.on('socket', socket => {
         serverIPAddress = socket.remoteAddress;
         serverPort = socket.remotePort;
+
+        // Node.js detaches the request from its socket once the full response has been received, so a
+        // late socket error (e.g. the server reset the connection without reading the request body) is
+        // left without a listener and crashes the process with an unhandled 'error'. The response is
+        // already in hand by then; earlier failures are still surfaced by the request 'error' handler.
+        if (!socketsWithSwallowedErrors.has(socket)) {
+          socketsWithSwallowedErrors.add(socket);
+          socket.on('error', () => {});
+        }
 
         if (request.reusedSocket) {
           reusedSocketAt = monotonicTime();

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -707,6 +707,29 @@ it('should retry ECONNRESET', {
   await request.dispose();
 });
 
+it('should not crash when the server resets the connection before reading the request body', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ playwright, server }) => {
+  server.setRoute('/refuse', (req, res) => {
+    res.writeHead(413, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'too large' }));
+    req.socket.destroy();
+  });
+  const request = await playwright.request.newContext();
+  // A large body keeps the upload in flight when the server resets, so the request socket sees a
+  // late write error after the response arrived; issuing several in parallel makes it reliable.
+  const body = 'x'.repeat(8 * 1024 * 1024);
+  const results = await Promise.all(Array.from({ length: 20 }, () =>
+    request.post(server.PREFIX + '/refuse', { data: body }).catch(e => e)));
+  for (const result of results) {
+    if (result instanceof Error)
+      expect(result.message).toContain('apiRequestContext.post:');
+    else
+      expect(result.status()).toBe(413);
+  }
+  await request.dispose();
+});
+
 it('should throw when failOnStatusCode is set to true inside APIRequest context options', async ({ playwright, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34204' });
   const request = await playwright.request.newContext({ failOnStatusCode: true });


### PR DESCRIPTION
## Summary
- When a server sends its response and then resets the connection without reading the request body (as workerd does when it refuses an oversized or rate-limited upload before consuming it), Node completes the response and detaches the request from its socket. The still-pending write of the unread body then errors on that socket, and with nothing listening for it the process exits with an unhandled `write ECONNRESET` that a `try/catch` around the call never sees.
- Keep an `error` listener on the request socket so this late error no longer reaches the process. The response is already in hand by then, so the request resolves with it (or rejects through the normal request-failure path) instead of taking down the whole process.

Fixes https://github.com/microsoft/playwright/issues/42074