### PR TITLE
feat(mcp): default codegen language from PW_LANG_NAME

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -81,11 +81,17 @@ export type CLIOptions = {
   viewportSize?: ViewportSize;
 };
 
+export const defaultCodegenLanguage: 'typescript' | 'python' | 'java' | 'csharp' =
+  process.env.PW_LANG_NAME === 'python' || process.env.PW_LANG_NAME === 'java' || process.env.PW_LANG_NAME === 'csharp'
+    ? process.env.PW_LANG_NAME
+    : 'typescript';
+
 const defaultConfig: MergedConfig = {
   browser: {
     launchOptions: {},
     contextOptions: {},
   },
+  codegen: defaultCodegenLanguage,
   timeouts: {
     action: 5000,
     navigation: 60000,
@@ -406,6 +412,8 @@ export function configFromEnv(env?: NodeJS.ProcessEnv): Config & { configFile?: 
   options.cdpEndpoint = envToString(e.PLAYWRIGHT_MCP_CDP_ENDPOINT);
   options.cdpHeader = headerParser(envToString(e.PLAYWRIGHT_MCP_CDP_HEADERS));
   options.cdpTimeout = numberParser(e.PLAYWRIGHT_MCP_CDP_TIMEOUT);
+  if (e.PLAYWRIGHT_MCP_CODEGEN)
+    options.codegen = enumParser<'typescript' | 'python' | 'java' | 'csharp' | 'none'>('--codegen', ['none', 'typescript', 'python', 'java', 'csharp'], e.PLAYWRIGHT_MCP_CODEGEN);
   options.config = envToString(e.PLAYWRIGHT_MCP_CONFIG);
   if (e.PLAYWRIGHT_MCP_CONSOLE_LEVEL)
     options.consoleLevel = enumParser<'error' | 'warning' | 'info' | 'debug'>('--console-level', ['error', 'warning', 'info', 'debug'], e.PLAYWRIGHT_MCP_CONSOLE_LEVEL);

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -16,7 +16,7 @@
 
 import { Option as ProgramOption } from 'commander';
 import * as mcpServer from '../utils/mcp/server';
-import { commaSeparatedList, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
+import { commaSeparatedList, defaultCodegenLanguage, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
 import { setupExitWatchdog } from './watchdog';
 import { createBrowserWithInfo } from './browserFactory';
 import { BrowserBackend } from '../backend/browserBackend';
@@ -42,7 +42,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)
       .option('--cdp-timeout <timeout>', 'timeout in milliseconds for connecting to CDP endpoint, defaults to 30000ms', numberParser)
-      .option('--codegen <lang>', 'specify the language to use for code generation, possible values: "typescript", "python", "java", "csharp", "none". Default is "typescript".', enumParser.bind(null, '--codegen', ['none', 'typescript', 'python', 'java', 'csharp']))
+      .option('--codegen <lang>', `specify the language to use for code generation, possible values: "typescript", "python", "java", "csharp", "none". Default is "${defaultCodegenLanguage}".`, enumParser.bind(null, '--codegen', ['none', 'typescript', 'python', 'java', 'csharp']))
       .option('--config <path>', 'path to the configuration file.')
       .option('--console-level <level>', 'level of console messages to return: "error", "warning", "info", "debug". Each level includes the messages of more severe levels.', enumParser.bind(null, '--console-level', ['error', 'warning', 'info', 'debug']))
       .option('--device <device>', 'device to emulate, for example: "iPhone 15"')

--- a/tests/mcp/codegen.spec.ts
+++ b/tests/mcp/codegen.spec.ts
@@ -31,6 +31,20 @@ async function navigateToForm(client: Client, server: any) {
   });
 }
 
+test('codegen defaults to PW_LANG_NAME', async ({ startClient, server }) => {
+  const { client } = await startClient({ env: { PW_LANG_NAME: 'python' } });
+  expect(await navigateToForm(client, server)).toHaveResponse({
+    code: `page.goto("${server.PREFIX}")`,
+  });
+
+  expect(await client.callTool({
+    name: 'browser_click',
+    arguments: { element: 'Submit button', target: 'e2' },
+  })).toHaveResponse({
+    code: `page.get_by_role("button", name="Submit").click()`,
+  });
+});
+
 test('codegen python', async ({ startClient, server }) => {
   const { client } = await startClient({ args: ['--codegen=python'] });
   expect(await navigateToForm(client, server)).toHaveResponse({


### PR DESCRIPTION
Language ports already set `PW_LANG_NAME` when they spawn the driver (`python` / `java` / `csharp`). MCP codegen now defaults from that, so `playwright mcp` under playwright-python emits Python without needing `--codegen=python`.

Also wires `PLAYWRIGHT_MCP_CODEGEN` through `configFromEnv`, which the flag docs already advertised.