### PR TITLE
fix(mcp): only enable /killkillkill under test

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/http.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/http.ts
@@ -22,6 +22,7 @@ import crypto from 'crypto';
 import debug from 'debug';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isUnderTest } from '@utils/debug';
 import { urlHostFromAddress } from '@utils/httpServer';
 import { createHttpServer, startHttpServer } from '@utils/network';
 import { ManualPromise } from '@isomorphic/manualPromise';
@@ -82,14 +83,7 @@ async function installHttpTransport(httpServer: http.Server, serverBackendFactor
     }
 
     const url = new URL(`http://localhost${req.url}`);
-    if (url.pathname === '/killkillkill') {
-      // Require POST plus a custom header to prevent cross-origin CSRF
-      // (a browser-coerced <img> GET or simple <form> POST can't add custom headers,
-      // and any cross-origin request with custom headers is blocked by CORS preflight).
-      if (req.method !== 'POST' || req.headers['x-pw-mcp-kill'] !== '1') {
-        res.statusCode = 405;
-        return res.end();
-      }
+    if (url.pathname === '/killkillkill' && isUnderTest()) {
       res.statusCode = 200;
       res.end('Killing process');
       // Simulate Ctrl+C in a way that works on Windows too.

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -152,7 +152,7 @@ test('http transport browser sigint', async ({ serverEndpoint, server }) => {
     arguments: { url: server.HELLO_WORLD },
   });
 
-  await fetch(new URL('/killkillkill', url).href, { method: 'POST', headers: { 'x-pw-mcp-kill': '1' } }).catch(() => {});
+  await fetch(new URL('/killkillkill', url).href).catch(() => {});
 
   await expect.poll(() => formatLog(stderr())).toEqual({
     'create browser (isolated)': 1,


### PR DESCRIPTION
`/killkillkill` was only meant for our graceful-SIGINT test (Windows can't do that via `SIGTERM`). Anyone who could reach the HTTP port could still trip it with the fixed header.

Gate it on `isUnderTest()` so production MCP HTTP servers don't expose it.

Fixes https://github.com/microsoft/playwright/issues/42129
