### PR TITLE
fix(core): avoid hanging temp folder cleanup on unremovable directories

### DIFF
--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -28,9 +28,24 @@ export async function mkdirIfNeeded(filePath: string) {
 }
 
 export async function removeFolders(dirs: string[]): Promise<(Error| undefined)[]> {
-  return await Promise.all(dirs.map((dir: string) =>
-    fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch(e => e)
-  ));
+  return await Promise.all(dirs.map(removeFolder));
+}
+
+async function removeFolder(dir: string): Promise<Error | undefined> {
+  // fs.rm retries every level of the tree, so maxRetries compounds with the depth and can hang forever on an entry that can never be removed; retry the whole tree here to keep it bounded.
+  const maxAttempts = 5;
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt)
+      await new Promise(f => setTimeout(f, 100 * attempt));
+    try {
+      await fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 0 });
+      return undefined;
+    } catch (e) {
+      lastError = e as Error;
+    }
+  }
+  return lastError;
 }
 
 export function canAccessFile(file: string) {


### PR DESCRIPTION
On Windows, launching and then closing Chromium can leave the Node process hanging forever. The browser itself closes fine, but the event loop stays alive because the temp profile cleanup never finishes.

Chromium writes a `Default/Shared Dictionary/cache` directory inside its temp profile with an AppContainer ACL that excludes the launching user, so listing it fails with a permanent `EPERM`. `removeFolders` calls `fs.rm` with `recursive: true` and `maxRetries: 10`, and Node retries that error at every level of the tree it walks, so the number of attempts grows with the directory depth and the call never settles.

This moves the retry up to the top level and calls `fs.rm` with `maxRetries: 0`, retrying the whole removal a few times with a short backoff. When it hits an error it can't recover from, it gives up after about a second and returns the error instead of holding the process open. The directory that can't be deleted is still left behind, since that user genuinely can't remove it, but it no longer keeps the process from exiting.

Fixes https://github.com/microsoft/playwright/issues/42109