### PR TITLE
fix(ci): do not turn complete clones shallow when capturing git diff

### DIFF
--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -153,8 +153,23 @@ async function gitCommitInfo(gitDir: string): Promise<GitCommitInfo | undefined>
 async function gitDiff(gitDir: string, ci?: CIInfo): Promise<string | undefined> {
   const diffLimit = 100_000;
   if (ci?.prBaseHash) {
-    // https://git-scm.com/docs/git-fetch
-    await runGit(['fetch', 'origin', ci.prBaseHash, '--depth=1', '--no-auto-maintenance', '--no-auto-gc', '--no-tags', '--no-recurse-submodules'], gitDir);
+    // Diff against the PR base commit. Whether it is present locally depends on the checkout:
+    // - fetch-depth: 0 (complete clone): the base is reachable from the base branch, no fetch
+    //   is needed. Fetching with `--depth=1` here would write `.git/shallow` and turn the
+    //   user's complete clone shallow for the rest of the CI job.
+    // - fetch-depth: 1 (default on GHA): only the PR merge commit exists, the base must be
+    //   fetched, and `--depth=1` keeps that fetch minimal in the already-shallow clone.
+    // - fetch-depth: N: the base is present iff it is within N commits of the merge commit.
+    // - Base branch force-pushed after the PR was created: the base may be missing even from
+    //   a complete clone; fetch without `--depth` so that the clone stays complete.
+    const hasBaseCommit = await runGit(['cat-file', '-e', `${ci.prBaseHash}^{commit}`], gitDir) !== undefined;
+    if (!hasBaseCommit) {
+      const isShallow = await runGit(['rev-parse', '--is-shallow-repository'], gitDir) === 'true';
+      const fetchArgs = ['fetch', 'origin', ci.prBaseHash, '--no-auto-maintenance', '--no-auto-gc', '--no-tags', '--no-recurse-submodules'];
+      if (isShallow)
+        fetchArgs.push('--depth=1');
+      await runGit(fetchArgs, gitDir);
+    }
     const diff = await runGit(['diff', ci.prBaseHash, 'HEAD'], gitDir);
     if (diff)
       return diff.substring(0, diffLimit);

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -3192,6 +3192,68 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       expect(prompt, 'contains diff').toContain(`+            expect(2).toBe(3);`);
     });
 
+    test('should not turn complete clone shallow when capturing diff', async ({ runInlineTest, writeFiles }, testInfo) => {
+      test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42203' });
+      const files = {
+        'playwright.config.ts': `export default {}`,
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({}) => { expect(2).toBe(2); });
+        `,
+      };
+      const baseDir = await writeFiles(files);
+      await initGitRepo(baseDir);
+      const originDir = testInfo.outputPath('origin.git');
+      await execGit(baseDir, ['clone', '--bare', baseDir, originDir]);
+      await execGit(originDir, ['config', 'uploadpack.allowAnySHA1InWant', 'true']);
+      await execGit(baseDir, ['remote', 'add', 'origin', originDir]);
+      const { stdout: baseSha } = await spawnAsync('git', ['rev-parse', 'HEAD~1'], { stdio: 'pipe', cwd: baseDir });
+
+      const result = await runInlineTest({}, { reporter: 'dot' }, {
+        PLAYWRIGHT_HTML_OPEN: 'never',
+        ...(await ghaPullRequestEnv(baseDir, baseSha.trim())),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.report.config.metadata.gitDiff).toContain('example.spec.ts');
+      const { stdout: isShallow } = await spawnAsync('git', ['rev-parse', '--is-shallow-repository'], { stdio: 'pipe', cwd: baseDir });
+      expect(isShallow.trim()).toBe('false');
+    });
+
+    test('should fetch missing pull request base commit when capturing diff', async ({ runInlineTest, writeFiles }, testInfo) => {
+      const files = {
+        'playwright.config.ts': `export default {}`,
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({}) => { expect(2).toBe(2); });
+        `,
+      };
+      const baseDir = await writeFiles(files);
+      await initGitRepo(baseDir);
+      const originDir = testInfo.outputPath('origin.git');
+      await execGit(baseDir, ['clone', '--bare', baseDir, originDir]);
+      await execGit(originDir, ['config', 'uploadpack.allowAnySHA1InWant', 'true']);
+      await execGit(baseDir, ['remote', 'add', 'origin', originDir]);
+
+      const otherDir = testInfo.outputPath('other');
+      await execGit(baseDir, ['clone', originDir, otherDir]);
+      await fs.promises.writeFile(path.join(otherDir, 'baseline.txt'), 'baseline');
+      await execGit(otherDir, ['add', 'baseline.txt']);
+      await execGit(otherDir, ['-c', 'user.email=shakespeare@example.local', '-c', 'user.name=William', 'commit', '-m', 'baseline']);
+      const { stdout: baseSha } = await spawnAsync('git', ['rev-parse', 'HEAD'], { stdio: 'pipe', cwd: otherDir });
+      await execGit(otherDir, ['push', 'origin', 'HEAD:refs/heads/baseline']);
+
+      const result = await runInlineTest({}, { reporter: 'dot' }, {
+        PLAYWRIGHT_HTML_OPEN: 'never',
+        ...(await ghaPullRequestEnv(baseDir, baseSha.trim())),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.report.config.metadata.gitDiff).toContain('baseline.txt');
+      const { stdout: isShallow } = await spawnAsync('git', ['rev-parse', '--is-shallow-repository'], { stdio: 'pipe', cwd: baseDir });
+      expect(isShallow.trim()).toBe('false');
+    });
+
     test('should include snapshot when page wasnt closed', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'example.spec.ts': `
@@ -3660,13 +3722,13 @@ function ghaCommitEnv() {
   };
 }
 
-async function ghaPullRequestEnv(baseDir: string) {
+async function ghaPullRequestEnv(baseDir: string, baseSha: string = 'main') {
   const eventPath = path.join(baseDir, 'event.json');
   await fs.promises.writeFile(eventPath, JSON.stringify({
     pull_request: {
       title: 'My PR',
       number: 42,
-      base: { sha: 'main' },
+      base: { sha: baseSha },
     },
   }));
   return {


### PR DESCRIPTION
## Summary
- Only fetch the PR base commit when it is missing locally; on `fetch-depth: 0` checkouts no fetch runs at all.
- Pass `--depth=1` only when the repository is already shallow — fetching with `--depth=1` into a complete clone wrote `.git/shallow` and truncated history for every subsequent CI step.

Fixes https://github.com/microsoft/playwright/issues/42203