### PR TITLE
chore(expect): pass expect title explicitly to library calls

### DIFF
--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -193,7 +193,10 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
       return await func(existingApiZone);
 
     const stackTrace = captureLibraryStackTrace();
-    const apiZone: ApiZone = { title: options?.title, apiName: stackTrace.apiName, frames: stackTrace.frames, internal: options?.internal ?? false, reported: false, userData: undefined, stepId: undefined };
+    let apiName = stackTrace.apiName;
+    if (apiName.startsWith('_') || apiName.includes('._'))
+      apiName = options?.title ?? apiName;
+    const apiZone: ApiZone = { title: options?.title, apiName, frames: stackTrace.frames, internal: options?.internal ?? false, reported: false, userData: undefined, stepId: undefined };
 
     try {
       const result = await currentZone().with('apiZone', apiZone).run(async () => await func(apiZone));

--- a/packages/playwright-core/src/client/clientInstrumentation.ts
+++ b/packages/playwright-core/src/client/clientInstrumentation.ts
@@ -20,9 +20,8 @@ import type { StackFrame } from './channels';
 import type { Page } from './page';
 import type { BrowserContextOptions } from './types';
 
-// Instrumentation can mutate the data, for example change apiName or stepId.
+// Instrumentation can mutate the data, for example change the stepId.
 export interface ApiCallData {
-  apiName: string;
   title?: string;
   frames: StackFrame[];
   userData: any;

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -514,31 +514,33 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
     return (await this._channel.title({}, kNoTimeout)).value;
   }
 
-  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'> & { timeout: number, signal?: AbortSignal }): Promise<ExpectResult> {
-    const { timeout, signal, ...rest } = options;
-    const params: channels.FrameExpectParams = { expression, ...rest, isNot: !!rest.isNot };
-    params.expectedValue = serializeArgument(rest.expectedValue);
-    try {
-      await this._channel.expect(params, { signal, timeout });
-      return { matches: !params.isNot };
-    } catch (e) {
-      if (e instanceof AbortError)
-        return { matches: !!params.isNot, errorMessage: 'Error: ' + assertionAbortedMessage(e.cause) };
-      if (!(e instanceof PlaywrightError))
-        throw e;
-      const details = e.details as channels.FrameExpectErrorDetails;
-      const received = details.received ? {
-        value: details.received.value !== undefined ? parseResult(details.received.value) : undefined,
-        ariaSnapshot: details.received.ariaSnapshot,
-      } : undefined;
-      return {
-        matches: !!params.isNot,
-        received,
-        log: e.log,
-        timedOut: details.timedOut,
-        errorMessage: details.customErrorMessage ? 'Error: ' + details.customErrorMessage : undefined,
-      };
-    }
+  async _expect(expression: string, options: Omit<channels.FrameExpectParams, 'expression'> & { timeout: number, signal?: AbortSignal, title?: string }): Promise<ExpectResult> {
+    const { timeout, signal, title, ...rest } = options;
+    return await this._wrapApiCall(async () => {
+      const params: channels.FrameExpectParams = { expression, ...rest, isNot: !!rest.isNot };
+      params.expectedValue = serializeArgument(rest.expectedValue);
+      try {
+        await this._channel.expect(params, { signal, timeout });
+        return { matches: !params.isNot };
+      } catch (e) {
+        if (e instanceof AbortError)
+          return { matches: !!params.isNot, errorMessage: 'Error: ' + assertionAbortedMessage(e.cause) };
+        if (!(e instanceof PlaywrightError))
+          throw e;
+        const details = e.details as channels.FrameExpectErrorDetails;
+        const received = details.received ? {
+          value: details.received.value !== undefined ? parseResult(details.received.value) : undefined,
+          ariaSnapshot: details.received.ariaSnapshot,
+        } : undefined;
+        return {
+          matches: !!params.isNot,
+          received,
+          log: e.log,
+          timedOut: details.timedOut,
+          errorMessage: details.customErrorMessage ? 'Error: ' + details.customErrorMessage : undefined,
+        };
+      }
+    }, { title });
   }
 }
 

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -84,6 +84,7 @@ export type ExpectScreenshotOptions = Omit<channels.PageExpectScreenshotOptions,
   signal?: AbortSignal,
   isNot: boolean,
   mask?: api.Locator[],
