### PR TITLE
fix(socks): reply with unspecified 0.0.0.0:0 bound address in SOCKS CONNECT

### DIFF
--- a/packages/utils/socksProxy.ts
+++ b/packages/utils/socksProxy.ts
@@ -226,13 +226,20 @@ class SocksConnection {
     }
   }
 
-  socketConnected(host: string, port: number) {
+  socketConnected(_host: string, _port: number) {
+    // Per RFC 1928 §6, the BND.ADDR/BND.PORT fields in the CONNECT reply are the bound address of
+    // the proxy's outgoing connection and are ignored by the client (Chromium does not use them).
+    // Encoding the socket's real local address here is both an information leak and a crash source:
+    // ipToSocksAddress() throws for any value that is not a clean IPv4/IPv6 address (e.g. what
+    // socket.localAddress may return on some platforms/Node versions), which drops the whole SOCKS
+    // connection and produces net::ERR_CONNECTION_CLOSED in the browser. Always send the unspecified
+    // address instead.
     this._writeBytes(Buffer.from([
       0x05,
       SocksReply.Succeeded,
       0x00, // RSV
-      ...ipToSocksAddress(host), // ATYP, Address
-      port >> 8, port & 0xFF // Port
+      ...ipToSocksAddress('0.0.0.0'), // ATYP, Address
+      0, 0 // Port
     ]));
     this._socket.on('data', data => this._client.onSocketData({ uid: this._uid, data }));
   }

--- a/tests/library/unit/socks.spec.ts
+++ b/tests/library/unit/socks.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net from 'net';
+import { test as it, expect } from '@playwright/test';
+import { utils } from '../../../packages/playwright-core/lib/coreBundle';
+
+const { SocksProxy } = utils;
+
+// Runs a SOCKS5 CONNECT handshake against the proxy and returns the raw 10-byte CONNECT reply
+// (the 2-byte greeting response is consumed before the request is sent). The client socket is
+// destroyed once the reply arrives so the proxy tears down the connection deterministically.
+function socks5Connect(proxyPort: number, targetHost: string, targetPort: number): Promise<Buffer> {
+  const socket = net.connect(proxyPort, '127.0.0.1');
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let greetingDone = false;
+
+    const done = (error: Error | null, reply?: Buffer) => {
+      socket.destroy();
+      if (error)
+        reject(error);
+      else
+        resolve(reply!);
+    };
+
+    socket.on('data', data => {
+      chunks.push(data);
+      const buffer = Buffer.concat(chunks);
+      if (!greetingDone) {
+        if (buffer.length < 2)
+          return;
+        // Consume the greeting response [0x05, 0x00] and issue the CONNECT request.
+        greetingDone = true;
+        chunks.length = 0;
+        chunks.push(buffer.subarray(2));
+        socket.write(Buffer.from([
+          0x05, 0x01, 0x00, 0x01, // VER=5, CMD=CONNECT, RSV, ATYP=IPv4
+          ...targetHost.split('.').map(Number),
+          targetPort >> 8, targetPort & 0xFF, // DST.PORT
+        ]));
+        return;
+      }
+      if (buffer.length >= 10)
+        done(null, buffer.subarray(0, 10));
+    });
+
+    socket.on('error', error => done(error));
+    // Greeting: VER=5, one method, no authentication.
+    socket.write(Buffer.from([0x05, 0x01, 0x00]));
+  });
+}
+
+it('should reply with the unspecified 0.0.0.0:0 bound address in the SOCKS CONNECT reply', async () => {
+  // A trivial TCP server that the proxy connects to on behalf of the client.
+  const target = net.createServer(socket => socket.destroy());
+  await new Promise<void>(f => target.listen(0, '127.0.0.1', () => f()));
+  const targetPort = (target.address() as net.AddressInfo).port;
+
+  const proxy = new SocksProxy();
+  const proxyPort = await proxy.listen(0, '127.0.0.1');
+
+  try {
+    const reply = await socks5Connect(proxyPort, '127.0.0.1', targetPort);
+    expect(reply[0]).toBe(0x05); // VER
+    expect(reply[1]).toBe(0x00); // REP = Succeeded
+    expect(reply[2]).toBe(0x00); // RSV
+    expect(reply[3]).toBe(0x01); // ATYP = IPv4
+    // Per RFC 1928, BND.ADDR/BND.PORT are ignored by the client, so the proxy must always report
+    // the unspecified address instead of the (leaky, and sometimes non-IP) socket.localAddress.
+    expect([...reply.subarray(4, 8)]).toEqual([0, 0, 0, 0]);
+    expect([...reply.subarray(8, 10)]).toEqual([0, 0]);
+  } finally {
+    await proxy.close();
+    await new Promise<void>(f => target.close(() => f()));
+  }
+});


### PR DESCRIPTION
## Problem

When `client_certificates` is configured, Playwright starts an internal SOCKS5 proxy to inject client certificates. The SOCKS5 CONNECT reply encodes the *client-side* local address of the proxy's outgoing socket (`socket.localAddress`) into the BND.ADDR/BND.PORT fields. That value is unreliable across platforms and Node versions: when it is not a clean IPv4/IPv6 address, `ipToSocksAddress()` throws (`Invalid IPv6 token` / `Only IPv4 and IPv6 addresses are supported`), which drops the SOCKS connection and surfaces as `net::ERR_CONNECTION_CLOSED` in the browser (see #42194). It also leaks the proxy's internal IP to the client.

## Root cause

`SocksConnection.socketConnected()` in `packages/utils/socksProxy.ts` encodes the `host`/`port` it is given into the reply. Both callers (`SocksProxy._handleDirect` and the client-certificates interceptor via `SocksProxy.socketConnected`) pass `socket.localAddress` / `socket.localPort`. Per RFC 1928 §6, BND.ADDR/BND.PORT in a CONNECT reply are the bound address of the proxy's outgoing connection and are ignored by the client, so encoding the real local address is both unnecessary and the crash source.

## Fix

Always send the unspecified address `0.0.0.0:0` in the SOCKS5 CONNECT reply, matching what `SocksConnection.socketFailed()` already does for error replies. The `host`/`port` arguments are kept for API compatibility but are now intentionally ignored.

## Test

New pure-node unit test `tests/library/unit/socks.spec.ts` performs a real SOCKS5 CONNECT handshake against `SocksProxy` and asserts that the reply's BND.ADDR/BND.PORT are `0.0.0.0:0`. Before the fix the reply echoes `socket.localAddress` (e.g. `127.0.0.1:<ephemeral port>`), so the assertion fails on the pristine tree and passes after the fix.

Fixes #42194