### PR TITLE
[Bug]: Bundled Firefox never enables the optimizing wasm tier: wasm 14-18x slower than stock Firefox, invalidating perf measurement

### DIFF
--- a/browser_patches/firefox/juggler/content/Runtime.js
+++ b/browser_patches/firefox/juggler/content/Runtime.js
@@ -56,6 +56,10 @@ const disallowedMessageCategories = new Set([
 class Runtime {
   constructor(isWorker = false) {
     this._debugger = new Debugger();
+    // Juggler does not implement WASM debugging, so allow WASM to use the
+    // optimizing Cranelift tier even though we have a Debugger attached.
+    // Without this, addDebuggee() forces WASM into debug mode (baseline-only).
+    this._debugger.allowUnobservedWasm = true;
     this._pendingPromises = new Map();
     this._executionContexts = new Map();
     this._windowToExecutionContext = new Map();


### PR DESCRIPTION
Set `allowUnobservedWasm = true` on the Juggler `Debugger` instance in `Runtime.js` so that `addDebuggee()` no longer forces WASM into baseline-only debug mode, restoring the Cranelift optimizing tier in Playwright's bundled Firefox.

Found via automated repo scanning, fix written and reviewed before opening.