+  title?: string,
 };
 
 export class Page extends ChannelOwner<channels.PageChannel> implements api.Page {
@@ -650,31 +651,33 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
   }
 
   async _expectScreenshot(options: ExpectScreenshotOptions): Promise<{ actual?: Buffer, previous?: Buffer, diff?: Buffer, errorMessage?: string, log?: string[], timedOut?: boolean}> {
-    const { timeout, signal, ...optionsWithoutTimeout } = options;
-    const mask = options?.mask ? options?.mask.map(locator => ({
-      frame: (locator as Locator)._frame._channel,
-      selector: (locator as Locator)._selector,
-    })) : undefined;
-    const locator = options.locator ? {
-      frame: (options.locator as Locator)._frame._channel,
-      selector: (options.locator as Locator)._selector,
-    } : undefined;
-    try {
-      const result = await this._channel.expectScreenshot({
-        ...optionsWithoutTimeout,
-        isNot: !!options.isNot,
-        locator,
-        mask,
-      }, { timeout, signal });
-      return { actual: result.actual };
-    } catch (e) {
-      if (e instanceof AbortError)
-        return { errorMessage: 'Error: ' + assertionAbortedMessage(e.cause) };
-      if (!(e instanceof PlaywrightError))
-        throw e;
-      const details = e.details as channels.PageExpectScreenshotErrorDetails;
-      return { ...details, errorMessage: details.customErrorMessage };
-    }
+    const { timeout, signal, title, ...optionsWithoutTimeout } = options;
+    return await this._wrapApiCall(async () => {
+      const mask = options?.mask ? options?.mask.map(locator => ({
+        frame: (locator as Locator)._frame._channel,
+        selector: (locator as Locator)._selector,
+      })) : undefined;
+      const locator = options.locator ? {
+        frame: (options.locator as Locator)._frame._channel,
+        selector: (options.locator as Locator)._selector,
+      } : undefined;
+      try {
+        const result = await this._channel.expectScreenshot({
+          ...optionsWithoutTimeout,
+          isNot: !!options.isNot,
+          locator,
+          mask,
+        }, { timeout, signal });
+        return { actual: result.actual };
+      } catch (e) {
+        if (e instanceof AbortError)
+          return { errorMessage: 'Error: ' + assertionAbortedMessage(e.cause) };
+        if (!(e instanceof PlaywrightError))
+          throw e;
+        const details = e.details as channels.PageExpectScreenshotErrorDetails;
+        return { ...details, errorMessage: details.customErrorMessage };
+      }
+    }, { title });
   }
 
   async title(): Promise<string> {

--- a/packages/playwright-core/src/client/types.ts
+++ b/packages/playwright-core/src/client/types.ts
@@ -149,4 +149,4 @@ export type AnnotateOptions = { duration?: number, position?: AnnotatePosition, 
 export type RemoteAddr = channels.RemoteAddr;
 export type SecurityDetails = channels.SecurityDetails;
 
-export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any, timeout: number, signal?: AbortSignal };
+export type FrameExpectParams = Omit<channels.FrameExpectParams, 'selector'|'expression'|'expectedValue'> & { expectedValue?: any, timeout: number, signal?: AbortSignal, title?: string };

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -97,18 +97,16 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
     const csiListener: ClientInstrumentationListener = {
       onApiCallBegin: (data, channel) => {
         const testInfo = globals.currentTestInfo();
-        // Some special calls do not get into steps.
-        if (!testInfo || data.apiName.includes('setTestIdAttribute') || data.apiName === 'tracing.groupEnd')
+        if (!testInfo)
           return;
+        if (channel.type === 'Tracing' && channel.method === 'tracingGroupEnd') {
+          // The "tracing.group" step ends together with the "tracing.groupEnd" call.
+          data.userData = (error?: Error) => tracingGroupSteps.pop()?.complete({ error });
+          return;
+        }
         const zone = currentZone().data<TestStepInternal>('stepZone');
-        const isExpectCall = data.apiName === 'locator._expect' || data.apiName === 'frame._expect' || data.apiName === 'page._expectScreenshot';
+        const isExpectCall = (channel.type === 'Frame' && channel.method === 'expect') || (channel.type === 'Page' && channel.method === 'expectScreenshot');
         if (zone && zone.category === 'expect' && isExpectCall) {
-          // Display the internal locator._expect call under the name of the enclosing expect call,
-          // and connect it to the existing expect step.
-          if (zone.apiName)
-            data.apiName = zone.apiName;
-          if (zone.shortTitle || zone.title)
-            data.title = zone.shortTitle ?? zone.title;
           data.stepId = zone.stepId;
           return;
         }
@@ -118,27 +116,20 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
           location: data.frames[0],
           category: 'pw:api',
           title: renderTitle(channel.type, channel.method, channel.params, data.title),
-          apiName: data.apiName,
           params: channel.params,
           group: getActionGroup({ type: channel.type, method: channel.method }),
         }, tracingGroupSteps[tracingGroupSteps.length - 1]);
-        data.userData = step;
         data.stepId = step.stepId;
-        if (data.apiName === 'tracing.group')
+        if (channel.type === 'Tracing' && channel.method === 'tracingGroup') {
+          // The step will end later, when the corresponding "tracing.groupEnd" call finishes.
           tracingGroupSteps.push(step);
+        } else {
+          data.userData = (error?: Error) => step.complete({ error });
+        }
       },
       onApiCallEnd: data => {
-
-        // "tracing.group" step will end later, when "tracing.groupEnd" finishes.
-        if (data.apiName === 'tracing.group')
-          return;
-        if (data.apiName === 'tracing.groupEnd') {
-          const step = tracingGroupSteps.pop();
-          step?.complete({ error: data.error });
-          return;
-        }
-        const step = data.userData;
-        step?.complete({ error: data.error });
+        const completeStep = data.userData as ((error?: Error) => void) | undefined;
+        completeStep?.(data.error);
       },
       onWillPause: ({ keepTestTimeout }) => {
         if (!keepTestTimeout)

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -101,7 +101,6 @@ interface ExpectStep {
 export interface ExpectTestInfo {
   _addStep(data: {
     category: 'expect';
-    apiName: string;
     title: string;
     shortTitle: string;
     params?: Record<string, any>;
@@ -333,14 +332,12 @@ function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: un
   const defaultTitle = `${info.poll ? 'poll ' : ''}${info.isSoft ? 'soft ' : ''}${info.isNot ? 'not ' : ''}${matcherName}${suffixes.short || ''}`;
   const shortTitle = customMessage || `Expect ${escapeWithQuotes(defaultTitle, '"')}`;
   const longTitle = shortTitle + (suffixes.long || '');
-  const apiName = `expect${info.poll ? '.poll ' : ''}${info.isSoft ? '.soft ' : ''}${info.isNot ? '.not' : ''}.${matcherName}${suffixes.short || ''}`;
 
   // This looks like it is unnecessary, but it isn't - we need to filter
   // out all the frames that belong to the test runner from caught runtime errors.
   const stackFrames = expectConfig().filteredStackTrace(captureRawStack());
   const stepData = {
     category: 'expect' as const,
-    apiName,
     title: longTitle,
     shortTitle,
     location: stackFrames[0],
@@ -370,7 +367,7 @@ function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: un
   try {
     const invoke = () => info.poll
       ? invokePollMatcher(matcherName, info, matcher, actual, args, promise)
-      : invokeMatcher(matcherName, info, matcher, actual, args, promise);
+      : invokeMatcher(matcherName, info, matcher, actual, args, promise, shortTitle);
     const result = step ? currentZone().with('stepZone', step).run(invoke) : invoke();
     if (result instanceof Promise)
       return result.then(finalizer, handleError);
@@ -387,6 +384,7 @@ function invokeMatcher(
   actual: unknown,
   args: any[],
   promise: 'resolves' | 'rejects' | undefined,
+  title: string,
 ): MatcherResult | Promise<MatcherResult> {
   const isNot = !!info.isNot;
   const timeout = info.timeout ?? expectConfig().timeout ?? defaultExpectTimeout;
@@ -396,6 +394,7 @@ function invokeMatcher(
     promise: promise ?? '',
     utils,
     timeout,
+    title,
     equals: throwUnsupportedExpectMatcherError as any,
   };
 

--- a/packages/playwright/src/matchers/matchers.ts
+++ b/packages/playwright/src/matchers/matchers.ts
@@ -42,6 +42,7 @@ import type { URLPattern } from '@isomorphic/urlMatch';
 
 export type ExpectMatcherStateInternal = Omit<ExpectMatcherState, 'utils'> & {
   utils: ExpectMatcherUtils & InternalMatcherUtils;
+  title: string;
 };
 
 type ExpectedTextValue = {
@@ -86,7 +87,7 @@ export function toBeAttached(
   const expected = attached ? 'attached' : 'detached';
   const arg = attached ? '' : '{ attached: false }';
   return toBeTruthy.call(this, 'toBeAttached', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout, signal });
+    return await locator._expect(attached ? 'to.be.attached' : 'to.be.detached', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -111,7 +112,7 @@ export function toBeChecked(
     arg = options?.checked === false ? `{ checked: false }` : '';
   }
   return toBeTruthy.call(this, 'toBeChecked', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue, signal });
+    return await locator._expect('to.be.checked', { isNot, timeout, expectedValue, signal, title: this.title });
   }, options);
 }
 
@@ -121,7 +122,7 @@ export function toBeDisabled(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeDisabled', locator, 'Locator', 'disabled', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.disabled', { isNot, timeout, signal });
+    return await locator._expect('to.be.disabled', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -134,7 +135,7 @@ export function toBeEditable(
   const expected = editable ? 'editable' : 'readOnly';
   const arg = editable ? '' : '{ editable: false }';
   return toBeTruthy.call(this, 'toBeEditable', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout, signal });
+    return await locator._expect(editable ? 'to.be.editable' : 'to.be.readonly', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -144,7 +145,7 @@ export function toBeEmpty(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeEmpty', locator, 'Locator', 'empty', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.empty', { isNot, timeout, signal });
+    return await locator._expect('to.be.empty', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -157,7 +158,7 @@ export function toBeEnabled(
   const expected = enabled ? 'enabled' : 'disabled';
   const arg = enabled ? '' : '{ enabled: false }';
   return toBeTruthy.call(this, 'toBeEnabled', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout, signal });
+    return await locator._expect(enabled ? 'to.be.enabled' : 'to.be.disabled', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -167,7 +168,7 @@ export function toBeFocused(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeFocused', locator, 'Locator', 'focused', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.focused', { isNot, timeout, signal });
+    return await locator._expect('to.be.focused', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -177,7 +178,7 @@ export function toBeHidden(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeHidden', locator, 'Locator', 'hidden', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.hidden', { isNot, timeout, signal });
+    return await locator._expect('to.be.hidden', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -190,7 +191,7 @@ export function toBeVisible(
   const expected = visible ? 'visible' : 'hidden';
   const arg = visible ? '' : '{ visible: false }';
   return toBeTruthy.call(this, 'toBeVisible', locator, 'Locator', expected, arg, async (isNot, timeout, signal) => {
-    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout, signal });
+    return await locator._expect(visible ? 'to.be.visible' : 'to.be.hidden', { isNot, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -200,7 +201,7 @@ export function toBeInViewport(
   options?: { timeout?: number, ratio?: number, signal?: AbortSignal },
 ) {
   return toBeTruthy.call(this, 'toBeInViewport', locator, 'Locator', 'in viewport', '', async (isNot, timeout, signal) => {
-    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout, signal });
+    return await locator._expect('to.be.in.viewport', { isNot, expectedNumber: options?.ratio, timeout, signal, title: this.title });
   }, options);
 }
 
@@ -213,12 +214,12 @@ export function toContainText(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
+      return await locator._expect('to.contain.text.array', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal, title: this.title });
     }, expected, { ...options, contains: true });
   } else {
     return toMatchText.call(this, 'toContainText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { matchSubstring: true, normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal });
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options.useInnerText, timeout, signal, title: this.title });
     }, expected, { ...options, matchSubstring: true });
   }
 }
@@ -231,7 +232,7 @@ export function toHaveAccessibleDescription(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleDescription', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.accessible.description', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -243,7 +244,7 @@ export function toHaveAccessibleName(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleName', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.accessible.name', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -255,7 +256,7 @@ export function toHaveAccessibleErrorMessage(
 ) {
   return toMatchText.call(this, 'toHaveAccessibleErrorMessage', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase, normalizeWhiteSpace: true });
-    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.accessible.error.message', { expectedText: expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -275,12 +276,12 @@ export function toHaveAttribute(
   }
   if (expected === undefined) {
     return toBeTruthy.call(this, 'toHaveAttribute', locator, 'Locator', 'have attribute', '', async (isNot, timeout, signal) => {
-      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout, signal });
+      return await locator._expect('to.have.attribute', { expressionArg: name, isNot, timeout, signal, title: this.title });
     }, options);
   }
   return toMatchText.call(this, 'toHaveAttribute', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected as (string | RegExp)], { ignoreCase: options?.ignoreCase });
-    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.attribute.value', { expressionArg: name, expectedText, isNot, timeout, signal, title: this.title });
   }, expected as (string | RegExp), options);
 }
 
@@ -293,12 +294,12 @@ export function toHaveClass(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout, signal });
+      return await locator._expect('to.have.class.array', { expectedText, isNot, timeout, signal, title: this.title });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.have.class', { expectedText, isNot, timeout, signal });
+      return await locator._expect('to.have.class', { expectedText, isNot, timeout, signal, title: this.title });
     }, expected, options);
   }
 }
