### PR TITLE
devops: add ESRP pipeline for publishing npm alpha versions

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -20,8 +20,8 @@ extends:
       os: linux
     sdl:
       sourceAnalysisPool:
+        # SDL tools require windows, see https://aka.ms/AAo6v8e
         name: DevDivPlaywrightAzurePipelinesWindows2022
-        # The image must be windows-based due to restrictions of the SDL tools. See: https://aka.ms/AAo6v8e
         os: windows
     stages:
     - stage: Stage

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,6 +1,4 @@
-# Publishes @next (alpha) versions of all npm packages via ESRP.
-# For now this pipeline only supports alpha releases with a commit timestamp
-# version, e.g. 1.55.0-alpha-1754000000000. Trigger it manually from the ADO UI.
+# Publishes @next (alpha) versions of all npm packages via ESRP. Manual trigger only.
 trigger: none
 
 pr: none

--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,0 +1,139 @@
+# Publishes @next (alpha) versions of all npm packages via ESRP.
+# For now this pipeline only supports alpha releases with a commit timestamp
+# version, e.g. 1.55.0-alpha-1754000000000. Trigger it manually from the ADO UI.
+trigger: none
+
+pr: none
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: DevDivPlaywrightAzurePipelinesUbuntu2204
+      os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: DevDivPlaywrightAzurePipelinesWindows2022
+        # The image must be windows-based due to restrictions of the SDL tools. See: https://aka.ms/AAo6v8e
+        os: windows
+    stages:
+    - stage: Stage
+      jobs:
+      - job: Build
+        displayName: "Build npm packages"
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            path: $(Build.ArtifactStagingDirectory)/esrp-build
+            artifact: esrp-build
+        steps:
+        - checkout: self
+          displayName: "Checkout code"
+
+        - task: Bash@3
+          displayName: "Check the branch is main"
+          inputs:
+            targetType: "inline"
+            script: |
+              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" ]]; then
+                echo "Alpha versions can only be published from main."
+                echo "Unexpected branch: $BUILD_SOURCE_BRANCH"
+                exit 1
+              fi
+          env:
+            BUILD_SOURCE_BRANCH: $(Build.SourceBranch)
+
+        - task: UseNode@1
+          inputs:
+            version: '26.x'
+          displayName: "Install Node.js"
+
+        - task: Bash@3
+          displayName: "setup .npmrc"
+          inputs:
+            targetType: "inline"
+            script: |
+              echo "registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/DevDiv_PublicPackages/npm/registry/" >> .npmrc
+
+        - task: npmAuthenticate@0
+          displayName: "authenticate the private npm registry"
+          inputs:
+            workingFile: .npmrc
+
+        - script: npm ci
+          displayName: "npm ci"
+
+        - script: npm run build
+          displayName: "npm run build"
+
+        - task: Bash@3
+          displayName: "Set alpha version with commit timestamp"
+          inputs:
+            targetType: "inline"
+            script: |
+              set -e
+              node utils/build/update_canary_version.js --alpha --commit-timestamp
+              node utils/workspace.js --ensure-consistent
+              VERSION=$(node utils/workspace.js --get-version)
+              if [[ "$VERSION" != *-alpha-* ]]; then
+                echo "ERROR: unexpected version '$VERSION', must be an alpha version"
+                exit 1
+              fi
+
+        - task: Bash@3
+          displayName: "Pack all packages"
+          inputs:
+            targetType: "inline"
+            script: |
+              set -e
+              mkdir -p "$(Build.ArtifactStagingDirectory)/esrp-build"
+              node utils/workspace.js --list-public-package-paths | while read package; do
+                # ESRP runs `npm publish` without a --tag argument, so the dist-tag
+                # has to be baked into each tarball via publishConfig.tag.
+                node -e "
+                  const fs = require('fs');
+                  const file = process.argv[1] + '/package.json';
+                  const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+                  pkg.publishConfig = { ...pkg.publishConfig, tag: 'next' };
+                  fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
+                " "$package"
+                npm pack --pack-destination="$(Build.ArtifactStagingDirectory)/esrp-build" "$package"
+              done
+              ls -la "$(Build.ArtifactStagingDirectory)/esrp-build"
+
+      - job: Publish
+        displayName: "ESRP Release to npm"
+        dependsOn: Build
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            artifactName: esrp-build
+            targetPath: $(Build.ArtifactStagingDirectory)/esrp-build
+        steps:
+          - checkout: none
+          - task: EsrpRelease@11
+            inputs:
+              connectedservicename: 'Playwright-ESRP-PME'
+              usemanagedidentity: true
+              keyvaultname: 'playwright-esrp-pme'
+              signcertname: 'ESRP-Release-Sign'
+              clientid: '13434a40-7de4-4c23-81a3-d843dc81c2c5'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
+              waitforreleasecompletion: true
+              owners: 'yurys@microsoft.com'
+              approvers: 'yurys@microsoft.com'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'Playwright'
+              domaintenantid: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+            displayName: 'ESRP Release to npm'


### PR DESCRIPTION
## Summary
- Add `.azure-pipelines/publish.yml` that builds npm tarballs of all public packages with an `-alpha-<commit timestamp>` version and releases them via `EsrpRelease@11` (`contenttype: npm`), modeled on the playwright-java ESRP pipeline.
- Manual trigger only, guarded to `main`; dist-tag `next` is baked into each tarball via `publishConfig.tag` since ESRP publishes without `--tag`.