### PR TITLE
fix(storageState): close IndexedDB connections opened by collect and restore

### DIFF
--- a/packages/injected/src/storageScript.ts
+++ b/packages/injected/src/storageScript.ts
@@ -76,61 +76,65 @@ export class StorageScript {
       throw new Error('Database version is unset');
 
     const db = await this._idbRequestToPromise(indexedDB.open(dbInfo.name));
-    if (db.objectStoreNames.length === 0)
-      return { name: dbInfo.name, version: dbInfo.version, stores: [] };
+    try {
+      if (db.objectStoreNames.length === 0)
+        return { name: dbInfo.name, version: dbInfo.version, stores: [] };
 
-    const transaction = db.transaction(db.objectStoreNames, 'readonly');
-    const stores = await Promise.all([...db.objectStoreNames].map(async storeName => {
-      const objectStore = transaction.objectStore(storeName);
+      const transaction = db.transaction(db.objectStoreNames, 'readonly');
+      const stores = await Promise.all([...db.objectStoreNames].map(async storeName => {
+        const objectStore = transaction.objectStore(storeName);
 
-      const keys = await this._idbRequestToPromise(objectStore.getAllKeys());
-      const records = await Promise.all(keys.map(async key => {
-        const record: IndexedDBDatabase['stores'][0]['records'][0] = {};
+        const keys = await this._idbRequestToPromise(objectStore.getAllKeys());
+        const records = await Promise.all(keys.map(async key => {
+          const record: IndexedDBDatabase['stores'][0]['records'][0] = {};
 
-        if (objectStore.keyPath === null) {
-          const { encoded, trivial } = this._trySerialize(key);
+          if (objectStore.keyPath === null) {
+            const { encoded, trivial } = this._trySerialize(key);
+            if (trivial)
+              record.key = trivial;
+            else
+              record.keyEncoded = encoded;
+          }
+
+          const value = await this._idbRequestToPromise(objectStore.get(key));
+          const { encoded, trivial } = this._trySerialize(value);
           if (trivial)
-            record.key = trivial;
+            record.value = trivial;
           else
-            record.keyEncoded = encoded;
-        }
+            record.valueEncoded = encoded;
 
-        const value = await this._idbRequestToPromise(objectStore.get(key));
-        const { encoded, trivial } = this._trySerialize(value);
-        if (trivial)
-          record.value = trivial;
-        else
-          record.valueEncoded = encoded;
+          return record;
+        }));
 
-        return record;
+        const indexes = [...objectStore.indexNames].map(indexName => {
+          const index = objectStore.index(indexName);
+          return {
+            name: index.name,
+            keyPath: typeof index.keyPath === 'string' ? index.keyPath : undefined,
+            keyPathArray: Array.isArray(index.keyPath) ? index.keyPath : undefined,
+            multiEntry: index.multiEntry,
+            unique: index.unique,
+          };
+        });
+
+        return {
+          name: storeName,
+          records: records,
+          indexes,
+          autoIncrement: objectStore.autoIncrement,
+          keyPath: typeof objectStore.keyPath === 'string' ? objectStore.keyPath : undefined,
+          keyPathArray: Array.isArray(objectStore.keyPath) ? objectStore.keyPath : undefined,
+        };
       }));
 
-      const indexes = [...objectStore.indexNames].map(indexName => {
-        const index = objectStore.index(indexName);
-        return {
-          name: index.name,
-          keyPath: typeof index.keyPath === 'string' ? index.keyPath : undefined,
-          keyPathArray: Array.isArray(index.keyPath) ? index.keyPath : undefined,
-          multiEntry: index.multiEntry,
-          unique: index.unique,
-        };
-      });
-
       return {
-        name: storeName,
-        records: records,
-        indexes,
-        autoIncrement: objectStore.autoIncrement,
-        keyPath: typeof objectStore.keyPath === 'string' ? objectStore.keyPath : undefined,
-        keyPathArray: Array.isArray(objectStore.keyPath) ? objectStore.keyPath : undefined,
+        name: dbInfo.name,
+        version: dbInfo.version,
+        stores,
       };
-    }));
-
-    return {
-      name: dbInfo.name,
-      version: dbInfo.version,
-      stores,
-    };
+    } finally {
+      db.close();
+    }
   }
 
   async collect(recordIndexedDB: boolean): Promise<SerializedStorage> {
@@ -159,21 +163,24 @@ export class StorageScript {
 
     // after `upgradeneeded` finishes, `success` event is fired.
     const db = await this._idbRequestToPromise(openRequest);
-
-    if (db.objectStoreNames.length === 0)
-      return;
-    const transaction = db.transaction(db.objectStoreNames, 'readwrite');
-    await Promise.all(dbInfo.stores.map(async store => {
-      const objectStore = transaction.objectStore(store.name);
-      await Promise.all(store.records.map(async record => {
-        await this._idbRequestToPromise(
-            objectStore.add(
-                record.value ?? parseEvaluationResultValue(record.valueEncoded),
-                record.key ?? parseEvaluationResultValue(record.keyEncoded),
-            )
-        );
+    try {
+      if (db.objectStoreNames.length === 0)
+        return;
+      const transaction = db.transaction(db.objectStoreNames, 'readwrite');
+      await Promise.all(dbInfo.stores.map(async store => {
+        const objectStore = transaction.objectStore(store.name);
+        await Promise.all(store.records.map(async record => {
+          await this._idbRequestToPromise(
+              objectStore.add(
+                  record.value ?? parseEvaluationResultValue(record.valueEncoded),
+                  record.key ?? parseEvaluationResultValue(record.keyEncoded),
+              )
+          );
+        }));
       }));
-    }));
+    } finally {
+      db.close();
+    }
   }
 
   async restore(originState: SetOriginStorage | undefined) {

--- a/tests/library/browsercontext-storage-state.spec.ts
+++ b/tests/library/browsercontext-storage-state.spec.ts
@@ -540,6 +540,41 @@ it('should support empty indexedDB', { annotation: { type: 'issue', description:
   expect(await context.storageState({ indexedDB: true })).toEqual(storageState);
 });
 
+it('should not leave IndexedDB connections open', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42258' } }, async ({ contextFactory, server }) => {
+  const context = await contextFactory();
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  await page.evaluate(async () => {
+    const openRequest = indexedDB.open('db', 1);
+    openRequest.onupgradeneeded = () => openRequest.result.createObjectStore('store');
+    await new Promise<void>((resolve, reject) => {
+      openRequest.onsuccess = () => {
+        const db = openRequest.result;
+        const transaction = db.transaction('store', 'readwrite');
+        transaction.objectStore('store').put('value', 'key');
+        transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        transaction.onerror = () => reject(transaction.error);
+      };
+      openRequest.onerror = () => reject(openRequest.error);
+    });
+  });
+
+  const state = await context.storageState({ indexedDB: true });
+
+  await page.evaluate(() => new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase('db');
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error('deleteDatabase was blocked'));
+  }));
+
+  await context.setStorageState(state);
+  expect(await context.storageState({ indexedDB: true })).toEqual(state);
+});
+
 it('should round-trip WebAuthn credentials with storageState', async ({ contextFactory, server }) => {
   const context = await contextFactory();
   const credential = await context.credentials.create(server.HOSTNAME);


### PR DESCRIPTION
## Summary
- `storageState({ indexedDB: true })` left the IndexedDB connections it opened in the inspected page, blocking any later `deleteDatabase` on that origin and making `setStorageState()` hang forever while a page was open there.
- Close the connections in `_collectDB` and `_restoreDB` once done.

Fixes https://github.com/microsoft/playwright/issues/42258