### PR TITLE
feat(trace): report requests still pending when an action ran

### DIFF
--- a/packages/playwright-core/src/tools/skills/playwright-trace/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-trace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-trace
-description: Inspect Playwright trace files from the command line — list actions, view requests, console, errors, snapshots and screenshots.
+description: Inspect Playwright trace files from the command line — list actions, view requests, console, errors, snapshots and screenshots, and find requests still pending when an action started or finished to diagnose race conditions behind flaky tests.
 allowed-tools: Bash(npx:*)
 ---
 
@@ -14,6 +14,8 @@ Inspect `.zip` trace files produced by Playwright tests without opening a browse
 2. Use `trace actions` to see all actions with their action IDs.
 3. Use `trace action <action-id>` to drill into a specific action — see parameters, logs, source location, and available snapshots.
 4. Use `trace requests`, `trace console`, or `trace errors` for cross-cutting views.
+   For a flaky or timing-dependent failure, use `trace actions --pending` to find actions
+   that ran while requests were still outstanding.
 5. Use `trace snapshot <action-id>` to get the DOM snapshot, or run a browser command against it.
 6. Use `trace close` to remove the extracted trace data when done.
 
@@ -46,6 +48,9 @@ npx playwright trace actions --grep "click"
 
 # Only failed actions
 npx playwright trace actions --errors-only
+
+# Only actions that ran while requests were pending (see "Pending requests")
+npx playwright trace actions --pending
 ```
 
 ### Action details
@@ -71,6 +76,9 @@ npx playwright trace requests --method POST
 
 # Only failed requests (status >= 400)
 npx playwright trace requests --failed
+
+# Only requests still pending at an action (see "Pending requests")
+npx playwright trace requests --pending-at <action-id>
 ```
 
 ### Request details
@@ -102,6 +110,71 @@ npx playwright trace console --stdio
 # All errors with stack traces and associated actions
 npx playwright trace errors
 ```
+
+### Pending requests
+
+Requests that had started but not finished at the moment an action ran. This is the main
+tool for diagnosing races — an action that ran while the page was still loading data is the
+usual cause of a flaky click, a stale assertion, or an element that moved.
+
+```bash
+# Which requests were still pending when this action started?
+npx playwright trace requests --pending-at <action-id>
+
+# ...and which were still unresolved when it finished?
+npx playwright trace requests --pending-at <action-id> --phase end
+
+# Every action that ran while requests were pending
+npx playwright trace actions --pending
+npx playwright trace actions --pending --phase end
+
+# Composes with the usual request filters
+npx playwright trace requests --pending-at <action-id> --grep "api"
+```
+
+`Overhang` (per action) and `Longest` (summary) report how long the request kept running
+*after* the reference moment — the size of the race window. A large overhang on the action
+that failed is strong evidence the test acted before the page had settled. `never` means the
+request had not completed by the end of the trace.
+
+Failed and aborted requests (including anything stopped by `route.abort()`) carry no end time
+in the trace, so whether they were still running cannot be determined. They are reported as a
+count rather than guessed at — use `trace requests --failed` to see them.
+
+```
+   # Method   Status   Name                    Started   Overhang
+   2. GET      200      cart                    -326ms       1.2s
+```
+
+Read this as: `/api/cart` began 326ms before the action and continued for 1.2s after it —
+so the action ran against a page that was still 1.2s away from having its cart data. The `#`
+column is the same request ordinal `trace requests` uses, so `trace request 2` drills in.
+
+### Start vs. end
+
+The two phases answer different questions, and the failure usually shows up in one of them:
+
+- **`--phase start` (default)** — *did we act too early?* Requests pending when the action
+  began mean the page was still filling in. Explains a click landing on a stale element, or
+  a locator resolving to the wrong node.
+- **`--phase end`** — *did we move on too early?* Requests still unresolved when the action
+  returned mean the **next** step starts in a racy state. Explains an assertion right after
+  a click that reads pre-update content.
+
+At `--phase end` an extra `Origin` column separates the two causes:
+
+```
+   # Method   Status   Name        Started   Overhang Origin
+   2. GET      200      cart        -593ms       2.1s before
+   4. GET      200      add            -2ms       1.9s during
+```
+
+- `before` — the request predated the action; the page never settled in the first place.
+  Fix by waiting for the app to reach a known state before acting.
+- `during` — the action itself triggered the request and returned without waiting for it.
+  This is the classic "clicked, then asserted immediately" bug: assert on an observable
+  post-condition (`expect(...).toHaveText(...)`, a response wait) rather than the click
+  returning.
 
 ### Snapshots
 
