### PR TITLE
test(filechooser): allow exact one second `lastModified` rounding

### DIFF
--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -859,7 +859,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
       // On Linux browser sometimes reduces the timestamp by 1ms: 1696272058110.0715  -> 1696272058109 or even
       // rounds it to seconds in WebKit: 1696272058110 -> 1696272058000.
       for (let i = 0; i < timestamps.length; i++)
-        expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThan(1000);
+        expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThanOrEqual(1000);
     });
 
     test('should connect over http', async ({ connect, startRemoteServer }) => {

--- a/tests/library/chromium/connect-over-cdp.spec.ts
+++ b/tests/library/chromium/connect-over-cdp.spec.ts
@@ -594,7 +594,7 @@ test('setInputFiles should preserve lastModified timestamp', async ({ browserTyp
     // On Linux browser sometimes reduces the timestamp by 1ms: 1696272058110.0715  -> 1696272058109 or even
     // rounds it to seconds in WebKit: 1696272058110 -> 1696272058000.
     for (let i = 0; i < timestamps.length; i++)
-      expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThan(1000);
+      expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThanOrEqual(1000);
     await cdpBrowser.close();
   } finally {
     await browserServer.close();

--- a/tests/page/page-set-input-files.spec.ts
+++ b/tests/page/page-set-input-files.spec.ts
@@ -436,5 +436,5 @@ test('should preserve lastModified timestamp', async ({ page, asset }) => {
   // On Linux browser sometimes reduces the timestamp by 1ms: 1696272058110.0715  -> 1696272058109 or even
   // rounds it to seconds in WebKit: 1696272058110 -> 1696272058000.
   for (let i = 0; i < timestamps.length; i++)
-    expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThan(1000);
+    expect(Math.abs(timestamps[i] - expectedTimestamps[i]), `expected: ${expectedTimestamps}; actual: ${timestamps}`).toBeLessThanOrEqual(1000);
 });


### PR DESCRIPTION
WebKit can round a millisecond timestamp down by exactly one second

for example, <https://github.com/microsoft/playwright-browsers/actions/runs/31034589073/job/92422156152>