### PR TITLE
fix(net): only commit to an address after the TLS handshake in happy eyeballs

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -343,7 +343,12 @@ export abstract class APIRequestContext extends SdkObject {
         = (url.protocol === 'https:' ? https : http).request;
       // If we have a proxy agent already, do not override it.
       const agent = options.agent || (url.protocol === 'https:' ? httpsHappyEyeballsAgent : httpHappyEyeballsAgent);
-      const requestOptions = { ...options, agent };
+      const requestOptions: SendRequestOptions = { ...options, agent };
+      // Happy eyeballs sockets are not attached to the request until the tls handshake,
+      // so request.destroy() cannot reach them. Bound each connection attempt with the
+      // remaining time budget so that stalled attempts do not outlive the request.
+      if (progress.deadline)
+        requestOptions.timeout = Math.max(1, progress.deadline - monotonicTime());
 
       const startAt = monotonicTime();
       const startAtWallTime = Date.now();

--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -617,6 +617,10 @@ export abstract class APIRequestContext extends SdkObject {
         const happyEyeBallsTimings = timingForSocket(socket);
         dnsLookupAt = happyEyeBallsTimings.dnsLookupAt;
         tcpConnectionAt = happyEyeBallsTimings.tcpConnectionAt;
+        // happy eyeballs hand off tls sockets after the handshake, so 'secureConnect' will not fire
+        tlsHandshakeAt = happyEyeBallsTimings.tlsHandshakeAt;
+        if (tlsHandshakeAt !== undefined)
+          captureSecurityDetails(socket);
 
         // non-happy-eyeballs sockets
         listeners.push(

--- a/packages/utils/happyEyeballs.ts
+++ b/packages/utils/happyEyeballs.ts
@@ -115,7 +115,7 @@ export async function createConnectionAsync(
   const hostname = clientRequestArgsToHostName(options);
   const addresses = await lookup(hostname);
   const dnsLookupAt = monotonicTime();
-  const sockets = new Set<net.Socket>();
+  const sockets = new Map<net.Socket, net.Socket>();
   let firstError;
   let errorCount = 0;
   const handleError = (socket: net.Socket, err: Error) => {
@@ -126,52 +126,73 @@ export async function createConnectionAsync(
     if (errorCount === addresses.length)
       oncreate?.(firstError);
   };
+  const abortAttempt = (socket: net.Socket, transport: net.Socket) => {
+    // Destroying a tls socket during the handshake does not close the underlying
+    // tcp connection, and neither does destroying the transport once it has been
+    // wrapped. Resetting the transport before touching the tls socket does.
+    transport.resetAndDestroy();
+    socket.destroy();
+  };
 
   const connected = new ManualPromise();
   for (const { address } of addresses) {
+    // Own the tcp transport instead of letting tls.connect() create it,
+    // so that a stalled attempt can be closed via abortAttempt().
+    const transport = net.createConnection({
+      ...options,
+      port: options.port as number,
+      host: address });
     const socket = useTLS ?
       tls.connect({
         ...(options as tls.ConnectionOptions),
-        port: options.port as number,
-        host: address,
+        socket: transport,
         servername: hostname }) :
-      net.createConnection({
-        ...options,
-        port: options.port as number,
-        host: address });
+      transport;
 
     (socket as any)[kDNSLookupAt] = dnsLookupAt;
-    // tls.connect() ignores the timeout option, so set it on the socket directly.
+    // tls.connect() ignores the timeout option, so set it on the transport directly.
+    // It bounds this connection attempt; the winner's timer is reset upon commitment.
     if (options.timeout !== undefined)
-      socket.setTimeout(options.timeout);
+      transport.setTimeout(options.timeout);
 
-    socket.on('connect', () => {
+    transport.on('connect', () => {
       (socket as any)[kTCPConnectionAt] = monotonicTime();
     });
     // For tls, wait for the handshake instead of committing upon tcp connection.
     // Otherwise, a route where tcp connects but tls stalls would starve
-    // working alternatives. A tls socket may fire 'error' or 'timeout' after
+    // working alternatives. A socket may fire 'error' or 'timeout' after
     // 'connect', which counts as a failed attempt for this address.
     socket.on(useTLS ? 'secureConnect' : 'connect', () => {
       if (!sockets.delete(socket))
         return;
       if (useTLS)
         (socket as any)[kTLSHandshakeAt] = monotonicTime();
+      transport.setTimeout(0);
       connected.resolve();
       oncreate?.(null, socket);
       // TODO: Cache the result?
       // Close other outstanding sockets.
-      for (const s of sockets)
-        s.destroy();
+      for (const [s, t] of sockets)
+        abortAttempt(s, t);
       sockets.clear();
     });
-    socket.on('timeout', () => {
+    transport.on('timeout', () => {
       // Timeout is not an error, so we have to manually close the socket.
-      socket.destroy();
+      abortAttempt(socket, transport);
       handleError(socket, new Error('Connection timeout'));
     });
-    socket.on('error', e => handleError(socket, e));
-    sockets.add(socket);
+    socket.on('error', e => {
+      if (socket !== transport)
+        transport.resetAndDestroy();
+      handleError(socket, e);
+    });
+    if (socket !== transport) {
+      transport.on('error', e => {
+        socket.destroy();
+        handleError(socket, e);
+      });
+    }
+    sockets.set(socket, transport);
     await Promise.race([
       connected,
       new Promise(f => setTimeout(f, connectionAttemptDelayMs))

--- a/packages/utils/happyEyeballs.ts
+++ b/packages/utils/happyEyeballs.ts
@@ -33,6 +33,7 @@ const connectionAttemptDelayMs = 300;
 
 const kDNSLookupAt = Symbol('kDNSLookupAt');
 const kTCPConnectionAt = Symbol('kTCPConnectionAt');
+const kTLSHandshakeAt = Symbol('kTLSHandshakeAt');
 
 class HttpHappyEyeballsAgent extends http.Agent {
   override createConnection(options: http.ClientRequestArgs, oncreate?: (err: Error | null, socket: stream.Duplex) => void): stream.Duplex | undefined {
@@ -86,10 +87,8 @@ export async function createTLSSocket(options: tls.ConnectionOptions): Promise<t
       createConnectionAsync(options, (err, socket) => {
         if (err)
           reject(err);
-        if (socket) {
-          socket.on('secureConnect', () => resolve(socket));
-          socket.on('error', error => reject(error));
-        }
+        if (socket)
+          resolve(socket);
       }, true).catch(err => reject(err));
     }
   });
@@ -142,17 +141,26 @@ export async function createConnectionAsync(
         host: address });
 
     (socket as any)[kDNSLookupAt] = dnsLookupAt;
+    // tls.connect() ignores the timeout option, so set it on the socket directly.
+    if (options.timeout !== undefined)
+      socket.setTimeout(options.timeout);
 
-    // Each socket may fire only one of 'connect', 'timeout' or 'error' events.
-    // None of these events are fired after socket.destroy() is called.
     socket.on('connect', () => {
       (socket as any)[kTCPConnectionAt] = monotonicTime();
-
+    });
+    // For tls, wait for the handshake instead of committing upon tcp connection.
+    // Otherwise, a route where tcp connects but tls stalls would starve
+    // working alternatives. A tls socket may fire 'error' or 'timeout' after
+    // 'connect', which counts as a failed attempt for this address.
+    socket.on(useTLS ? 'secureConnect' : 'connect', () => {
+      if (!sockets.delete(socket))
+        return;
+      if (useTLS)
+        (socket as any)[kTLSHandshakeAt] = monotonicTime();
       connected.resolve();
       oncreate?.(null, socket);
       // TODO: Cache the result?
       // Close other outstanding sockets.
-      sockets.delete(socket);
       for (const s of sockets)
         s.destroy();
       sockets.clear();
@@ -213,5 +221,6 @@ export function timingForSocket(socket: net.Socket | tls.TLSSocket) {
   return {
     dnsLookupAt: (socket as any)[kDNSLookupAt] as number | undefined,
     tcpConnectionAt: (socket as any)[kTCPConnectionAt] as number | undefined,
+    tlsHandshakeAt: (socket as any)[kTLSHandshakeAt] as number | undefined,
   };
 }

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -53,6 +53,10 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   };
   if (params.rejectUnauthorized !== undefined)
     options.rejectUnauthorized = params.rejectUnauthorized;
+  // Bound each connection attempt, including the tls handshake, so that
+  // a single stalled address cannot hang the request without a socket.
+  if (params.socketTimeout !== undefined)
+    options.timeout = params.socketTimeout;
 
   const proxyURL = getProxyForUrl(params.url);
   if (proxyURL) {

--- a/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
+++ b/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
@@ -79,6 +79,7 @@ it('should fall back to another address when tls handshake stalls', async ({ con
   const stalledSockets = new Set<net.Socket>();
   const stallServer = net.createServer(socket => {
     stalledSockets.add(socket);
+    socket.on('error', () => {});
     socket.on('close', () => stalledSockets.delete(socket));
   });
   await new Promise<void>((resolve, reject) => {
@@ -96,11 +97,49 @@ it('should fall back to another address when tls handshake stalls', async ({ con
     } as any);
     expect(response.status()).toBe(200);
     expect(await response.text()).toBe('Hello');
+    await expect.poll(() => stalledSockets.size).toBe(0);
   } finally {
     for (const socket of stalledSockets)
       socket.destroy();
     await new Promise(resolve => stallServer.close(resolve));
     await new Promise(resolve => httpsServer.close(resolve));
+  }
+});
+
+it('should close stalled sockets when the request times out', async ({ context }) => {
+  it.skip(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
+  const stalledSockets = new Set<net.Socket>();
+  let socketsSeen = 0;
+  const trackSocket = (socket: net.Socket) => {
+    ++socketsSeen;
+    stalledSockets.add(socket);
+    socket.on('error', () => {});
+    socket.on('close', () => stalledSockets.delete(socket));
+  };
+  const stallServer6 = net.createServer(trackSocket);
+  const port = await new Promise<number>(resolve => stallServer6.listen(0, '::1', () => resolve((stallServer6.address() as net.AddressInfo).port)));
+  const stallServer4 = net.createServer(trackSocket);
+  await new Promise<void>((resolve, reject) => {
+    stallServer4.on('error', reject);
+    stallServer4.listen(port, '127.0.0.1', resolve);
+  });
+  try {
+    const error = await context.request.get(`https://localhost:${port}/`, {
+      ignoreHTTPSErrors: true,
+      timeout: 1000,
+      __testHookLookup: (): LookupAddress[] => [
+        { address: '::1', family: 6 },
+        { address: '127.0.0.1', family: 4 },
+      ],
+    } as any).catch(e => e);
+    expect(error.message).toContain('Timeout 1000ms exceeded');
+    expect(socketsSeen).toBe(2);
+    await expect.poll(() => stalledSockets.size).toBe(0);
+  } finally {
+    for (const socket of stalledSockets)
+      socket.destroy();
+    await new Promise(resolve => stallServer4.close(resolve));
+    await new Promise(resolve => stallServer6.close(resolve));
   }
 });
 

--- a/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
+++ b/tests/library/browsercontext-fetch-happy-eyeballs.spec.ts
@@ -15,7 +15,11 @@
  */
 
 import type { LookupAddress } from 'dns';
+import https from 'https';
+import net from 'net';
+
 import { contextTest as it, expect } from '../config/browserTest';
+import { TestServer } from '../config/testserver';
 
 it.skip(({ mode }) => mode !== 'default');
 
@@ -66,6 +70,39 @@ it('https post should work with ignoreHTTPSErrors option', async ({ context, htt
   expect(interceptedHostnameLookup).toBe('localhost');
 });
 
+
+it('should fall back to another address when tls handshake stalls', async ({ context }) => {
+  it.skip(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');
+  // https://github.com/microsoft/playwright/issues/42193
+  const httpsServer = https.createServer(await TestServer.certOptions(), (req, res) => res.end('Hello'));
+  const port = await new Promise<number>(resolve => httpsServer.listen(0, '127.0.0.1', () => resolve((httpsServer.address() as net.AddressInfo).port)));
+  const stalledSockets = new Set<net.Socket>();
+  const stallServer = net.createServer(socket => {
+    stalledSockets.add(socket);
+    socket.on('close', () => stalledSockets.delete(socket));
+  });
+  await new Promise<void>((resolve, reject) => {
+    stallServer.on('error', reject);
+    stallServer.listen(port, '::1', resolve);
+  });
+  try {
+    const response = await context.request.get(`https://localhost:${port}/`, {
+      ignoreHTTPSErrors: true,
+      timeout: 5000,
+      __testHookLookup: (): LookupAddress[] => [
+        { address: '::1', family: 6 },
+        { address: '127.0.0.1', family: 4 },
+      ],
+    } as any);
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toBe('Hello');
+  } finally {
+    for (const socket of stalledSockets)
+      socket.destroy();
+    await new Promise(resolve => stallServer.close(resolve));
+    await new Promise(resolve => httpsServer.close(resolve));
+  }
+});
 
 it('should work with ip6 and port as the host', async ({ request, server }) => {
   it.skip(!!process.env.INSIDE_DOCKER, 'docker does not support IPv6 by default');


### PR DESCRIPTION
## Summary
- Happy eyeballs committed to an address on tcp `connect` and destroyed the other candidates, so a route where tcp connects but the TLS handshake stalls starved working alternatives (e.g. browser download retries never reaching IPv4 after an IPv6 TLS timeout).
- TLS connections now commit on `secureConnect`; a handshake error counts as a failed attempt for that address.
- `socketTimeout` now bounds each connection attempt, so a handshake stall on every address fails instead of hanging without a socket. Api requests bound each attempt with their remaining time budget.
- Aborted attempts now own and reset their tcp transport: destroying a tls socket during a stalled handshake does not close the underlying tcp connection, so losing and timed-out attempts leaked connections.
- Server fetch reads the handshake timestamp and security details from the already-secure socket handed over by the agent.

Fixes https://github.com/microsoft/playwright/issues/42193