### PR TITLE
fix(cli): do not lose live sessions to transient pipe connect failures

### DIFF
--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -48,6 +48,8 @@ export type BrowserDescriptor = EndpointInfo & {
   browser: BrowserInfo;
 };
 
+export type BrowserStatus = BrowserDescriptor & { canConnect: boolean };
+
 export interface ServerRegistryEvents {
   added: (descriptor: BrowserDescriptor) => void;
   removed: (guid: string) => void;
@@ -96,13 +98,13 @@ class ServerRegistry extends EventEmitter {
       await this._ready;
       const statuses = await Promise.all(
           [...this._descriptors.values()].map(async descriptor => {
-            const dead = await endpointIsDead(descriptor);
-            return { descriptor, dead };
+            const canConnect = await canConnectTo(descriptor);
+            return { descriptor, canConnect };
           }),
       );
       const result = new Map<string, BrowserDescriptor[]>();
-      for (const { descriptor, dead } of statuses) {
-        if (dead) {
+      for (const { descriptor, canConnect } of statuses) {
+        if (!canConnect) {
           await fs.promises.unlink(path.join(this._browsersDir(), descriptor.browser.guid)).catch(() => {});
           continue;
         }
@@ -218,30 +220,25 @@ class ServerRegistry extends EventEmitter {
   }
 }
 
-// Error codes that prove no server is listening on the endpoint. Anything else
-// (e.g. EBUSY when a Windows named pipe rejects a concurrent connection while
-// another client is mid-handshake, or a timeout) may come from a live server,
-// so the registry entry must be kept.
-const deadEndpointErrorCodes = new Set(['ECONNREFUSED', 'ENOENT']);
-
-async function endpointIsDead(descriptor: BrowserDescriptor): Promise<boolean> {
+async function canConnectTo(descriptor: BrowserDescriptor): Promise<boolean> {
   if (!descriptor.endpoint)
-    return true;
-  let socket: net.Socket;
+    return false;
   if (descriptor.endpoint.startsWith('ws://') || descriptor.endpoint.startsWith('wss://')) {
-    const url = new URL(descriptor.endpoint);
-    socket = net.createConnection(Number(url.port), url.hostname);
-  } else {
-    socket = net.createConnection(descriptor.endpoint);
+    return await new Promise(resolve => {
+      const url = new URL(descriptor.endpoint!);
+      const socket = net.createConnection(Number(url.port), url.hostname, () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.on('error', () => resolve(false));
+    });
   }
   return await new Promise(resolve => {
-    const done = (dead: boolean) => {
+    const socket = net.createConnection(descriptor.endpoint ?? (descriptor as any).pipeName, () => {
       socket.destroy();
-      resolve(dead);
-    };
-    socket.once('connect', () => done(false));
-    socket.once('error', (error: NodeJS.ErrnoException) => done(deadEndpointErrorCodes.has(error.code ?? '')));
-    socket.setTimeout(5000, () => done(false));
+      resolve(true);
+    });
+    socket.on('error', () => resolve(false));
   });
 }
 

--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -48,8 +48,6 @@ export type BrowserDescriptor = EndpointInfo & {
   browser: BrowserInfo;
 };
 
-export type BrowserStatus = BrowserDescriptor & { canConnect: boolean };
-
 export interface ServerRegistryEvents {
   added: (descriptor: BrowserDescriptor) => void;
   removed: (guid: string) => void;
@@ -98,13 +96,13 @@ class ServerRegistry extends EventEmitter {
       await this._ready;
       const statuses = await Promise.all(
           [...this._descriptors.values()].map(async descriptor => {
-            const canConnect = await canConnectTo(descriptor);
-            return { descriptor, canConnect };
+            const dead = await endpointIsDead(descriptor);
+            return { descriptor, dead };
           }),
       );
       const result = new Map<string, BrowserDescriptor[]>();
-      for (const { descriptor, canConnect } of statuses) {
-        if (!canConnect) {
+      for (const { descriptor, dead } of statuses) {
+        if (dead) {
           await fs.promises.unlink(path.join(this._browsersDir(), descriptor.browser.guid)).catch(() => {});
           continue;
         }
@@ -220,25 +218,30 @@ class ServerRegistry extends EventEmitter {
   }
 }
 
-async function canConnectTo(descriptor: BrowserDescriptor): Promise<boolean> {
+// Error codes that prove no server is listening on the endpoint. Anything else
+// (e.g. EBUSY when a Windows named pipe rejects a concurrent connection while
+// another client is mid-handshake, or a timeout) may come from a live server,
+// so the registry entry must be kept.
+const deadEndpointErrorCodes = new Set(['ECONNREFUSED', 'ENOENT']);
+
+async function endpointIsDead(descriptor: BrowserDescriptor): Promise<boolean> {
   if (!descriptor.endpoint)
-    return false;
+    return true;
+  let socket: net.Socket;
   if (descriptor.endpoint.startsWith('ws://') || descriptor.endpoint.startsWith('wss://')) {
-    return await new Promise(resolve => {
-      const url = new URL(descriptor.endpoint!);
-      const socket = net.createConnection(Number(url.port), url.hostname, () => {
-        socket.destroy();
-        resolve(true);
-      });
-      socket.on('error', () => resolve(false));
-    });
+    const url = new URL(descriptor.endpoint);
+    socket = net.createConnection(Number(url.port), url.hostname);
+  } else {
+    socket = net.createConnection(descriptor.endpoint);
   }
   return await new Promise(resolve => {
-    const socket = net.createConnection(descriptor.endpoint ?? (descriptor as any).pipeName, () => {
+    const done = (dead: boolean) => {
       socket.destroy();
-      resolve(true);
-    });
-    socket.on('error', () => resolve(false));
+      resolve(dead);
+    };
+    socket.once('connect', () => done(false));
+    socket.once('error', (error: NodeJS.ErrnoException) => done(deadEndpointErrorCodes.has(error.code ?? '')));
+    socket.setTimeout(5000, () => done(false));
   });
 }
 

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -228,6 +228,11 @@ async function httpStatusCode(url: URL, ignoreHTTPSErrors: boolean, onLog?: (dat
 }
 
 export function decorateServer(server: net.Server) {
+  // Windows named-pipe servers pre-post only 4 accept instances by default,
+  // so concurrent clients can transiently fail to connect. Node reads this
+  // env var when a server starts listening on a pipe.
+  if (process.platform === 'win32')
+    process.env.NODE_PENDING_PIPE_INSTANCES ??= '32';
   const sockets = new Set<net.Socket>();
   server.on('connection', socket => {
     sockets.add(socket);

--- a/tests/mcp/annotate.spec.ts
+++ b/tests/mcp/annotate.spec.ts
@@ -455,7 +455,7 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   await cli('-s=first', 'show', { bindTitle });
   const browser = await connectToDashboard(bindTitle);
   const dashboard = browser.contexts()[0].pages()[0];
-  await expect(dashboard.locator('#display')).toBeVisible();
+  await expect(dashboard.locator('#display')).toBeVisible({ timeout: 15_000 });
 
   const sampleCenter = () => dashboard.evaluate(() => {
     const img = document.querySelector('#display') as HTMLImageElement | null;
@@ -480,7 +480,7 @@ test('should switch screencast to -s session on show --annotate', async ({ conne
   void annotatePromise.finally(() => { done = true; });
 
   await expect(dashboard.getByRole('main', { name: 'Dashboard: annotate' })).toBeVisible({ timeout: 15_000 });
-  await expect(activeSession(dashboard)).toHaveAccessibleName('Session second');
+  await expect(activeSession(dashboard)).toHaveAccessibleName('Session second', { timeout: 15_000 });
 
   await expect.poll(async () => {
     const c = await sampleCenter();


### PR DESCRIPTION
## Summary
- Windows named-pipe servers pre-post only 4 accept instances (libuv default), so a burst of concurrent clients (registry probes, dashboard trackers, `playwright-cli list`) can transiently fail to connect. `serverRegistry.list()` treated any failed probe as a dead session and deleted its registry entry, permanently hiding a live session from the dashboard — `show --annotate -s=<session>` then engaged against the previously selected session.
- Set `NODE_PENDING_PIPE_INSTANCES=32` for our pipe servers, prune registry entries only on ECONNREFUSED/ENOENT, and cap probes with a timeout instead of hanging on a busy pipe.
- Fixes the flaky `should switch screencast to -s session on show --annotate` (and the `#display` visibility variant) on windows-firefox bots.

Recent failures of the test on windows-firefox:
- https://github.com/microsoft/playwright/actions/runs/30948261262/job/92123562988 (active session stuck)
- https://github.com/microsoft/playwright/actions/runs/30935167147 (active session stuck)
- https://github.com/microsoft/playwright/actions/runs/30933859906 (#display never visible)
- https://github.com/microsoft/playwright/actions/runs/30864655498 (active session stuck)
- https://github.com/microsoft/playwright/actions/runs/30854798207 (active session stuck)
- https://github.com/microsoft/playwright/actions/runs/30852617825 (#display never visible)
- https://github.com/microsoft/playwright/actions/runs/30850842677 (active session stuck)