### PR TITLE
test(firefox): drop init-script console workaround

### DIFF
--- a/tests/mcp/init-script.spec.ts
+++ b/tests/mcp/init-script.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 
 
 for (const context of ['isolated', 'persistent']) {
-  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server, mcpBrowser }, testInfo) => {
+  test(`--init-script option loads and executes script (${context})`, async ({ startClient, server }, testInfo) => {
     // Create a temporary init script
     const initScriptPath = testInfo.outputPath('init-script1.js');
     const initScriptContent1 = `window.testInitScriptExecuted = true;`;
@@ -55,9 +55,7 @@ for (const context of ['isolated', 'persistent']) {
 
     expect(await client.callTool({
       name: 'browser_console_messages',
-      // FIXME: in firefox commit event comes after console messages from the init script.
-      // See https://github.com/microsoft/playwright/issues/39624.
-      arguments: { all: mcpBrowser === 'firefox' }
+      arguments: {}
     })).toHaveResponse({
       result: expect.stringMatching(/Init script executed successfully.*Custom log/ms),
     });


### PR DESCRIPTION
Firefox now emits the navigation commit before running init scripts, so their console output is attributed to the new document and returned by the default (since-navigation) console filter. Remove the firefox-specific `all: true` workaround.

Fixes https://github.com/microsoft/playwright/issues/39624
