### PR TITLE
Revert "test: roll stable-test-runner to 1.63.0-alpha-2026-08-03"

### DIFF
--- a/tests/playwright-test/stable-test-runner/package-lock.json
+++ b/tests/playwright-test/stable-test-runner/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@playwright/test": "^1.63.0-alpha-2026-08-03"
+        "@playwright/test": "^1.62.0-alpha-2026-07-20"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.63.0-alpha-2026-08-03",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0-alpha-2026-08-03.tgz",
-      "integrity": "sha512-3tUjv9lTNbxgo++eevWQS1erslCqe6YnRH6ff6JRkpzW0V2AdtHk6udYUsIBV6ltlyCs5BvDprXfnnHlqrQm1g==",
+      "version": "1.62.0-alpha-2026-07-20",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0-alpha-2026-07-20.tgz",
+      "integrity": "sha512-Lb218lZdfhxIJpDF3QRaVqDjNyruDfN7gKIYbMRCHRfTsgQqz6cp2xJznDrc80k3gLC6Wby/twFkbfaKWUd/rg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.63.0-alpha-2026-08-03"
+        "playwright": "1.62.0-alpha-2026-07-20"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.63.0-alpha-2026-08-03",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-03.tgz",
-      "integrity": "sha512-s0r6u3nDnXUBZi7o1PdrE8sOk9SGhXGVzOrPqLGn90lW5JgUOA2bt7QxyuZdqoZeL5WUl0tGplJPbg0H2jzJSg==",
+      "version": "1.62.0-alpha-2026-07-20",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0-alpha-2026-07-20.tgz",
+      "integrity": "sha512-/h5GCcC7LUQOUS+XpGhY5B+UWsyU7PC2oEVzSjqn6dBf2FQBohD+JV0FDrmQkhcTqn5AoWNTbEEPswu9WZvtZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-alpha-2026-08-03"
+        "playwright-core": "1.62.0-alpha-2026-07-20"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.63.0-alpha-2026-08-03",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-03.tgz",
-      "integrity": "sha512-3bQL6rtqLdh2iuUTpFcI0XVrOcvxsLcRwAp2gBnb3Jh8FIy4wuny3z0QXhR/sjS8wwcZ0mCnLKcKzP3AIrf0XA==",
+      "version": "1.62.0-alpha-2026-07-20",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0-alpha-2026-07-20.tgz",
+      "integrity": "sha512-JCPvar5AJouLPK5dce8+M/tC3f0gfSt564h1pdL5aHSW5SAaTyPPKdZ01DnGeuftrCzXQIExEc5SDKBV109JHA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/playwright-test/stable-test-runner/package.json
+++ b/tests/playwright-test/stable-test-runner/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "@playwright/test": "^1.63.0-alpha-2026-08-03"
+    "@playwright/test": "^1.62.0-alpha-2026-07-20"
   }
 }


### PR DESCRIPTION
Reverts microsoft/playwright#42091

```
npm error code E404
npm error 404 Not Found - GET https://packagefeedproxy.microsoft.io/npm/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-03.tgz - Cannot find the file playwright-core-1.63.0-alpha-2026-08-03.tgz in package 'playwright-core 1.63.0-alpha-2026-08-03' in feed 'npm-public'
npm error 404
```

