### PR TITLE
fix(chromium): only re-fetch replay-safe requests when reading response body

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -599,6 +599,12 @@ class InterceptableRequest {
       if (interceptable._originalRequestRoute?._fulfilled)
         return Buffer.from('');
 
+      // Only prefetch requests are safe to load again - they are served from the http
+      // cache. For anything else, loading the resource again may reach the server and
+      // produce side effects, so prefer an empty body instead.
+      if (!request.headerValue('sec-purpose')?.startsWith('prefetch'))
+        return Buffer.from('');
+
       // For <link prefetch we are going to receive empty body with non-empty content-length expectation. Reach out for the actual content.
       const resource = await session.send('Network.loadNetworkResource', { url: request.url(), frameId: request.serviceWorker() ? undefined : request.frame()!._id, options: { disableCache: false, includeCredentials: true } });
       const chunks: Buffer[] = [];

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -557,6 +557,12 @@ export class CRNetworkManager {
   }
 }
 
+// Sec-Fetch-Dest values of static subresources that are safe to fetch again.
+const kRefetchSafeDestinations = new Set([
+  'audio', 'audioworklet', 'font', 'image', 'manifest', 'paintworklet', 'script',
+  'serviceworker', 'sharedworker', 'style', 'track', 'video', 'worker', 'xslt',
+]);
+
 const kInterceptableRequest = Symbol('InterceptableRequest');
 
 class InterceptableRequest {
@@ -599,13 +605,17 @@ class InterceptableRequest {
       if (interceptable._originalRequestRoute?._fulfilled)
         return Buffer.from('');
 
-      // Only prefetch requests are safe to load again - they are served from the http
-      // cache. For anything else, loading the resource again may reach the server and
-      // produce side effects, so prefer an empty body instead.
-      if (!request.headerValue('sec-purpose')?.startsWith('prefetch'))
+      // Re-fetching the resource may produce side effects on the server, only
+      // do it for GETs of static subresources and prefetch requests.
+      if (request.method() !== 'GET')
+        return Buffer.from('');
+      const rawHeaders = await request.internalRawRequestHeaders();
+      const rawHeaderValue = (name: string) => rawHeaders.find(h => h.name.toLowerCase() === name)?.value;
+      const isPrefetch = !!rawHeaderValue('sec-purpose')?.startsWith('prefetch');
+      const secFetchDest = rawHeaderValue('sec-fetch-dest');
+      if (!isPrefetch && (!secFetchDest || !kRefetchSafeDestinations.has(secFetchDest)))
         return Buffer.from('');
 
-      // For <link prefetch we are going to receive empty body with non-empty content-length expectation. Reach out for the actual content.
       const resource = await session.send('Network.loadNetworkResource', { url: request.url(), frameId: request.serviceWorker() ? undefined : request.frame()!._id, options: { disableCache: false, includeCredentials: true } });
       const chunks: Buffer[] = [];
       while (resource.resource.stream) {

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -354,6 +354,28 @@ it('should return body for prefetch script', async ({ page, server, browserName 
   expect(body.toString()).toBe('// Scripts will be pre-fetched');
 });
 
+it('should not fetch the resource again when reading the body', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42002' });
+  let requestCount = 0;
+  server.setRoute('/pixel.gif', (req, res) => {
+    ++requestCount;
+    res.setHeader('content-type', 'image/gif');
+    res.end(Buffer.from('R0lGODlhAQABAAAAACw=', 'base64')); // truncated 1x1 gif
+  });
+  server.setRoute('/page.html', (req, res) => {
+    res.setHeader('content-type', 'text/html');
+    res.end('<html><body><img src="/pixel.gif"></body></html>');
+  });
+  const [response] = await Promise.all([
+    page.waitForResponse('**/pixel.gif'),
+    page.goto(server.PREFIX + '/page.html'),
+  ]);
+  // Chromium may evict the body of the response, in which case reading it
+  // must not fall back to re-fetching the resource over the network.
+  await response.body().catch(() => {});
+  expect(requestCount).toBe(1);
+});
+
 it('should bypass disk cache when page interception is enabled', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/30000' });
   await page.goto(server.PREFIX + '/frames/one-frame.html');

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -354,13 +354,12 @@ it('should return body for prefetch script', async ({ page, server, browserName 
   expect(body.toString()).toBe('// Scripts will be pre-fetched');
 });
 
-it('should not fetch the resource again when reading the body', async ({ page, server }) => {
+it('should return body for image with evicted body', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42002' });
-  let requestCount = 0;
+  const imageBase64 = 'R0lGODlhAQABAAAAACw='; // truncated 1x1 gif, Chromium evicts its body
   server.setRoute('/pixel.gif', (req, res) => {
-    ++requestCount;
     res.setHeader('content-type', 'image/gif');
-    res.end(Buffer.from('R0lGODlhAQABAAAAACw=', 'base64')); // truncated 1x1 gif
+    res.end(Buffer.from(imageBase64, 'base64'));
   });
   server.setRoute('/page.html', (req, res) => {
     res.setHeader('content-type', 'text/html');
@@ -370,10 +369,8 @@ it('should not fetch the resource again when reading the body', async ({ page, s
     page.waitForResponse('**/pixel.gif'),
     page.goto(server.PREFIX + '/page.html'),
   ]);
-  // Chromium may evict the body of the response, in which case reading it
-  // must not fall back to re-fetching the resource over the network.
-  await response.body().catch(() => {});
-  expect(requestCount).toBe(1);
+  const body = await response.body();
+  expect(body.toString('base64')).toBe(imageBase64);
 });
 
 it('should bypass disk cache when page interception is enabled', async ({ page, server }) => {


### PR DESCRIPTION
## Summary
- Chromium sometimes evicts response bodies; `response.body()` fell back to `Network.loadNetworkResource`, silently issuing a real second network request for any resource, including requests that may have side effects on the server.
- Only re-fetch requests that are safe to replay: GETs of static subresources (side-effect-free `Sec-Fetch-Dest` values) and prefetch requests (`Sec-Purpose: prefetch`, served from the http cache). Return an empty body otherwise.

Fixes https://github.com/microsoft/playwright/issues/42002