### PR TITLE
fix(browsercontext): finish the close when saving artifacts fails

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -525,11 +525,25 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
       return;
     this._closeReason = options.reason;
     this._closingStatus = 'closing';
-    await this.request.dispose(options);
-    await this._instrumentation.runBeforeCloseBrowserContext(this);
-    await this.tracing._exportAllHars();
-    await this._channel.close(options, kNoTimeout);
-    await this._closedPromise;
+    // Saving artifacts may fail, e.g. when the HAR path is not writable. Do not let that
+    // abort the close - the context would be left running while reporting itself as closed,
+    // and could never be closed again. Close it first, report the first failure afterwards.
+    let error: Error | undefined;
+    try {
+      await this.request.dispose(options);
+      await this._instrumentation.runBeforeCloseBrowserContext(this);
+      await this.tracing._exportAllHars();
+    } catch (e) {
+      error = e;
+    }
+    try {
+      await this._channel.close(options, kNoTimeout);
+      await this._closedPromise;
+    } catch (e) {
+      error ??= e;
+    }
+    if (error)
+      throw error;
   }
 
   async _enableRecorder(params: channels.BrowserContextEnableRecorderParams, eventSink?: RecorderEventSink) {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -558,8 +558,16 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       this.emit(BrowserContext.Events.BeforeClose);
       this._closedStatus = 'closing';
 
-      await progress.race(this.tracing.flush());
-      await progress.race(Promise.all(this.pages().map(page => page.screencast.handlePageOrContextClose())));
+      // Saving artifacts may fail, e.g. when the HAR path is not writable. Do not let that
+      // abort the close - the context would be stuck in the 'closing' state, and every
+      // subsequent close() would hang on _closePromise. Close it first, report afterwards.
+      let error: Error | undefined;
+      try {
+        await progress.race(this.tracing.flush());
+        await progress.race(Promise.all(this.pages().map(page => page.screencast.handlePageOrContextClose())));
+      } catch (e) {
+        error = e;
+      }
 
       if (this._customCloseHandler) {
         await progress.race(this._customCloseHandler());
@@ -580,6 +588,9 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       // Custom handler should trigger didCloseInternal itself.
       if (!this._customCloseHandler)
         this._didCloseInternal();
+
+      if (error)
+        throw error;
     }
     await this._closePromise;
   }

--- a/tests/library/browsercontext-basic.spec.ts
+++ b/tests/library/browsercontext-basic.spec.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { browserTest as it, expect } from '../config/browserTest';
 import { attachFrame, verifyViewport } from '../config/utils';
@@ -211,6 +213,24 @@ it('close() should be callable twice', async ({ browser }) => {
   await context.close();
   await context.close();
 });
+
+// The HAR path points at a directory, so writing the HAR fails. A plain HAR is written by
+// the server, a zipped one by the client - closing must survive either failure.
+for (const harName of ['test.har', 'test.har.zip']) {
+  it(`close() should still close the context when the ${harName} export fails`, async ({ browser }, testInfo) => {
+    const harPath = testInfo.outputPath(harName);
+    fs.mkdirSync(harPath, { recursive: true });
+    const context = await browser.newContext({ recordHar: { path: harPath } });
+    const page = await context.newPage();
+
+    const error = await context.close().catch(e => e);
+    expect(error.message).toContain(harPath);
+    expect(context.isClosed()).toBe(true);
+    expect(browser.contexts().length).toBe(0);
+    expect(page.isClosed()).toBe(true);
+    await context.close();
+  });
+}
 
 it('should pass self to close event', async ({ browser }) => {
   const newContext = await browser.newContext();


### PR DESCRIPTION
Fixes #42069. Replaces #42070, which cached the close error and hid the actual bug.

`close()` marks the context as closing and only then saves artifacts, so a failure while saving aborts the teardown halfway. On the server `_closedStatus` stays `'closing'` and `_didCloseInternal()` is never reached, so the context stays alive and every later `close()` waits on `_closePromise` forever. On the client `_closingStatus` stays `'closing'`, so `isClosed()` reports a context that still navigates and opens pages, and every later `close()` returns early and resolves.

Both sides now finish the teardown they started and report the first failure afterwards, so a failed `close()` leaves a closed context behind instead of a live one.

One test per half: reverting the client change fails both, reverting the server change fails only the plain-HAR one, since a zipped HAR is written by the client and a plain one by the server. The server half also covers the other language clients — playwright-python's `close()` sets `_closing_or_closed` before the same steps, so without it a second `close()` from Python never returns.

Validating `recordHar.path` upfront is worth doing separately, but it can't replace this: the same abort happens for a video, a trace or a full disk.
