### PR TITLE
Add background workspaces for token connections

### DIFF
--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -7,7 +7,8 @@
     "debugger",
     "activeTab",
     "tabs",
-    "tabGroups"
+    "tabGroups",
+    "storage"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -16,7 +16,8 @@
 
 import { debugLog } from './relayConnection';
 import { PendingConnections } from './pendingConnection';
-import { ConnectedTabGroup, cleanupStalePlaywrightGroups, isNonDebuggableUrl, ungroupTabs, uniqueGroupStyle } from './connectedTabGroup';
+import { ConnectedTabGroup, isNonDebuggableUrl, ungroupTabs, uniqueGroupStyle } from './connectedTabGroup';
+import { BackgroundWorkspace, clearBackgroundWorkspace, initializeBackgroundWorkspaceCleanup, persistBackgroundWorkspace, provisionBackgroundWorkspace } from './backgroundWorkspace';
 
 type PageMessage = {
   type: 'connectionRequested';
@@ -44,12 +45,12 @@ class PlaywrightExtension {
   private _pendingConnections = new PendingConnections();
   // Service worker restarts lose all connection state, so any existing
   // Playwright groups are stale. Connections wait on this before reconciling.
-  private _cleanupPromise: Promise<void>;
+  private _cleanupPromise: Promise<string>;
 
   constructor() {
     chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
     chrome.action.onClicked.addListener(this._onActionClicked.bind(this));
-    this._cleanupPromise = cleanupStalePlaywrightGroups();
+    this._cleanupPromise = initializeBackgroundWorkspaceCleanup();
   }
 
   // Promise-based message handling is not supported in Chrome: https://issues.chromium.org/issues/40753031
@@ -69,11 +70,7 @@ class PlaywrightExtension {
             (error: any) => sendResponse({ success: false, error: error.message }));
         return true;
       case 'connectToTab': {
-        // Token-bypass (no specific pick) falls back to the connect page itself
-        // so `ConnectedTabGroup` always has a concrete tab to start from. Both
-        // sender.tab and UI-supplied tabs come from chrome.tabs.query / runtime
-        // message sender, where `id` is always defined.
-        const selectedTab = (message.tab ?? sender.tab!) as chrome.tabs.Tab & { id: number };
+        const selectedTab = message.tab as (chrome.tabs.Tab & { id: number }) | undefined;
         this._connectTab(sender.tab!.id!, selectedTab, message.clientName).then(
             () => sendResponse({ success: true }),
             (error: any) => sendResponse({ success: false, error: error.message }));
@@ -99,32 +96,48 @@ class PlaywrightExtension {
     }
   }
 
-  private async _connectTab(selectorTabId: number, tab: chrome.tabs.Tab & { id: number }, clientName: string | undefined): Promise<void> {
+  private async _connectTab(selectorTabId: number, tab: (chrome.tabs.Tab & { id: number }) | undefined, clientName: string | undefined): Promise<void> {
     try {
-      await this._cleanupPromise;
+      const sessionId = await this._cleanupPromise;
       this._releaseTab(selectorTabId);
-      if (tab.id !== selectorTabId && this._connectedTabIds().has(tab.id))
+      if (tab && tab.id !== selectorTabId && this._connectedTabIds().has(tab.id))
         throw new Error('This tab is already connected to another client');
 
       const connection = await this._pendingConnections.take(selectorTabId);
       if (!connection)
         throw new Error('Pending client connection closed');
 
+      const createdWorkspace = tab ? undefined : await provisionBackgroundWorkspace();
+      const workspace: BackgroundWorkspace | undefined = createdWorkspace;
+      const selectedTab = tab ?? createdWorkspace!.tab;
       const id = ++this._lastConnectionId;
       const taken = [...this._connections.values()].map(group => group.groupStyle);
-      const group = new ConnectedTabGroup(connection, tab, clientName, uniqueGroupStyle(clientName, taken), tabId => this._pendingConnections.has(tabId));
-      group.onclose = () => this._connections.delete(id);
+      const group = new ConnectedTabGroup(connection, selectedTab, clientName, uniqueGroupStyle(clientName, taken), tabId => this._pendingConnections.has(tabId), workspace?.windowId);
+      if (workspace) {
+        connection.setWorkspaceWindow(workspace.windowId);
+        connection.markOwnedTab(selectedTab.id);
+        connection.markOwnedTab(workspace.anchorTabId);
+        await persistBackgroundWorkspace(sessionId, workspace, [...connection.ownedTabIds]);
+        connection.onownershipchange = ownedTabIds => void persistBackgroundWorkspace(sessionId, workspace!, ownedTabIds);
+      }
+      group.onclose = () => {
+        this._connections.delete(id);
+        connection.onownershipchange = undefined;
+        if (workspace)
+          void clearBackgroundWorkspace();
+      };
       this._connections.set(id, group);
-
-      await Promise.all([
-        chrome.tabs.update(tab.id, { active: true }),
-        chrome.windows.update(tab.windowId, { focused: true }),
-      ]).catch(() => {});
-
-      if (tab.id !== selectorTabId)
+      await group.initialize(selectedTab);
+      if (!workspace) {
+        await Promise.all([
+          chrome.tabs.update(selectedTab.id, { active: true }),
+          chrome.windows.update(selectedTab.windowId, { focused: true }),
+        ]).catch(() => {});
+      }
+      if (!workspace && selectedTab.id !== selectorTabId)
         await chrome.tabs.remove(selectorTabId).catch(() => {});
     } catch (error: any) {
-      debugLog(`Failed to connect tab ${tab.id}:`, error.message);
+      debugLog(`Failed to connect from selector tab ${selectorTabId}:`, error.message);
       throw error;
     }
   }

--- a/packages/extension/src/backgroundWorkspace.ts
+++ b/packages/extension/src/backgroundWorkspace.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanupStalePlaywrightGroups } from './connectedTabGroup';
+
+const STORAGE_KEY = 'playwright.backgroundWorkspace';
+const SESSION_KEY = 'playwright.backgroundWorkspace.session';
+
+export type BackgroundWorkspace = {
+  windowId: number;
+  tab: chrome.tabs.Tab & { id: number };
+  anchorTabId: number;
+};
+
+type PersistedWorkspace = {
+  sessionId: string;
+  windowId: number;
+  ownedTabIds: number[];
+  anchorTabId: number;
+};
+
+export async function initializeBackgroundWorkspaceCleanup(): Promise<string> {
+  const sessionId = await sessionIdentifier();
+  const value = (await chrome.storage.local.get(STORAGE_KEY))[STORAGE_KEY];
+  if (isPersistedWorkspace(value) && value.sessionId === sessionId)
+    await cleanupWorkspace(value);
+  await chrome.storage.local.remove(STORAGE_KEY);
+  await cleanupStalePlaywrightGroups();
+  return sessionId;
+}
+
+export async function persistBackgroundWorkspace(sessionId: string, workspace: BackgroundWorkspace, ownedTabIds: readonly number[]): Promise<void> {
+  await chrome.storage.local.set({
+    [STORAGE_KEY]: { sessionId, windowId: workspace.windowId, anchorTabId: workspace.anchorTabId, ownedTabIds: [...ownedTabIds] },
+  });
+}
+
+export async function clearBackgroundWorkspace(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}
+
+export async function provisionBackgroundWorkspace(): Promise<BackgroundWorkspace> {
+  let bootstrapTabId: number | undefined;
+  let windowId: number | undefined;
+  try {
+    const bootstrap = await chrome.tabs.create({ url: 'about:blank', active: false });
+    if (bootstrap.id === undefined)
+      throw new Error('Chrome did not create a workspace bootstrap tab');
+    bootstrapTabId = bootstrap.id;
+    const createdWindow = await chrome.windows.create({ tabId: bootstrapTabId, type: 'normal', focused: false });
+    if (createdWindow?.id === undefined)
+      throw new Error('Chrome did not create a separate workspace window');
+    windowId = createdWindow.id;
+    const tab = await chrome.tabs.create({ windowId, url: 'about:blank', active: true });
+    if (tab.id === undefined)
+      throw new Error('Chrome did not create an initial workspace tab');
+    const managedTab = await chrome.tabs.update(tab.id, { autoDiscardable: false }) as chrome.tabs.Tab & { id: number };
+    await chrome.windows.update(windowId, { state: 'minimized' });
+    return { windowId, tab: managedTab, anchorTabId: bootstrapTabId };
+  } catch (error) {
+    if (windowId !== undefined)
+      await chrome.windows.remove(windowId).catch(() => {});
+    else if (bootstrapTabId !== undefined)
+      await chrome.tabs.remove(bootstrapTabId).catch(() => {});
+    throw error;
+  }
+}
+
+async function sessionIdentifier(): Promise<string> {
+  const existing = (await chrome.storage.session.get(SESSION_KEY))[SESSION_KEY];
+  if (typeof existing === 'string')
+    return existing;
+  const sessionId = crypto.randomUUID();
+  await chrome.storage.session.set({ [SESSION_KEY]: sessionId });
+  return sessionId;
+}
+
+async function cleanupWorkspace(workspace: PersistedWorkspace): Promise<void> {
+  try {
+    const window = await chrome.windows.get(workspace.windowId);
+    if (window.state !== 'minimized')
+      return;
+    const tabs = await chrome.tabs.query({ windowId: workspace.windowId });
+    const tabIds = new Set(tabs.map(tab => tab.id).filter((tabId): tabId is number => tabId !== undefined));
+    const managed = workspace.ownedTabIds.filter(tabId => tabIds.has(tabId));
+    if (tabIds.has(workspace.anchorTabId))
+      managed.push(workspace.anchorTabId);
+    if (!managed.length)
+      return;
+    const preserved = tabs.filter(tab => tab.id !== undefined && !managed.includes(tab.id));
+    if (preserved.length)
+      await chrome.tabs.remove(managed);
+    else
+      await chrome.windows.remove(workspace.windowId);
+  } catch {
+    // A missing or user-modified workspace is already safe to leave alone.
+  }
+}
+
+function isPersistedWorkspace(value: unknown): value is PersistedWorkspace {
+  if (!value || typeof value !== 'object')
+    return false;
+  const candidate = value as Partial<PersistedWorkspace>;
+  return typeof candidate.sessionId === 'string' && Number.isInteger(candidate.windowId) && Number.isInteger(candidate.anchorTabId) &&
+    Array.isArray(candidate.ownedTabIds) && candidate.ownedTabIds.every(tabId => Number.isInteger(tabId));
+}

--- a/packages/extension/src/connectedTabGroup.ts
+++ b/packages/extension/src/connectedTabGroup.ts
@@ -76,17 +76,19 @@ export class ConnectedTabGroup {
   private _isTabReserved: (tabId: number) => boolean;
   private _groupId: number | null = null;
   private _groupTabIds: Set<number> = new Set();
-  private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
+  private _onTabUpdatedListener: (tabId: number, changeInfo: chrome.tabs.OnUpdatedInfo, tab: chrome.tabs.Tab) => void;
   private _onTabRemovedListener: (tabId: number) => void;
+  private _workspaceWindowId: number | undefined;
 
   onclose?: () => void;
 
-  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab, clientName: string | undefined, groupStyle: GroupStyle, isTabReserved: (tabId: number) => boolean) {
+  constructor(connection: RelayConnection, selectedTab: chrome.tabs.Tab, clientName: string | undefined, groupStyle: GroupStyle, isTabReserved: (tabId: number) => boolean, workspaceWindowId?: number) {
     this.clientName = clientName;
     this.groupStyle = groupStyle;
     this._isTabReserved = isTabReserved;
     this._connection = connection;
-    this._connection.onclose = () => this._onConnectionClose();
+    this._workspaceWindowId = workspaceWindowId;
+    this._connection.onclose = () => void this._onConnectionClose();
     this._connection.ontabattached = (tabId: number) => this._onTabAttached(tabId);
     this._connection.ontabdetached = (tabId: number) => this._onTabDetached(tabId);
     this._onTabUpdatedListener = this._onTabUpdated.bind(this);
@@ -97,8 +99,17 @@ export class ConnectedTabGroup {
     // handshake. The relay holds Playwright-side CDP traffic until
     // `didInitialize` arrives, so it sees a fully populated tab model by the
     // time it handles `Target.setAutoAttach`.
-    this._connection.attachTab(selectedTab);
-    this._connection.didInitialize();
+  }
+
+  async initialize(selectedTab: chrome.tabs.Tab): Promise<void> {
+    try {
+      await this._addTabToGroup(selectedTab.id!);
+      this._connection.attachTab(selectedTab);
+      this._connection.didInitialize();
+    } catch (error) {
+      this._connection.close('Background workspace initialization failed');
+      throw error;
+    }
   }
 
   connectedTabIds(): number[] {
@@ -113,10 +124,11 @@ export class ConnectedTabGroup {
     if (!this._groupTabIds.has(tabId))
       return;
     this._groupTabIds.delete(tabId);
+    this._connection.markTabReclaimed(tabId);
     this._connection.detachTab(tabId);
   }
 
-  private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab): void {
+  private _onTabUpdated(tabId: number, changeInfo: chrome.tabs.OnUpdatedInfo, tab: chrome.tabs.Tab): void {
     if (changeInfo.groupId !== undefined)
       this._onTabGroupChanged(tabId, tab);
     if (changeInfo.url === undefined)
@@ -149,6 +161,7 @@ export class ConnectedTabGroup {
         this._connection.attachTab(tab);
     } else {
       this._groupTabIds.delete(tabId);
+      this._connection.markTabReclaimed(tabId);
       if (this._connection.attachedTabs.has(tabId))
         this._connection.detachTab(tabId);
     }
@@ -158,9 +171,9 @@ export class ConnectedTabGroup {
     this._groupTabIds.delete(tabId);
   }
 
-  private _onTabAttached(tabId: number): void {
+  private async _onTabAttached(tabId: number): Promise<void> {
     void this._updateBadge(tabId, CONNECTED_BADGE);
-    void this._addTabToGroup(tabId);
+    await this._addTabToGroup(tabId);
   }
 
   // The debugger detached (drag-out, tab close, or external action). Clear the
@@ -170,13 +183,25 @@ export class ConnectedTabGroup {
     void this._updateBadge(tabId, { text: '' });
   }
 
-  private _onConnectionClose(): void {
+  private async _onConnectionClose(): Promise<void> {
     chrome.tabs.onUpdated.removeListener(this._onTabUpdatedListener);
     chrome.tabs.onRemoved.removeListener(this._onTabRemovedListener);
     const groupTabs = [...this._groupTabIds];
     this._groupTabIds.clear();
-    if (groupTabs.length)
+    if (this._workspaceWindowId !== undefined) {
+      try {
+        const tabs = await chrome.tabs.query({ windowId: this._workspaceWindowId });
+        const preserved = tabs.filter(tab => tab.id !== undefined && !this._connection.ownedTabIds.has(tab.id));
+        if (preserved.length)
+          await chrome.tabs.remove(tabs.map(tab => tab.id).filter((id): id is number => id !== undefined && !preserved.some(tab => tab.id === id)));
+        else
+          await chrome.windows.remove(this._workspaceWindowId);
+      } catch (error: any) {
+        debugLog('Error cleaning up background workspace:', error);
+      }
+    } else if (groupTabs.length) {
       void ungroupTabs(groupTabs);
+    }
     this.onclose?.();
   }
 
@@ -200,14 +225,24 @@ export class ConnectedTabGroup {
     if (this._groupTabIds.has(tabId))
       return;
     try {
+      if (this._workspaceWindowId !== undefined && this._connection.ownedTabIds.has(tabId)) {
+        const tab = await chrome.tabs.get(tabId);
+        if (tab.windowId !== this._workspaceWindowId)
+          await chrome.tabs.move(tabId, { windowId: this._workspaceWindowId, index: -1 });
+      }
       await retryOnDrag(async () => {
         if (this._groupId === null) {
-          this._groupId = await chrome.tabs.group({ tabIds: [tabId] });
+          this._groupId = await chrome.tabs.group({
+            tabIds: [tabId],
+            ...(this._workspaceWindowId === undefined ? {} : { createProperties: { windowId: this._workspaceWindowId } }),
+          });
           await chrome.tabGroups.update(this._groupId, this.groupStyle);
         } else {
           await chrome.tabs.group({ groupId: this._groupId, tabIds: [tabId] });
         }
       });
+      if (this._workspaceWindowId !== undefined)
+        await chrome.windows.update(this._workspaceWindowId, { state: 'minimized' });
       this._groupTabIds.add(tabId);
     } catch (error: any) {
       debugLog('Error adding tab to group:', error);
@@ -218,7 +253,7 @@ export class ConnectedTabGroup {
 
 export async function ungroupTabs(tabIds: number[]): Promise<void> {
   try {
-    await retryOnDrag(() => chrome.tabs.ungroup(tabIds));
+    await retryOnDrag(() => chrome.tabs.ungroup(tabIds as [number, ...number[]]));
   } catch (error: any) {
     debugLog('Error ungrouping tabs:', error);
   }

--- a/packages/extension/src/relayConnection.ts
+++ b/packages/extension/src/relayConnection.ts
@@ -68,13 +68,38 @@ export class RelayConnection {
   private _closed = false;
   private _pendingReattach = new Set<number>();
   private _recentReattach = new Set<number>();
+  private _workspaceWindowId: number | undefined;
+  private _ownedTabIds = new Set<number>();
 
   onclose?: () => void;
-  ontabattached?: (tabId: number) => void;
+  onownershipchange?: (ownedTabIds: number[]) => void;
+  ontabattached?: (tabId: number) => void | Promise<void>;
   ontabdetached?: (tabId: number) => void;
 
   get attachedTabs(): ReadonlySet<number> {
     return this._attachedTabs;
+  }
+
+  setWorkspaceWindow(windowId: number): void {
+    this._workspaceWindowId = windowId;
+  }
+
+  get ownedTabIds(): ReadonlySet<number> {
+    return this._ownedTabIds;
+  }
+
+  markOwnedTab(tabId: number): void {
+    this._ownedTabIds.add(tabId);
+    this._notifyOwnershipChanged();
+  }
+
+  markTabReclaimed(tabId: number): void {
+    if (this._ownedTabIds.delete(tabId))
+      this._notifyOwnershipChanged();
+  }
+
+  private _notifyOwnershipChanged(): void {
+    this.onownershipchange?.([...this._ownedTabIds]);
   }
 
   constructor(ws: WebSocket) {
@@ -128,11 +153,11 @@ export class RelayConnection {
     this._checkLastTabDetached();
   }
 
-  private _notifyTabAttached(tabId: number): void {
+  private async _notifyTabAttached(tabId: number): Promise<void> {
     this._attachedTabs.add(tabId);
     this._hasEverAttached = true;
     this._pendingReattach.delete(tabId);
-    this.ontabattached?.(tabId);
+    await this.ontabattached?.(tabId);
   }
 
   private _notifyTabDetached(tabId: number): void {
@@ -175,6 +200,15 @@ export class RelayConnection {
   // Forwards chrome.* events concerning attached tabs to the relay, then runs
   // shared detach bookkeeping.
   private _onChromeEvent(fullMethod: string, args: any[]): void {
+    if (fullMethod === 'chrome.tabs.onRemoved' && this._ownedTabIds.delete(args[0] as number))
+      this._notifyOwnershipChanged();
+    if (fullMethod === 'chrome.tabs.onCreated') {
+      const tab = args[0] as chrome.tabs.Tab;
+      if (tab.id !== undefined && tab.openerTabId !== undefined && this._ownedTabIds.has(tab.openerTabId)) {
+        this.markOwnedTab(tab.id);
+        void chrome.tabs.update(tab.id, { autoDiscardable: false }).catch(() => {});
+      }
+    }
     const tabId = this._tabIdForEventArgs(fullMethod, args);
     if (tabId === undefined || !this._attachedTabs.has(tabId))
       return;
@@ -281,13 +315,30 @@ export class RelayConnection {
   private async _handleCommand(message: ProtocolCommand): Promise<any> {
     if (!ALLOWED_CHROME_COMMANDS.has(message.method))
       throw new Error(`Unknown method: ${message.method}`);
-    const args = (message.params ?? []) as any[];
+    const args = [...(message.params ?? [])] as any[];
+    if (message.method === 'chrome.debugger.sendCommand' && this._workspaceWindowId !== undefined &&
+        (args[1] === 'Page.bringToFront' || args[1] === 'Target.activateTarget'))
+      return {};
+    if (message.method === 'chrome.tabs.create' && this._workspaceWindowId !== undefined) {
+      const workspace = await chrome.windows.get(this._workspaceWindowId).catch(() => undefined);
+      if (!workspace || workspace.state !== 'minimized' || workspace.focused)
+        throw new Error('Background workspace is unavailable');
+      args[0] = { ...(args[0] ?? {}), windowId: this._workspaceWindowId, active: true };
+    }
     const result = await invokeChromeMethod(message.method, args);
+    if (message.method === 'chrome.tabs.create' && result?.id !== undefined) {
+      if (this._workspaceWindowId !== undefined && result.windowId !== this._workspaceWindowId) {
+        await chrome.tabs.remove(result.id).catch(() => {});
+        throw new Error('Chrome created the tab outside the background workspace');
+      }
+      this.markOwnedTab(result.id);
+      await chrome.tabs.update(result.id, { autoDiscardable: false });
+    }
     // Attach bookkeeping; detach flows through the chrome.debugger.onDetach event.
     if (message.method === 'chrome.debugger.attach') {
       const target = args[0] as chrome.debugger.Debuggee | undefined;
       if (target?.tabId !== undefined)
-        this._notifyTabAttached(target.tabId);
+        await this._notifyTabAttached(target.tabId);
     }
     return result ?? {};
   }

--- a/tests/extension/extension.spec.ts
+++ b/tests/extension/extension.spec.ts
@@ -444,12 +444,18 @@ test(`bypass connection dialog with token`, async ({ browserWithExtension, start
   });
 
   expect(await navigateResponse).toHaveResponse({
-    snapshot: expect.stringContaining(`- generic [active] [ref=f1e1]: Hello, world!`),
+    snapshot: expect.stringContaining(`Hello, world!`),
   });
 
-  const page = await browserContext.newPage();
-  await page.goto(`chrome-extension://${extensionId}/status.html`);
-  await expect(page.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
+  const statusPage = await browserContext.newPage();
+  await statusPage.goto(`chrome-extension://${extensionId}/status.html`);
+  const workspace = await statusPage.evaluate(async () => {
+    const windows = await chrome.windows.getAll({ populate: true });
+    return windows.find(window => window.tabs?.some(tab => tab.url?.includes('/hello-world')));
+  });
+  expect(workspace).toMatchObject({ state: 'minimized', focused: false });
+
+  await expect(statusPage.locator('.client-info')).toContainText(`Connected to "${clientName}"`);
 });
 
 test(`reconnects after the extension connection drops`, {


### PR DESCRIPTION
## Summary

Token-authorized Playwright Extension connections now receive an isolated Chrome workspace instead of taking focus in the user’s existing window.

- Create and minimize a dedicated workspace window for token-bypass connections.
- Keep MCP-created tabs in that workspace and suppress focus commands there.
- Track extension-owned tabs so cleanup removes only agent-created tabs while preserving user-reclaimed tabs.
- Clean up stale workspaces after an extension service-worker restart within the same browser session.

Selected-tab connections retain the existing foreground behavior.

## Validation

- `npx eslint packages/extension/src/background.ts packages/extension/src/backgroundWorkspace.ts packages/extension/src/connectedTabGroup.ts packages/extension/src/relayConnection.ts tests/extension/extension.spec.ts`
- `npx tsc -p packages/extension --noEmit`
- `npx vite build --clearScreen=false` from `packages/extension`
- `npx playwright test --config=tests/extension/playwright.config.ts --project=chromium tests/extension/extension.spec.ts --grep "bypass connection dialog with token"`

The regression test verifies the token-bypass workspace is minimized and unfocused.