@@ -168,4 +241,10 @@ npx playwright trace requests --failed
 
 # 8. Any console errors?
 npx playwright trace console --errors-only
+
+# 9. Did it act before the page settled? (races behind flaky failures)
+npx playwright trace requests --pending-at 12
+
+# 10. Did it move on before the work it started had finished?
+npx playwright trace requests --pending-at 12 --phase end
 ```

--- a/packages/playwright-core/src/tools/trace/traceActions.ts
+++ b/packages/playwright-core/src/tools/trace/traceActions.ts
@@ -20,13 +20,21 @@ import { buildActionTree } from '@isomorphic/trace/traceModel';
 import { asLocatorDescription } from '@isomorphic/locatorGenerators';
 import { msToString } from '@isomorphic/formatUtils';
 import { loadTrace, formatTimestamp, actionTitle } from './traceUtils';
+import { parsePhase, printPendingActions } from './tracePending';
 
 import type { ActionTraceEventInContext } from '@isomorphic/trace/traceModel';
 import type { Language } from '@isomorphic/locatorGenerators';
 
-export async function traceActions(options: { grep?: string, errorsOnly?: boolean }) {
+export async function traceActions(options: { grep?: string, errorsOnly?: boolean, pending?: boolean, phase?: string }) {
   const trace = await loadTrace();
   const actions = filterActions(trace.model.actions, options);
+
+  if (options.pending) {
+    const phase = parsePhase(options.phase);
+    if (phase !== undefined)
+      printPendingActions(trace, actions, phase, () => true);
+    return;
+  }
 
   // Tree view
   const { rootItem } = buildActionTree(actions);

--- a/packages/playwright-core/src/tools/trace/traceCli.ts
+++ b/packages/playwright-core/src/tools/trace/traceCli.ts
@@ -54,7 +54,9 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .description('list actions in the trace')
       .option('--grep <pattern>', 'filter actions by title pattern')
       .option('--errors-only', 'only show failed actions')
-      .action(async (options: { grep?: string, errorsOnly?: boolean }) => {
+      .option('--pending', 'only actions that ran while requests were still pending')
+      .option('--phase <phase>', `with --pending, measure at each action's "start" or "end"`, 'start')
+      .action(async (options: { grep?: string, errorsOnly?: boolean, pending?: boolean, phase?: string }) => {
         traceActions(options).catch(logErrorAndExit);
       });
 
@@ -72,7 +74,9 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
       .option('--method <method>', 'filter by HTTP method')
       .option('--status <code>', 'filter by status code')
       .option('--failed', 'only show failed requests (status >= 400)')
