### PR TITLE
fix(cli): print -s instead of --s after attach

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/output.ts
+++ b/packages/playwright-core/src/tools/cli-client/output.ts
@@ -224,7 +224,7 @@ export class TextOutput implements Output {
   attach(session: string, pid: number | undefined, endpoint: string | undefined, toolResult: string): void {
     if (endpoint) {
       console.log(`### Session \`${session}\` created, attached to \`${endpoint}\`.`);
-      console.log(`Run commands with: playwright-cli --s=${session} <command>`);
+      console.log(`Run commands with: playwright-cli -s=${session} <command>`);
       console.log('');
     } else {
       console.log(`### Browser \`${session}\` opened with pid ${pid}.`);

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -293,7 +293,7 @@ workspace1:
     await page.setContent('<title>My Page</title>');
     const { output: openOutput } = await cli('attach', 'foobar');
     expect(openOutput).toContain('### Session `foobar` created, attached to `foobar`.');
-    expect(openOutput).toContain('Run commands with: playwright-cli --s=foobar <command>');
+    expect(openOutput).toContain('Run commands with: playwright-cli -s=foobar <command>');
     const { output: listOutput } = await cli('list', '--all');
     expect(listOutput).toBe(`### Browsers
 /:
@@ -326,7 +326,7 @@ workspace1:
     await page.setContent('<title>Alias Page</title>');
     const { output: openOutput } = await cli('attach', 'foobar', '--session=mybrowser');
     expect(openOutput).toContain('### Session `mybrowser` created, attached to `foobar`.');
-    expect(openOutput).toContain('Run commands with: playwright-cli --s=mybrowser <command>');
+    expect(openOutput).toContain('Run commands with: playwright-cli -s=mybrowser <command>');
     await cli('-s', 'mybrowser', 'close');
   });
 


### PR DESCRIPTION
The attach success message told you to run `playwright-cli --s=...`, but the flag is `-s`. Everywhere else already uses the short form.