### PR TITLE
fix(gitCommitInfo): do not shallow the repository when capturing the diff

### DIFF
--- a/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
+++ b/packages/playwright/src/plugins/gitCommitInfoPlugin.ts
@@ -154,7 +154,10 @@ async function gitDiff(gitDir: string, ci?: CIInfo): Promise<string | undefined>
   const diffLimit = 100_000;
   if (ci?.prBaseHash) {
     // https://git-scm.com/docs/git-fetch
-    await runGit(['fetch', 'origin', ci.prBaseHash, '--depth=1', '--no-auto-maintenance', '--no-auto-gc', '--no-tags', '--no-recurse-submodules'], gitDir);
+    // --depth=1 turns a complete checkout into a shallow one, so only pass it when already shallow.
+    const isShallow = await runGit(['rev-parse', '--is-shallow-repository'], gitDir) === 'true';
+    const depthArgs = isShallow ? ['--depth=1'] : [];
+    await runGit(['fetch', 'origin', ci.prBaseHash, ...depthArgs, '--no-auto-maintenance', '--no-auto-gc', '--no-tags', '--no-recurse-submodules'], gitDir);
     const diff = await runGit(['diff', ci.prBaseHash, 'HEAD'], gitDir);
     if (diff)
       return diff.substring(0, diffLimit);

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -1556,6 +1556,29 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       `);
     });
 
+    test('should not shallow the repository when capturing the diff', async ({ runInlineTest, writeFiles }) => {
+      test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42203' });
+      const files = {
+        'playwright.config.ts': `export default {}`,
+        'example.spec.ts': `
+          import { test, expect } from '@playwright/test';
+          test('sample', async ({}) => { expect(2).toBe(2); });
+        `,
+      };
+      const baseDir = await writeFiles(files);
+      await initGitRepo(baseDir);
+      await execGit(baseDir, ['remote', 'add', 'origin', baseDir]);
+
+      const result = await runInlineTest(files, { reporter: 'dot,html' }, {
+        PLAYWRIGHT_HTML_OPEN: 'never',
+        ...(await ghaPullRequestEnv(baseDir))
+      });
+
+      expect(result.exitCode).toBe(0);
+      const { stdout } = await spawnAsync('git', ['rev-parse', '--is-shallow-repository'], { stdio: 'pipe', cwd: baseDir });
+      expect(stdout.trim()).toBe('false');
+    });
+
     test('should not include git metadata w/o CI', async ({ runInlineTest, showReport, page }) => {
       const result = await runInlineTest({
         'playwright.config.ts': `


### PR DESCRIPTION
On a pull request, git info capture fetches the PR base commit with `--depth=1`. On a checkout that has full history, that flag does not just bound the fetch, it writes `.git/shallow` and grafts history at the base commit. The repository stays shallow for the rest of the CI job, so anything reading git history afterwards (a `git describe`, a Hugo `enableGitInfo` build, changelog generation) sees every file's last commit collapsed onto the graft boundary.

Only pass `--depth=1` when the checkout is already shallow.

Fixes https://github.com/microsoft/playwright/issues/42203