### PR TITLE
fix(extension): do not treat orphaned preferences entries as an installed extension

### DIFF
--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -67,15 +67,30 @@ export async function isPlaywrightExtensionInstalled(userDataDir: string): Promi
 
 async function isExtensionInstalledInProfile(profileDir: string): Promise<boolean> {
   // Covers two install shapes: web store drops the extension into <profile>/Extensions/<id>;
-  // `--load-extension` does not, and only shows up as the id inside <profile>/Preferences.
+  // `--load-extension` does not, and only shows up as a settings record in the preferences.
   if (await pathExists(path.join(profileDir, 'Extensions', playwrightExtensionId)))
     return true;
+  // Depending on the platform, `extensions.settings` lives in either Preferences or
+  // Secure Preferences.
+  for (const fileName of ['Preferences', 'Secure Preferences']) {
+    if (await hasExtensionSettingsRecord(path.join(profileDir, fileName)))
+      return true;
+  }
+  return false;
+}
+
+async function hasExtensionSettingsRecord(prefsPath: string): Promise<boolean> {
+  let prefs: any;
   try {
-    const prefs = await fs.promises.readFile(path.join(profileDir, 'Preferences'), 'utf-8');
-    return prefs.includes(`"${playwrightExtensionId}"`);
+    prefs = JSON.parse(await fs.promises.readFile(prefsPath, 'utf-8'));
   } catch {
     return false;
   }
+  // Uninstalling leaves orphaned entries behind: an empty `extensions.settings.<id>` record,
+  // `protection.macs.extensions.settings.<id>` and `updateclientdata.apps.<id>`. Only a
+  // populated settings record indicates an actual installation.
+  const record = prefs?.extensions?.settings?.[playwrightExtensionId];
+  return !!record && typeof record === 'object' && Object.keys(record).length > 0;
 }
 
 async function pathExists(p: string): Promise<boolean> {

--- a/packages/playwright-core/src/tools/utils/extension.ts
+++ b/packages/playwright-core/src/tools/utils/extension.ts
@@ -66,12 +66,11 @@ export async function isPlaywrightExtensionInstalled(userDataDir: string): Promi
 }
 
 async function isExtensionInstalledInProfile(profileDir: string): Promise<boolean> {
-  // Covers two install shapes: web store drops the extension into <profile>/Extensions/<id>;
-  // `--load-extension` does not, and only shows up as a settings record in the preferences.
+  // Web store installs unpack into <profile>/Extensions/<id>; `--load-extension` only
+  // leaves a settings record in the preferences.
   if (await pathExists(path.join(profileDir, 'Extensions', playwrightExtensionId)))
     return true;
-  // Depending on the platform, `extensions.settings` lives in either Preferences or
-  // Secure Preferences.
+  // `extensions.settings` lives in Preferences or Secure Preferences depending on the platform.
   for (const fileName of ['Preferences', 'Secure Preferences']) {
     if (await hasExtensionSettingsRecord(path.join(profileDir, fileName)))
       return true;
@@ -86,9 +85,7 @@ async function hasExtensionSettingsRecord(prefsPath: string): Promise<boolean> {
   } catch {
     return false;
   }
-  // Uninstalling leaves orphaned entries behind: an empty `extensions.settings.<id>` record,
-  // `protection.macs.extensions.settings.<id>` and `updateclientdata.apps.<id>`. Only a
-  // populated settings record indicates an actual installation.
+  // Uninstalling leaves an orphaned empty settings record behind, so require a populated one.
   const record = prefs?.extensions?.settings?.[playwrightExtensionId];
   return !!record && typeof record === 'object' && Object.keys(record).length > 0;
 }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -310,9 +310,8 @@ test(`launches the profile that has the extension`, {
 test(`ignores orphaned preferences entries of an uninstalled extension`, {
   annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1712' },
 }, async ({ startClient, server }, testInfo) => {
-  // Uninstalling the extension leaves orphaned entries in the profile's Preferences (an empty
-  // `extensions.settings.<id>` record, `protection.macs.*` and `updateclientdata.apps.*`). Those
-  // must not be mistaken for an installation, otherwise the wrong profile is launched.
+  // Default has orphaned entries of an uninstalled extension; they must not win over the
+  // actual installation in Profile 1.
   const userDataDir = testInfo.outputPath('multi-profile');
   await fs.mkdir(path.join(userDataDir, 'Default'), { recursive: true });
   await fs.writeFile(path.join(userDataDir, 'Default', 'Preferences'), JSON.stringify({
@@ -320,13 +319,11 @@ test(`ignores orphaned preferences entries of an uninstalled extension`, {
     protection: { macs: { extensions: { settings: { [extensionId]: 'DEADBEEF' } } } },
     updateclientdata: { apps: { [extensionId]: { pv: '0.3.0' } } },
   }));
-  // The extension is actually installed in Profile 1 via `--load-extension`, which only writes a
-  // populated settings record into Preferences.
   await fs.mkdir(path.join(userDataDir, 'Profile 1'), { recursive: true });
   await fs.writeFile(path.join(userDataDir, 'Profile 1', 'Preferences'), JSON.stringify({
     extensions: { settings: { [extensionId]: { path: '/tmp/extension', location: 4 } } },
   }));
-  // Ordering prefers the last used profile; make it the one with the orphaned entries.
+  // Make the profile with the orphaned entries the preferred, last used one.
   await fs.writeFile(path.join(userDataDir, 'Local State'), JSON.stringify({
     profile: { last_used: 'Default' },
   }));

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -307,6 +307,45 @@ test(`launches the profile that has the extension`, {
   }).toPass();
 });
 
+test(`ignores orphaned preferences entries of an uninstalled extension`, {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1712' },
+}, async ({ startClient, server }, testInfo) => {
+  // Uninstalling the extension leaves orphaned entries in the profile's Preferences (an empty
+  // `extensions.settings.<id>` record, `protection.macs.*` and `updateclientdata.apps.*`). Those
+  // must not be mistaken for an installation, otherwise the wrong profile is launched.
+  const userDataDir = testInfo.outputPath('multi-profile');
+  await fs.mkdir(path.join(userDataDir, 'Default'), { recursive: true });
+  await fs.writeFile(path.join(userDataDir, 'Default', 'Preferences'), JSON.stringify({
+    extensions: { settings: { [extensionId]: {} } },
+    protection: { macs: { extensions: { settings: { [extensionId]: 'DEADBEEF' } } } },
+    updateclientdata: { apps: { [extensionId]: { pv: '0.3.0' } } },
+  }));
+  // The extension is actually installed in Profile 1 via `--load-extension`, which only writes a
+  // populated settings record into Preferences.
+  await fs.mkdir(path.join(userDataDir, 'Profile 1'), { recursive: true });
+  await fs.writeFile(path.join(userDataDir, 'Profile 1', 'Preferences'), JSON.stringify({
+    extensions: { settings: { [extensionId]: { path: '/tmp/extension', location: 4 } } },
+  }));
+  // Ordering prefers the last used profile; make it the one with the orphaned entries.
+  await fs.writeFile(path.join(userDataDir, 'Local State'), JSON.stringify({
+    profile: { last_used: 'Default' },
+  }));
+
+  const executablePath = testInfo.outputPath('echo.sh');
+  await fs.writeFile(executablePath, '#!/bin/bash\necho "Custom exec args: $@" > "$(dirname "$0")/output.txt"', { mode: 0o755 });
+
+  const { client } = await startClient({
+    args: [`--extension`, `--executable-path=${executablePath}`],
+    env: { PWTEST_EXTENSION_USER_DATA_DIR: userDataDir },
+  });
+
+  client.callTool({ name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } }).catch(() => {});
+  await expect(async () => {
+    const output = await fs.readFile(testInfo.outputPath('output.txt'), 'utf8');
+    expect(output).toContain(`--profile-directory=Profile 1`);
+  }).toPass();
+});
+
 test(`fails when extension is missing in custom userDataDir`, async ({ startClient, server }) => {
   const userDataDir = test.info().outputPath('empty-profile');
 


### PR DESCRIPTION
## Summary
- Uninstalling the extension leaves orphaned entries in the profile's Preferences (empty `extensions.settings.<id>` record, `protection.macs.*`, `updateclientdata.apps.*`) that matched the substring check, so the wrong profile could be launched.
- Require a populated `extensions.settings.<id>` record instead; also read `Secure Preferences`, where the record lives on Windows/macOS.

Fixes https://github.com/microsoft/playwright-mcp/issues/1712