### PR TITLE
chore(deps): roll chokidar to 4.0.3, drop fsevents optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@vitejs/plugin-basic-ssl": "2.3.0",
         "@vitejs/plugin-react": "6.0.3",
         "@zip.js/zip.js": "2.7.73",
-        "chokidar": "3.6.0",
+        "chokidar": "4.0.3",
         "chromium-bidi": "12.1.0",
         "colors": "1.4.0",
         "commander": "15.0.0",
@@ -4142,28 +4142,19 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chromium-bidi": {
@@ -8092,29 +8083,17 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">= 14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recorder": {
@@ -9341,6 +9320,57 @@
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/vite-plugin-static-copy/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/web": {
       "resolved": "packages/web",
       "link": true
@@ -9646,9 +9676,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "packages/playwright-browser-chromium": {
@@ -9762,20 +9789,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "packages/recorder": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@vitejs/plugin-basic-ssl": "2.3.0",
     "@vitejs/plugin-react": "6.0.3",
     "@zip.js/zip.js": "2.7.73",
-    "chokidar": "3.6.0",
+    "chokidar": "4.0.3",
     "chromium-bidi": "12.1.0",
     "colors": "1.4.0",
     "commander": "15.0.0",

--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -23,6 +23,7 @@ import chokidar from 'chokidar';
 
 import { packageJSON, packageRoot } from './package';
 
+import type { FSWatcher } from 'chokidar';
 // Only client depenencies with backward compatibility guarantees should be imported here.
 import type { LaunchOptions } from '../types/types';
 
@@ -58,7 +59,7 @@ export interface ServerRegistryEvents {
 
 class ServerRegistry extends EventEmitter {
   private _descriptors = new Map<string, BrowserDescriptor>();
-  private _watcher: chokidar.FSWatcher | undefined;
+  private _watcher: FSWatcher | undefined;
   private _watcherRefs = 0;
   private _ready: Promise<void> | undefined;
 

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -51,8 +51,5 @@
   "license": "Apache-2.0",
   "dependencies": {
     "playwright-core": "1.63.0-next"
-  },
-  "optionalDependencies": {
-    "fsevents": "2.3.2"
   }
 }

--- a/packages/playwright/src/runner/fsWatcher.ts
+++ b/packages/playwright/src/runner/fsWatcher.ts
@@ -49,15 +49,23 @@ export class FSWatcher {
     if (!this._watchedPaths.length)
       return;
 
-    const ignored = [...this._ignoredFolders, '**/node_modules/**'];
+    // Chokidar calls the matcher with paths normalized to forward slashes.
+    const ignoredPrefixes = this._ignoredFolders.map(folder => folder.replace(/\\/g, '/') + '/');
+    const ignored = (file: string) => {
+      if (file.split('/').includes('node_modules'))
+        return true;
+      return ignoredPrefixes.some(prefix => (file + '/').startsWith(prefix));
+    };
     this._fsWatcher = chokidar.watch(watchedPaths, { ignoreInitial: true, ignored }).on('all', async (event, file) => {
+      if (event !== 'add' && event !== 'addDir' && event !== 'change' && event !== 'unlink' && event !== 'unlinkDir')
+        return;
       if (this._throttleTimer)
         clearTimeout(this._throttleTimer);
       this._collector.push({ event, file });
       this._throttleTimer = setTimeout(() => this._reportEventsIfAny(), 250);
     });
 
-    await new Promise((resolve, reject) => this._fsWatcher!.once('ready', resolve).once('error', reject));
+    await new Promise<void>((resolve, reject) => this._fsWatcher!.once('ready', () => resolve()).once('error', reject));
   }
 
   async close() {

--- a/tests/installation/bundle-licenses.spec.ts
+++ b/tests/installation/bundle-licenses.spec.ts
@@ -24,8 +24,8 @@ import { test, expect } from './npmTest';
 // summary and is only checked for presence.
 const EXPECTED: Record<string, Record<string, number>> = {
   'playwright-core': {
-    'lib/serverRegistry.js.LICENSE': 10,
-    'lib/utilsBundle.js.LICENSE': 80,
+    'lib/serverRegistry.js.LICENSE': 2,
+    'lib/utilsBundle.js.LICENSE': 75,
     // Vendored WebP codec (libwebp compiled to WASM), not a bundle sidecar.
     'lib/webp_codec.LICENSE': 0,
   },

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -22,6 +22,7 @@ const chokidar = require('chokidar');
 const fs = require('fs');
 const { workspace } = require('../workspace');
 const { build, context } = require('esbuild');
+const { minimatch } = require('minimatch');
 
 /**
  * @typedef {{
@@ -77,6 +78,43 @@ const ROOT = path.join(__dirname, '..', '..');
  */
 function filePath(relative) {
   return path.join(ROOT, ...relative.split('/'));
+}
+
+/**
+ * @param {string} p
+ * @returns {string}
+ */
+function toPosixPath(p) {
+  return p.split(path.sep).join('/');
+}
+
+/**
+ * Chokidar v4 dropped glob support: watch the static directory prefix of a
+ * glob instead, and filter emitted paths with `pathMatcher`.
+ * @param {string} pattern
+ * @returns {string}
+ */
+function globBase(pattern) {
+  const magicIndex = pattern.search(/[*?{[]/);
+  if (magicIndex === -1)
+    return pattern;
+  return pattern.slice(0, pattern.lastIndexOf(path.sep, magicIndex));
+}
+
+/**
+ * @param {string[]} patterns absolute files, directories or globs
+ * @returns {(file: string) => boolean}
+ */
+function pathMatcher(patterns) {
+  const posixPatterns = patterns.map(toPosixPath);
+  return file => {
+    const posixFile = toPosixPath(file);
+    return posixPatterns.some(pattern => {
+      if (pattern.search(/[*?{[]/) === -1)
+        return posixFile === pattern || posixFile.startsWith(pattern + '/');
+      return minimatch(posixFile, pattern, { dot: true });
+    });
+  };
 }
 
 /**
@@ -185,14 +223,15 @@ async function runWatch() {
         clearTimeout(timeout);
       timeout = setTimeout(callback, 500);
     };
-    chokidar.watch([...paths, ...mustExist, onChange.script].filter(Boolean).map(filePath)).on('all', reschedule);
+    chokidar.watch([...paths, ...mustExist, onChange.script].filter(Boolean).map(filePath).map(globBase)).on('all', reschedule);
     callback();
   }
 
   for (const { files, from, to, ignored } of copyFiles) {
-    const watcher = chokidar.watch([filePath(files)], { ignored });
+    const matches = pathMatcher([filePath(files)]);
+    const watcher = chokidar.watch(globBase(filePath(files)), { ignored: pathMatcher(ignored || []) });
     watcher.on('all', (event, file) => {
-      if (event === 'add' || event === 'change')
+      if ((event === 'add' || event === 'change') && matches(file))
         copyFile(file, from, to);
     });
   }
@@ -212,11 +251,11 @@ async function runWatch() {
 
 async function runBuild() {
   for (const { files, from, to, ignored } of copyFiles) {
-    const watcher = chokidar.watch([filePath(files)], {
-      ignored
-    });
+    const matches = pathMatcher([filePath(files)]);
+    const watcher = chokidar.watch(globBase(filePath(files)), { ignored: pathMatcher(ignored || []) });
     watcher.on('add', file => {
-      copyFile(file, from, to);
+      if (matches(file))
+        copyFile(file, from, to);
     });
     await new Promise(x => watcher.once('ready', x));
     watcher.close();
@@ -330,9 +369,14 @@ class EsbuildStep extends Step {
     this._context = await context(this._options);
     disposables.push(() => this._context?.dispose());
 
-    const watcher = chokidar.watch([...this._options.entryPoints, ...(this._watchPaths || [])]);
+    const watchPaths = [...this._options.entryPoints, ...(this._watchPaths || [])];
+    const matches = pathMatcher(watchPaths);
+    const watcher = chokidar.watch([...new Set(watchPaths.map(globBase))]);
     await new Promise(x => watcher.once('ready', x));
-    watcher.on('all', () => this._rebuild());
+    watcher.on('all', (event, file) => {
+      if (matches(file))
+        this._rebuild();
+    });
 
     await this._rebuild();
     console.log('==== Esbuild watching:', this._relativeEntryPoints().join(', '), `(started in ${Date.now() - start}ms)`);
@@ -623,7 +667,6 @@ steps.push(new EsbuildStep({
   bundle: true,
   entryPoints: [filePath('packages/playwright-core/src/serverRegistry.js')],
   outfile: filePath('packages/playwright-core/lib/serverRegistry.js'),
-  external: ['fsevents'],
 }, [filePath('packages/playwright-core/src/*')]));
 
 const playwrightCoreSrc = filePath('packages/playwright-core/src');
@@ -634,7 +677,7 @@ steps.push(new EsbuildStep({
   bundle: true,
   entryPoints: [filePath('packages/playwright-core/src/utilsBundle.ts')],
   outfile: filePath('packages/playwright-core/lib/utilsBundle.js'),
-  external: ['fsevents', 'express', '@anthropic-ai/sdk'],
+  external: ['express', '@anthropic-ai/sdk'],
   alias: {
     'raw-body': filePath('utils/build/raw-body.ts'),
   },


### PR DESCRIPTION
## Summary
- Chokidar v4 watches via plain fs.watch instead of fsevents, so the `playwright` package no longer needs its pinned `fsevents` optional dependency.
- Chokidar v4 dropped glob support: the test runner watcher ignores folders via a matcher function, and the build script matches watched paths with minimatch.
- Vendored bundles shrink accordingly (serverRegistry bundle: 13 → 2 inlined packages).

Fixes https://github.com/microsoft/playwright/issues/42235