### PR TITLE
feat(agents): add Cursor support to init-agents and init-skills

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -41,13 +41,17 @@ When using a bundled entry point, replace `playwright-cli` with `npx playwright 
 
 ### Installing skills
 
-Coding agents like Claude Code and GitHub Copilot can use locally installed skills for richer context about available commands:
+Coding agents like Claude Code, Cursor, and GitHub Copilot can use locally installed skills for richer context about available commands:
 
 ```bash
 playwright-cli install --skills
 ```
 
-To share the skills across all your projects, add the `-g` flag to install them into your home directory (`~/.claude/skills` or, with `--skills=agents`, `~/.agents/skills`):
+To share the skills across all your projects, add the `-g` flag to install them into your home directory:
+
+- Default: `~/.claude/skills`
+- `--skills=agents`: `~/.agents/skills`
+- `--skills=cursor`: `~/.cursor/skills`
 
 ```bash
 playwright-cli install --skills -g

--- a/docs/src/test-agents-js.md
+++ b/docs/src/test-agents-js.md
@@ -47,8 +47,19 @@ npx playwright init-agents --loop=codex
 npx playwright init-agents --loop=opencode
 ```
 
+```bash tab=bash-cursor
+npx playwright init-agents --loop=cursor
+```
+
 :::note
 VS Code v1.105 (released October 9, 2025) is needed for the agentic experience to function properly in VS Code.
+:::
+
+:::note
+Cursor's native subagents inherit whatever MCP tools are available to the parent agent rather than
+supporting a documented per-agent tool allowlist. As a result, the generated **🎭 planner**, **🎭
+generator** and **🎭 healer** subagents can all see the full Playwright Test MCP tool set in Cursor,
+and rely on their instructions to stay within their intended workflow.
 :::
 
 Once the agents have been generated, you can use your AI tool of choice to command these agents to build Playwright Tests. 

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -1113,7 +1113,7 @@ const install = declareCommand({
   category: 'install',
   args: z.object({}),
   options: z.object({
-    skills: z.string().optional().describe('Install skills, possible values: claude (default), agents.'),
+    skills: z.string().optional().describe('Install skills, possible values: claude (default), agents, cursor.'),
     global: z.boolean().optional().describe('Install skills into the home directory instead of the workspace (alias: -g). Requires --skills.'),
   }),
   toolName: '',

--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -27,7 +27,7 @@ import { setupExitWatchdog } from '../mcp/watchdog';
 import { createBrowserWithInfo } from '../mcp/browserFactory';
 import * as configUtils from '../mcp/config';
 import { createClientInfo } from '../cli-client/registry';
-import { installSkills } from '../utils/installSkills';
+import { installSkills, resolveSkillTarget } from '../utils/installSkills';
 import { registry as browserRegistry } from '../../server/registry/index';
 import type { Command } from 'commander';
 
@@ -44,8 +44,8 @@ export function decorateProgram(program: Command) {
       .option('--cdp <url>', 'connect to an existing browser via CDP endpoint URL')
       .option('--endpoint <endpoint>', 'attach to a running Playwright browser endpoint')
       .option('--init-workspace', 'initialize workspace')
-      .option('--init-skills <value>', 'install skills for the given agent type ("claude" or "agents")')
-      .option('--init-skills-global <value>', 'install skills for the given agent type ("claude" or "agents") into the home directory')
+      .option('--init-skills <value>', 'install skills for the given agent type ("claude", "agents", or "cursor")')
+      .option('--init-skills-global <value>', 'install skills for the given agent type ("claude", "agents", or "cursor") into the home directory')
 
       .action(async (sessionName: string, options: any) => {
         if (options.initWorkspace) {
@@ -97,7 +97,7 @@ export async function initWorkspace(initSkills: string | undefined, initSkillsGl
 
   const skills = initSkillsGlobal ?? initSkills;
   if (skills) {
-    const target = skills === 'agents' ? 'agents' : 'claude';
+    const target = resolveSkillTarget(skills);
     try {
       await installSkills(['playwright-cli'], target, { global: globalSkills });
     } catch (error) {

--- a/packages/playwright-core/src/tools/utils/installSkills.ts
+++ b/packages/playwright-core/src/tools/utils/installSkills.ts
@@ -23,9 +23,16 @@ import path from 'path';
 import { libPath } from '../../package';
 
 export const allSkills = ['playwright-cli', 'playwright-component-testing', 'playwright-trace'] as const;
+export const skillTargets = ['claude', 'agents', 'cursor'] as const;
 
 export type SkillName = typeof allSkills[number];
-export type SkillTarget = 'claude' | 'agents';
+export type SkillTarget = typeof skillTargets[number];
+
+export function resolveSkillTarget(value: string | undefined): SkillTarget {
+  if (value === 'agents' || value === 'cursor')
+    return value;
+  return 'claude';
+}
 
 export async function installSkills(skills: readonly SkillName[], target: SkillTarget = 'claude', options?: { global?: boolean }) {
   const cwd = process.cwd();

--- a/packages/playwright/src/agents/generateAgents.ts
+++ b/packages/playwright/src/agents/generateAgents.ts
@@ -35,6 +35,14 @@ async function loadAgentSpecs(): Promise<AgentSpec[]> {
   return Promise.all(files.filter(file => file.endsWith('.agent.md')).map(file => parseAgentSpec(path.join(__dirname, file))));
 }
 
+// On Windows, npx resolves to npx.cmd which cannot be executed without shell: true.
+// See: https://code.claude.com/docs/en/mcp#dynamic-tool-updates
+function playwrightTestMcpServer(): { command: string, args: string[] } {
+  return process.platform === 'win32'
+    ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
+    : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
+}
+
 export class ClaudeGenerator {
   static async init(fullConfig: FullConfigInternal, projectName: string, prompts: boolean) {
     await initRepo(fullConfig, projectName, {
@@ -47,11 +55,7 @@ export class ClaudeGenerator {
     for (const agent of agents)
       await writeFile(`.claude/agents/${agent.name}.md`, ClaudeGenerator.agentSpec(agent), '🤖', 'agent definition');
 
-    // On Windows, npx resolves to npx.cmd which cannot be executed without shell: true.
-    // See: https://code.claude.com/docs/en/mcp#dynamic-tool-updates
-    const mcpServer = process.platform === 'win32'
-      ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
-      : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
+    const mcpServer = playwrightTestMcpServer();
     await writeFile('.mcp.json', JSON.stringify({
       mcpServers: {
         'playwright-test': mcpServer,
@@ -125,9 +129,7 @@ export class CodexGenerator {
     }
 
     const sandboxMode = agent.tools.includes('edit') ? 'workspace-write' : 'read-only';
-    const mcpServer = process.platform === 'win32'
-      ? { command: 'cmd', args: ['/c', 'npx', 'playwright', 'run-test-mcp-server'] }
-      : { command: 'npx', args: ['playwright', 'run-test-mcp-server'] };
+    const mcpServer = playwrightTestMcpServer();
 
     const examples = agent.examples.length
       ? ` Examples: ${agent.examples.map(example => `<example>${example}</example>`).join('')}`
@@ -145,6 +147,62 @@ export class CodexGenerator {
     if (enabledTools.length)
       lines.push(`enabled_tools = ${tomlArray(enabledTools)}`);
     lines.push('');
+    return lines.join('\n');
+  }
+}
+
+export class CursorGenerator {
+  static async init(fullConfig: FullConfigInternal, projectName: string, prompts: boolean) {
+    await initRepo(fullConfig, projectName, {
+      promptsFolder: prompts ? '.cursor/commands' : undefined,
+    });
+
+    const agents = await loadAgentSpecs();
+
+    await fs.promises.mkdir('.cursor/agents', { recursive: true });
+    for (const agent of agents)
+      await writeFile(`.cursor/agents/${agent.name}.md`, CursorGenerator.agentSpec(agent), '🤖', 'agent definition');
+
+    await CursorGenerator.appendToMCPJson();
+
+    initRepoDone();
+  }
+
+  static async appendToMCPJson() {
+    await fs.promises.mkdir('.cursor', { recursive: true });
+
+    const mcpJsonPath = '.cursor/mcp.json';
+    let mcpJson: any = { mcpServers: {} };
+    try {
+      mcpJson = JSON.parse(fs.readFileSync(mcpJsonPath, 'utf8'));
+    } catch {
+    }
+
+    if (!mcpJson.mcpServers)
+      mcpJson.mcpServers = {};
+
+    mcpJson.mcpServers['playwright-test'] = {
+      type: 'stdio',
+      ...playwrightTestMcpServer(),
+    };
+    await writeFile(mcpJsonPath, JSON.stringify(mcpJson, null, 2), '🔧', 'mcp configuration');
+  }
+
+  // Cursor subagents do not support a documented per-agent MCP tool allowlist
+  // (unlike Claude/Codex/VSCode), so no `tools:` field is emitted here. See
+  // https://docs.cursor.com for the current state of subagent frontmatter.
+  static agentSpec(agent: AgentSpec): string {
+    const examples = agent.examples.length ? ` Examples: ${agent.examples.map(example => `<example>${example}</example>`).join('')}` : '';
+    const header = {
+      name: agent.name,
+      description: agent.description + examples,
+      model: 'inherit',
+    };
+    const lines: string[] = [];
+    lines.push(`---`);
+    lines.push(yaml.stringify(header, { lineWidth: 100000 }) + `---`);
+    lines.push('');
+    lines.push(agent.instructions);
     return lines.join('\n');
   }
 }

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -26,7 +26,7 @@ import { builtInReporters, config, configLoader } from './common';
 import { runTests, clearCache, runTestServerAction } from './cli/testActions';
 import { showReport, mergeReports } from './cli/reportActions';
 import { TestServerBackend, testServerBackendTools } from './mcp/test/testBackend';
-import { ClaudeGenerator, CodexGenerator, OpencodeGenerator, VSCodeGenerator, CopilotGenerator } from './agents/generateAgents';
+import { ClaudeGenerator, CodexGenerator, CursorGenerator, OpencodeGenerator, VSCodeGenerator, CopilotGenerator } from './agents/generateAgents';
 import { packageRoot, packageJSON } from './package';
 
 export { program };
@@ -162,7 +162,7 @@ function addInitAgentsCommand(program: Command) {
   const command = program.command('init-agents');
   command.description('Initialize repository agents');
   const option = command.createOption('--loop <loop>', 'Agentic loop provider');
-  option.choices(['claude', 'codex', 'copilot', 'opencode', 'vscode', 'vscode-legacy']);
+  option.choices(['claude', 'codex', 'copilot', 'cursor', 'opencode', 'vscode', 'vscode-legacy']);
   command.addOption(option);
   command.option('-c, --config <file>', `Configuration file to find a project to use for seed test`);
   command.option('--project <project>', 'Project to use for seed test');
@@ -177,6 +177,8 @@ function addInitAgentsCommand(program: Command) {
       await ClaudeGenerator.init(loadedConfig, opts.project, opts.prompts);
     } else if (opts.loop === 'codex') {
       await CodexGenerator.init(loadedConfig, opts.project, opts.prompts);
+    } else if (opts.loop === 'cursor') {
+      await CursorGenerator.init(loadedConfig, opts.project, opts.prompts);
     } else {
       await CopilotGenerator.init(loadedConfig, opts.project, opts.prompts);
       return;
@@ -188,7 +190,7 @@ function addInitSkillsCommand(program: Command) {
   const command = program.command('init-skills');
   command.description('Install Playwright agent skills');
   const option = command.createOption('--loop <loop>', 'Agentic loop provider');
-  option.choices(['claude', 'agents']);
+  option.choices(['claude', 'agents', 'cursor']);
   option.default('claude');
   command.addOption(option);
   command.action(async opts => {

--- a/tests/mcp/cli-misc.spec.ts
+++ b/tests/mcp/cli-misc.spec.ts
@@ -60,6 +60,14 @@ test('install workspace w/--skills=agents', async ({ cli }, testInfo) => {
   expect(fs.existsSync(skillFile)).toBe(true);
 });
 
+test('install workspace w/--skills=cursor', async ({ cli }, testInfo) => {
+  const { output } = await cli('install', '--skills=cursor');
+  expect(output).toContain(`Skill installed to \`.cursor${path.sep}skills${path.sep}playwright-cli\`.`);
+
+  const skillFile = testInfo.outputPath('.cursor', 'skills', 'playwright-cli', 'SKILL.md');
+  expect(fs.existsSync(skillFile)).toBe(true);
+});
+
 test('install w/--skills -g installs into the home directory', async ({ cli }, testInfo) => {
   const fakeHome = testInfo.outputPath('fake-home');
   await fs.promises.mkdir(fakeHome, { recursive: true });

--- a/tests/mcp/init-agents.spec.ts
+++ b/tests/mcp/init-agents.spec.ts
@@ -122,6 +122,86 @@ test('codex generates agent toml files', async ({  }) => {
   expect(healerToml).toMatch(/enabled_tools = \[[^\]]*"test_debug"[^\]]*\]/);
 });
 
