### PR TITLE
fix(chromium): apply offline mode to pages created in offline context

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -542,6 +542,7 @@ class FrameSession {
       promises.push(this._updateGeolocation(true));
       if (!skipDefaultOverrides)
         promises.push(this._updateEmulateMedia());
+      promises.push(this._crPage.updateOffline());
       promises.push(this._updateFileChooserInterception(true));
       for (const initScript of this._crPage._page.allInitScripts())
         promises.push(this._evaluateOnNewDocument(initScript, 'main', true /* runImmediately */));


### PR DESCRIPTION
## Summary
This PR fixes a bug where pages created in an already-offline BrowserContext incorrectly report navigator.onLine === true instead of false.

## Fixes
Closes #42174

## Problem
When creating a page on a BrowserContext that already has offline mode enabled:
- context.setOffline(true) is called first
- Then context.newPage() is called
- The new page reports navigator.onLine === true (WRONG)
- Expected: navigator.onLine === false

Toggling offline on existing pages works correctly.

## Root Cause
During page initialization in FrameSession._initialize(), the offline state from the parent context was never applied to the new page. While other context options like geolocation, user agent, and emulated media were properly applied during initialization, updateOffline() was missing from the initialization chain.

## Solution
Added this._crPage.updateOffline() to the initialization promise chain in _initialize(), ensuring new pages receive their parent context's offline state during setup.

## Changes
- Modified: packages/playwright-core/src/server/chromium/crPage.ts
- Added updateOffline() call during page initialization
- Only affects Chromium (Firefox/WebKit have different implementations)

## Impact
- Pages created in offline contexts now correctly report navigator.onLine === false
- No breaking changes
- No impact on existing page toggling behavior
- Minimal code change (1 line)

## Testing
Tested with the repro from #42174:
`javascript
const { chromium } = require('@playwright/test');

(async () => {
  const browser = await chromium.launch();
  const context = await browser.newContext();
  await context.setOffline(true);
  const page = await context.newPage();
  const result = await page.evaluate(() => navigator.onLine);
  console.log(result); // Now correctly returns false
  await browser.close();
})();
`

## Type of Change
- Bug fix (fixes #42174)
- Non-breaking change
- Chromium-specific fix