### PR TITLE
fix(mcp): report the actual remote browser name in browserInfo

### DIFF
--- a/packages/playwright-core/src/tools/index.ts
+++ b/packages/playwright-core/src/tools/index.ts
@@ -25,7 +25,7 @@ export { createConnection } from './mcp/index';
 export { resolveCLIConfigForCLI, resolveCLIConfigForMCP } from './mcp/config';
 export { outputDir } from './backend/context';
 export { isSystemDirectory } from '@utils/fileUtils';
-export { isProfileLocked } from './mcp/browserFactory';
+export { createBrowserWithInfo, isProfileLocked } from './mcp/browserFactory';
 export { compareSemver } from './utils/socketConnection';
 export { extractTrace, DirTraceLoaderBackend } from './trace/traceParser';
 export { decorateMCPCommand } from './mcp/program';

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -152,7 +152,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
   // created, so create one when attaching to such a server.
   if (!browser.contexts().length)
     await browser.newContext(config.browser.contextOptions);
-  return { browser, browserInfo: browserInfo(browser, config), canBind: false, ownership: 'attached' };
+  return { browser, browserInfo: { ...browserInfo(browser, config), browserName: browser._browserName }, canBind: false, ownership: 'attached' };
 }
 
 async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {

--- a/tests/mcp/remote-endpoint.spec.ts
+++ b/tests/mcp/remote-endpoint.spec.ts
@@ -16,6 +16,10 @@
 
 import { test, expect } from './fixtures';
 
+import { tools } from '../../packages/playwright-core/lib/coreBundle';
+
+const { resolveCLIConfigForMCP, createBrowserWithInfo } = tools;
+
 test.skip(({ mcpBrowser }) => mcpBrowser !== 'chromium', 'Run only on the chromium project; the remote server connection is browser-agnostic.');
 
 test('connect without headers fails on run-server endpoint', async ({ startClient, server, runServerEndpoint }) => {
@@ -58,6 +62,18 @@ test('remoteEndpoint accepts ConnectOptions object with headers', async ({ start
   expect(response).toHaveResponse({
     page: expect.stringContaining('Page Title: Title'),
   });
+});
+
+test('browserInfo reports the browser running on the remote endpoint, not the configured one', async ({ wsEndpoint }, testInfo) => {
+  // Empty env to isolate the test from the host environment.
+  const config = await resolveCLIConfigForMCP({ browser: 'firefox', endpoint: wsEndpoint }, {});
+  const { browser, browserInfo } = await createBrowserWithInfo(config, { clientName: 'test-client', cwd: testInfo.outputPath() }, {});
+  try {
+    expect(config.browser.browserName).toBe('firefox');
+    expect(browserInfo.browserName).toBe('chromium');
+  } finally {
+    await browser.close();
+  }
 });
 
 test('back-compat: remoteHeaders config still selects the browser on run-server endpoint', async ({ startClient, server, runServerEndpoint }) => {


### PR DESCRIPTION
## Summary
- When MCP attaches to a remote endpoint, the server decides which browser it runs, which may differ from the configured `browserName`. Report the connected browser's name in `browserInfo` instead of the configured one.
- Add a test attaching to a chromium `launchServer` endpoint with a `firefox` config.

Related discussion: #42226