### PR TITLE
fix(chromium): capture retina video when deviceScaleFactor > 1

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -842,7 +842,7 @@ When set to `minimal`, only record information necessary for routing from HAR. T
   - `dir` ?<[path]> Path to the directory to put videos into. If not specified, the videos will be stored in `artifactsDir` (see [`method: BrowserType.launch`] options).
   - `size` ?<[Object]> Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport`
     scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
-    Actual picture of each page will be scaled down if necessary to fit the specified size.
+    Actual picture of each page will be scaled down if necessary to fit the specified size. In headless Chromium, when [`option: Browser.newContext.deviceScaleFactor`] is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by [`option: Browser.newContext.deviceScaleFactor`] produces a high-dpi ("retina") video.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
   - `showActions` ?<[Object]> If specified, enables visual annotations on interacted elements during video recording.
@@ -872,7 +872,7 @@ not recorded. Make sure to call [`method: BrowserContext.close`] for videos to b
 
 Dimensions of the recorded videos. If not specified the size will be equal to `viewport`
 scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450.
-Actual picture of each page will be scaled down if necessary to fit the specified size.
+Actual picture of each page will be scaled down if necessary to fit the specified size. In headless Chromium, when [`option: Browser.newContext.deviceScaleFactor`] is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by [`option: Browser.newContext.deviceScaleFactor`] produces a high-dpi ("retina") video.
 
 ## context-option-proxy
 - `proxy` <[Object]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -11649,7 +11649,11 @@ export interface Browser {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -17829,7 +17833,11 @@ export interface BrowserType<Unused = {}> {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -24497,7 +24505,11 @@ export interface Electron {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -25219,7 +25231,11 @@ export interface AndroidDevice {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -26438,7 +26454,11 @@ export interface BrowserContextOptions {
     /**
      * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
      * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-     * each page will be scaled down if necessary to fit the specified size.
+     * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+     * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+     * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+     * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+     * produces a high-dpi ("retina") video.
      */
     size?: {
       /**

--- a/packages/playwright-core/src/server/chromium/crInput.ts
+++ b/packages/playwright-core/src/server/chromium/crInput.ts
@@ -102,13 +102,14 @@ export class RawMouseImpl implements input.RawMouse {
   }
 
   async move(progress: Progress, x: number, y: number, button: types.MouseButton | 'none', buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, forClick: boolean): Promise<void> {
+    const inputScale = this._page._inputScale();
     const actualMove = async (progress: Progress) => {
       await progress.race(this._client.send('Input.dispatchMouseEvent', {
         type: 'mouseMoved',
         button,
         buttons: toButtonsMask(buttons),
-        x,
-        y,
+        x: x * inputScale,
+        y: y * inputScale,
         modifiers: toModifiersMask(modifiers),
         force: buttons.size > 0 ? 0.5 : 0,
       }));
@@ -125,12 +126,13 @@ export class RawMouseImpl implements input.RawMouse {
   async down(progress: Progress, x: number, y: number, button: types.MouseButton, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, clickCount: number): Promise<void> {
     if (this._dragManager.isDragging())
       return;
+    const inputScale = this._page._inputScale();
     await progress.race(this._client.send('Input.dispatchMouseEvent', {
       type: 'mousePressed',
       button,
       buttons: toButtonsMask(buttons),
-      x,
-      y,
+      x: x * inputScale,
+      y: y * inputScale,
       modifiers: toModifiersMask(modifiers),
       clickCount,
       force: buttons.size > 0 ? 0.5 : 0,
@@ -142,22 +144,24 @@ export class RawMouseImpl implements input.RawMouse {
       await this._dragManager.drop(progress, x, y, modifiers);
       return;
     }
+    const inputScale = this._page._inputScale();
     await progress.race(this._client.send('Input.dispatchMouseEvent', {
       type: 'mouseReleased',
       button,
       buttons: toButtonsMask(buttons),
-      x,
-      y,
+      x: x * inputScale,
+      y: y * inputScale,
       modifiers: toModifiersMask(modifiers),
       clickCount
     }));
   }
 
   async wheel(progress: Progress, x: number, y: number, buttons: Set<types.MouseButton>, modifiers: Set<types.KeyboardModifier>, deltaX: number, deltaY: number): Promise<void> {
+    const inputScale = this._page._inputScale();
     await progress.race(this._client.send('Input.dispatchMouseEvent', {
       type: 'mouseWheel',
-      x,
-      y,
+      x: x * inputScale,
+      y: y * inputScale,
       modifiers: toModifiersMask(modifiers),
       deltaX,
       deltaY,
@@ -167,17 +171,20 @@ export class RawMouseImpl implements input.RawMouse {
 
 export class RawTouchscreenImpl implements input.RawTouchscreen {
   private _client: CRSession;
+  private _page: CRPage;
 
-  constructor(client: CRSession) {
+  constructor(page: CRPage, client: CRSession) {
+    this._page = page;
     this._client = client;
   }
   async tap(progress: Progress, x: number, y: number, modifiers: Set<types.KeyboardModifier>) {
+    const inputScale = this._page._inputScale();
     await progress.race(Promise.all([
       this._client.send('Input.dispatchTouchEvent', {
         type: 'touchStart',
         modifiers: toModifiersMask(modifiers),
         touchPoints: [{
-          x, y
+          x: x * inputScale, y: y * inputScale
         }]
       }),
       this._client.send('Input.dispatchTouchEvent', {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -82,7 +82,7 @@ export class CRPage implements PageDelegate {
     const dragManager = new DragManager(this);
     this.rawKeyboard = new RawKeyboardImpl(client, browserContext._browser._platform() === 'mac', dragManager);
     this.rawMouse = new RawMouseImpl(this, client, dragManager);
-    this.rawTouchscreen = new RawTouchscreenImpl(client);
+    this.rawTouchscreen = new RawTouchscreenImpl(this, client);
     this._pdf = new CRPDF(client);
     this._coverage = new CRCoverage(client);
     this._browserContext = browserContext;
@@ -177,6 +177,12 @@ export class CRPage implements PageDelegate {
 
   async updateEmulatedViewportSize(preserveWindowBoundaries?: boolean): Promise<void> {
     await this._mainFrameSession._updateViewport(preserveWindowBoundaries);
+  }
+
+  // Input.dispatch* coordinates are interpreted in window coordinates, before the
+  // emulation scale (if any) is applied - see _surfaceScale().
+  _inputScale(): number {
+    return this._mainFrameSession._surfaceScale();
   }
 
   async bringToFront(): Promise<void> {
@@ -451,8 +457,14 @@ class FrameSession {
       }
     }
 
-    if (this._isMainFrame() && hasUIWindow && !this._page.isStorageStatePage)
+    if (this._isMainFrame() && hasUIWindow && !this._page.isStorageStatePage) {
+      // When the surface is scaled for high-dpi video recording, resize the window
+      // before Page.startScreencast, so that the screencast captures the final surface
+      // size instead of adapting to the resize mid-stream - see _surfaceScale().
+      if (this._surfaceScale() !== 1)
+        await this._updateViewport();
       startAutomaticVideoRecording(this._crPage._page);
+    }
 
     let lifecycleEventsEnabled: Promise<any>;
     if (!this._isMainFrame())
@@ -924,6 +936,7 @@ class FrameSession {
     const viewportSize = emulatedSize.viewport;
     const screenSize = emulatedSize.screen;
     const isLandscape = screenSize.width > screenSize.height;
+    const surfaceScale = this._surfaceScale();
     const metricsOverride: Protocol.Emulation.setDeviceMetricsOverrideParameters = {
       mobile: !!options.isMobile,
       width: viewportSize.width,
@@ -934,7 +947,10 @@ class FrameSession {
       screenOrientation: !!options.isMobile ? (
         isLandscape ? { angle: 90, type: 'landscapePrimary' } : { angle: 0, type: 'portraitPrimary' }
       ) : { angle: 0, type: 'landscapePrimary' },
-      dontSetVisibleSize: preserveWindowBoundaries
+      // Rendering the viewport into a larger window requires the visible size
+      // to stay at the window size, and the page to be scaled up to fill it.
+      scale: surfaceScale !== 1 ? surfaceScale : undefined,
+      dontSetVisibleSize: preserveWindowBoundaries || (surfaceScale !== 1 ? true : undefined)
     };
     if (JSON.stringify(this._metricsOverride) === JSON.stringify(metricsOverride))
       return;
@@ -958,14 +974,37 @@ class FrameSession {
         }
       }
       promises.push(this.setWindowBounds({
-        width: viewportSize.width + insets.width,
-        height: viewportSize.height + insets.height
+        width: Math.round(viewportSize.width * surfaceScale) + insets.width,
+        height: Math.round(viewportSize.height * surfaceScale) + insets.height
       }));
     }
     // Make sure that the viewport emulationis set after the embedder window resize.
     promises.push(this._client.send('Emulation.setDeviceMetricsOverride', metricsOverride));
     await Promise.all(promises);
     this._metricsOverride = metricsOverride;
+  }
+
+  // In headless, the compositor surface has exactly one physical pixel per CSS pixel of
+  // the window, no matter the emulated deviceScaleFactor. Screencast captures the surface,
+  // so video recording could never contain more pixels than the CSS viewport size and
+  // "deviceScaleFactor: 2" did not produce a retina video. When recording video with
+  // deviceScaleFactor > 1, grow the window to viewport * deviceScaleFactor and render the
+  // page scaled up by the same factor, so that the surface holds true high-dpi pixels for
+  // the screencast to capture. Page.captureScreenshot re-rasters with its own scale and is
+  // not affected by the surface scale.
+  _surfaceScale(): number {
+    const browserContext = this._crPage._browserContext;
+    const deviceScaleFactor = browserContext._options.deviceScaleFactor || 1;
+    if (deviceScaleFactor === 1 || !browserContext._options.recordVideo)
+      return 1;
+    // A headful window is laid out in real screen pixels - on an actual high-dpi display
+    // the surface is scaled by the OS already, and growing the window would change its
+    // visible size on screen.
+    if (browserContext._browser.options.headful)
+      return 1;
+    if (!this._windowId)
+      return 1;
+    return deviceScaleFactor;
   }
 
   async windowBounds(): Promise<WindowBounds> {

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -11649,7 +11649,11 @@ export interface Browser {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -17829,7 +17833,11 @@ export interface BrowserType<Unused = {}> {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -24497,7 +24505,11 @@ export interface Electron {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -25219,7 +25231,11 @@ export interface AndroidDevice {
       /**
        * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
        * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-       * each page will be scaled down if necessary to fit the specified size.
+       * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+       * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+       * produces a high-dpi ("retina") video.
        */
       size?: {
         /**
@@ -26438,7 +26454,11 @@ export interface BrowserContextOptions {
     /**
      * Optional dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to
      * fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of
-     * each page will be scaled down if necessary to fit the specified size.
+     * each page will be scaled down if necessary to fit the specified size. In headless Chromium, when
+     * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+     * is larger than `1`, the page is captured at device resolution, so a `size` of `viewport` multiplied by
+     * [`deviceScaleFactor`](https://playwright.dev/docs/api/class-browser#browser-new-context-option-device-scale-factor)
+     * produces a high-dpi ("retina") video.
      */
     size?: {
       /**

--- a/tests/library/video.spec.ts
+++ b/tests/library/video.spec.ts
@@ -733,6 +733,45 @@ it.describe('screencast', () => {
     expectAll(pixels, isAlmostRed);
   });
 
+  it('should record retina video with deviceScaleFactor', async ({ browserType, browserName, headless }, testInfo) => {
+    it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37701' });
+    it.fixme(browserName !== 'chromium', 'Screencast cannot produce more pixels than the css viewport size');
+    it.fixme(browserName === 'chromium' && !headless, 'Headed window surface is laid out in real screen pixels');
+
+    const viewport = { width: 320, height: 240 };
+    const size = { width: 640, height: 480 };
+    const browser = await browserType.launch();
+
+    const videoDir = testInfo.outputPath('');
+    const context = await browser.newContext({
+      viewport,
+      deviceScaleFactor: 2,
+      recordVideo: {
+        dir: videoDir,
+        size,
+      },
+    });
+
+    const page = await context.newPage();
+    await page.setContent(`<div style='margin: 0; background: red; position: fixed; right:0; bottom:0; width: 30px; height: 30px;'></div>`);
+    await ensureSomeFrames(page);
+    await page.close();
+    await context.close();
+    await browser.close();
+
+    const videoFiles = findVideos(videoDir);
+    expect(videoFiles.length).toBe(1);
+    const videoPlayer = new VideoPlayer(videoFiles[0]);
+    expect(videoPlayer.videoWidth).toBe(size.width);
+    expect(videoPlayer.videoHeight).toBe(size.height);
+
+    // The whole video frame must be covered by the page: the bottom right corner
+    // should be part of the red square rendered at device pixels, not the gray
+    // letterboxing that used to fill everything beyond the css viewport size.
+    const pixels = videoPlayer.seekLastFrame({ x: size.width - 20, y: size.height - 20 }).data;
+    expectAll(pixels, isAlmostRed);
+  });
+
   it('should work with video+trace', async ({ browser, trace, headless, browserName, isHeadlessShell }, testInfo) => {
     it.skip(trace === 'on');
     it.fixme(!headless, 'different trace screencast image size on all browsers');


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/37701

### Problem

In headless Chromium, the compositor surface has exactly one physical pixel per CSS pixel of the window, no matter the emulated `deviceScaleFactor`. `Page.startScreencast` captures that surface, so recorded video can never contain more pixels than the CSS viewport size. Recording with:

```js
{
  viewport: { width: 960, height: 520 },
  deviceScaleFactor: 2,
  recordVideo: { size: { width: 1920, height: 1040 } },
}
```

produced a 1920x1040 video where the page filled only the top-left quarter and the rest was gray letterboxing. Screenshots are not affected because `Page.captureScreenshot` re-rasters with its own scale.

### Fix

When recording video with `deviceScaleFactor > 1` in headless Chromium:
- grow the browser window to `viewport * deviceScaleFactor` (`Browser.setWindowBounds`), and
- render the page scaled up by the same factor (`Emulation.setDeviceMetricsOverride` with `scale` and `dontSetVisibleSize: true`),

so the surface holds true high-dpi pixels for the screencast to capture. The page still lays out at the CSS viewport size with `devicePixelRatio == deviceScaleFactor`. The window is resized before `Page.startScreencast` so the screencast captures the final surface size from the first frame.

`Input.dispatchMouseEvent` / `Input.dispatchTouchEvent` coordinates are interpreted before the emulation scale, so they are multiplied by the scale. `Input.dispatchDragEvent` coordinates are already transformed by the renderer and stay untouched (verified empirically). Wheel deltas are not scaled.

The protocol traffic is unchanged unless `recordVideo` + `deviceScaleFactor > 1` + headless are all present. Headed mode is excluded: the window is laid out in real screen pixels there, and on an actual high-dpi display the OS already scales the surface.

Firefox and WebKit have the same limitation inside their screencast implementations (browser_patches); the new test carries `fixme` annotations for them, matching the existing hidpi test.

### Verification

- New test `should record retina video with deviceScaleFactor` fails on the unpatched tree and passes patched (20/20 with `--repeat-each=10`).
- Full `video.spec.ts`, `page-mouse`, `page-drag`, `wheel`, `tap`, `page-screenshot`, `elementhandle-screenshot`, `emulation`, `browsercontext-viewport*` chromium suites pass.
- Manually validated with `deviceScaleFactor: 2`: video frames are true 2x rasters filling the full frame; clicks/tap/drag/wheel coordinates, all screenshot variants, `setViewportSize`, and popups behave identically to an unpatched build.
