### PR TITLE
fix(test): honor --no-deps in UI mode

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -95,7 +95,7 @@ npx playwright test --ui
 | `--last-failed-file <file>` | Override the default last-run JSON path for `--last-failed` (default: `<outputDir>/.last-run.json`). Same as `PLAYWRIGHT_LAST_RUN_OUTPUT_FILE` environment variable. |
 | `--list` | Collect all the tests and report them, but do not run. |
 | `--max-failures <N>` or `-x` | Stop after the first `N` failures. Passing `-x` stops after the first failure. |
-| `--no-deps` | Do not run project dependencies. |
+| `--no-deps` | Do not run project dependencies. Also applies in UI Mode (`--ui`). |
 | `--output <dir>` | Folder for output artifacts (default: "test-results"). |
 | `--only-changed [ref]` | Only run test files that have been changed between 'HEAD' and 'ref'. Defaults to running all uncommitted changes. Only supports Git. |
 | `--pass-with-no-tests` | Makes test run succeed even if no tests were found. |

--- a/docs/src/test-global-setup-teardown-js.md
+++ b/docs/src/test-global-setup-teardown-js.md
@@ -130,7 +130,7 @@ teardown('delete database', async ({ }) => {
 
 All test filtering options, such as `--grep`/`--grep-invert`, `--shard`, filtering directly by location in the command line, or using [`test.only()`](./api/class-test.md#test-only), directly select the primary tests to be run. If those tests belong to a project with dependencies, all tests from those dependencies will also run.
 
-You can pass `--no-deps` command line option to ignore all dependencies and teardowns. Only your directly selected projects will run.
+You can pass `--no-deps` command line option to ignore all dependencies and teardowns. Only your directly selected projects will run. This also applies in [UI Mode](./test-ui-mode.md) (`--ui`).
 
 ### More examples
 

--- a/docs/src/test-projects-js.md
+++ b/docs/src/test-projects-js.md
@@ -220,7 +220,7 @@ You can also teardown your setup by adding a [`property: TestProject.teardown`] 
 
 All test filtering options, such as `--grep`/`--grep-invert`, `--shard`, filtering directly by location in the command line, or using [`test.only()`](./api/class-test.md#test-only), directly select the primary tests to be run. If those tests belong to a project with dependencies, all tests from those dependencies will also run.
 
-You can pass `--no-deps` command line option to ignore all dependencies and teardowns. Only your directly selected projects will run.
+You can pass `--no-deps` command line option to ignore all dependencies and teardowns. Only your directly selected projects will run. This also applies in [UI Mode](./test-ui-mode.md) (`--ui`).
 
 ## Custom project parameters
 

--- a/packages/playwright/src/cli/testActions.ts
+++ b/packages/playwright/src/cli/testActions.ts
@@ -119,6 +119,7 @@ function overridesFromOptions(options: { [key: string]: any }): ipc.ConfigCLIOve
     forbidOnly: options.forbidOnly ? true : undefined,
     fullyParallel: options.fullyParallel ? true : undefined,
     globalTimeout: options.globalTimeout ? parseInt(options.globalTimeout, 10) : undefined,
+    ignoreProjectDependencies: options.deps === false ? true : undefined,
     maxFailures: options.x ? 1 : (options.maxFailures ? parseInt(options.maxFailures, 10) : undefined),
     outputDir: options.output ? path.resolve(process.cwd(), options.output) : undefined,
     pause: !!process.env.PWPAUSE,

--- a/packages/playwright/src/common/configLoader.ts
+++ b/packages/playwright/src/common/configLoader.ts
@@ -108,7 +108,7 @@ export async function loadConfig(location: ConfigLocation, overrides?: ConfigCLI
   validateConfig(location.resolvedConfigFile || '<default config>', userConfig);
   const fullConfig = new FullConfigInternal(location, userConfig, overrides || {}, metadata);
   fullConfig.defineConfigWasUsed = !!(userConfig as any)[kDefineConfigWasUsed];
-  if (ignoreProjectDependencies) {
+  if (ignoreProjectDependencies || overrides?.ignoreProjectDependencies) {
     for (const project of fullConfig.projects) {
       project.deps = [];
       project.teardown = undefined;

--- a/packages/playwright/src/common/ipc.ts
+++ b/packages/playwright/src/common/ipc.ts
@@ -29,6 +29,7 @@ export type ConfigCLIOverrides = {
   forbidOnly?: boolean;
   fullyParallel?: boolean;
   globalTimeout?: number;
+  ignoreProjectDependencies?: boolean;
   maxFailures?: number;
   outputDir?: string;
   pause?: boolean;

--- a/tests/playwright-test/ui-mode-test-setup.spec.ts
+++ b/tests/playwright-test/ui-mode-test-setup.spec.ts
@@ -310,6 +310,31 @@ test('should run part of the setup only', async ({ runUITest }) => {
   `);
 });
 
+test('should honor --no-deps in UI mode', async ({ runUITest }) => {
+  const { page } = await runUITest(testsWithSetup, undefined, { additionalArgs: ['--no-deps'] });
+  await page.getByText('Status:').click();
+  await page.getByRole('checkbox', { name: 'setup' }).setChecked(true);
+  await page.getByRole('checkbox', { name: 'teardown' }).setChecked(true);
+  await page.getByRole('checkbox', { name: 'test' }).setChecked(true);
+
+  await page.getByText('test.ts').hover();
+  await page.getByRole('treeitem', { name: 'test.ts' }).getByRole('button', { name: 'Run' }).click();
+
+  await expect.poll(dumpTestTree(page)).toBe(`
+    ▼ ◯ setup.ts
+        ◯ setup
+    ▼ ◯ teardown.ts
+        ◯ teardown
+    ▼ ✅ test.ts <=
+        ✅ test
+  `);
+
+  await page.getByTitle('Toggle output').click();
+  await expect(page.getByTestId('output')).toContainText(`from-test`);
+  await expect(page.getByTestId('output')).not.toContainText(`from-setup`);
+  await expect(page.getByTestId('output')).not.toContainText(`from-teardown`);
+});
+
 for (const useWeb of [true, false]) {
   test.describe(`web-mode: ${useWeb}`, () => {
     test('should run teardown with SIGINT', async ({ runUITest, nodeVersion }) => {


### PR DESCRIPTION
## Summary

Fixes #42262.

`--no-deps` was applied only on the plain CLI path via `loadConfigFromFile(..., opts.deps === false)`. UI mode goes through the out-of-process test server with `ConfigCLIOverrides`, which had no way to carry that flag, so dependencies came back when the server reloaded the config.

This adds `ignoreProjectDependencies` to `ConfigCLIOverrides`, sets it from `--no-deps` in `overridesFromOptions`, and honors it in `loadConfig`. Docs note that the flag also applies with `--ui`.

## Test plan

- [x] `npm run ttest -- --grep "should honor --no-deps in UI mode"` — passed
- [x] `npm run ttest -- tests/playwright-test/deps.spec.ts --grep "should not run projects with dependencies when --no-deps"` — passed