### PR TITLE
test: update webkit expectations for NWLoader on macOS

### DIFF
--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -97,7 +97,8 @@ it('should only have one websocket entry', async ({ contextFactory, server }, te
   expect(wsEntry._resourceType).toBe('websocket');
 });
 
-it('should include websocket handshake headers and status', async ({ contextFactory, server }, testInfo) => {
+it('should include websocket handshake headers and status', async ({ contextFactory, server, browserName, isMac, macVersion }, testInfo) => {
+  it.fixme(browserName === 'webkit' && isMac && macVersion >= 26, 'NWLoader does not reflect the wire handshake headers (Sec-WebSocket-Key, Connection, Upgrade) in NSURLSessionWebSocketTask.currentRequest');
   server.onceWebSocketConnection(ws => {
     ws.on('message', () => ws.close());
   });

--- a/tests/page/page-network-sizes.spec.ts
+++ b/tests/page/page-network-sizes.spec.ts
@@ -93,8 +93,9 @@ it('should have the correct responseBodySize for chunked request', async ({ page
   const sizes = await response.request().sizes();
   // The actual file size is 5100 bytes. The extra 75 bytes are coming from the chunked encoding headers and end bytes.
   if (browserName === 'webkit')
-    // It should be 5175 there. On the actual network response, the body has a size of 5175.
-    expect(sizes.responseBodySize).toBe(5173);
+    // WebKit on macOS reports 5173 with the legacy CFNetwork loader (builds <= 2346) and the
+    // correct 5175 with NWLoader. TODO: expect 5175 once the NWLoader-based build ships.
+    expect([5173, 5175]).toContain(sizes.responseBodySize);
   else
     expect(sizes.responseBodySize).toBe(5175);
 });


### PR DESCRIPTION
WebKit on macOS is switching from the legacy CFNetwork loader to NWLoader (microsoft/playwright-browsers#2470). Two test expectations change:

- `page-network-sizes.spec.ts` "should have the correct responseBodySize for chunked request": NWLoader reports the correct 5175 (the legacy loader undercounted the chunked encoding bytes as 5173). Transitionally accepts both values until the NWLoader-based build ships, then can be tightened to 5175.
- `har-websocket.spec.ts` "should include websocket handshake headers and status": marked fixme for webkit on macOS 26+ — NWLoader there does not reflect the wire handshake headers (`Sec-WebSocket-Key`, `Connection`, `Upgrade`) in `NSURLSessionWebSocketTask.currentRequest`, so they are missing from the reported handshake request. macOS 15 is unaffected.

Refernce https://github.com/microsoft/playwright-browsers/issues/2464