### PR TITLE
fix(fetch): do not crash on late EPIPE after refused body

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -600,6 +600,10 @@ export abstract class APIRequestContext extends SdkObject {
         serverPort = socket.remotePort;
 
         socket.on('error', handleRequestError);
+        // Keep-alive sockets outlive the request - drop our listener so they do not
+        // pile up. If the socket is already destroyed (server reset after refusing the
+        // body), keep it: a late write EPIPE can still fire, and the listener dies with
+        // the socket anyway.
         request.once('close', () => {
           if (!socket.destroyed)
             socket.off('error', handleRequestError);

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -600,10 +600,8 @@ export abstract class APIRequestContext extends SdkObject {
         serverPort = socket.remotePort;
 
         socket.on('error', handleRequestError);
-        // Keep-alive sockets outlive the request - drop our listener so they do not
-        // pile up. If the socket is already destroyed (server reset after refusing the
-        // body), keep it: a late write EPIPE can still fire, and the listener dies with
-        // the socket anyway.
+        // Drop on keep-alive reuse so listeners do not accumulate. Keep if destroyed:
+        // a late write EPIPE may still fire after a refused-body reset.
         request.once('close', () => {
           if (!socket.destroyed)
             socket.off('error', handleRequestError);

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -600,6 +600,10 @@ export abstract class APIRequestContext extends SdkObject {
         serverPort = socket.remotePort;
 
         socket.on('error', handleRequestError);
+        request.once('close', () => {
+          if (!socket.destroyed)
+            socket.off('error', handleRequestError);
+        });
 
         if (request.reusedSocket) {
           reusedSocketAt = monotonicTime();

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -356,10 +356,20 @@ export abstract class APIRequestContext extends SdkObject {
       let serverPort: number | undefined;
 
       let securityDetails: har.SecurityDetails | undefined;
+      let responseReceived = false;
 
       const listeners: RegisteredListener[] = [];
 
+      const handleRequestError = (error: Error) => {
+        // Write errors after we received a response are swallowed, following undici behaviour:
+        // https://github.com/nodejs/undici/blob/01a912e49a50c48009ed2639d2a457a6ec26752a/lib/dispatcher/client-h1.js#L735
+        if (responseReceived && isNetworkConnectionError(error))
+          return;
+        reject(error);
+      };
+
       const request = requestConstructor(url, requestOptions as any, async response => {
+        responseReceived = true;
         const responseAt = monotonicTime();
 
         const notifyRequestFinished = (body?: Buffer) => {
@@ -559,7 +569,7 @@ export abstract class APIRequestContext extends SdkObject {
         body.on('data', chunk => chunks.push(chunk));
         body.on('end', notifyBodyFinished);
       });
-      request.on('error', reject);
+      request.on('error', handleRequestError);
       destroyRequest = () => request.destroy();
 
       listeners.push(
@@ -588,6 +598,8 @@ export abstract class APIRequestContext extends SdkObject {
       request.on('socket', socket => {
         serverIPAddress = socket.remoteAddress;
         serverPort = socket.remotePort;
+
+        socket.on('error', handleRequestError);
 
         if (request.reusedSocket) {
           reusedSocketAt = monotonicTime();

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -707,6 +707,38 @@ it('should retry ECONNRESET', {
   await request.dispose();
 });
 
+it('should not crash when server refuses body before reading it', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42074' }
+}, async ({ playwright, server }) => {
+  // Respond without reading the body, then reset. Node emits a late write
+  // EPIPE/ECONNRESET on the request socket; without a listener that becomes an
+  // unhandled 'error' and kills the process.
+  server.setRoute('/refuse', (req, res) => {
+    req.pause();
+    setTimeout(() => {
+      res.writeHead(413, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'too large' }));
+      req.socket.destroy();
+    }, 50);
+  });
+
+  const request = await playwright.request.newContext();
+  // Large body so the client is still writing when the reset lands.
+  // Prefer CROSS_PROCESS_PREFIX (127.0.0.1) over PREFIX (localhost/::1) for a stable race.
+  const result = await request.post(server.CROSS_PROCESS_PREFIX + '/refuse', {
+    data: Buffer.alloc(20 * 1024 * 1024, 0x78),
+    headers: { 'content-type': 'text/plain' },
+    maxRetries: 0,
+  }).catch(e => e);
+  if (result instanceof Error)
+    expect(result.message).toMatch(/apiRequestContext\.post|ECONNRESET|EPIPE|ECONNABORTED|socket/i);
+  else {
+    expect(result.status()).toBe(413);
+    expect(await result.text()).toBe(JSON.stringify({ error: 'too large' }));
+  }
+  await request.dispose();
+});
+
 it('should throw when failOnStatusCode is set to true inside APIRequest context options', async ({ playwright, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34204' });
   const request = await playwright.request.newContext({ failOnStatusCode: true });

--- a/tests/library/global-fetch.spec.ts
+++ b/tests/library/global-fetch.spec.ts
@@ -730,9 +730,9 @@ it('should not crash when server refuses body before reading it', {
     headers: { 'content-type': 'text/plain' },
     maxRetries: 0,
   }).catch(e => e);
-  if (result instanceof Error)
+  if (result instanceof Error) {
     expect(result.message).toMatch(/apiRequestContext\.post|ECONNRESET|EPIPE|ECONNABORTED|socket/i);
-  else {
+  } else {
     expect(result.status()).toBe(413);
     expect(await result.text()).toBe(JSON.stringify({ error: 'too large' }));
   }


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/42074. `node:http` has a footgun where `socket.on('error')` is bubbled up into `request.on('error')` while the request is ongoing. If the server decides not to read the request body in full, e.g. to prevent DoS, there is a race where it first responds `413`, fulfilling the response and unlinking `socket.on('error')` from `request.on('error')`, and only after that the client receives an error while trying to finish writing its request body. This is an unhandled error event and crashes the host process.

The fix is to listen for the `error` event and swallow it if the race was detected. Axios fixed this race in https://github.com/axios/axios/pull/10576, i'm looking into what `got` does now.