### PR TITLE
test(mcp): cover stdio disconnect cleanup

### DIFF
--- a/tests/mcp/fixtures.ts
+++ b/tests/mcp/fixtures.ts
@@ -61,7 +61,7 @@ export type StartClient = (options?: {
   rootsResponseDelay?: number,
   env?: NodeJS.ProcessEnv,
   noTimeoutForTest?: boolean,
-}) => Promise<{ client: Client, stderr: () => string }>;
+}) => Promise<{ client: Client, stderr: () => string, transport: Transport }>;
 
 
 type TestFixtures = {
@@ -151,10 +151,10 @@ export const test = serverTest.extend<TestFixtures & TestOptions, WorkerFixtures
       clients.push(client);
       await client.connect(transport);
       await client.ping();
-      return { client, stderr: () => stderrBuffer };
+      return { client, stderr: () => stderrBuffer, transport };
     });
 
-    await Promise.all(clients.map(client => client.close()));
+    await Promise.all(clients.map(client => client.close().catch(() => {})));
   },
 
   wsEndpoint: async ({ }, use) => {

--- a/tests/mcp/fixtures.ts
+++ b/tests/mcp/fixtures.ts
@@ -61,7 +61,7 @@ export type StartClient = (options?: {
   rootsResponseDelay?: number,
   env?: NodeJS.ProcessEnv,
   noTimeoutForTest?: boolean,
-}) => Promise<{ client: Client, stderr: () => string, transport: Transport }>;
+}) => Promise<{ client: Client, stderr: () => string, closeTransport: () => Promise<void> }>;
 
 
 type TestFixtures = {
@@ -95,6 +95,7 @@ export const test = serverTest.extend<TestFixtures & TestOptions, WorkerFixtures
   startClient: async ({ mcpHeadless, mcpBrowser, mcpArgs, mcpServerType, mcpCaps }, use, testInfo) => {
     const configDir = path.dirname(test.info().config.configFile!);
     const clients: Client[] = [];
+    const disconnectedClients = new Set<Client>();
 
     await use(async options => {
       let args: string[] = mcpArgs ?? [];
@@ -151,10 +152,24 @@ export const test = serverTest.extend<TestFixtures & TestOptions, WorkerFixtures
       clients.push(client);
       await client.connect(transport);
       await client.ping();
-      return { client, stderr: () => stderrBuffer, transport };
+      return {
+        client,
+        stderr: () => stderrBuffer,
+        closeTransport: async () => {
+          disconnectedClients.add(client);
+          await transport.close();
+        },
+      };
     });
 
-    await Promise.all(clients.map(client => client.close().catch(() => {})));
+    await Promise.all(clients.map(async client => {
+      try {
+        await client.close();
+      } catch (e) {
+        if (!disconnectedClients.has(client))
+          throw e;
+      }
+    }));
   },
 
   wsEndpoint: async ({ }, use) => {

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -161,6 +161,29 @@ test('isolated context', async ({ startClient, server }) => {
   });
 });
 
+test('isolated stdio server closes browser on client transport disconnect', async ({ startClient, server }) => {
+  const { client, stderr, transport } = await startClient({
+    args: [`--isolated`],
+    env: { DEBUG: 'pw:mcp:test' },
+  });
+
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    snapshot: expect.stringContaining(`Hello, world!`),
+  });
+
+  await transport.close();
+
+  await expect.poll(() => formatLog(stderr())).toEqual({
+    'create browser (isolated)': 1,
+    'create context': 1,
+    'close browser': 1,
+    'gracefully closing 1': 1,
+  });
+});
+
 test('isolated context relaunches the browser after it dies', async ({ startClient, server, mcpBrowser }, testInfo) => {
   test.skip(!['chrome', 'msedge', 'chromium'].includes(mcpBrowser!), 'The test kills the browser over CDP');
 

--- a/tests/mcp/launch.spec.ts
+++ b/tests/mcp/launch.spec.ts
@@ -162,7 +162,7 @@ test('isolated context', async ({ startClient, server }) => {
 });
 
 test('isolated stdio server closes browser on client transport disconnect', async ({ startClient, server }) => {
-  const { client, stderr, transport } = await startClient({
+  const { client, stderr, closeTransport } = await startClient({
     args: [`--isolated`],
     env: { DEBUG: 'pw:mcp:test' },
   });
@@ -174,7 +174,7 @@ test('isolated stdio server closes browser on client transport disconnect', asyn
     snapshot: expect.stringContaining(`Hello, world!`),
   });
 
-  await transport.close();
+  await closeTransport();
 
   await expect.poll(() => formatLog(stderr())).toEqual({
     'create browser (isolated)': 1,


### PR DESCRIPTION
## Summary
- add regression coverage for isolated MCP stdio cleanup when the client transport disconnects
- expose the stdio transport from the MCP test fixture so the test can close the transport directly
- make fixture cleanup tolerate an already-closed client after simulated disconnect

## Test Plan
- npm run build
- npm run test-mcp -- --project=chromium tests/mcp/launch.spec.ts -g "isolated stdio server closes browser on client transport disconnect"
- npm run test-mcp -- --project=chromium tests/mcp/launch.spec.ts
- npx eslint tests/mcp/fixtures.ts tests/mcp/launch.spec.ts
- npm run tsc

References #41918
