### PR TITLE
fix(chromium): use resource type when deciding if evicted body can be re-fetched

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -557,12 +557,6 @@ export class CRNetworkManager {
   }
 }
 
-// Sec-Fetch-Dest values of static subresources that are safe to fetch again.
-const kRefetchSafeDestinations = new Set([
-  'audio', 'audioworklet', 'font', 'image', 'manifest', 'paintworklet', 'script',
-  'serviceworker', 'sharedworker', 'style', 'track', 'video', 'worker', 'xslt',
-]);
-
 // Resource types of static subresources that are safe to fetch again. Unlike
 // Sec-Fetch-Dest, resource type is reported for plain http origins as well.
 const kRefetchSafeResourceTypes = new Set<network.ResourceType>([
@@ -617,10 +611,8 @@ class InterceptableRequest {
         return Buffer.from('');
       if (!kRefetchSafeResourceTypes.has(request.resourceType())) {
         const rawHeaders = await request.internalRawRequestHeaders();
-        const rawHeaderValue = (name: string) => rawHeaders.find(h => h.name.toLowerCase() === name)?.value;
-        const isPrefetch = !!rawHeaderValue('sec-purpose')?.startsWith('prefetch');
-        const secFetchDest = rawHeaderValue('sec-fetch-dest');
-        if (!isPrefetch && (!secFetchDest || !kRefetchSafeDestinations.has(secFetchDest)))
+        const isPrefetch = rawHeaders.some(h => h.name.toLowerCase() === 'sec-purpose' && h.value.startsWith('prefetch'));
+        if (!isPrefetch)
           return Buffer.from('');
       }
 

--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -563,6 +563,12 @@ const kRefetchSafeDestinations = new Set([
   'serviceworker', 'sharedworker', 'style', 'track', 'video', 'worker', 'xslt',
 ]);
 
+// Resource types of static subresources that are safe to fetch again. Unlike
+// Sec-Fetch-Dest, resource type is reported for plain http origins as well.
+const kRefetchSafeResourceTypes = new Set<network.ResourceType>([
+  'font', 'image', 'manifest', 'media', 'script', 'stylesheet', 'texttrack',
+]);
+
 const kInterceptableRequest = Symbol('InterceptableRequest');
 
 class InterceptableRequest {
@@ -609,12 +615,14 @@ class InterceptableRequest {
       // do it for GETs of static subresources and prefetch requests.
       if (request.method() !== 'GET')
         return Buffer.from('');
-      const rawHeaders = await request.internalRawRequestHeaders();
-      const rawHeaderValue = (name: string) => rawHeaders.find(h => h.name.toLowerCase() === name)?.value;
-      const isPrefetch = !!rawHeaderValue('sec-purpose')?.startsWith('prefetch');
-      const secFetchDest = rawHeaderValue('sec-fetch-dest');
-      if (!isPrefetch && (!secFetchDest || !kRefetchSafeDestinations.has(secFetchDest)))
-        return Buffer.from('');
+      if (!kRefetchSafeResourceTypes.has(request.resourceType())) {
+        const rawHeaders = await request.internalRawRequestHeaders();
+        const rawHeaderValue = (name: string) => rawHeaders.find(h => h.name.toLowerCase() === name)?.value;
+        const isPrefetch = !!rawHeaderValue('sec-purpose')?.startsWith('prefetch');
+        const secFetchDest = rawHeaderValue('sec-fetch-dest');
+        if (!isPrefetch && (!secFetchDest || !kRefetchSafeDestinations.has(secFetchDest)))
+          return Buffer.from('');
+      }
 
       const resource = await session.send('Network.loadNetworkResource', { url: request.url(), frameId: request.serviceWorker() ? undefined : request.frame()!._id, options: { disableCache: false, includeCredentials: true } });
       const chunks: Buffer[] = [];

--- a/tests/page/page-network-response.spec.ts
+++ b/tests/page/page-network-response.spec.ts
@@ -344,8 +344,9 @@ it('should report if request was fromServiceWorker', async ({ page, server, isAn
   }
 });
 
-it('should return body for prefetch script', async ({ page, server, browserName }) => {
+it('should return body for prefetch script', async ({ page, server, browserName, browserMajorVersion }) => {
   it.skip(browserName === 'webkit', 'No prefetch in WebKit: https://caniuse.com/link-rel-prefetch');
+  it.skip(browserName === 'chromium' && browserMajorVersion < 138, 'Requires Sec-Purpose header, shipped in Chrome 138');
   const [response] = await Promise.all([
     page.waitForResponse('**/prefetch.js'),
     page.goto(server.PREFIX + '/prefetch.html')


### PR DESCRIPTION
## Summary
- The re-fetch gate from #42124 relied on `Sec-Fetch-Dest`, which Chromium only sends to potentially trustworthy origins; Android tests reach the server via plain-http `10.0.2.2`, so `response.body()` always returned an empty body there.
- Accept requests whose CDP resource type is a static subresource, falling back to the header checks otherwise.
- Skip the prefetch test on Chromium < 138: `Sec-Purpose` on `<link rel=prefetch>` only shipped in Chrome 138 and the Android emulator's Chrome is older.