### PR TITLE
chore(extension): mark 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9740,7 +9740,7 @@
     },
     "packages/extension": {
       "name": "@playwright/extension",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Playwright Extension",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Connect your browser to AI agents through Playwright MCP server and CLI. Enables AI-driven web testing, debugging, and automation.",
   "permissions": [
     "debugger",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/extension",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Playwright Browser Extension",
   "private": true,
   "repository": {


### PR DESCRIPTION
## Summary
- Bump extension version to 0.3.0 (minor: extension protocol v1 support was removed in #41857)