### PR TITLE
fix(net): pass a generous autoSelectFamilyAttemptTimeout

### DIFF
--- a/packages/playwright-core/src/server/fetch.ts
+++ b/packages/playwright-core/src/server/fetch.ts
@@ -25,7 +25,7 @@ import { assert } from '@isomorphic/assert';
 import { constructURLBasedOnBaseURL } from '@isomorphic/urlMatch';
 import { eventsHelper } from '@utils/eventsHelper';
 import { monotonicTime } from '@isomorphic/time';
-import { createProxyAgent, dualStackLookup, flattenAggregateError } from '@utils/network';
+import { createProxyAgent, flattenAggregateError, happyEyeballsOptions } from '@utils/network';
 import { getUserAgent } from './userAgent';
 import { BrowserContext, findMatchingHttpCredentials, verifyClientCertificates } from './browserContext';
 import { Cookie, CookieStore, domainMatches, parseRawCookie } from './cookieStore';
@@ -343,8 +343,9 @@ export abstract class APIRequestContext extends SdkObject {
         = (url.protocol === 'https:' ? https : http).request;
       // Without an explicit proxy agent, the default global agent is used, which
       // has keep-alive enabled and connects with Happy Eyeballs (autoSelectFamily).
-      const requestOptions = { ...options };
-      requestOptions.lookup = options.__testHookLookup ? lookupWithTestHook(options.__testHookLookup) : dualStackLookup;
+      const requestOptions = { ...options, ...happyEyeballsOptions };
+      if (options.__testHookLookup)
+        requestOptions.lookup = lookupWithTestHook(options.__testHookLookup);
 
       const startAt = monotonicTime();
       const startAtWallTime = Date.now();

--- a/packages/playwright-core/src/server/transport.ts
+++ b/packages/playwright-core/src/server/transport.ts
@@ -16,7 +16,7 @@
  */
 
 import ws from 'ws';
-import { dualStackLookup, flattenAggregateError } from '@utils/network';
+import { flattenAggregateError, happyEyeballsOptions } from '@utils/network';
 import { makeWaitForNextTask } from '@utils/task';
 import type { WebSocket } from 'ws';
 import type { Progress } from './progress';
@@ -138,7 +138,7 @@ export class WebSocketTransport implements ConnectionTransport {
       maxPayload: 256 * 1024 * 1024, // 256Mb,
       headers: options.headers,
       followRedirects: options.followRedirects,
-      lookup: dualStackLookup,
+      ...happyEyeballsOptions,
       perMessageDeflate,
     });
     this._ws.on('upgrade', response => {

--- a/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvBrowser.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import ws from 'ws';
 import { debugLogger, RecentLogsCollector } from '@utils/debugLogger';
 import { removeFolders } from '@utils/fileUtils';
-import { dualStackLookup } from '@utils/network';
+import { happyEyeballsOptions } from '@utils/network';
 import { headersArrayToObject } from '@isomorphic/headers';
 import { Browser } from '../../browser';
 import { helper } from '../../helper';
@@ -96,7 +96,7 @@ class DeferredWebSocketTransport implements ConnectOverCDPTransport {
       maxPayload: 256 * 1024 * 1024,
       headers: this._headers,
       followRedirects: true,
-      lookup: dualStackLookup,
+      ...happyEyeballsOptions,
       perMessageDeflate,
       allowSynchronousEvents: false,
     });

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -50,7 +50,7 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
   const options: https.RequestOptions = {
     method: params.method || 'GET',
     headers: params.headers,
-    lookup: dualStackLookup,
+    ...happyEyeballsOptions,
   };
   if (params.rejectUnauthorized !== undefined)
     options.rejectUnauthorized = params.rejectUnauthorized;
@@ -160,7 +160,7 @@ export function createProxyAgent(proxy?: ProxySettings, forUrl?: URL) {
 // of a family that is not listed in /etc/hosts — e.g. resolving to only 127.0.0.1 even though
 // ::1 is served. Separate family: 4 and family: 6 lookups do not have these problems. Native
 // Happy Eyeballs (autoSelectFamily) then races connection attempts across the families.
-export const dualStackLookup: net.LookupFunction = (hostname, options, callback) => {
+const dualStackLookup: net.LookupFunction = (hostname, options, callback) => {
   const families = options.family === 4 || options.family === 6 ? [options.family] : [6, 4];
   void Promise.allSettled(families.map(family => dns.promises.lookup(hostname, { all: true, family }))).then(results => {
     const perFamily = results.map(result => result.status === 'fulfilled' ? result.value : []);
@@ -184,6 +184,17 @@ export const dualStackLookup: net.LookupFunction = (hostname, options, callback)
   });
 };
 
+// Node.js aborts every connection attempt but the last one after autoSelectFamilyAttemptTimeout,
+// and its 250ms default is too short for a TCP handshake over a slow network, failing connections
+// that would have succeeded: https://github.com/nodejs/node/issues/54359. Floor it at 5s to
+// survive two SYN retransmits, honoring a higher process-wide default when the user set one.
+// Revisit when attempts run in parallel: https://github.com/nodejs/node/issues/48145.
+export const happyEyeballsOptions = {
+  lookup: dualStackLookup,
+  autoSelectFamily: true,
+  autoSelectFamilyAttemptTimeout: Math.max(5000, net.getDefaultAutoSelectFamilyAttemptTimeout()),
+};
+
 // When every raced connection attempt fails, Node.js reports an AggregateError with an
 // empty message and the individual failures in the `errors` property. Surface those instead.
 export function flattenAggregateError(error: Error): Error {
@@ -195,7 +206,7 @@ export function flattenAggregateError(error: Error): Error {
 
 export async function createSocket(host: string, port: number): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
-    const socket = net.createConnection({ host, port, lookup: dualStackLookup });
+    const socket = net.createConnection({ host, port, ...happyEyeballsOptions });
     socket.on('connect', () => resolve(socket));
     socket.on('error', error => reject(flattenAggregateError(error)));
   });


### PR DESCRIPTION
## Summary
- Node.js aborts every Happy Eyeballs attempt but the last one after `autoSelectFamilyAttemptTimeout`; the 250ms default fails slow but working routes: https://github.com/nodejs/node/issues/54359
- Bundle `lookup`, `autoSelectFamily: true` and a 10s attempt timeout into a shared `happyEyeballsOptions`, spread at all connection sites.