@@ -314,14 +315,14 @@ export function toContainClass(
       throw new Error(`"expected" argument in toContainClass cannot contain RegExp values`);
     return toEqual.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected);
-      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout, signal });
+      return await locator._expect('to.contain.class.array', { expectedText, isNot, timeout, signal, title: this.title });
     }, expected, options);
   } else {
     if (isRegExp(expected))
       throw new Error(`"expected" argument in toContainClass cannot be a RegExp value`);
     return toMatchText.call(this, 'toContainClass', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected]);
-      return await locator._expect('to.contain.class', { expectedText, isNot, timeout, signal });
+      return await locator._expect('to.contain.class', { expectedText, isNot, timeout, signal, title: this.title });
     }, expected, options);
   }
 }
@@ -333,7 +334,7 @@ export function toHaveCount(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toEqual.call(this, 'toHaveCount', locator, 'Locator', async (isNot, timeout, signal) => {
-    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout, signal });
+    return await locator._expect('to.have.count', { expectedNumber: expected, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -347,7 +348,7 @@ export function toHaveCSS(
 ) {
   return toMatchText.call(this, 'toHaveCSS', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout, signal });
+    return await locator._expect('to.have.css', { expressionArg: name, expectedText, isNot, pseudo: options?.pseudo, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -359,7 +360,7 @@ export function toHaveId(
 ) {
   return toMatchText.call(this, 'toHaveId', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.id', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.id', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -371,7 +372,7 @@ export function toHaveJSProperty(
   options?: { timeout?: number, signal?: AbortSignal },
 ) {
   return toEqual.call(this, 'toHaveJSProperty', locator, 'Locator', async (isNot, timeout, signal) => {
-    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout, signal });
+    return await locator._expect('to.have.property', { expressionArg: name, expectedValue: expected, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -385,7 +386,7 @@ export function toHaveRole(
     throw new Error(`"role" argument in toHaveRole must be a string`);
   return toMatchText.call(this, 'toHaveRole', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.role', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.role', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -398,12 +399,12 @@ export function toHaveText(
   if (Array.isArray(expected)) {
     return toEqual.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues(expected, { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
+      return await locator._expect('to.have.text.array', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal, title: this.title });
     }, expected, options);
   } else {
     return toMatchText.call(this, 'toHaveText', locator, 'Locator', async (isNot, timeout, signal) => {
       const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true, ignoreCase: options.ignoreCase });
-      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal });
+      return await locator._expect('to.have.text', { expectedText, isNot, useInnerText: options?.useInnerText, timeout, signal, title: this.title });
     }, expected, options);
   }
 }
@@ -416,7 +417,7 @@ export function toHaveValue(
 ) {
   return toMatchText.call(this, 'toHaveValue', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected]);
-    return await locator._expect('to.have.value', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.value', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -428,7 +429,7 @@ export function toHaveValues(
 ) {
   return toEqual.call(this, 'toHaveValues', locator, 'Locator', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues(expected);
-    return await locator._expect('to.have.values', { expectedText, isNot, timeout, signal });
+    return await locator._expect('to.have.values', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -440,7 +441,7 @@ export function toHaveTitle(
 ) {
   return toMatchText.call(this, 'toHaveTitle', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { normalizeWhiteSpace: true });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout, signal });
+    return await (page.mainFrame() as FrameEx)._expect('to.have.title', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 
@@ -461,7 +462,7 @@ export function toHaveURL(
   expected = typeof expected === 'string' ? constructURLBasedOnBaseURL(baseURL, expected) : expected;
   return toMatchText.call(this, 'toHaveURL', page, 'Page', async (isNot, timeout, signal) => {
     const expectedText = serializeExpectedTextValues([expected], { ignoreCase: options?.ignoreCase });
-    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout, signal });
+    return await (page.mainFrame() as FrameEx)._expect('to.have.url', { expectedText, isNot, timeout, signal, title: this.title });
   }, expected, options);
 }
 

--- a/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchAriaSnapshot.ts
@@ -91,7 +91,7 @@ export async function toMatchAriaSnapshot(
   if (globalChildren && !expected.match(/^- \/children:/m))
     expected = `- /children: ${globalChildren}\n` + expected;
 
-  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout, signal: options.signal };
+  const expectParams = { expectedValue: expected, isNot: this.isNot, timeout, signal: options.signal, title: this.title };
   const { matches: pass, received, log, timedOut, errorMessage } = locator ?
     await (locator as LocatorEx)._expect('to.match.aria', expectParams) :
     await ((receiver as Page).mainFrame() as FrameEx)._expect('to.match.aria', expectParams);

--- a/packages/playwright/src/matchers/toMatchSnapshot.ts
+++ b/packages/playwright/src/matchers/toMatchSnapshot.ts
@@ -365,6 +365,7 @@ export async function toHaveScreenshot(
     isNot: !!this.isNot,
     timeout,
     signal: helper.options.signal,
+    title: this.title,
     type: screenshotType,
     comparator: helper.options.comparator,
     maxDiffPixels: helper.options.maxDiffPixels,

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -44,7 +44,6 @@ interface TestStepData {
   shortTitle?: string;
   category: TestStepCategory;
   location?: Location;
-  apiName?: string;
   params?: Record<string, any>;
   box?: boolean;
   // steps with any defined group are hidden from the report

--- a/tests/installation/playwright-packages-install-behavior.spec.ts
+++ b/tests/installation/playwright-packages-install-behavior.spec.ts
@@ -114,6 +114,6 @@ test('@playwright/test should work', async ({ exec, checkInstalledSoftwareOnDisk
   expect(result3).toContain('3 passed');
 
   const result4 = await exec('npx playwright test -c . failing.spec.js', { expectToExitWithError: true, env: { DEBUG: 'pw:api' } });
-  expect(result4).toContain('expect.toHaveText started');
+  expect(result4).toContain('Expect "toHaveText" started');
   expect(result4).toContain('failing.spec.js:5:38');
 });


### PR DESCRIPTION
## Summary
- Matchers pass their step title explicitly to `locator._expect`, `frame._expect` and `page._expectScreenshot`, instead of the test runner plumbing apiName/title into the api call through the instrumentation listener.
- The apiName is inferred from the stack, falling back to the explicit title for internal methods like `locator._expect`.
- The test runner instrumentation matches api calls by channel type/method, and `apiName` is removed from `ApiCallData`.