-      .action(async (options: { grep?: string, method?: string, status?: string, failed?: boolean }) => {
+      .option('--pending-at <action-id>', 'only requests still pending when the given action ran')
+      .option('--phase <phase>', `with --pending-at, measure at the action's "start" or "end"`, 'start')
+      .action(async (options: { grep?: string, method?: string, status?: string, failed?: boolean, pendingAt?: string, phase?: string }) => {
         traceRequests(options).catch(logErrorAndExit);
       });
 

--- a/packages/playwright-core/src/tools/trace/tracePending.ts
+++ b/packages/playwright-core/src/tools/trace/tracePending.ts
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+import { msToString } from '@isomorphic/formatUtils';
+
+import { actionTitle } from './traceUtils';
+
+import type { LoadedTrace } from './traceUtils';
+import type { ActionTraceEventInContext, ResourceEntry } from '@isomorphic/trace/traceModel';
+
+export type PendingRequest = {
+  resource: ResourceEntry;
+  ordinal: number;
+  // Request start, relative to the reference timestamp. Always <= 0.
+  startedAt: number;
+  // How long the request kept running past the reference timestamp, or undefined when it was
+  // still pending at the end of the trace.
+  overhang: number | undefined;
+};
+
+type PendingResult = {
+  requests: PendingRequest[];
+  // Requests that terminated without a recorded duration, so it cannot be known whether they
+  // were still running at the reference timestamp. Reported as a count rather than guessed at.
+  indeterminate: number;
+};
+
+// A request that failed or was aborted is finished, but `harEntry.time` is left at its -1
+// default, so its end is unknown. Only a request with neither marker is genuinely pending.
+function terminatedWithoutDuration(resource: ResourceEntry): boolean {
+  return resource.response._failureText !== undefined || !!resource._wasAborted;
+}
+
+// Requests that had started but not finished at `timestamp`.
+function pendingAt(trace: LoadedTrace, timestamp: number): PendingResult {
+  // `model.resources` is already sorted by `_monotonicTime`, so the results come out
+  // longest-running first, which is the order most likely to explain a race.
+  const requests: PendingRequest[] = [];
+  let indeterminate = 0;
+  for (const [index, resource] of trace.model.resources.entries()) {
+    const start = resource._monotonicTime;
+    if (start === undefined || start > timestamp)
+      continue;
+    if (resource.time >= 0) {
+      const end = start + resource.time;
+      if (end <= timestamp)
+        continue;
+      requests.push({ resource, ordinal: index + 1, startedAt: start - timestamp, overhang: end - timestamp });
+      continue;
+    }
+    if (terminatedWithoutDuration(resource)) {
+      ++indeterminate;
+      continue;
+    }
+    // Never completed within the trace, so it was outstanding from its start onwards.
+    requests.push({ resource, ordinal: index + 1, startedAt: start - timestamp, overhang: undefined });
+  }
+  return { requests, indeterminate };
+}
+
+function requestName(resource: ResourceEntry): string {
+  let name: string;
+  try {
+    const url = new URL(resource.request.url);
+    name = url.pathname.substring(url.pathname.lastIndexOf('/') + 1) || url.host;
+    if (url.search)
+      name += url.search;
+  } catch {
+    name = resource.request.url;
+  }
+  return name.length > 45 ? name.substring(0, 42) + '...' : name;
+}
+
+// Whether to measure at the moment the action began or the moment it returned.
+export type Phase = 'start' | 'end';
+
+// The action timestamp to measure against. Undefined when the action never finished,
+// which only happens for `end`.
+function referenceTime(action: ActionTraceEventInContext, phase: Phase): number | undefined {
+  if (phase === 'start')
+    return action.startTime;
+  return action.endTime ? action.endTime : undefined;
+}
+
+// Reads the shared `--phase` option, reporting a bad value rather than silently defaulting.
+export function parsePhase(value: string | undefined): Phase | undefined {
+  if (value === undefined)
+    return 'start';
+  if (value === 'start' || value === 'end')
+    return value;
+  console.error(`Invalid --phase value '${value}'. Expected 'start' or 'end'.`);
+  process.exitCode = 1;
+  return undefined;
+}
+
+function canComputePending(trace: LoadedTrace): boolean {
+  if (!trace.model.resources.some(r => r._monotonicTime !== undefined)) {
+    console.error('  This trace has no request timing information, so pending requests cannot be computed.');
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
+// `trace requests --pending-at <action-id>`: requests still pending at one action.
+export function printPendingRequests(trace: LoadedTrace, actionId: string, phase: Phase, matches: (r: PendingRequest) => boolean) {
+  if (!trace.model.resources.length) {
+    console.log('  No network requests');
+    return;
+  }
+  if (!canComputePending(trace))
+    return;
+
+  const action = trace.resolveActionId(actionId);
+  if (!action) {
+    console.error(`Action '${actionId}' not found. Use 'trace actions' to see available action IDs.`);
+    process.exitCode = 1;
+    return;
+  }
+  const timestamp = referenceTime(action, phase);
+  if (timestamp === undefined) {
+    console.error(`Action '${actionId}' never finished, so it has no end to measure against.`);
+    process.exitCode = 1;
+    return;
+  }
+  const result = pendingAt(trace, timestamp);
+  printForAction(trace, action, phase, { ...result, requests: result.requests.filter(matches) });
+}
+
+// `trace actions --pending`: every action that overlapped a pending request.
+export function printPendingActions(trace: LoadedTrace, actions: ActionTraceEventInContext[], phase: Phase, matches: (r: PendingRequest) => boolean) {
+  if (!trace.model.resources.length) {
+    console.log('  No network requests');
+    return;
+  }
+  if (!canComputePending(trace))
+    return;
+  printSummary(trace, actions, phase, matches);
+}
+
+function printForAction(trace: LoadedTrace, action: ActionTraceEventInContext, phase: Phase, result: PendingResult) {
+  const { requests, indeterminate } = result;
+  const at = phase === 'end' ? 'finished' : 'started';
+  const timestamp = referenceTime(action, phase)!;
+  console.log(`\n  ${actionTitle(action)} — ${at} at ${msToString(timestamp - trace.model.startTime)}\n`);
+
+  if (!requests.length) {
+    console.log(`  No requests were pending when this action ${at}.`);
+    printIndeterminate(indeterminate);
+    console.log('');
+    return;
+  }
+
+  // At the action's end a request may have been triggered by the action itself, which is a
+  // different problem from one the page never settled. At the start everything predates it.
+  const showOrigin = phase === 'end';
+  const originHeader = showOrigin ? ` ${'Origin'.padEnd(7)}` : '';
+  const originRule = showOrigin ? ` ${'─'.repeat(7)}` : '';
+  console.log(`  ${'#'.padStart(4)} ${'Method'.padEnd(8)} ${'Status'.padEnd(8)} ${'Name'.padEnd(45)} ${'Started'.padStart(10)} ${'Overhang'.padStart(10)}${originHeader}`);
+  console.log(`  ${'─'.repeat(4)} ${'─'.repeat(8)} ${'─'.repeat(8)} ${'─'.repeat(45)} ${'─'.repeat(10)} ${'─'.repeat(10)}${originRule}`);
+
+  for (const { resource, ordinal, startedAt, overhang } of requests) {
+    const status = resource.response.status > 0 ? String(resource.response.status) : 'ERR';
+    // `startedAt` is relative to the reference timestamp and never positive.
+    const started = `-${msToString(-startedAt)}`;
+    const over = overhang === undefined ? 'never' : msToString(overhang);
+    const origin = showOrigin ? ` ${(resource._monotonicTime! < action.startTime ? 'before' : 'during').padEnd(7)}` : '';
+    console.log(`  ${(ordinal + '.').padStart(4)} ${resource.request.method.padEnd(8)} ${status.padEnd(8)} ${requestName(resource).padEnd(45)} ${started.padStart(10)} ${over.padStart(10)}${origin}`);
+  }
+
+  console.log(`\n  ${requests.length} request(s) still pending. 'Overhang' is how long each kept running after the action ${at}.`);
+  if (showOrigin)
+    console.log(`  'Origin' is whether the request predated the action ('before') or was started by it ('during').`);
+  printIndeterminate(indeterminate);
+  console.log(`  Inspect one with 'npx playwright trace request <#>'.\n`);
+}
+
+function printIndeterminate(count: number) {
+  if (count)
+    console.log(`  ${count} failed or aborted request(s) have no recorded end time and were not evaluated.`);
+}
+
+function printUnfinished(count: number) {
+  if (count)
+    console.log(`  ${count} action(s) never finished and have no end to measure against.`);
+}
+
+function printSummary(trace: LoadedTrace, actions: ActionTraceEventInContext[], phase: Phase, matches: (r: PendingRequest) => boolean) {
+  const at = phase === 'end' ? 'finished' : 'started';
+  const rows: { action: ActionTraceEventInContext, requests: PendingRequest[] }[] = [];
+  let unfinished = 0;
+  for (const action of actions) {
+    const timestamp = referenceTime(action, phase);
+    if (timestamp === undefined) {
+      ++unfinished;
+      continue;
+    }
+    const requests = pendingAt(trace, timestamp).requests.filter(matches);
+    if (requests.length)
+      rows.push({ action, requests });
+  }
+
+  if (!rows.length) {
+    console.log(`\n  No action ${at} while a request was pending.`);
+    printUnfinished(unfinished);
+    console.log('');
+    return;
+  }
+
+  console.log(`\n  Actions that ${at} while requests were still pending\n`);
+  console.log(`  ${'#'.padStart(4)} ${'Action'.padEnd(50)} ${'Pending'.padStart(9)} ${'Longest'.padStart(10)}`);
+  console.log(`  ${'─'.repeat(4)} ${'─'.repeat(50)} ${'─'.repeat(9)} ${'─'.repeat(10)}`);
+
+  for (const { action, requests } of rows) {
+    const ordinal = trace.callIdToOrdinal.get(action.callId);
+    // An unfinished request outranks any finished one.
+    const unfinished = requests.some(r => r.overhang === undefined);
+    const longest = unfinished ? 'never' : msToString(Math.max(...requests.map(r => r.overhang!)));
+    let title = actionTitle(action);
+    if (title.length > 50)
+      title = title.substring(0, 47) + '...';
+    console.log(`  ${((ordinal ?? '?') + '.').padStart(4)} ${title.padEnd(50)} ${String(requests.length).padStart(9)} ${longest.padStart(10)}`);
+  }
+
+  console.log(`\n  'Longest' is how long the slowest pending request kept running after the action ${at}.`);
+  printUnfinished(unfinished);
+  const phaseArg = phase === 'end' ? ' --phase end' : '';
+  console.log(`  Drill in with 'npx playwright trace requests --pending-at <action-id>${phaseArg}'.\n`);
+}

--- a/packages/playwright-core/src/tools/trace/traceRequests.ts
+++ b/packages/playwright-core/src/tools/trace/traceRequests.ts
@@ -19,10 +19,20 @@
 import path from 'path';
 import { msToString } from '@isomorphic/formatUtils';
 import { loadTrace } from './traceUtils';
+import { parsePhase, printPendingRequests } from './tracePending';
 
-export async function traceRequests(options: { grep?: string, method?: string, status?: string, failed?: boolean }) {
+export async function traceRequests(options: { grep?: string, method?: string, status?: string, failed?: boolean, pendingAt?: string, phase?: string }) {
   const trace = await loadTrace();
   const model = trace.model;
+
+  if (options.pendingAt !== undefined) {
+    const phase = parsePhase(options.phase);
+    if (phase === undefined)
+      return;
+    const pattern = options.grep ? new RegExp(options.grep, 'i') : undefined;
+    printPendingRequests(trace, options.pendingAt, phase, r => !pattern || pattern.test(r.resource.request.url));
+    return;
+  }
 
   // Build indexed list with stable ordinals before filtering.
   let indexed = model.resources.map((r, i) => ({ resource: r, ordinal: i + 1 }));

--- a/tests/mcp/trace-cli.spec.ts
+++ b/tests/mcp/trace-cli.spec.ts
@@ -16,6 +16,9 @@
 
 import fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
+
+import { chromium } from 'playwright-core';
 
 import { test, expect } from './trace-cli-fixtures';
 
@@ -257,4 +260,140 @@ test('trace attachments lists attachments', async ({ runTraceCli }) => {
   expect(exitCode).toBe(0);
   // Our test trace has no attachments, just verify it doesn't crash
   expect(stdout).toBeTruthy();
+});
+
+test('trace requests --pending-at reports requests outstanding when an action started', async ({ __servers }, testInfo) => {
+  const server = __servers.server;
+  // /slow stays open well past the click; /fast settles before it.
+  server.setRoute('/slow', (req, res) => void setTimeout(() => res.end('slow'), 3000));
+  server.setRoute('/fast', (req, res) => res.end('fast'));
+  server.setContent('/inflight', `
+    <button id="go">Go</button>
+    <script>fetch('/slow'); fetch('/fast');</script>
+  `, 'text/html');
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  await context.tracing.start({ snapshots: true });
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/inflight');
+  // Click while /slow is still outstanding but /fast has long since finished.
+  await page.waitForTimeout(500);
+  await page.locator('#go').click();
+  const cwd = testInfo.outputPath('inflight');
+  const tracePath = path.join(cwd, 'trace.zip');
+  await context.tracing.stop({ path: tracePath });
+  await browser.close();
+  server.reset();
+
+  fs.mkdirSync(cwd, { recursive: true });
+  const cliPath = path.resolve(__dirname, '../../packages/playwright-core/cli.js');
+  const run = (...args: string[]) => execFileSync(process.execPath, [cliPath, 'trace', ...args], { cwd, encoding: 'utf-8' });
+
+  run('open', tracePath);
+  const clickId = /^\s*(\d+)\..*Click/m.exec(run('actions'))?.[1];
+  expect(clickId).toBeTruthy();
+
+  const forClick = run('requests', '--pending-at', clickId!);
+  expect(forClick).toContain('slow');
+  // /fast completed before the click, so it is not outstanding.
+  expect(forClick).not.toContain('fast');
+
+  // Without an action id, every action that started mid-request is summarized.
+  expect(run('actions', '--pending')).toContain('Click');
+
+  // Filtering narrows to matching URLs only.
+  expect(run('requests', '--pending-at', clickId!, '--grep', 'fast')).toContain('No requests were pending');
+});
+
+test('trace requests --pending-at --phase end separates carried-over requests from ones the action started', async ({ __servers }, testInfo) => {
+  const server = __servers.server;
+  server.setRoute('/slow', (req, res) => void setTimeout(() => res.end('slow'), 5000));
+  server.setRoute('/onclick', (req, res) => void setTimeout(() => res.end('onclick'), 5000));
+  server.setContent('/inflight-end', `
+    <button id="go" onmousedown="fetch('/onclick')">Go</button>
+    <script>fetch('/slow');</script>
+  `, 'text/html');
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  await context.tracing.start({ snapshots: true });
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/inflight-end');
+  await page.waitForTimeout(500);
+  // The click returns without waiting for the request it triggered. `delay` holds the button
+  // down between mousedown and mouseup, so the request it starts is comfortably inside the
+  // action rather than racing its end.
+  await page.locator('#go').click({ delay: 1000 });
+  const cwd = testInfo.outputPath('inflight-end');
+  const tracePath = path.join(cwd, 'trace.zip');
+  await context.tracing.stop({ path: tracePath });
+  await browser.close();
+  server.reset();
+
+  fs.mkdirSync(cwd, { recursive: true });
+  const cliPath = path.resolve(__dirname, '../../packages/playwright-core/cli.js');
+  const run = (...args: string[]) => execFileSync(process.execPath, [cliPath, 'trace', ...args], { cwd, encoding: 'utf-8' });
+
+  run('open', tracePath);
+  const clickId = /^\s*(\d+)\..*Click/m.exec(run('actions'))?.[1];
+  expect(clickId).toBeTruthy();
+
+  // At the start, only the request that predates the click is outstanding.
+  const atStart = run('requests', '--pending-at', clickId!);
+  expect(atStart).toContain('slow');
+  expect(atStart).not.toContain('onclick');
+
+  // At the end, the request the click itself triggered is outstanding too, and the two
+  // are distinguished by origin.
+  const atEnd = run('requests', '--pending-at', clickId!, '--phase', 'end');
+  expect(atEnd).toContain('slow');
+  expect(atEnd).toContain('onclick');
+  expect(atEnd).toContain('before');
+  expect(atEnd).toContain('during');
+
+  // The summary honours the phase as well.
+  expect(run('actions', '--pending', '--phase', 'end')).toContain('finished while requests were still pending');
+});
+
+test('trace requests --pending-at does not report aborted requests as pending', async ({ __servers }, testInfo) => {
+  const server = __servers.server;
+  server.setRoute('/late', (req, res) => void setTimeout(() => res.end('late'), 5000));
+  server.setContent('/inflight-abort', `
+    <button id="go">Go</button>
+    <script>fetch('/blocked').catch(() => {}); fetch('/late');</script>
+  `, 'text/html');
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  // An aborted request finishes without a recorded duration; it must not be mistaken for one
+  // that is still running.
+  await context.route('**/blocked', route => route.abort());
+  await context.tracing.start({ snapshots: true });
+  const page = await context.newPage();
+  await page.goto(server.PREFIX + '/inflight-abort');
+  await page.waitForTimeout(500);
+  await page.locator('#go').click();
+  const cwd = testInfo.outputPath('inflight-abort');
+  const tracePath = path.join(cwd, 'trace.zip');
+  await context.tracing.stop({ path: tracePath });
+  await browser.close();
+  server.reset();
+
+  fs.mkdirSync(cwd, { recursive: true });
+  const cliPath = path.resolve(__dirname, '../../packages/playwright-core/cli.js');
+  const run = (...args: string[]) => execFileSync(process.execPath, [cliPath, 'trace', ...args], { cwd, encoding: 'utf-8' });
+
+  run('open', tracePath);
+  const clickId = /^\s*(\d+)\..*Click/m.exec(run('actions'))?.[1];
+  const output = run('requests', '--pending-at', clickId!);
+  expect(output).toContain('late');
+  expect(output).not.toContain('blocked');
+  expect(output).toContain('no recorded end time');
+});
+
+test('trace requests --pending-at rejects an unknown --phase value', async ({ runTraceCli }) => {
+  const { stderr, exitCode } = await runTraceCli(['requests', '--pending-at', '1', '--phase', 'middle']);
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain(`Invalid --phase value 'middle'`);
 });


### PR DESCRIPTION
## Summary
- `trace actions --pending` lists actions that started (or finished, with `--phase end`) while requests were still outstanding
- `trace requests --pending-at <action-id> [--phase start|end]` lists which requests were pending at that point, and how long each overran
- Aborted requests are excluded from pending results

Fixes https://github.com/microsoft/playwright/issues/42172