### PR TITLE
fix(mcp): mention PLAYWRIGHT_MCP_EXECUTABLE_PATH in extension not found error

### DIFF
--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -30,7 +30,7 @@ export async function createExtensionBrowser(channel: string, executablePath: st
   if (!executablePath) {
     userDataDir = process.env.PWTEST_EXTENSION_USER_DATA_DIR ?? defaultUserDataDirForChannel(channel);
     if (userDataDir && !await isPlaywrightExtensionInstalled(userDataDir))
-      throw new Error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}`);
+      throw new Error(`Playwright Extension not found in "${userDataDir}". Install it from ${playwrightExtensionInstallUrl}, or set the PLAYWRIGHT_MCP_EXECUTABLE_PATH environment variable to use a browser at a custom location.`);
   }
 
   const relay = new CDPRelayServer(channel, executablePath, userDataDir);


### PR DESCRIPTION
## Summary
- Suggest the `PLAYWRIGHT_MCP_EXECUTABLE_PATH` environment variable in the "Playwright Extension not found" error, for browsers at custom locations (e.g. a Windows host browser from WSL2).

Fixes https://github.com/microsoft/playwright/issues/42092