### PR TITLE
feat(trace): add --grep filter to trace console

### DIFF
--- a/packages/playwright-core/src/tools/skills/playwright-trace/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-trace/SKILL.md
@@ -94,6 +94,9 @@ npx playwright trace console --browser
 
 # Only stdout/stderr (no browser console)
 npx playwright trace console --stdio
+
+# Filter by message text pattern
+npx playwright trace console --grep "failed to fetch"
 ```
 
 ### Errors

--- a/packages/playwright-core/src/tools/trace/traceCli.ts
+++ b/packages/playwright-core/src/tools/trace/traceCli.ts
@@ -86,11 +86,12 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
   traceCommand
       .command('console')
       .description('show console messages')
+      .option('--grep <pattern>', 'filter by message text pattern')
       .option('--errors-only', 'only show errors')
       .option('--warnings', 'show errors and warnings')
       .option('--browser', 'only browser console messages')
       .option('--stdio', 'only stdout/stderr')
-      .action(async (options: { errorsOnly?: boolean, warnings?: boolean, browser?: boolean, stdio?: boolean }) => {
+      .action(async (options: { grep?: string, errorsOnly?: boolean, warnings?: boolean, browser?: boolean, stdio?: boolean }) => {
         traceConsole(options).catch(logErrorAndExit);
       });
 

--- a/packages/playwright-core/src/tools/trace/traceConsole.ts
+++ b/packages/playwright-core/src/tools/trace/traceConsole.ts
@@ -18,7 +18,7 @@
 
 import { loadTrace, formatTimestamp } from './traceUtils';
 
-export async function traceConsole(options: { errorsOnly?: boolean, warnings?: boolean, browser?: boolean, stdio?: boolean }) {
+export async function traceConsole(options: { grep?: string, errorsOnly?: boolean, warnings?: boolean, browser?: boolean, stdio?: boolean }) {
   const trace = await loadTrace();
   const model = trace.model;
 
@@ -88,12 +88,18 @@ export async function traceConsole(options: { errorsOnly?: boolean, warnings?: b
 
   items.sort((a, b) => a.timestamp - b.timestamp);
 
-  if (!items.length) {
+  let filtered = items;
+  if (options.grep) {
+    const pattern = new RegExp(options.grep, 'i');
+    filtered = filtered.filter(item => pattern.test(item.text));
+  }
+
+  if (!filtered.length) {
     console.log('  No console entries');
     return;
   }
 
-  for (const item of items) {
+  for (const item of filtered) {
     const ts = formatTimestamp(item.timestamp, model.startTime);
     const source = item.type === 'browser' ? '[browser]' : `[${item.type}]`;
     const level = item.level.padEnd(8);

--- a/tests/mcp/trace-cli.spec.ts
+++ b/tests/mcp/trace-cli.spec.ts
@@ -161,6 +161,14 @@ test('trace console --errors-only', async ({ runTraceCli }) => {
   expect(stdout).not.toContain('info message');
 });
 
+test('trace console --grep filters by message text', async ({ runTraceCli }) => {
+  const { stdout, exitCode } = await runTraceCli(['console', '--grep', 'warning']);
+  expect(exitCode).toBe(0);
+  expect(stdout).toContain('warning message');
+  expect(stdout).not.toContain('info message');
+  expect(stdout).not.toContain('error message');
+});
+
 test('trace errors', async ({ runTraceCli }) => {
   const { stdout, exitCode } = await runTraceCli(['errors']);
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- Add `--grep <pattern>` to `trace console`, filtering by console/stdio message text with the same case-insensitive regex behavior as `trace requests --grep`
- Update SKILL.md docs

Fixes https://github.com/microsoft/playwright/issues/42216