### PR TITLE
feat(mcp): clean up output artifacts

### DIFF
--- a/packages/playwright-core/src/tools/backend/common.ts
+++ b/packages/playwright-core/src/tools/backend/common.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+
 import * as z from 'zod';
 import { defineTabTool, defineTool } from './tool';
 import { renderTabsMarkdown } from './response';
+import { outputDir } from './context';
 
 const close = defineTool({
   capability: 'core',
@@ -56,7 +59,25 @@ const resize = defineTabTool({
   },
 });
 
+const cleanup = defineTool({
+  capability: 'core',
+
+  schema: {
+    name: 'browser_cleanup',
+    title: 'Clean up output files',
+    description: 'Delete all files created by the MCP server in its output directory, which defaults to .playwright-mcp.',
+    inputSchema: z.object({}),
+    type: 'action',
+  },
+
+  handle: async (context, params, response) => {
+    await fs.promises.rm(outputDir(context.options), { recursive: true, force: true });
+    response.addTextResult('MCP output files cleaned up.');
+  },
+});
+
 export default [
   close,
-  resize
+  resize,
+  cleanup,
 ];

--- a/tests/mcp/capabilities.spec.ts
+++ b/tests/mcp/capabilities.spec.ts
@@ -31,6 +31,7 @@ test('test snapshot tool list', async ({ client }) => {
     'browser_hover',
     'browser_select_option',
     'browser_type',
+    'browser_cleanup',
     'browser_close',
     'browser_navigate_back',
     'browser_navigate',

--- a/tests/mcp/core.spec.ts
+++ b/tests/mcp/core.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs/promises';
+import path from 'path';
 import { pathToFileURL } from 'url';
 import { test, expect } from './fixtures';
 
@@ -28,6 +29,33 @@ test('browser_navigate', async ({ client, server }) => {
 - Page Title: Title`,
     snapshot: `- generic [active] [ref=e1]: Hello, world!`,
   });
+});
+
+test('browser_cleanup deletes MCP output files', async ({ startClient }, testInfo) => {
+  const outputDir = testInfo.outputPath('.playwright-mcp');
+  await fs.mkdir(path.join(outputDir, 'traces', 'resources'), { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'screenshot.png'), 'screenshot');
+  await fs.writeFile(path.join(outputDir, 'traces', 'resources', 'resource'), 'resource');
+
+  const { client } = await startClient();
+  expect(await client.callTool({
+    name: 'browser_cleanup',
+  })).toHaveResponse({
+    result: 'MCP output files cleaned up.',
+  });
+
+  await expect(fs.stat(outputDir)).rejects.toThrow();
+});
+
+test('browser_cleanup deletes configured output files', async ({ startClient }, testInfo) => {
+  const outputDir = testInfo.outputPath('output');
+  await fs.mkdir(outputDir);
+  await fs.writeFile(path.join(outputDir, 'screenshot.png'), 'screenshot');
+
+  const { client } = await startClient({ config: { outputDir } });
+  await client.callTool({ name: 'browser_cleanup' });
+
+  await expect(fs.stat(outputDir)).rejects.toThrow();
 });
 
 test('browser_navigate surfaces non-2xx HTTP status', async ({ client, server }) => {


### PR DESCRIPTION
## Problem

When the MCP runs, it leaves remnants in the working directory that can, if not correctly .gitignore'd, pollute the repo with unnecessary output.

## Proposed solution

Add a `browser_cleanup` core MCP tool that recursively removes the MCP output directory, which defaults to `.playwright-mcp` and respects configured output directories. Cover default and configured cleanup paths and include the tool in the core capability list.