### PR TITLE
fix(web): make expandable section headers keyboard operable

### DIFF
--- a/packages/trace-viewer/src/ui/attachmentsTab.tsx
+++ b/packages/trace-viewer/src/ui/attachmentsTab.tsx
@@ -69,14 +69,14 @@ const ExpandableAttachment: React.FunctionComponent<ExpandableAttachmentProps> =
 
   const title = <span style={{ marginLeft: 5 }} ref={ref} aria-label={attachment.name}>
     <span>{linkifyText(attachment.name)}</span>
-    {hasContent && <a style={{ marginLeft: 5 }} href={downloadURL(model, attachment)}>download</a>}
   </span>;
+  const download = hasContent && <a style={{ marginLeft: 5 }} href={downloadURL(model, attachment)}>download</a>;
 
   if (!isTextAttachment || !hasContent)
-    return <div style={{ marginLeft: 20 }}>{title}</div>;
+    return <div style={{ marginLeft: 20 }}>{title}{download}</div>;
 
   return <div className={clsx(flash && 'yellow-flash')}>
-    <Expandable title={title} expanded={expanded} setExpanded={setExpanded} expandOnTitleClick={true}>
+    <Expandable title={title} titleChildren={download} expanded={expanded} setExpanded={setExpanded} expandOnTitleClick={true}>
       {placeholder && <i>{placeholder}</i>}
     </Expandable>
     {expanded && attachmentText !== null && <div className='vbox' style={{ height: snippetHeight }}>

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -140,13 +140,11 @@ const ExpandableSection: React.FC<{
     setExpanded={setExpanded}
     expandOnTitleClick
     title={
-      <>
-        <span className='network-request-details-header'>{title}
-          {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
-        </span>
-        { titleChildren }
-      </>
+      <span className='network-request-details-header'>{title}
+        {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
+      </span>
     }
+    titleChildren={titleChildren}
     className={className}
   >
     {data && <table className='network-request-details-table'>

--- a/packages/web/src/components/expandable.css
+++ b/packages/web/src/components/expandable.css
@@ -30,6 +30,26 @@
   cursor: pointer;
 }
 
+.expandable-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  outline: none;
+}
+
+.expandable-toggle:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .expandable-content {
   margin-left: 25px;
 }

--- a/packages/web/src/components/expandable.spec.ts
+++ b/packages/web/src/components/expandable.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect, test } from '@playwright/test';
 
-import type { Collapsed, Expanded, Stateful, StatefulTitleClick } from './expandable.story';
+import type { Collapsed, Expanded, Stateful, StatefulTitleClick, StatefulTitleClickWithControl } from './expandable.story';
 
 test.use({ viewport: { width: 500, height: 500 } });
 
@@ -45,6 +45,24 @@ test('title click should expand when enabled', async ({ mount }) => {
   const component = await mount<typeof StatefulTitleClick>('components/expandable/StatefulTitleClick');
   await component.getByText('Title').click();
   await expect(component.getByTestId('expanded')).toHaveValue('true');
+});
+
+test('title should expand with the keyboard when title click is enabled', async ({ mount, page }) => {
+  const component = await mount<typeof StatefulTitleClick>('components/expandable/StatefulTitleClick');
+  const title = component.getByRole('button', { name: 'Title' });
+  await title.focus();
+  await expect(title).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
+  await page.keyboard.press('Space');
+  await expect(component.getByTestId('expanded')).toHaveValue('false');
+});
+
+test('titleChildren should render next to the toggle, not inside it', async ({ mount }) => {
+  const component = await mount<typeof StatefulTitleClickWithControl>('components/expandable/StatefulTitleClickWithControl');
+  const download = component.getByRole('link', { name: 'download' });
+  await expect(download).toBeVisible();
+  await expect(component.getByRole('button', { name: 'Title' }).getByRole('link')).toHaveCount(0);
 });
 
 test('title click should not expand by default', async ({ mount }) => {

--- a/packages/web/src/components/expandable.story.tsx
+++ b/packages/web/src/components/expandable.story.tsx
@@ -38,3 +38,12 @@ export const StatefulTitleClick = () => {
     <form hidden><input data-testid='expanded' readOnly value={String(expanded)} /></form>
   </>;
 };
+
+// Network details and the attachments tab both render a control next to the title.
+export const StatefulTitleClickWithControl = () => {
+  const [expanded, setExpanded] = React.useState(false);
+  return <>
+    <Expandable expanded={expanded} setExpanded={setExpanded} expandOnTitleClick title='Title' titleChildren={<a href='#download'>download</a>}>Details text</Expandable>
+    <form hidden><input data-testid='expanded' readOnly value={String(expanded)} /></form>
+  </>;
+};

--- a/packages/web/src/components/expandable.tsx
+++ b/packages/web/src/components/expandable.tsx
@@ -20,11 +20,14 @@ import { clsx } from '../uiUtils';
 
 export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
   title: React.JSX.Element | string,
+  // Rendered next to the title, outside of the toggle. Use it for links and buttons,
+  // which cannot be nested inside the toggle button.
+  titleChildren?: React.ReactNode,
   setExpanded: (expanded: boolean) => void,
   expanded: boolean,
   expandOnTitleClick?: boolean,
   className?: string;
-}>> = ({ title, children, setExpanded, expanded, expandOnTitleClick, className }) => {
+}>> = ({ title, titleChildren, children, setExpanded, expanded, expandOnTitleClick, className }) => {
   const titleId = React.useId();
   const regionId = React.useId();
 
@@ -36,21 +39,24 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
     onClick={!expandOnTitleClick ? onClick : undefined} />;
 
   return <div className={clsx('expandable', expanded && 'expanded', className)}>
-    {expandOnTitleClick ?
-      <div
-        id={titleId}
-        role='button'
-        aria-expanded={expanded}
-        aria-controls={regionId}
-        className='expandable-title'
-        onClick={onClick}>
-        {chevron}
-        {title}
-      </div> :
-      <div className='expandable-title'>
-        {chevron}
-        {title}
-      </div>}
+    <div className='expandable-title'>
+      {expandOnTitleClick ?
+        <button
+          id={titleId}
+          type='button'
+          aria-expanded={expanded}
+          aria-controls={regionId}
+          className='expandable-toggle'
+          onClick={onClick}>
+          {chevron}
+          {title}
+        </button> :
+        <>
+          {chevron}
+          {title}
+        </>}
+      {titleChildren}
+    </div>
     {expanded && <div id={regionId} aria-labelledby={titleId} role='region' className='expandable-content'>{children}</div>}
   </div>;
 };


### PR DESCRIPTION
## Rationale

`Expandable`'s title carries `role="button"`, `aria-expanded` and `aria-controls`, but it is a `div` with no `tabIndex` (`packages/web/src/components/expandable.tsx:40-49`). It tells assistive tech there is a button and then never takes focus, so in the trace viewer no attachment header and no section of network details can be expanded without a mouse. On main, focusing the real `Request Headers` header fails with `toBeFocused` receiving `inactive`.

The fix is the one already used for tab strips in #41434 and html-reporter chips in #42149: a native `<button>` plus a `:focus-visible` ring, no key handlers, Enter and Space come from the platform.

The plain div-to-button swap does not work here on its own. Both call sites render interactive content inside the title, the attachments tab a `download` link and network details the pretty-print toggle. A link or button nested inside a button is invalid and hides those controls from the accessibility tree, so they move to a `titleChildren` slot rendered next to the toggle rather than inside it.

The chevron-only variant (`expandOnTitleClick` unset, used by the UI mode filter panel) is left alone. Its title is an `<input>` and an icon-only toggle would need a label invented for it, which felt like a separate decision rather than something to fold in here.

Layout is unchanged. I measured the bounding boxes of the section header, the pretty-print button, the attachment name and the download link before and after, each against its own rebuilt bundle, and they are identical.

## Test

`expandable.spec.ts` gets the keyboard case, plus a check that `titleChildren` stays outside the toggle. On current main the first one fails with `toBeFocused` receiving `inactive`, and the second fails because the link ends up nested in the button.

Fixes https://github.com/microsoft/playwright/issues/42263

---

apologies if anything here is off, I worked through the fix with my own reasoning and used claude code as a sounding board for the design calls, especially the nested-interactive-content part. if I have got something wrong I would genuinely like to hear it. freshman in college trying to contribute something useful :)