### PR TITLE
devops: move npm publishing to ESRP pipeline

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,7 +1,25 @@
-# Publishes @next (alpha) versions of all npm packages via ESRP. Manual trigger only.
-trigger: none
+# Publishes all npm packages via ESRP:
+# - @next (alpha with today's date) from main, daily on schedule
+# - @next (alpha with commit timestamp) from main, on manual trigger
+# - @beta (beta with commit timestamp) from release-* branches, on push
+# - @latest from v* release tags (pushed when a GitHub release is published)
+trigger:
+  branches:
+    include:
+    - release-*
+  tags:
+    include:
+    - v*
 
 pr: none
+
+schedules:
+- cron: '10 5 * * *'
+  displayName: "Daily @next publish"
+  branches:
+    include:
+    - main
+  always: true
 
 resources:
   repositories:
@@ -36,12 +54,12 @@ extends:
           displayName: "Checkout code"
 
         - task: Bash@3
-          displayName: "Check the branch is main"
+          displayName: "Check the branch is main, release-* or a v* tag"
           inputs:
             targetType: "inline"
             script: |
-              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" ]]; then
-                echo "Alpha versions can only be published from main."
+              if [[ "$BUILD_SOURCE_BRANCH" != "refs/heads/main" && "$BUILD_SOURCE_BRANCH" != refs/heads/release-* && "$BUILD_SOURCE_BRANCH" != refs/tags/v* ]]; then
+                echo "Can only publish from main, release-* branches or v* tags."
                 echo "Unexpected branch: $BUILD_SOURCE_BRANCH"
                 exit 1
               fi
@@ -78,18 +96,44 @@ extends:
           displayName: "npm run build"
 
         - task: Bash@3
-          displayName: "Set alpha version with commit timestamp"
+          name: setVersion
+          displayName: "Set version and dist-tag"
           inputs:
             targetType: "inline"
             script: |
               set -e
-              node utils/build/update_canary_version.js --alpha --commit-timestamp
+              if [[ "$BUILD_SOURCE_BRANCH" == refs/tags/v* ]]; then
+                # Release version is already checked in, only publish what the tag points at.
+                NPM_DIST_TAG="latest"
+              elif [[ "$BUILD_SOURCE_BRANCH" == refs/heads/release-* ]]; then
+                NPM_DIST_TAG="beta"
+                node utils/build/update_canary_version.js --beta --commit-timestamp
+              elif [[ "$BUILD_REASON" == "Schedule" ]]; then
+                NPM_DIST_TAG="next"
+                node utils/build/update_canary_version.js --alpha --today-date
+              else
+                NPM_DIST_TAG="next"
+                node utils/build/update_canary_version.js --alpha --commit-timestamp
+              fi
               node utils/workspace.js --ensure-consistent
               VERSION=$(node utils/workspace.js --get-version)
-              if [[ "$VERSION" != *-alpha-* ]]; then
+              if [[ "$NPM_DIST_TAG" == "latest" && "$BUILD_SOURCE_BRANCH" != "refs/tags/v$VERSION" ]]; then
+                echo "ERROR: version '$VERSION' does not match tag '$BUILD_SOURCE_BRANCH'"
+                exit 1
+              fi
+              if [[ "$NPM_DIST_TAG" == "beta" && "$VERSION" != *-beta-* ]]; then
+                echo "ERROR: unexpected version '$VERSION', must be a beta version"
+                exit 1
+              fi
+              if [[ "$NPM_DIST_TAG" == "next" && "$VERSION" != *-alpha-* ]]; then
                 echo "ERROR: unexpected version '$VERSION', must be an alpha version"
                 exit 1
               fi
+              echo "Publishing version $VERSION with dist-tag $NPM_DIST_TAG"
+              echo "##vso[task.setvariable variable=npmDistTag;isOutput=true]$NPM_DIST_TAG"
+          env:
+            BUILD_SOURCE_BRANCH: $(Build.SourceBranch)
+            BUILD_REASON: $(Build.Reason)
 
         - task: Bash@3
           displayName: "Pack all packages"
@@ -106,6 +150,8 @@ extends:
       - job: Publish
         displayName: "ESRP Release to npm"
         dependsOn: Build
+        variables:
+          npmDistTag: $[ dependencies.Build.outputs['setVersion.npmDistTag'] ]
         templateContext:
           type: releaseJob
           isProduction: true
@@ -125,7 +171,7 @@ extends:
               intent: 'PackageDistribution'
               contenttype: 'npm'
               # npm dist-tag to publish with.
-              productstate: 'next'
+              productstate: '$(npmDistTag)'
               folderlocation: '$(Build.ArtifactStagingDirectory)/esrp-build'
               waitforreleasecompletion: true
               owners: 'yurys@microsoft.com'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,4 +1,6 @@
-name: "publish release - npm, trace viewer"
+# npm publishing (@next, @beta and @latest) is done by the ESRP pipeline,
+# see .azure-pipelines/publish.yml
+name: "publish release - trace viewer"
 
 on:
   workflow_dispatch:
@@ -11,41 +13,6 @@ on:
     types: [published]
 
 jobs:
-  publish-npm:
-    name: "publish NPM"
-    runs-on: ubuntu-24.04
-    if: github.repository == 'microsoft/playwright'
-    permissions:
-      id-token: write  # This is required for OIDC login (NPM publish) to succeed
-      contents: read   # This is required for actions/checkout to succeed
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-      with:
-        node-version: lts/*
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm ci
-    - run: npm run build
-
-    - name: "@next: publish with commit timestamp (triggered manually)"
-      if: contains(github.ref, 'main') && github.event_name == 'workflow_dispatch'
-      run: |
-        node utils/build/update_canary_version.js --alpha --commit-timestamp
-        utils/publish_all_packages.sh --alpha
-    - name: "@next: publish with today's date (triggered automatically)"
-      if: contains(github.ref, 'main') && github.event.schedule
-      run: |
-        node utils/build/update_canary_version.js --alpha --today-date
-        utils/publish_all_packages.sh --alpha
-    - name: "@beta: publish with commit timestamp (triggered automatically)"
-      if: contains(github.ref, 'release') && github.event_name == 'push'
-      run: |
-        node utils/build/update_canary_version.js --beta --commit-timestamp
-        utils/publish_all_packages.sh --beta
-    - name: "publish release to NPM"
-      if: github.event_name == 'release' && github.event.action == 'published'
-      run: utils/publish_all_packages.sh --release
-
   publish-trace-viewer:
     name: "publish Trace Viewer to trace.playwright.dev"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- The ESRP pipeline now publishes all npm versions: daily @next (today's date) from main on schedule, @next with commit timestamp on manual runs, @ beta on pushes to release-* branches and @latest from v* release tags (pushed when a GitHub release is published).
- Dist-tag is computed in the Build job and passed to `EsrpRelease` via an output variable.
- The GitHub Actions workflow only deploys the trace viewer now.