### PR TITLE
fix(web): make the image diff mode switcher keyboard operable

### DIFF
--- a/packages/web/src/shared/imageDiffView.css
+++ b/packages/web/src/shared/imageDiffView.css
@@ -1,0 +1,37 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+.image-diff-tab {
+  flex: none;
+  margin: 0 10px;
+  padding: 0;
+  cursor: pointer;
+  user-select: none;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}
+
+.image-diff-tab.selected {
+  font-weight: 600;
+}
+
+.image-diff-tab:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}

--- a/packages/web/src/shared/imageDiffView.spec.ts
+++ b/packages/web/src/shared/imageDiffView.spec.ts
@@ -29,6 +29,16 @@ test('should render links', async ({ mount }) => {
   ]);
 });
 
+test('should switch mode with the keyboard', async ({ mount, page }) => {
+  const component = await mount<typeof Default>('shared/imageDiffView/Default');
+  const sxs = component.getByRole('tab', { name: 'Side by side' });
+  await sxs.focus();
+  await expect(sxs).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(sxs).toHaveAttribute('aria-selected', 'true');
+  await expect(component.locator('img')).toHaveCount(2);
+});
+
 test('should show diff by default', async ({ mount }) => {
   const component = await mount<typeof Default>('shared/imageDiffView/Default');
   const image = component.locator('img');

--- a/packages/web/src/shared/imageDiffView.tsx
+++ b/packages/web/src/shared/imageDiffView.tsx
@@ -15,7 +15,8 @@
 */
 
 import * as React from 'react';
-import { useMeasure } from '../uiUtils';
+import './imageDiffView.css';
+import { clsx, useMeasure } from '../uiUtils';
 import { ResizeView } from './resizeView';
 
 type TestAttachment = {
@@ -90,20 +91,23 @@ export const ImageDiffView: React.FC<{
   const fitWidth = imageWidth * scale;
   const fitHeight = imageHeight * scale;
 
-  const modeStyle: React.CSSProperties = {
-    flex: 'none',
-    margin: '0 10px',
-    cursor: 'pointer',
-    userSelect: 'none',
-  };
+  const modeTab = (value: typeof mode, label: React.ReactNode) => <button
+    type='button'
+    role='tab'
+    aria-selected={mode === value}
+    className={clsx('image-diff-tab', mode === value && 'selected')}
+    onClick={() => setMode(value)}>
+    {label}
+  </button>;
+
   return <div data-testid='test-result-image-mismatch' style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 'auto' }} ref={ref}>
     {isLoaded && <>
-      <div data-testid='test-result-image-mismatch-tabs' style={{ display: 'flex', margin: '10px 0 20px' }}>
-        {diff.diff && <div style={{ ...modeStyle, fontWeight: mode === 'diff' ? 600 : 'initial' }} onClick={() => setMode('diff')}>Diff</div>}
-        <div style={{ ...modeStyle, fontWeight: mode === 'actual' ? 600 : 'initial' }} onClick={() => setMode('actual')}>Actual</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'expected' ? 600 : 'initial' }} onClick={() => setMode('expected')}>{expectedImageTitle}</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'sxs' ? 600 : 'initial' }} onClick={() => setMode('sxs')}>Side by side</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'slider' ? 600 : 'initial' }} onClick={() => setMode('slider')}>Slider</div>
+      <div data-testid='test-result-image-mismatch-tabs' role='tablist' style={{ display: 'flex', margin: '10px 0 20px' }}>
+        {diff.diff && modeTab('diff', 'Diff')}
+        {modeTab('actual', 'Actual')}
+        {modeTab('expected', expectedImageTitle)}
+        {modeTab('sxs', 'Side by side')}
+        {modeTab('slider', 'Slider')}
       </div>
       <div style={{ display: 'flex', justifyContent: 'center', flex: 'auto', minHeight: fitHeight + 60 }}>
         {diff.diff && mode === 'diff' && <ImageWithSize image={diffImage} alt='Diff' hideSize={hideDetails} canvasWidth={fitWidth} canvasHeight={fitHeight} scale={scale}/>}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -182,7 +182,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('text=Image mismatch')).toBeVisible();
       await expect(page.locator('text=Snapshot mismatch')).toHaveCount(0);
 
-      await expect(page.getByTestId('test-screenshot-error-view').getByTestId('test-result-image-mismatch-tabs').locator('div')).toHaveText([
+      await expect(page.getByTestId('test-screenshot-error-view').getByTestId('test-result-image-mismatch-tabs').getByRole('tab')).toHaveText([
         'Diff',
         'Actual',
         'Expected',


### PR DESCRIPTION
## Rationale

The `Diff` / `Actual` / `Expected` / `Side by side` / `Slider` row in the screenshot diff view is five bare divs with an `onClick` (`packages/web/src/shared/imageDiffView.tsx:102-106`). No `role`, no `tabIndex`, no key handling. Tab walks past the whole row, so someone looking at a failed visual comparison cannot change which image is shown without a mouse, and a screen reader is never told the controls exist. Which mode is active is signalled only by `fontWeight`, so that is invisible to assistive tech too.

`ImageDiffView` is shared, so this covers three surfaces: the html reporter result view and error view, and the trace viewer attachments tab.

The fix is the approach this repo already settled on in #41434 and used again for chips in #42149: native elements plus a focus ring, no key handlers, Enter and Space come from the platform. Here that means `<button role="tab" aria-selected>` inside a `role="tablist"`, matching how `TabbedPaneTab` is written. `aria-selected` also gives the active mode a machine-readable representation it did not have.

The inline `modeStyle` object is replaced by a class in a new `imageDiffView.css`, which is how every other component in this tree is structured, and is what lets the focus ring use the shared `--vscode-focusBorder` token instead of the browser default.

Rendering is unchanged. I measured every switcher's box and computed font weight before and after against the same story, and the position, size and weight are identical for all five.

## Test

`imageDiffView.spec.ts` gets one keyboard case: focus `Side by side`, press Enter, assert it becomes selected and that two images are shown. On current main it fails at `toBeFocused` because no element matches `role=tab` at all.

`reporter-html.spec.ts` asserted the row via `.locator('div')`, which is now `.getByRole('tab')`. That test still pins the same five labels in the same order.

Fixes https://github.com/microsoft/playwright/issues/42266

---

apologies if I have misjudged anything here, I traced it myself and leaned on claude code to check my approach lined up with how the repo already does keyboard support rather than inventing a new pattern. very happy to be corrected. freshman in college trying to contribute something real :)