### PR TITLE
fix(har): do not stall context close when saving the har fails

### DIFF
--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -528,9 +528,11 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     this._closingStatus = 'closing';
     await this.request.dispose(options);
     await this._instrumentation.runBeforeCloseBrowserContext(this);
-    await this.tracing._exportAllHars();
+    const harError = await this.tracing._exportAllHars().catch(e => e);
     await this._channel.close(options, kNoTimeout);
     await this._closedPromise;
+    if (harError)
+      throw harError;
   }
 
   async _enableRecorder(params: channels.BrowserContextEnableRecorderParams, eventSink?: RecorderEventSink) {

--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -554,6 +554,7 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
   }
 
   async close(progress: Progress, options: { reason?: string }) {
+    let flushError: Error | undefined;
     if (this._closedStatus === 'open') {
       if (options.reason)
         this._closeReason = options.reason;
@@ -561,8 +562,8 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       this._closedStatus = 'closing';
 
       await progress.race(Promise.all([
-        this.tracing.flush(),
-        this.fetchRequest.tracing().flush(),
+        this.tracing.flush().catch(e => flushError = flushError ?? e),
+        this.fetchRequest.tracing().flush().catch(e => flushError = flushError ?? e),
       ]));
       await progress.race(Promise.all(this.pages().map(page => page.screencast.handlePageOrContextClose())));
 
@@ -587,6 +588,8 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
         this._didCloseInternal();
     }
     await this._closePromise;
+    if (flushError)
+      throw flushError;
   }
 
   async newPage(progress: Progress, forStorageState?: boolean): Promise<Page> {

--- a/packages/playwright-core/src/server/har/harRecorder.ts
+++ b/packages/playwright-core/src/server/har/harRecorder.ts
@@ -141,9 +141,7 @@ export class HarRecorder implements HarTracerDelegate {
 
   async flush() {
     await this._flush();
-    const error = await this._fs.syncAndGetError();
-    if (error)
-      throw error;
+    await this._fs.sync();
   }
 
   async export(mode: 'archive' | 'entries'): Promise<{ entries?: NameValue[], artifact?: Artifact }> {
@@ -154,9 +152,7 @@ export class HarRecorder implements HarTracerDelegate {
     const zipPath = this._harFilePath + '.zip';
     if (mode === 'archive')
       this._fs.zip(entries, zipPath);
-    const error = await this._fs.syncAndGetError();
-    if (error)
-      throw error;
+    await this._fs.sync();
     if (mode === 'entries')
       return { entries };
     const artifact = new Artifact(this._context, zipPath);

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -337,7 +337,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     this._closeAllGroups();
     this._harTracer.stop();
     this.flushHarEntries();
-    await this._fs.syncAndGetError().finally(() => {
+    await this._fs.sync().finally(() => {
       this._state = undefined;
     });
   }
@@ -363,7 +363,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     this.abort();
     for (const harRecorder of this.harRecorders.values())
       await harRecorder.flush();
-    await this._fs.syncAndGetError();
+    await this._fs.sync();
   }
 
   harStart(page: Page | null, options: RecordHarOptions): string {
@@ -442,7 +442,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
     // Make sure all file operations complete.
     let error: Error | undefined;
     try {
-      await progress.race(this._fs.syncAndGetError());
+      await progress.race(this._fs.sync());
     } catch (e) {
       error = e as Error;
     }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -177,9 +177,7 @@ export class TestTracing {
     if (!this._options)
       return;
 
-    const error = await this._liveTraceFile?.fs.syncAndGetError();
-    if (error)
-      throw error;
+    await this._liveTraceFile?.fs.sync();
 
     if (this._shouldAbandonTrace()) {
       for (const file of this._temporaryTraceFiles)

--- a/packages/utils/serializedFS.ts
+++ b/packages/utils/serializedFS.ts
@@ -86,11 +86,15 @@ export class SerializedFS {
     this._appendOperation({ op: 'copyFile', from, to });
   }
 
-  async syncAndGetError() {
+  async sync() {
     for (const file of this._buffers.keys())
       this._flushFile(file);
     await this._operationsDone;
-    return this._error;
+    if (this._error) {
+      const e = this._error;
+      this._error = undefined;
+      throw e;
+    }
   }
 
   zip(entries: NameValue[], zipFileName: string) {

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -940,6 +940,19 @@ it('should not hang on slow chunked response', async ({ browserName, browser, co
   expect(log.browser!.version).toBe(browser.version());
 });
 
+it('should close the context when saving the har fails', async ({ contextFactory, server }, testInfo) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42231' });
+  const filePath = testInfo.outputPath('not-a-directory');
+  fs.writeFileSync(filePath, 'data');
+  const context = await contextFactory({ recordHar: { path: path.join(filePath, 'test.har') } });
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  const closed = new Promise(f => context.on('close', f));
+  await expect(context.close()).rejects.toThrow(/ENOTDIR|ENOENT|EEXIST/);
+  await closed;
+  await context.close();
+});
+
 it('should support HAR larger than 512MB', async ({ contextFactory, server, browserName }, testInfo) => {
   it.skip(browserName !== 'chromium', 'serializer is browser-agnostic; one browser is enough');
   it.slow();


### PR DESCRIPTION
## Summary
- A HAR save error no longer aborts `browserContext.close()` midway: the context now always closes, and the error is thrown after the close completes. Previously the context was left in a permanent 'closing' state, stalling teardown.
- `SerializedFS.syncAndGetError()` is replaced with `sync()` that throws the first error once, so callers cannot accidentally drop it and the error does not stick forever.

Fixes https://github.com/microsoft/playwright/issues/42231