### PR TITLE
fix(cli): hide Windows daemon consoles

### DIFF
--- a/packages/playwright-core/src/tools/backend/devtools.ts
+++ b/packages/playwright-core/src/tools/backend/devtools.ts
@@ -135,7 +135,7 @@ const annotate = defineTabTool({
     const daemonArgs = [daemonScript, `--pageId=${pageId}`];
 
     // Spawn the dashboard daemon (idempotent — the singleton socket guards against duplicates).
-    const daemon = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore' });
+    const daemon = spawn(process.execPath, daemonArgs, { detached: true, stdio: 'ignore', windowsHide: true });
     daemon.unref();
 
     // Spawn the annotate client in JSON mode to capture the raw payload over stdout.

--- a/packages/playwright-core/src/tools/cli-client/program.ts
+++ b/packages/playwright-core/src/tools/cli-client/program.ts
@@ -248,6 +248,7 @@ export async function program(options?: { embedderVersion?: string}) {
       const child = spawn(process.execPath, daemonArgs, {
         detached: !foreground,
         stdio: foreground ? 'inherit' : ['pipe', 'pipe', 'ignore'],
+        windowsHide: true,
       });
       if (foreground) {
         await new Promise<void>(resolve => child.on('exit', () => resolve()));

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -148,6 +148,7 @@ export class Session {
       detached: true,
       stdio: ['ignore', 'pipe', err],
       cwd: process.cwd(), // Will be used as root.
+      windowsHide: true,
     });
 
     let signalled = false;

--- a/packages/utils/processLauncher.ts
+++ b/packages/utils/processLauncher.ts
@@ -233,7 +233,7 @@ export async function launchProcess(options: LaunchProcessOptions): Promise<Laun
       // Force kill the browser.
       try {
         if (process.platform === 'win32') {
-          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true });
+          const taskkillProcess = childProcess.spawnSync(`taskkill /pid ${spawnedProcess.pid} /T /F`, { shell: true, windowsHide: true });
           const [stdout, stderr] = [taskkillProcess.stdout.toString(), taskkillProcess.stderr.toString()];
           if (stdout)
             options.log(`[pid=${spawnedProcess.pid}] taskkill stdout: ${stdout}`);


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/42152. This fix is scoped to CLI and MCP and `/taskkill`, so compared to https://github.com/microsoft/playwright/pull/38776 it should have a much smaller blast radius. In my testing the `cli open --headed` and `cli show` commands still worked fine across CMD and PowerShell.

Two constraints that might limit our risk appetite here:
- this only helps CMD users, PowerShell was already fine in my testing
- `npx` has the same bug, so anybody who uses us through `npx` won't see an improvement