### PR TITLE
fix(webkit): enable Tab keyboard navigation on macOS

### DIFF
--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -134,7 +134,7 @@ export class WebKit extends BrowserType {
     // the host setting. Must come before 'about:blank': the embedder treats any argument not
     // starting with '--' as an initial URL, and 'about:blank' must remain the last one.
     // See https://github.com/microsoft/playwright/issues/41808.
-    if (process.platform === 'darwin' && !isWSL)
+    if (process.platform === 'darwin')
       webkitArguments.push('-AppleKeyboardUIMode', '2');
     const proxy = options.proxyOverride || options.proxy;
     if (proxy) {

--- a/packages/playwright-core/src/server/webkit/webkit.ts
+++ b/packages/playwright-core/src/server/webkit/webkit.ts
@@ -127,6 +127,15 @@ export class WebKit extends BrowserType {
       webkitArguments.push(`--user-data-dir=${isWSL ? await translatePathToWSL(userDataDir) : userDataDir}`);
     else
       webkitArguments.push(`--no-startup-window`);
+    // On macOS, WebKit decides whether Tab traverses all focusable elements (buttons, links)
+    // based on the "AppleKeyboardUIMode" preference, which defaults to the OS-level
+    // "Keyboard navigation" setting and makes Tab behavior machine-dependent. Pass it as an
+    // NSUserDefaults argument so Tab always traverses all focusable elements regardless of
+    // the host setting. Must come before 'about:blank': the embedder treats any argument not
+    // starting with '--' as an initial URL, and 'about:blank' must remain the last one.
+    // See https://github.com/microsoft/playwright/issues/41808.
+    if (process.platform === 'darwin' && !isWSL)
+      webkitArguments.push('-AppleKeyboardUIMode', '2');
     const proxy = options.proxyOverride || options.proxy;
     if (proxy) {
       if (process.platform === 'darwin') {

--- a/tests/page/page-focus.spec.ts
+++ b/tests/page/page-focus.spec.ts
@@ -78,9 +78,9 @@ it('should traverse focus in all directions', async function({ page }) {
   expect(await page.evaluate(() => (document.activeElement as HTMLInputElement).value)).toBe('1');
 });
 
-it('should traverse only form elements', async function({ page, browserName, platform }) {
+it('should traverse all controls with Tab', async function({ page, browserName, platform }) {
   it.skip(platform !== 'darwin' || browserName !== 'webkit',
-      'Chromium and WebKit both have settings for tab traversing all links, but it is only on by default in WebKit.');
+      'WebKit on macOS only traverses all controls with Tab when full keyboard access is enabled, which Playwright now forces. See https://github.com/microsoft/playwright/issues/41808.');
 
   await page.setContent(`
     <input id="input-1">
@@ -91,21 +91,18 @@ it('should traverse only form elements', async function({ page, browserName, pla
   await page.keyboard.press('Tab');
   expect(await page.evaluate(() => document.activeElement.id)).toBe('input-1');
   await page.keyboard.press('Tab');
+  expect(await page.evaluate(() => document.activeElement.id)).toBe('button');
+  await page.keyboard.press('Tab');
   expect(await page.evaluate(() => document.activeElement.id)).toBe('input-2');
   await page.keyboard.press('Shift+Tab');
+  expect(await page.evaluate(() => document.activeElement.id)).toBe('button');
+  await page.keyboard.press('Shift+Tab');
   expect(await page.evaluate(() => document.activeElement.id)).toBe('input-1');
+  // Links are only reachable with Option+Tab (macOS full keyboard access semantics).
   await page.keyboard.press('Alt+Tab');
   expect(await page.evaluate(() => document.activeElement.id)).toBe('button');
   await page.keyboard.press('Alt+Tab');
   expect(await page.evaluate(() => document.activeElement.id)).toBe('link');
-  await page.keyboard.press('Alt+Tab');
-  expect(await page.evaluate(() => document.activeElement.id)).toBe('input-2');
-  await page.keyboard.press('Alt+Shift+Tab');
-  expect(await page.evaluate(() => document.activeElement.id)).toBe('link');
-  await page.keyboard.press('Alt+Shift+Tab');
-  expect(await page.evaluate(() => document.activeElement.id)).toBe('button');
-  await page.keyboard.press('Alt+Shift+Tab');
-  expect(await page.evaluate(() => document.activeElement.id)).toBe('input-1');
 });
 
 it('clicking checkbox should activate it', async ({ page, browserName, headless, platform }) => {


### PR DESCRIPTION
## Summary

- Tab keyboard navigation in WebKit on macOS was machine-dependent: with the OS "Keyboard navigation" setting off, Tab skipped buttons and links and only traversed form fields.
- Playwright now passes `-AppleKeyboardUIMode 2` as an NSUserDefaults argument when launching WebKit on macOS, so full keyboard access is always on and Tab traverses all controls regardless of the host setting.
- The darwin-gated focus test asserts the new deterministic behavior; links remain Option+Tab-only per macOS full keyboard access semantics.

Fixes #41808

Session-settled decisions carried from planning: force `AppleKeyboardUIMode=2` for WebKit on macOS via launch args (user-approved, over documenting the workaround).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
