### PR TITLE
fix(aria): annotate aria-hidden elements in AI snapshots

### DIFF
--- a/packages/injected/src/ariaSnapshot.ts
+++ b/packages/injected/src/ariaSnapshot.ts
@@ -135,6 +135,8 @@ export function generateAriaTree(rootElement: Element, publicOptions: AriaTreeOp
     }
 
     const childAriaNode = visible ? toAriaNode(element, options, nameSourceElements) : null;
+    if (childAriaNode && element.getAttribute('aria-hidden')?.toLowerCase() === 'true')
+      childAriaNode.props['aria-hidden'] = 'true';
     let elementInfo: { element: Element, nameFromContentRefs: string[] } | undefined;
     if (childAriaNode) {
       if (childAriaNode.ref) {
@@ -502,6 +504,8 @@ export function renderAriaTreeAsJSON(ariaSnapshot: AriaSnapshot, publicOptions: 
       node.url = ariaNode.props.url;
     if (ariaNode.props.placeholder !== undefined)
       node.placeholder = ariaNode.props.placeholder;
+    if (ariaNode.props['aria-hidden'] !== undefined)
+      node.ariaHidden = true;
 
     const singleTextChild = ariaNode.children.length === 1 && typeof ariaNode.children[0] === 'string' ? ariaNode.children[0] : undefined;
     const isAtDepthLimit = !!publicOptions.depth && depth === publicOptions.depth;

--- a/packages/isomorphic/ariaSnapshot.ts
+++ b/packages/isomorphic/ariaSnapshot.ts
@@ -66,6 +66,7 @@ export type AriaNodeJSON = {
   level?: number;
   pressed?: true | 'mixed';
   selected?: true;
+  ariaHidden?: true;
   ref?: string;
   cursor?: 'pointer';
   box?: { x: number, y: number, width: number, height: number };

--- a/packages/isomorphic/ariaSnapshotRenderer.ts
+++ b/packages/isomorphic/ariaSnapshotRenderer.ts
@@ -67,6 +67,8 @@ export function renderAriaSnapshotAsYaml(snapshot: AriaSnapshotJSON, options: Ar
       key += ` [pressed]`;
     if (node.selected === true)
       key += ` [selected]`;
+    if (node.ariaHidden)
+      key += ` [aria-hidden]`;
     if (node.ref) {
       key += ` [ref=${node.ref}]`;
       if (node.cursor === 'pointer')

--- a/tests/page/page-aria-snapshot-ai.spec.ts
+++ b/tests/page/page-aria-snapshot-ai.spec.ts
@@ -931,3 +931,43 @@ it('should limit depth', async ({ page }) => {
       - listitem [ref=e8]
   `);
 });
+
+it('should annotate aria-hidden elements', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42223' } }, async ({ page }) => {
+  await page.setContent(`
+    <h2>Visible heading</h2>
+    <div aria-hidden="true">
+      <h1>Hidden heading</h1>
+      <p>Hidden content</p>
+    </div>
+    <h2>After hidden</h2>
+  `);
+
+  expect(await snapshotForAI(page)).toContainYaml(`
+    - generic [active] [ref=e1]:
+      - heading "Visible heading" [level=2] [ref=e2]
+      - generic [aria-hidden] [ref=e3]:
+        - heading [level=1] [ref=e4]: Hidden heading
+        - paragraph [ref=e5]: Hidden content
+      - heading "After hidden" [level=2] [ref=e6]
+  `);
+
+  // Default snapshot excludes aria-hidden elements entirely.
+  const defaultSnapshot = await page.locator('body').ariaSnapshot();
+  expect(defaultSnapshot).not.toContain('Hidden content');
+});
+
+it('should only annotate the top element in a hidden subtree', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42223' } }, async ({ page }) => {
+  await page.setContent(`
+    <div aria-hidden="true">
+      <h1>Heading</h1>
+      <p>Paragraph</p>
+    </div>
+  `);
+
+  // Only the element with aria-hidden="true" gets the annotation, not its descendants.
+  expect(await snapshotForAI(page)).toContainYaml(`
+    - generic [aria-hidden] [ref=e2]:
+      - heading [level=1] [ref=e3]: Heading
+      - paragraph [ref=e4]: Paragraph
+  `);
+});


### PR DESCRIPTION
## Rationale

The AI-mode snapshot (`mode: "ai"`) intentionally includes `aria-hidden` elements because they are visually visible, but nothing distinguishes them from ARIA-visible content. When a test fails and `error-context.md` is generated, agents (and humans) see content that `getByRole` and `ariaSnapshot()` will never find, with no indication why.

This adds an `[aria-hidden]` annotation following the same bracket pattern as `[checked]`, `[disabled]`, `[expanded]` etc. Elements included only through visual visibility (not ARIA visibility) now render with `[aria-hidden]` in the key. Default-mode snapshots are completely unaffected since they exclude these elements entirely.

Fixes #42223