### PR TITLE
chore(recorder): render highlights via the shared element highlight

### DIFF
--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -54,7 +54,7 @@ export class Highlight {
   private _glassPaneElement: HTMLElement;
   private _glassPaneShadow: ShadowRoot;
   private _renderedEntries: RenderedHighlightEntry[] = [];
-  private _actionPointElement: HTMLElement;
+  private _actionPointElement: HTMLElement | undefined;
   private _actionCursorElement: HTMLElement;
   private _titleElement: HTMLElement;
   private _userOverlayContainer: HTMLElement;
@@ -84,8 +84,6 @@ export class Highlight {
     this._glassPaneElement.style.pointerEvents = 'none';
     this._glassPaneElement.style.display = 'flex';
     this._glassPaneElement.style.backgroundColor = 'transparent';
-    this._actionPointElement = document.createElement('x-pw-action-point');
-    this._actionPointElement.setAttribute('hidden', 'true');
     this._actionCursorElement = document.createElement('x-pw-action-cursor');
     this._actionCursorElement.style.visibility = 'hidden';
     this._actionCursorElement.appendChild(this._createCursorSvg(document));
@@ -105,7 +103,6 @@ export class Highlight {
       styleElement.textContent = highlightCSS;
       this._glassPaneShadow.appendChild(styleElement);
     }
-    this._glassPaneShadow.appendChild(this._actionPointElement);
     this._glassPaneShadow.appendChild(this._actionCursorElement);
     this._glassPaneShadow.appendChild(this._titleElement);
     this._glassPaneShadow.appendChild(this._userOverlayContainer);
@@ -153,8 +150,15 @@ export class Highlight {
       return;
     const tick = () => {
       const entries: HighlightEntry[] = [];
+      const glassPanes = [...this._injectedScript.document.querySelectorAll('x-pw-glass')];
       for (const { selector, cssStyle } of this._elementHighlightSelectors.values()) {
-        const elements = this._injectedScript.querySelectorAll(selector, this._injectedScript.document.documentElement);
+        let elements: Element[] = [];
+        try {
+          elements = this._injectedScript.querySelectorAll(selector, this._injectedScript.document.documentElement);
+        } catch {
+        }
+        // Do not accidentally match our own highlight.
+        elements = elements.filter(element => !glassPanes.some(pane => this._injectedScript.utils.isInsideScope(pane, element)));
         const locator = asLocator(this._language, stringifySelector(selector));
         const color = elements.length > 1 ? '#f6b26b7f' : '#6fa8dc7f';
         for (let i = 0; i < elements.length; ++i) {
@@ -178,6 +182,10 @@ export class Highlight {
   }
 
   showActionPoint(x: number, y: number, fadeDuration?: number) {
+    if (!this._actionPointElement) {
+      this._actionPointElement = this._injectedScript.document.createElement('x-pw-action-point');
+      this._glassPaneShadow.appendChild(this._actionPointElement);
+    }
     this._actionPointElement.style.top = y + 'px';
     this._actionPointElement.style.left = x + 'px';
     this._actionPointElement.hidden = false;
@@ -188,7 +196,8 @@ export class Highlight {
   }
 
   hideActionPoint() {
-    this._actionPointElement.hidden = true;
+    if (this._actionPointElement)
+      this._actionPointElement.hidden = true;
   }
 
   moveActionCursor(x: number, y: number, fadeDuration?: number) {

--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -159,11 +159,12 @@ export class Highlight {
         }
         // Do not accidentally match our own highlight.
         elements = elements.filter(element => !glassPanes.some(pane => this._injectedScript.utils.isInsideScope(pane, element)));
-        const locator = asLocator(this._language, stringifySelector(selector));
+        // There is no locator representation for the aria template, skip the tooltip.
+        const locator = selector.parts.some(part => part.name === 'aria-template') ? undefined : asLocator(this._language, stringifySelector(selector));
         const color = elements.length > 1 ? '#f6b26b7f' : '#6fa8dc7f';
         for (let i = 0; i < elements.length; ++i) {
           const suffix = elements.length > 1 ? ` [${i + 1} of ${elements.length}]` : '';
-          entries.push({ element: elements[i], color, tooltipText: locator + suffix, cssStyle });
+          entries.push({ element: elements[i], color, tooltipText: locator === undefined ? undefined : locator + suffix, cssStyle });
         }
       }
       this.updateHighlight(entries);

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -243,6 +243,7 @@ export class InjectedScript {
     this._engines.set('internal:role', createRoleEngine(true));
     this._engines.set('internal:describe', this._createDescribeEngine());
     this._engines.set('aria-ref', this._createAriaRefEngine());
+    this._engines.set('aria-template', this._createAriaTemplateEngine());
 
     for (const { name, source } of options.customEngines)
       this._engines.set(name, this.eval(source));
@@ -737,6 +738,17 @@ export class InjectedScript {
     const queryAll = (root: SelectorRoot, selector: string): Element[] => {
       const result = this._lastAriaSnapshotForQuery?.info?.get(selector);
       return result && result.element.isConnected ? [result.element] : [];
+    };
+    return { queryAll };
+  }
+
+  _createAriaTemplateEngine() {
+    const queryAll = (root: SelectorRoot, body: string): Element[] => {
+      const template = JSON.parse(body) as AriaTemplateNode;
+      const rootElement = root.nodeType === 9 /* Node.DOCUMENT_NODE */ ? (root as Document).documentElement : root as Element;
+      if (!rootElement)
+        return [];
+      return getAllElementsMatchingExpectAriaTemplate(rootElement, template);
     };
     return { queryAll };
   }

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -20,7 +20,7 @@ import clipPaths from './clipPaths';
 
 import type { Point } from '@isomorphic/types';
 import type { AriaSnapshot } from '../ariaSnapshot';
-import type { Highlight, HighlightEntry } from '../highlight';
+import type { Highlight } from '../highlight';
 import type { InjectedScript } from '../injectedScript';
 import type { ElementText } from '../selectorUtils';
 import type * as actions from '@isomorphic/codegen/actions';
@@ -1276,7 +1276,6 @@ export class Recorder {
   private _listeners: (() => void)[] = [];
   private _currentTool: RecorderTool;
   private _tools: Record<Mode, RecorderTool>;
-  private _lastHighlightedAriaTemplateJSON: string = 'undefined';
   private _lastActionAutoexpectSnapshot: AriaSnapshot | undefined;
   readonly highlight: Highlight;
   readonly overlay: Overlay | undefined;
@@ -1392,25 +1391,6 @@ export class Recorder {
     this.highlight.setLanguage(state.language);
     this._switchCurrentTool();
     this.overlay?.setUIState(state);
-
-    let highlight: HighlightEntry[] | 'clear' | 'noop' = 'noop';
-    const ariaTemplateJSON = JSON.stringify(state.ariaTemplate);
-    if (this._lastHighlightedAriaTemplateJSON !== ariaTemplateJSON) {
-      const elements = state.ariaTemplate ? this.injectedScript.getAllElementsMatchingExpectAriaTemplate(this.document, state.ariaTemplate) : [];
-      if (elements.length) {
-        const color = elements.length > 1 ? HighlightColors.multiple : HighlightColors.single;
-        highlight = elements.map(element => ({ element, color }));
-        this._lastHighlightedAriaTemplateJSON = ariaTemplateJSON;
-      } else {
-        highlight = 'clear';
-        this._lastHighlightedAriaTemplateJSON = 'undefined';
-      }
-    }
-
-    if (highlight === 'clear')
-      this.highlight.clearHighlight();
-    else if (highlight !== 'noop')
-      this.highlight.updateHighlight(highlight);
   }
 
   clearHighlight() {
@@ -1526,7 +1506,6 @@ export class Recorder {
   private _onScroll(event: Event) {
     if (!event.isTrusted)
       return;
-    this._lastHighlightedAriaTemplateJSON = 'undefined';
     this.highlight.hideActionPoint();
     this._currentTool.onScroll?.(event);
   }
@@ -1554,7 +1533,6 @@ export class Recorder {
   }
 
   updateHighlight(model: HighlightModel | null, userGesture: boolean) {
-    this._lastHighlightedAriaTemplateJSON = 'undefined';
     this._updateHighlight(model, userGesture);
   }
 

--- a/packages/injected/src/recorder/recorder.ts
+++ b/packages/injected/src/recorder/recorder.ts
@@ -25,7 +25,6 @@ import type { InjectedScript } from '../injectedScript';
 import type { ElementText } from '../selectorUtils';
 import type * as actions from '@isomorphic/codegen/actions';
 import type { ElementInfo, Mode, OverlayState, UIState } from '@recorder/recorderTypes';
-import type { Language } from '@isomorphic/locatorGenerators';
 
 const HighlightColors = {
   multiple: '#f6b26b7f',
@@ -1277,7 +1276,6 @@ export class Recorder {
   private _listeners: (() => void)[] = [];
   private _currentTool: RecorderTool;
   private _tools: Record<Mode, RecorderTool>;
-  private _lastHighlightedSelector: string | undefined = undefined;
   private _lastHighlightedAriaTemplateJSON: string = 'undefined';
   private _lastActionAutoexpectSnapshot: AriaSnapshot | undefined;
   readonly highlight: Highlight;
@@ -1396,12 +1394,6 @@ export class Recorder {
     this.overlay?.setUIState(state);
 
     let highlight: HighlightEntry[] | 'clear' | 'noop' = 'noop';
-    if (state.actionSelector !== this._lastHighlightedSelector) {
-      const entries = state.actionSelector ? entriesForSelectorHighlight(this.injectedScript, state.language, state.actionSelector, this.document) : null;
-      highlight = entries?.length ? entries : 'clear';
-      this._lastHighlightedSelector = entries?.length ? state.actionSelector : undefined;
-    }
-
     const ariaTemplateJSON = JSON.stringify(state.ariaTemplate);
     if (this._lastHighlightedAriaTemplateJSON !== ariaTemplateJSON) {
       const elements = state.ariaTemplate ? this.injectedScript.getAllElementsMatchingExpectAriaTemplate(this.document, state.ariaTemplate) : [];
@@ -1410,8 +1402,7 @@ export class Recorder {
         highlight = elements.map(element => ({ element, color }));
         this._lastHighlightedAriaTemplateJSON = ariaTemplateJSON;
       } else {
-        if (!this._lastHighlightedSelector)
-          highlight = 'clear';
+        highlight = 'clear';
         this._lastHighlightedAriaTemplateJSON = 'undefined';
       }
     }
@@ -1535,7 +1526,6 @@ export class Recorder {
   private _onScroll(event: Event) {
     if (!event.isTrusted)
       return;
-    this._lastHighlightedSelector = undefined;
     this._lastHighlightedAriaTemplateJSON = 'undefined';
     this.highlight.hideActionPoint();
     this._currentTool.onScroll?.(event);
@@ -1564,7 +1554,6 @@ export class Recorder {
   }
 
   updateHighlight(model: HighlightModel | null, userGesture: boolean) {
-    this._lastHighlightedSelector = undefined;
     this._lastHighlightedAriaTemplateJSON = 'undefined';
     this._updateHighlight(model, userGesture);
   }
@@ -1818,21 +1807,6 @@ function removeEventListeners(listeners: (() => void)[]) {
   for (const listener of listeners)
     listener();
   listeners.splice(0, listeners.length);
-}
-
-function entriesForSelectorHighlight(injectedScript: InjectedScript, language: Language, selector: string, ownerDocument: Document): HighlightEntry[] {
-  try {
-    const parsedSelector = injectedScript.parseSelector(selector);
-    const elements = injectedScript.querySelectorAll(parsedSelector, ownerDocument);
-    const color = elements.length > 1 ? HighlightColors.multiple : HighlightColors.single;
-    const locator = injectedScript.utils.asLocator(language, selector);
-    return elements.map((element, index) => {
-      const suffix = elements.length > 1 ? ` [${index + 1} of ${elements.length}]` : '';
-      return { element, color, tooltipText: locator + suffix };
-    });
-  } catch (e) {
-    return [];
-  }
 }
 
 export type SvgJson = {

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -272,11 +272,11 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async highlight(params: channels.FrameHighlightParams, progress: Progress): Promise<void> {
-    return await this._frame.addHighlight(progress, params.selector, params.style);
+    return await progress.race(this._frame.addHighlight(params.selector, params.style));
   }
 
   async hideHighlight(params: channels.FrameHideHighlightParams, progress: Progress): Promise<void> {
-    return await this._frame.removeHighlight(progress, params.selector);
+    return await progress.race(this._frame.removeHighlight(params.selector));
   }
 
   async expect(params: channels.FrameExpectParams, progress: Progress): Promise<channels.FrameExpectResult> {

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1372,16 +1372,16 @@ export class Frame extends SdkObject<FrameEventMap> {
     return result;
   }
 
-  async addHighlight(progress: Progress, selector: string, style?: string) {
-    await progress.race(this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }, style) => {
+  async addHighlight(selector: string, style?: string) {
+    await this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }, style) => {
       return injected.addHighlight(info.parsed, style);
-    }, style));
+    }, style);
   }
 
-  async removeHighlight(progress: Progress, selector: string) {
-    await progress.race(this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }) => {
+  async removeHighlight(selector: string) {
+    await this.selectors.callOnSelector(selector, { strict: false, callWithoutMatches: true }, ({ injected, info }) => {
       return injected.removeHighlight(info.parsed);
-    }, {}));
+    }, {});
   }
 
   async hideHighlight() {

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -77,7 +77,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   private _params: RecorderParams;
   private _mode: Mode;
   private _highlightedSelector: string | undefined;
-  private _highlightedAriaTemplate: AriaTemplateNode | undefined;
   private _overlayState: OverlayState = { offsetX: 0 };
   private _currentCallsMetadata = new Map<CallMetadata, SdkObject>();
   private _actionPoints = new Map<string, Point>();
@@ -180,7 +179,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         const uiState: UIState = {
           mode,
           actionPoint,
-          ariaTemplate: this._highlightedAriaTemplate,
           language: this._currentLanguage,
           testIdAttributeName: this._testIdAttributeName(),
           overlay: this._overlayState,
@@ -249,7 +247,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   async setMode(mode: Mode) {
     if (this._mode === mode)
       return;
-    this._highlightedAriaTemplate = undefined;
     this._updateHighlightedSelector(undefined).catch(() => {});
     this._mode = mode;
     this.emit(RecorderEvent.ModeChanged, this._mode);
@@ -307,15 +304,11 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
 
   async setHighlightedSelector(selector: string) {
     const converted = locatorOrSelectorAsSelector(this._currentLanguage, selector, this._context.selectors().testIdAttributeName());
-    this._highlightedAriaTemplate = undefined;
     await this._updateHighlightedSelector(converted || undefined);
-    await this._refreshOverlay();
   }
 
   async setHighlightedAriaTemplate(ariaTemplate: AriaTemplateNode) {
-    this._highlightedAriaTemplate = ariaTemplate;
-    await this._updateHighlightedSelector(undefined);
-    await this._refreshOverlay();
+    await this._updateHighlightedSelector('aria-template=' + JSON.stringify(ariaTemplate));
   }
 
   step() {
@@ -345,9 +338,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async hideHighlightedSelector() {
-    this._highlightedAriaTemplate = undefined;
     await this._updateHighlightedSelector(undefined);
-    await this._refreshOverlay();
   }
 
   pausedSourceId() {
@@ -395,12 +386,10 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     this._currentCallsMetadata.set(metadata, sdkObject);
     this._updateUserSources();
     this._updateCallLog([metadata]);
-    if (isScreenshotCommand(metadata)) {
+    if (isScreenshotCommand(metadata))
       this.hideHighlightedSelector();
-    } else if (!metadata.internal && metadata.params && metadata.params.selector) {
-      this._highlightedAriaTemplate = undefined;
+    else if (!metadata.internal && metadata.params && metadata.params.selector)
       this._updateHighlightedSelector(metadata.params.selector).catch(() => {});
-    }
   }
 
   async onAfterCall(progress: Progress) {

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -18,7 +18,6 @@ import EventEmitter from 'events';
 import fs from 'fs';
 
 import { locatorOrSelectorAsSelector } from '@isomorphic/locatorParser';
-import { stringifySelector } from '@isomorphic/selectorParser';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { isUnderTest } from '@utils/debug';
 import { eventsHelper } from '@utils/eventsHelper';
@@ -77,7 +76,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   private _context: BrowserContext;
   private _params: RecorderParams;
   private _mode: Mode;
-  private _highlightedElement: { selector?: string, ariaTemplate?: AriaTemplateNode } = {};
+  private _highlightedSelector: string | undefined;
+  private _highlightedAriaTemplate: AriaTemplateNode | undefined;
   private _overlayState: OverlayState = { offsetX: 0 };
   private _currentCallsMetadata = new Map<CallMetadata, SdkObject>();
   private _actionPoints = new Map<string, Point>();
@@ -166,16 +166,12 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     const controller = new ProgressController();
     await controller.run(async progress => {
       await this._context.exposeBinding(progress, '__pw_recorderState', async source => {
-        let actionSelector: string | undefined;
         let actionPoint: Point | undefined;
         const hasActiveScreenshotCommand = [...this._currentCallsMetadata.keys()].some(isScreenshotCommand);
         if (!hasActiveScreenshotCommand) {
-          actionSelector = await this._scopeHighlightedSelectorToFrame(source.frame);
           for (const [metadata, sdkObject] of this._currentCallsMetadata) {
-            if (source.page === sdkObject.attribution.page) {
+            if (source.page === sdkObject.attribution.page)
               actionPoint = this._actionPoints.get(metadata.id) || actionPoint;
-              actionSelector = actionSelector || metadata.params.selector;
-            }
           }
         }
         let mode = this._mode;
@@ -184,8 +180,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         const uiState: UIState = {
           mode,
           actionPoint,
-          actionSelector,
-          ariaTemplate: this._highlightedElement.ariaTemplate,
+          ariaTemplate: this._highlightedAriaTemplate,
           language: this._currentLanguage,
           testIdAttributeName: this._testIdAttributeName(),
           overlay: this._overlayState,
@@ -254,7 +249,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   async setMode(mode: Mode) {
     if (this._mode === mode)
       return;
-    this._highlightedElement = {};
+    this._highlightedAriaTemplate = undefined;
+    this._updateHighlightedSelector(undefined).catch(() => {});
     this._mode = mode;
     this.emit(RecorderEvent.ModeChanged, this._mode);
     this._setEnabled(this._isRecording());
@@ -310,12 +306,15 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async setHighlightedSelector(selector: string) {
-    this._highlightedElement = { selector: locatorOrSelectorAsSelector(this._currentLanguage, selector, this._context.selectors().testIdAttributeName()) };
+    const converted = locatorOrSelectorAsSelector(this._currentLanguage, selector, this._context.selectors().testIdAttributeName());
+    this._highlightedAriaTemplate = undefined;
+    await this._updateHighlightedSelector(converted || undefined);
     await this._refreshOverlay();
   }
 
   async setHighlightedAriaTemplate(ariaTemplate: AriaTemplateNode) {
-    this._highlightedElement = { ariaTemplate };
+    this._highlightedAriaTemplate = ariaTemplate;
+    await this._updateHighlightedSelector(undefined);
     await this._refreshOverlay();
   }
 
@@ -346,7 +345,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
   }
 
   async hideHighlightedSelector() {
-    this._highlightedElement = {};
+    this._highlightedAriaTemplate = undefined;
+    await this._updateHighlightedSelector(undefined);
     await this._refreshOverlay();
   }
 
@@ -367,29 +367,17 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     return this._callLogs;
   }
 
-  private async _scopeHighlightedSelectorToFrame(frame: Frame): Promise<string | undefined> {
-    if (!this._highlightedElement.selector)
+  private async _updateHighlightedSelector(selector: string | undefined) {
+    const previous = this._highlightedSelector;
+    if (previous === selector)
       return;
-    try {
-      const mainFrame = frame._page.mainFrame();
-      const resolved = await mainFrame.selectors.callOnSelector(this._highlightedElement.selector, { callWithoutMatches: true }, () => {}, {});
-      // selector couldn't be found, don't highlight anything
-      if (!resolved)
-        return '';
-
-      // selector points to no specific frame, highlight in all frames
-      if (resolved.frame === mainFrame)
-        return stringifySelector(resolved.info.parsed);
-
-      // selector points to this frame, highlight it
-      if (resolved.frame === frame)
-        return stringifySelector(resolved.info.parsed);
-
-      // selector points to a different frame, highlight nothing
-      return '';
-    } catch {
-      return '';
-    }
+    this._highlightedSelector = selector;
+    await Promise.all(this._context.pages().map(async page => {
+      if (previous)
+        await page.mainFrame().removeHighlight(previous).catch(() => {});
+      if (selector)
+        await page.mainFrame().addHighlight(selector).catch(() => {});
+    }));
   }
 
   private async _refreshOverlay() {
@@ -407,10 +395,12 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
     this._currentCallsMetadata.set(metadata, sdkObject);
     this._updateUserSources();
     this._updateCallLog([metadata]);
-    if (isScreenshotCommand(metadata))
+    if (isScreenshotCommand(metadata)) {
       this.hideHighlightedSelector();
-    else if (metadata.params && metadata.params.selector)
-      this._highlightedElement = { selector: metadata.params.selector };
+    } else if (!metadata.internal && metadata.params && metadata.params.selector) {
+      this._highlightedAriaTemplate = undefined;
+      this._updateHighlightedSelector(metadata.params.selector).catch(() => {});
+    }
   }
 
   async onAfterCall(progress: Progress) {
@@ -496,6 +486,8 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
 
   private async _onPage(page: Page) {
     const frame = page.mainFrame();
+    if (this._highlightedSelector)
+      frame.addHighlight(this._highlightedSelector).catch(() => {});
     page.on(Page.Events.Close, () => {
       this._signalProcessor.addAction({
         pageGuid: page.guid,

--- a/packages/playwright-core/src/server/selectors.ts
+++ b/packages/playwright-core/src/server/selectors.ts
@@ -44,7 +44,7 @@ export class Selectors {
       'internal:and', 'internal:or', 'internal:chain',
       'role', 'internal:attr', 'internal:label', 'internal:text',
       'internal:role', 'internal:testid', 'internal:describe',
-      'aria-ref'
+      'aria-ref', 'aria-template'
     ]);
     this._builtinEnginesInMainWorld = new Set([
       '_react', '_vue',

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -54,7 +54,6 @@ export type OverlayState = {
 export type UIState = {
   mode: Mode;
   actionPoint?: Point;
-  ariaTemplate?: AriaTemplateNode;
   language: Language;
   testIdAttributeName: string;
   overlay: OverlayState;

--- a/packages/recorder/src/recorderTypes.d.ts
+++ b/packages/recorder/src/recorderTypes.d.ts
@@ -54,7 +54,6 @@ export type OverlayState = {
 export type UIState = {
   mode: Mode;
   actionPoint?: Point;
-  actionSelector?: string;
   ariaTemplate?: AriaTemplateNode;
   language: Language;
   testIdAttributeName: string;

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -293,16 +293,16 @@ export const InspectModeController: React.FunctionComponent<{
     for (const { recorder, frameSelector } of recorders) {
       const actionSelector = fullSelector?.startsWith(frameSelector) ? fullSelector.substring(frameSelector.length).trim() : undefined;
       const ariaTemplate = parsedSnapshot?.errors.length === 0 ? parsedSnapshot.fragment : undefined;
+      const highlightSelector = actionSelector || (ariaTemplate ? 'aria-template=' + JSON.stringify(ariaTemplate) : undefined);
       recorder.injectedScript.hideHighlight();
-      if (actionSelector) {
+      if (highlightSelector) {
         try {
-          recorder.injectedScript.addHighlight(recorder.injectedScript.parseSelector(actionSelector));
+          recorder.injectedScript.addHighlight(recorder.injectedScript.parseSelector(highlightSelector));
         } catch {
         }
       }
       recorder.setUIState({
         mode: isInspecting ? 'inspecting' : 'none',
-        ariaTemplate,
         language: sdkLanguage,
         testIdAttributeName,
         overlay: { offsetX: 0 },

--- a/packages/trace-viewer/src/ui/snapshotTab.tsx
+++ b/packages/trace-viewer/src/ui/snapshotTab.tsx
@@ -293,9 +293,15 @@ export const InspectModeController: React.FunctionComponent<{
     for (const { recorder, frameSelector } of recorders) {
       const actionSelector = fullSelector?.startsWith(frameSelector) ? fullSelector.substring(frameSelector.length).trim() : undefined;
       const ariaTemplate = parsedSnapshot?.errors.length === 0 ? parsedSnapshot.fragment : undefined;
+      recorder.injectedScript.hideHighlight();
+      if (actionSelector) {
+        try {
+          recorder.injectedScript.addHighlight(recorder.injectedScript.parseSelector(actionSelector));
+        } catch {
+        }
+      }
       recorder.setUIState({
         mode: isInspecting ? 'inspecting' : 'none',
-        actionSelector,
         ariaTemplate,
         language: sdkLanguage,
         testIdAttributeName,

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -318,7 +318,8 @@ test('should highlight inside iframe', async ({ backend, connectedBrowser }, tes
   await expect(highlight).toHaveCount(0);
 
   await backend.highlight({ selector: `getByText('bar')` }, undefined);
-  await expect(highlight).toHaveCount(1);
+  // TODO: highlight inside the iframe as well when piercing frames is supported.
+  await expect(highlight).toHaveCount(0);
   await expect(page.locator('x-pw-highlight')).toHaveCount(1);
 });
 

--- a/tests/library/inspector/pause.spec.ts
+++ b/tests/library/inspector/pause.spec.ts
@@ -567,7 +567,10 @@ it.describe('pause', () => {
 
     const box1Promise = waitForTestLog<BoundingBox>(page, 'Highlight box for test: ');
     await recorderPage.click('[title="Step over (F10)"]');
-    const box2 = roundBox((await page.locator('#target').boundingBox())!);
+    // Use an internal call to avoid pausing on it instead of the stepped-over click.
+    const box2 = await (page as any)._wrapApiCall(async () => {
+      return roundBox((await page.locator('#target').boundingBox())!);
+    }, { internal: true });
     const box1 = roundBox(await box1Promise);
     expect(box1).toEqual(box2);
 


### PR DESCRIPTION
## Summary
- Recorder highlights the current selector through the shared element highlight (`Frame.addHighlight`) instead of the `UIState`.
- New internal `aria-template=<json>` selector engine, so that the highlighted aria template goes through the same code path.
- Trace viewer highlights via `injectedScript.addHighlight()` directly.
- Shared element highlight fixes: the action point element is created lazily, the rAF loop ignores glass panes and tolerates unqueryable selectors, and internal calls are not tracked as actions.
- Highlights are confined to the frame the selector resolves to for now; cross-frame highlighting will be restored together with piercing frames support.