+test('cursor generates agent files and mcp config', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor'] });
+
+  const agentsDir = path.join(baseDir, '.cursor', 'agents');
+  for (const name of ['playwright-test-planner', 'playwright-test-generator', 'playwright-test-healer']) {
+    const filePath = path.join(agentsDir, `${name}.md`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain(`name: ${name}`);
+    expect(content).toContain('model: inherit');
+    expect(content).not.toContain('tools:');
+    expect(content.trim().split('\n').length).toBeGreaterThan(3);
+  }
+
+  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.cursor', 'mcp.json'), 'utf-8'));
+  expect(mcpJson.mcpServers['playwright-test'].type).toBe('stdio');
+  if (process.platform === 'win32') {
+    expect(mcpJson.mcpServers['playwright-test'].command).toBe('cmd');
+    expect(mcpJson.mcpServers['playwright-test'].args).toEqual(['/c', 'npx', 'playwright', 'run-test-mcp-server']);
+  } else {
+    expect(mcpJson.mcpServers['playwright-test'].command).toBe('npx');
+    expect(mcpJson.mcpServers['playwright-test'].args).toEqual(['playwright', 'run-test-mcp-server']);
+  }
+});
+
+test('cursor preserves existing mcp servers', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+    '.cursor/mcp.json': JSON.stringify({
+      mcpServers: {
+        'existing': { type: 'stdio', command: 'existing-server', args: [] },
+      },
+    }),
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor'] });
+
+  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.cursor', 'mcp.json'), 'utf-8'));
+  expect(mcpJson.mcpServers['existing'].command).toBe('existing-server');
+  expect(mcpJson.mcpServers['playwright-test']).toBeTruthy();
+});
+
+test('cursor generates prompts with --prompts', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor', '--prompts'] });
+
+  const commandsDir = path.join(baseDir, '.cursor', 'commands');
+  expect(fs.existsSync(commandsDir)).toBe(true);
+  expect(fs.readdirSync(commandsDir).length).toBeGreaterThan(0);
+});
+
+test('cursor does not generate commands without --prompts', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor'] });
+
+  expect(fs.existsSync(path.join(baseDir, '.cursor', 'commands'))).toBe(false);
+});
+
+test('cursor generation is idempotent', async ({  }) => {
+  const baseDir = await writeFiles({
+    'playwright.config.ts': `module.exports = {};`,
+  });
+
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor'] });
+  await runInitAgents({ cwd: baseDir, args: ['--loop', 'cursor'] });
+
+  const mcpJson = JSON.parse(fs.readFileSync(path.join(baseDir, '.cursor', 'mcp.json'), 'utf-8'));
+  expect(Object.keys(mcpJson.mcpServers)).toEqual(['playwright-test']);
+});
+
 test('init-skills installs all skills', async ({  }) => {
   const baseDir = await writeFiles({});
 
@@ -139,4 +219,14 @@ test('init-skills installs into .agents with --loop agents', async ({  }) => {
 
   for (const skill of ['playwright-cli', 'playwright-component-testing', 'playwright-trace'])
     expect(fs.existsSync(path.join(baseDir, '.agents', 'skills', skill, 'SKILL.md'))).toBe(true);
+});
+
+test('init-skills installs into .cursor with --loop cursor', async ({  }) => {
+  const baseDir = await writeFiles({});
+
+  await spawnAsync('npx', ['playwright', 'init-skills', '--loop', 'cursor'], { cwd: baseDir, shell: true });
+
+  for (const skill of ['playwright-cli', 'playwright-component-testing', 'playwright-trace'])
+    expect(fs.existsSync(path.join(baseDir, '.cursor', 'skills', skill, 'SKILL.md'))).toBe(true);
+  expect(fs.existsSync(path.join(baseDir, '.cursor', 'skills', 'playwright-cli', 'references', 'tracing.md'))).toBe(true);
 });


### PR DESCRIPTION
I recently joined a team that uses Cursor almost exclusively, and hit this gap firsthand — `init-agents` had no Cursor target, so this closes that.

## Summary
- Add a `CursorGenerator` that reuses the canonical planner/generator/healer agent specs to produce native Cursor subagents under `.cursor/agents`
- Merge the Playwright Test MCP server into `.cursor/mcp.json`, preserving any existing entries
- Write reusable commands to `.cursor/commands` when `--prompts` is passed
- Add `cursor` as an `init-skills` loop and `playwright-cli install --skills` target, installing into `.cursor/skills`

## Compatibility note
Cursor's native subagents currently inherit whatever MCP tools are available to the parent agent rather than supporting a documented per-agent tool allowlist. No unsupported `tools:` frontmatter is generated as a result; this is documented in the Test Agents guide.

Fixes https://github.com/microsoft/playwright/issues/41563