### PR TITLE
devops: authenticate stable-test-runner npm registry in ESRP pipeline

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -59,11 +59,17 @@ extends:
             targetType: "inline"
             script: |
               echo "registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/DevDiv_PublicPackages/npm/registry/" >> .npmrc
+              echo "registry=https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/DevDiv_PublicPackages/npm/registry/" >> tests/playwright-test/stable-test-runner/.npmrc
 
         - task: npmAuthenticate@0
           displayName: "authenticate the private npm registry"
           inputs:
             workingFile: .npmrc
+
+        - task: npmAuthenticate@0
+          displayName: "authenticate the private npm registry for stable-test-runner"
+          inputs:
+            workingFile: tests/playwright-test/stable-test-runner/.npmrc
 
         - script: npm ci
           displayName: "npm ci"


### PR DESCRIPTION
## Summary
- `npm run build` runs `npm ci` in `tests/playwright-test/stable-test-runner`, which failed with E401 in the ESRP pipeline.
- Append the internal registry to its `.npmrc` and add a second `npmAuthenticate` step, same as publish-docker.yml.