### PR TITLE
fix(mcp): print the path shared by browser_find matches once

### DIFF
--- a/packages/playwright-core/src/tools/backend/find.ts
+++ b/packages/playwright-core/src/tools/backend/find.ts
@@ -92,21 +92,26 @@ const find = defineTabTool({
         path.add(ancestor);
     }
 
-    const snippets = windows.map(window => {
-      const indices = ancestorIndices(lines, indents, window.start);
+    // Render all the windows into a single tree, so that a path shared by several matches is
+    // printed once instead of being repeated for every one of them.
+    const included = new Set<number>();
+    for (const window of windows) {
+      for (const ancestor of ancestorIndices(lines, indents, window.start))
+        included.add(ancestor);
       for (let i = window.start; i <= window.end; i++)
-        indices.push(i);
-      const out: string[] = [];
-      for (let i = 0; i < indices.length; i++) {
-        const index = indices[i];
-        if (i > 0 && index > indices[i - 1] + 1 && !path.has(index) && !path.has(indices[i - 1]))
-          out.push(' '.repeat(indents[index]) + '...');
-        out.push(lines[index]);
-      }
-      return out.join('\n');
-    });
+        included.add(i);
+    }
+
+    const indices = [...included].sort((a, b) => a - b);
+    const out: string[] = [];
+    for (let i = 0; i < indices.length; i++) {
+      const index = indices[i];
+      if (i > 0 && index > indices[i - 1] + 1 && !path.has(index) && !path.has(indices[i - 1]))
+        out.push(' '.repeat(indents[index]) + '...');
+      out.push(lines[index]);
+    }
     const matchWord = matchedLines.length === 1 ? 'match' : 'matches';
-    response.addTextResult(`Found ${matchedLines.length} ${matchWord} for ${query}:\n\n${snippets.join('\n\n----\n\n')}`);
+    response.addTextResult(`Found ${matchedLines.length} ${matchWord} for ${query}:\n\n${out.join('\n')}`);
   },
 });
 

--- a/tests/mcp/find.spec.ts
+++ b/tests/mcp/find.spec.ts
@@ -132,6 +132,51 @@ test('browser_find marks gaps within off-path context with an ellipsis', async (
   });
 });
 
+const repeatedPage = `
+  <main>
+    <section aria-label="Sidebar">
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="/a">Target A</a></li>
+          <li>filler one</li>
+          <li>filler two</li>
+          <li>filler three</li>
+          <li>filler four</li>
+          <li>filler five</li>
+          <li><a href="/b">Target B</a></li>
+        </ul>
+      </nav>
+    </section>
+  </main>
+`;
+
+test('browser_find prints the path shared by several matches once', async ({ client, server }) => {
+  server.setContent('/', repeatedPage, 'text/html');
+  await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX } });
+
+  const response = await client.callTool({
+    name: 'browser_find',
+    arguments: { text: 'Target' },
+  });
+
+  expect(response).toHaveResponse({
+    result: expect.stringContaining(`Found 2 matches for "Target":
+
+- main [ref=e2]:
+  - region "Sidebar" [ref=e3]:
+    - navigation "Primary" [ref=e4]:
+      - list [ref=e5]:
+        - listitem [ref=e6]:`),
+  });
+  // Both matches live in the same tree, so the path above them is printed once and the gap
+  // between the two context windows is marked with an ellipsis.
+  expect(response).toHaveResponse({
+    result: expect.stringContaining(`        - listitem [ref=e9]: filler two
+        ...
+        - listitem [ref=e11]: filler four`),
+  });
+});
+
 test('browser_find is case-insensitive for text', async ({ client, server }) => {
   server.setContent('/', listPage, 'text/html');
   await client.callTool({ name: 'browser_navigate', arguments: { url: server.PREFIX } });


### PR DESCRIPTION
Fixes #42077

`browser_find` rendered every context window as an independent snippet and recomputed
`ancestorIndices()` for each one, so the path from the root was re-emitted once per match. On a page
where several matches sit under a common deep ancestor, that made `find` produce more output than
the full snapshot it is supposed to replace: on a 6-card job board fixture, `browser_snapshot` was
59 lines and `browser_find` was 84.

This collects the ancestor paths and context windows of all matches into one sorted set of line
indices and renders them as a single tree. A shared path is printed once, and the existing ellipsis
rule now marks the gap between windows. Same fixture after the change: 54 lines. The `----`
separator between snippets is gone, since there is only one tree now.

Verified on Ubuntu 20.04 x64, node 22.14, chromium r1237 and firefox 1539. New test in
`tests/mcp/find.spec.ts` fails before the change and passes after. All existing find and cli-find
tests pass on chromium and firefox. I could not run webkit, its binaries do not install on this
host, so if webkit numbers refs differently the new test may need the same adjustment the existing
ref-asserting tests would.

Two things in the issue are deliberately not addressed here. The full ancestor chain for a single
match is unchanged, that is the behavior added in #41654 and it is a product decision rather than a
bug. There is still no `--max-results` on `find`. The issue's third point, no depth limit on
`snapshot`, is already fixed on main - `browser_snapshot` honors `depth` both page-wide and relative
to a `target` root.

Thanks to @dcondrey for the report.