### PR TITLE
fix(cli): measure unix socket path limit in bytes, not characters

### DIFF
--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -127,10 +127,14 @@ export function makeSocketPath(domain: string, name: string): string {
   const baseDir = process.env.PWTEST_SOCKETS_DIR || path.join(os.tmpdir(), `pw-${userNameHash}`);
   const dir = path.join(baseDir, domain);
   const suffix = '.sock';
-  const maxNameLength = UNIX_SOCKET_PATH_MAX - dir.length - path.sep.length - suffix.length;
+  const maxNameLength = UNIX_SOCKET_PATH_MAX - Buffer.byteLength(dir + path.sep) - suffix.length;
   if (maxNameLength < 1)
     throw new Error(`Socket directory path is too long (${dir.length} chars); set PWTEST_SOCKETS_DIR to a shorter location.`);
-  const fsFriendlyName = trimLongString(sanitizeForFilePath(name), maxNameLength);
+  let fsFriendlyName = trimLongString(sanitizeForFilePath(name), maxNameLength);
+  // sun_path is limited in bytes, while trimLongString counts characters, so
+  // multi-byte names can still overflow. Substitute a digest that always fits.
+  if (Buffer.byteLength(fsFriendlyName) > maxNameLength)
+    fsFriendlyName = calculateSha1(name).slice(0, Math.min(16, maxNameLength));
   const result = path.join(dir, `${fsFriendlyName}${suffix}`);
   fs.mkdirSync(dir, { recursive: true });
   return result;

--- a/tests/mcp/cli-misc.spec.ts
+++ b/tests/mcp/cli-misc.spec.ts
@@ -102,3 +102,13 @@ test('open with very long session name (issue 40878)', async ({ cli, server }) =
   expect(result.exitCode).toBe(0);
   expect(result.output).toContain('Page URL');
 });
+
+test('open with long multi-byte session name (issue 42153)', async ({ cli, server }) => {
+  // Multi-byte session names fit the character-based trim but still overflow
+  // sun_path's byte limit, so the daemon could not listen on the socket.
+  const longSessionName = 'セッション名がとても長い場合の動作を確認するためのテスト';
+  const result = await cli(`-s=${longSessionName}`, 'open', server.PREFIX);
+  expect(result.error).toBe('');
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('Page URL');
+});


### PR DESCRIPTION
## Summary
- `makeSocketPath` trims the socket name by character count, but `sun_path` is limited in bytes, so multi-byte session names could still overflow the limit and the kernel truncated the path (newer libuv fails `listen` with `EINVAL` instead).
- Measure the composed path in utf-8 bytes and substitute a sha1 digest for the name when the trimmed name still does not fit.

Fixes https://github.com/microsoft/playwright/issues/42153