### PR TITLE
fix(cli): hash unix socket basenames to stay within sun_path

### DIFF
--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -126,7 +126,9 @@ export function makeSocketPath(domain: string, name: string): string {
   }
   const baseDir = process.env.PWTEST_SOCKETS_DIR || path.join(os.tmpdir(), `pw-${userNameHash}`);
   const dir = path.join(baseDir, domain);
-  const result = path.join(dir, calculateSha1(name).slice(0, 16) + '.sock');
+  let result = path.join(dir, sanitizeForFilePath(name) + '.sock');
+  if (Buffer.byteLength(result) > UNIX_SOCKET_PATH_MAX)
+    result = path.join(dir, calculateSha1(name).slice(0, 16) + '.sock');
   if (Buffer.byteLength(result) > UNIX_SOCKET_PATH_MAX)
     throw new Error(`Socket directory path is too long (${Buffer.byteLength(dir)} bytes); set PWTEST_SOCKETS_DIR to a shorter location.`);
   fs.mkdirSync(dir, { recursive: true });

--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -126,12 +126,9 @@ export function makeSocketPath(domain: string, name: string): string {
   }
   const baseDir = process.env.PWTEST_SOCKETS_DIR || path.join(os.tmpdir(), `pw-${userNameHash}`);
   const dir = path.join(baseDir, domain);
-  const suffix = '.sock';
-  const maxNameLength = UNIX_SOCKET_PATH_MAX - dir.length - path.sep.length - suffix.length;
-  if (maxNameLength < 1)
-    throw new Error(`Socket directory path is too long (${dir.length} chars); set PWTEST_SOCKETS_DIR to a shorter location.`);
-  const fsFriendlyName = trimLongString(sanitizeForFilePath(name), maxNameLength);
-  const result = path.join(dir, `${fsFriendlyName}${suffix}`);
+  const result = path.join(dir, calculateSha1(name).slice(0, 16) + '.sock');
+  if (Buffer.byteLength(result) > UNIX_SOCKET_PATH_MAX)
+    throw new Error(`Socket directory path is too long (${Buffer.byteLength(dir)} bytes); set PWTEST_SOCKETS_DIR to a shorter location.`);
   fs.mkdirSync(dir, { recursive: true });
   return result;
 }

--- a/tests/mcp/cli-misc.spec.ts
+++ b/tests/mcp/cli-misc.spec.ts
@@ -102,3 +102,10 @@ test('open with very long session name (issue 40878)', async ({ cli, server }) =
   expect(result.exitCode).toBe(0);
   expect(result.output).toContain('Page URL');
 });
+
+test('open with long multi-byte session name (issue 42153)', async ({ cli, server }) => {
+  const result = await cli('-s=セッション名がとても長い場合の動作を確認するためのテスト', 'open', server.PREFIX);
+  expect(result.error).toBe('');
+  expect(result.exitCode).toBe(0);
+  expect(result.output).toContain('Page URL');
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/playwright/issues/42153 by implementing the hashing Pavel suggested. We don't need to worry about versioning here because we only touch what path is written into the registry json file, and older/newer clients will happily read the hashed path from there.