### PR TITLE
feat(install): add --no-remove option to keep unused browsers

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -1146,7 +1146,23 @@ mvn test
 
 Playwright keeps track of the clients that use its browsers. When there are no more clients that require a particular version of the browser, that version is deleted from the system. That way you can safely use Playwright instances of different versions and at the same time, you don't waste disk space for the browsers that are no longer in use.
 
-To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BROWSER_GC=1` environment variable.
+To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BROWSER_GC=1` environment variable, or pass the `--no-remove` option to the install command:
+
+```bash js
+npx playwright install --no-remove
+```
+
+```bash java
+mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --no-remove"
+```
+
+```bash python
+playwright install --no-remove
+```
+
+```bash csharp
+pwsh bin/Debug/netX/playwright.ps1 install --no-remove
+```
 
 ### List all installed browsers:
 

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -220,6 +220,7 @@ npx playwright install --with-deps
 | `--dry-run` | Don't perform installation, just print information |
 | `--only-shell` | Only install chromium-headless-shell instead of full Chromium |
 | `--no-shell` | Don't install chromium-headless-shell |
+| `--no-remove` | Don't remove unused browsers |
 
 #### Install Deps Options
 

--- a/packages/playwright-core/src/cli/installActions.ts
+++ b/packages/playwright-core/src/cli/installActions.ts
@@ -87,7 +87,7 @@ export async function markDockerImage(dockerImageNameTemplate: string) {
   await writeDockerVersion(dockerImageNameTemplate);
 }
 
-export async function installBrowsers(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean, progress?: boolean }) {
+export async function installBrowsers(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean, progress?: boolean, remove?: boolean }) {
   if (options.progress === false)
     process.env.PLAYWRIGHT_DOWNLOAD_NO_PROGRESS = '1';
   if (isLikelyNpxGlobal()) {
@@ -134,7 +134,7 @@ export async function installBrowsers(args: string[], options: { withDeps?: bool
     const browsers = await registry.listInstalledBrowsers();
     printGroupedByPlaywrightVersion(browsers);
   } else {
-    await registry.install(executables, { force: options.force });
+    await registry.install(executables, { force: options.force, gc: options.remove });
     await registry.validateHostRequirementsForExecutablesIfNeeded(executables, process.env.PW_LANG_NAME || 'javascript').catch((e: Error) => {
       e.name = 'Playwright Host validation warning';
       console.error(e);

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -82,7 +82,8 @@ export function decorateProgram(program: Command) {
       .option('--only-shell', 'only install headless shell when installing chromium')
       .option('--no-shell', 'do not install chromium headless shell')
       .option('--no-progress', 'do not show download progress bars')
-      .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean, progress?: boolean }) {
+      .option('--no-remove', 'do not remove unused browsers')
+      .action(async function(args: string[], options: { withDeps?: boolean, force?: boolean, dryRun?: boolean, list?: boolean, shell?: boolean, noShell?: boolean, onlyShell?: boolean, progress?: boolean, remove?: boolean }) {
         try {
           await installBrowsers(args, options);
         } catch (e) {

--- a/tests/installation/playwright-cli-install-should-work.spec.ts
+++ b/tests/installation/playwright-cli-install-should-work.spec.ts
@@ -15,6 +15,7 @@
  */
 import { test, expect } from './npmTest';
 import { chromium } from '@playwright/test';
+import fs from 'fs';
 import path from 'path';
 import http from 'http';
 import https from 'https';
@@ -162,6 +163,20 @@ test('install command should work with HTTPS proxy for HTTP downloads', async ({
   });
   expect(requestCount).toBeGreaterThan(0);
   httpsProxyServer.close();
+});
+
+test('install --no-remove should keep unused browsers', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42214' } }, async ({ exec, _browsersPath }) => {
+  await exec('npm i playwright');
+  const staleDirectory = path.join(_browsersPath, 'webkit-1000');
+  await fs.promises.mkdir(staleDirectory, { recursive: true });
+
+  const result = await exec('npx playwright install ffmpeg --no-remove');
+  expect(result).not.toContain('Removing unused browser');
+  expect(fs.existsSync(staleDirectory)).toBe(true);
+
+  const result2 = await exec('npx playwright install ffmpeg');
+  expect(result2).toContain('Removing unused browser');
+  expect(fs.existsSync(staleDirectory)).toBe(false);
 });
 
 test('should be able to remove browsers', async ({ exec, checkInstalledSoftwareOnDisk }) => {


### PR DESCRIPTION
## Summary
- Add `--no-remove` option to `playwright install` that skips the removal of unused browsers of other Playwright installations (same effect as `PLAYWRIGHT_SKIP_BROWSER_GC=1`).
- Document the option in `browsers.md` and `test-cli-js.md`, add an installation test.

Fixes https://github.com/microsoft/playwright/issues/42214