### PR TITLE
chore(bidi): mark all `no such frame` errors with type `closed`

### DIFF
--- a/packages/playwright-core/src/server/bidi/bidiConnection.ts
+++ b/packages/playwright-core/src/server/bidi/bidiConnection.ts
@@ -248,6 +248,8 @@ export class BidiSession extends EventEmitter {
       const callback = this._callbacks.get(object.id)!;
       this._callbacks.delete(object.id);
       if (object.type === 'error') {
+        if (object.error === 'no such frame')
+          callback.error.type = 'closed';
         callback.error.setMessage(object.error + '\nMessage: ' + object.message);
         callback.reject(callback.error);
       } else if (object.type === 'success') {


### PR DESCRIPTION
Bidi commands may fail with a `no such frame` error before the `browsingContext.contextDestroyed` event is sent, in this case the Playwright server sends a `ProtocolError` instead of a `TargetClosedError`.
This PR marks all `no such frame` errors with the type `closed`.
Fixes "should reject all promises when page is closed" in `library/page-close.spec.ts`.
