### PR TITLE
fix(mcp): map browserName to remoteOptions in createRemoteBrowser

### DIFF
--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -125,8 +125,8 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   // eslint-disable-next-line no-restricted-syntax
   const remoteHeaders = (config.browser as any).remoteHeaders as Record<string, string> | undefined;
   const remoteOptions = typeof remote === 'string'
-    ? { endpoint: remote, headers: remoteHeaders }
-    : { ...remote, headers: { ...remoteHeaders, ...remote.headers } };
+    ? { endpoint: remote, headers: remoteHeaders, browserName: config.browser.browserName }
+    : { ...remote, browserName: config.browser.browserName, headers: { ...remoteHeaders, ...remote.headers } };
 
   const descriptor = await serverRegistry.find(remoteOptions.endpoint);
   if (descriptor) {


### PR DESCRIPTION
### Problem

When launching the Playwright MCP server and configuring a remote WebSocket/CDP endpoint (e.g. `playwright-mcp --endpoint ws://127.0.0.1:8082`), initialization fails immediately with:
```
TypeError: async initializeServer: Cannot read properties of undefined (reading 'launch')
```

### Root Cause

In `packages/playwright-core/src/tools/mcp/browserFactory.ts`, `createRemoteBrowser()` maps connection settings to `remoteOptions`. However, the `browserName` parameter is completely omitted:
```typescript
const remoteOptions = typeof remote === 'string'
  ? { endpoint: remote, headers: remoteHeaders }
  : { ...remote, headers: { ...remoteHeaders, ...remote.headers } };
```

Because `browserName` is missing from `remoteOptions`, the underlying `connectToBrowser()` utility does not populate the `"x-playwright-browser"` header in the WebSocket request handshake. 
When the upstream browser server accepts the connection, its internal `initializeServer()` function parses the requested browser type as `undefined`, leading to a crash when it tries to call `launch()` on the undefined browser instance (i.e., `this._playwright[undefined].launch()`).

### Solution

Forward `browserName: config.browser.browserName` within `remoteOptions` so that the `"x-playwright-browser"` header is correctly transmitted in the WebSocket connection.