### PR TITLE
docs(cli): clarify skill installation command

### DIFF
--- a/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
@@ -6,6 +6,12 @@ allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 
 # Browser Automation with playwright-cli
 
+> **Installation note:** The commands below use `playwright-cli` for brevity. If
+> you installed the skills with `npx playwright cli install --skills agents`,
+> use `npx playwright cli` instead. For example, `playwright-cli open` becomes
+> `npx playwright cli open`. The standalone `playwright-cli` command is only
+> available when `@playwright/cli` has been installed globally.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Fixes #42135

## Summary

Moves the installation command guidance to the top of the `playwright-cli` skill. Users who install skills with `npx playwright cli install --skills agents` now see immediately that the examples should be run with `npx playwright cli`, while the standalone `playwright-cli` command requires a global `@playwright/cli` installation.

This is a minor documentation-only change.

AI assistance was used to prepare this patch; the change was reviewed for scope and wording.

## Testing

Documentation-only change; no runtime tests are required. Verified with `git diff --check`.
