### PR TITLE
fix(html-reporter): use a button element for the chip header

### DIFF
--- a/packages/html-reporter/src/chip.css
+++ b/packages/html-reporter/src/chip.css
@@ -15,6 +15,8 @@
 */
 
 .chip-header {
+  display: block;
+  width: 100%;
   border: 1px solid var(--color-border-default);
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
@@ -22,12 +24,20 @@
   padding: 0 8px;
   border-bottom: none;
   margin-top: 12px;
+  color: inherit;
+  font: inherit;
   font-weight: 600;
   line-height: 38px;
+  text-align: left;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;
+}
+
+.chip-header:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: -1px;
 }
 
 .chip-header-allow-selection {

--- a/packages/html-reporter/src/chip.spec.ts
+++ b/packages/html-reporter/src/chip.spec.ts
@@ -50,6 +50,17 @@ test('body render prop is rendered', async ({ mount }) => {
   await expect(component.getByText('Chip children')).toBeVisible();
 });
 
+test('expand collapse with the keyboard', async ({ mount, page }) => {
+  const component = await mount<typeof AutoCollapsed>('chip/AutoCollapsed');
+  const header = component.getByRole('button', { name: 'Title' });
+  await header.focus();
+  await expect(header).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(component.getByText('Body')).toBeVisible();
+  await page.keyboard.press('Space');
+  await expect(component.getByText('Body')).not.toBeVisible();
+});
+
 test('setExpanded should work', async ({ mount }) => {
   const component = await mount<typeof AutoCollapsed>('chip/AutoCollapsed');
   await component.getByText('Title').click();

--- a/packages/html-reporter/src/chip.spec.ts
+++ b/packages/html-reporter/src/chip.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect, test } from '@playwright/test';
 
-import type { Auto, AutoCollapsed, Stateful, WithBody } from './chip.story';
+import type { Auto, AutoCollapsed, NotExpandable, Stateful, WithBody } from './chip.story';
 
 test.use({ viewport: { width: 500, height: 500 } });
 
@@ -48,6 +48,12 @@ test('body render prop is rendered', async ({ mount }) => {
   const component = await mount<typeof WithBody>('chip/WithBody');
   await expect(component.getByText('Body from render prop')).toBeVisible();
   await expect(component.getByText('Chip children')).toBeVisible();
+});
+
+test('chip without setExpanded is not a button', async ({ mount }) => {
+  const component = await mount<typeof NotExpandable>('chip/NotExpandable');
+  await expect(component.getByRole('button')).toHaveCount(0);
+  await expect(component.getByText('Body')).toBeVisible();
 });
 
 test('expand collapse with the keyboard', async ({ mount, page }) => {

--- a/packages/html-reporter/src/chip.story.tsx
+++ b/packages/html-reporter/src/chip.story.tsx
@@ -33,3 +33,6 @@ export const Stateful = () => {
 
 export const WithBody = () =>
   <AutoChip header='Title' body={() => 'Body from render prop'}>Chip children</AutoChip>;
+
+export const NotExpandable = () =>
+  <Chip header='Title'>Body</Chip>;

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -34,8 +34,7 @@ export const Chip: React.FC<{
 }> = ({ header, footer, expanded, setExpanded, children, noInsets, body, dataTestId }) => {
   const id = React.useId();
   return <div className='chip' data-testid={dataTestId}>
-    <div
-      role='button'
+    <button
       aria-expanded={!!expanded}
       aria-controls={id}
       className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
@@ -43,7 +42,7 @@ export const Chip: React.FC<{
       title={typeof header === 'string' ? header : undefined}>
       {setExpanded ? (expanded ? <icons.downArrow /> : <icons.rightArrow />) : <icons.spacer />}
       {header}
-    </div>
+    </button>
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>
       {children}
       {body && body()}

--- a/packages/html-reporter/src/chip.tsx
+++ b/packages/html-reporter/src/chip.tsx
@@ -33,16 +33,23 @@ export const Chip: React.FC<{
   dataTestId?: string,
 }> = ({ header, footer, expanded, setExpanded, children, noInsets, body, dataTestId }) => {
   const id = React.useId();
+  const title = typeof header === 'string' ? header : undefined;
+  const headerContent = <>
+    {setExpanded ? (expanded ? <icons.downArrow /> : <icons.rightArrow />) : <icons.spacer />}
+    {header}
+  </>;
   return <div className='chip' data-testid={dataTestId}>
-    <button
+    {setExpanded ? <button
+      type='button'
       aria-expanded={!!expanded}
       aria-controls={id}
-      className={clsx('chip-header', setExpanded && ' expanded-' + expanded)}
-      onClick={() => setExpanded?.(!expanded)}
-      title={typeof header === 'string' ? header : undefined}>
-      {setExpanded ? (expanded ? <icons.downArrow /> : <icons.rightArrow />) : <icons.spacer />}
-      {header}
-    </button>
+      className={clsx('chip-header', 'expanded-' + expanded)}
+      onClick={() => setExpanded(!expanded)}
+      title={title}>
+      {headerContent}
+    </button> : <div className='chip-header' title={title}>
+      {headerContent}
+    </div>}
     {(!setExpanded || expanded) && <div id={id} role='region' className={clsx('chip-body', noInsets && 'chip-body-no-insets')}>
       {children}
       {body && body()}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3431,7 +3431,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(page.getByRole('link', { name: 'Speedboard' })).toHaveAttribute('aria-selected', 'true');
 
         await expect(page).toMatchAriaSnapshot(`
-          - button "Slowest Tests"
+          - text: /Slowest Tests/
           - region:
             - list:
               - listitem:
@@ -3455,7 +3455,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         `);
         await page.getByText('foo').first().click();
         await expect(page).toMatchAriaSnapshot(`
-          - button "Slowest Tests"
+          - text: /Slowest Tests/
         `);
 
         await page.getByRole('link', { name: 'Failed' }).click();


### PR DESCRIPTION
## Rationale

Came across this while reading through the html-reporter components. The chip header — every collapsible section of a test (`Errors`, `Test Steps`, `Screenshots`, `Traces`, `Attachments`) and every file row in the list — is a `<div role="button">`. A div can't take focus, so those sections cannot be expanded or collapsed with a keyboard at all: `$$('.chip-header').map(e => e.tabIndex)` returns `-1` for each and Tab walks past them, even though the header already carries `aria-expanded`/`aria-controls` and `chip.spec.ts` asserts it as a button in an aria snapshot.

This converts the header to a `<button>` and adds a `:focus-visible` outline, the same way tab elements were converted in #41440 and #41434. No key handlers — Enter and Space come from the platform.

Before — Tab walks past every section header, so nothing can be expanded from the keyboard:

https://github.com/user-attachments/assets/c8afe6b4-e677-484d-9e96-ea236569ffa1

After — the headers take focus, Enter and Space toggle them:

https://github.com/user-attachments/assets/212da3d1-a9c5-4243-a3bc-a723a5aaaa3f



## Test

`chip.spec.ts` gets a keyboard case: the header takes focus and toggles on Enter and Space. On the current `<div>` it fails with `toBeFocused` receiving `inactive`.
