### PR TITLE
docs(locator): drop type markup from ariaSnapshotJSON details

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -256,15 +256,15 @@ await page.getByRole('list').ariaSnapshotJSON();
 
 This method returns the same tree as [`method: Locator.ariaSnapshot`], serialized as a JSON value instead of YAML markup.
 The result is a list of nodes, each node being either a plain string with static text, or an object with the following properties:
-* `role` <[string]> Aria role of the element.
-* `name` <[string]> Accessible name of the element, if any.
-* `text` <[string]> Text content of the element, when it is the only child.
-* `children` <[Array]> Child nodes and text fragments.
+* `role` Aria role of the element.
+* `name` Accessible name of the element, if any.
+* `text` Text content of the element, when it is the only child.
+* `children` Child nodes and text fragments.
 * Boolean and value properties for element state flags: `checked`, `disabled`, `expanded`, `active`, `invalid`, `level`, `pressed` and `selected`.
 * Additional element properties, for example `url` for links and `placeholder` for text boxes.
-* `ref` <[string]> Element reference for AI-optimized snapshots.
-* `cursor` <[string]> Set to `"pointer"` for clickable elements in AI-optimized snapshots.
-* `box` <[Object]> Bounding box of the element when [`option: Locator.ariaSnapshotJSON.boxes`] is set.
+* `ref` Element reference for AI-optimized snapshots.
+* `cursor` Set to `"pointer"` for clickable elements in AI-optimized snapshots.
+* `box` Bounding box of the element when [`option: Locator.ariaSnapshotJSON.boxes`] is set.
 
 ### option: Locator.ariaSnapshotJSON.mode
 * since: v1.63

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -14413,16 +14413,16 @@ export interface Locator {
    * [locator.ariaSnapshot([options])](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot), serialized
    * as a JSON value instead of YAML markup. The result is a list of nodes, each node being either a plain string with
    * static text, or an object with the following properties:
-   * - `role` <[string]> Aria role of the element.
-   * - `name` <[string]> Accessible name of the element, if any.
-   * - `text` <[string]> Text content of the element, when it is the only child.
-   * - `children` <[Array]> Child nodes and text fragments.
+   * - `role` Aria role of the element.
+   * - `name` Accessible name of the element, if any.
+   * - `text` Text content of the element, when it is the only child.
+   * - `children` Child nodes and text fragments.
    * - Boolean and value properties for element state flags: `checked`, `disabled`, `expanded`, `active`, `invalid`,
    *   `level`, `pressed` and `selected`.
    * - Additional element properties, for example `url` for links and `placeholder` for text boxes.
-   * - `ref` <[string]> Element reference for AI-optimized snapshots.
-   * - `cursor` <[string]> Set to `"pointer"` for clickable elements in AI-optimized snapshots.
-   * - `box` <[Object]> Bounding box of the element when
+   * - `ref` Element reference for AI-optimized snapshots.
+   * - `cursor` Set to `"pointer"` for clickable elements in AI-optimized snapshots.
+   * - `box` Bounding box of the element when
    *   [`boxes`](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot-json-option-boxes) is set.
    * @param options
    */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -14413,16 +14413,16 @@ export interface Locator {
    * [locator.ariaSnapshot([options])](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot), serialized
    * as a JSON value instead of YAML markup. The result is a list of nodes, each node being either a plain string with
    * static text, or an object with the following properties:
-   * - `role` <[string]> Aria role of the element.
-   * - `name` <[string]> Accessible name of the element, if any.
-   * - `text` <[string]> Text content of the element, when it is the only child.
-   * - `children` <[Array]> Child nodes and text fragments.
+   * - `role` Aria role of the element.
+   * - `name` Accessible name of the element, if any.
+   * - `text` Text content of the element, when it is the only child.
+   * - `children` Child nodes and text fragments.
    * - Boolean and value properties for element state flags: `checked`, `disabled`, `expanded`, `active`, `invalid`,
    *   `level`, `pressed` and `selected`.
    * - Additional element properties, for example `url` for links and `placeholder` for text boxes.
-   * - `ref` <[string]> Element reference for AI-optimized snapshots.
-   * - `cursor` <[string]> Set to `"pointer"` for clickable elements in AI-optimized snapshots.
-   * - `box` <[Object]> Bounding box of the element when
+   * - `ref` Element reference for AI-optimized snapshots.
+   * - `cursor` Set to `"pointer"` for clickable elements in AI-optimized snapshots.
+   * - `box` Bounding box of the element when
    *   [`boxes`](https://playwright.dev/docs/api/class-locator#locator-aria-snapshot-json-option-boxes) is set.
    * @param options
    */


### PR DESCRIPTION
The freeform Details list on `locator.ariaSnapshotJSON` used `<[string]>` / `<[Object]>` type markup. That syntax only gets escaped when it goes through the structured property renderer - in plain prose it lands in the MDX as-is and Docusaurus chokes on it (`Unexpected character '['`).

That's what's breaking the docs roll: https://github.com/microsoft/playwright.dev/pull/2115

Dropped the type annotations and left the field names + descriptions.