### PR TITLE
fix(chromium): dispose worker sessions when their frame session is disposed

### DIFF
--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -42,6 +42,9 @@ export type ConnectionEventMap = {
 // should ignore.
 export const kBrowserCloseMessageId = -9999;
 
+// Error code returned by the browser for a message addressed to a closed or unknown session.
+const kSessionNotFoundErrorCode = -32001;
+
 export class CRConnection extends SdkObject {
   private _lastId = 0;
   private readonly _transport: ConnectionTransport;
@@ -79,9 +82,13 @@ export class CRConnection extends SdkObject {
     this._protocolLogger('receive', message);
     if (message.id === kBrowserCloseMessageId)
       return;
-    const session = this._sessions.get(message.sessionId || '');
-    if (session)
-      session._onMessage(message);
+    // Unknown session error has no sessionId, so route it by the message id.
+    const session = message.error?.code === kSessionNotFoundErrorCode ? this._sessionWithCallback(message.id) : this._sessions.get(message.sessionId || '');
+    session?._onMessage(message);
+  }
+
+  private _sessionWithCallback(id: number | undefined): CRSession | undefined {
+    return [...this._sessions.values()].find(session => session._hasCallback(id));
   }
 
   _onClose(reason?: string) {
@@ -151,18 +158,22 @@ export class CRSession extends SdkObject<Protocol.EventMap & ConnectionEventMap>
     return this.send(method, params).catch((error: ProtocolError) => debugLogger.log('error', error));
   }
 
+  _hasCallback(id: number | undefined): boolean {
+    return id !== undefined && this._callbacks.has(id);
+  }
+
   _onMessage(object: ProtocolResponse) {
     if (object.id && this._callbacks.has(object.id)) {
       const callback = this._callbacks.get(object.id)!;
       this._callbacks.delete(object.id);
       if (object.error) {
+        if (object.error.code === kSessionNotFoundErrorCode)
+          callback.error.type = 'closed';
         callback.error.setMessage(object.error.message);
         callback.reject(callback.error);
       } else {
         callback.resolve(object.result);
       }
-    } else if (object.id && object.error?.code === -32001) {
-      // Message to a closed session, just ignore it.
     } else {
       assert(!object.id, object?.error?.message || undefined);
       Promise.resolve().then(() => {

--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -83,12 +83,16 @@ export class CRConnection extends SdkObject {
     if (message.id === kBrowserCloseMessageId)
       return;
     // Unknown session error has no sessionId, so route it by the message id.
-    const session = message.error?.code === kSessionNotFoundErrorCode ? this._sessionWithCallback(message.id) : this._sessions.get(message.sessionId || '');
+    const session = message.id && message.error?.code === kSessionNotFoundErrorCode ?
+      this._sessionWithCallback(message.id) : this._sessions.get(message.sessionId || '');
     session?._onMessage(message);
   }
 
-  private _sessionWithCallback(id: number | undefined): CRSession | undefined {
-    return [...this._sessions.values()].find(session => session._hasCallback(id));
+  private _sessionWithCallback(id: number): CRSession | undefined {
+    for (const session of this._sessions.values()) {
+      if (session._hasCallback(id))
+        return session;
+    }
   }
 
   _onClose(reason?: string) {
@@ -158,8 +162,8 @@ export class CRSession extends SdkObject<Protocol.EventMap & ConnectionEventMap>
     return this.send(method, params).catch((error: ProtocolError) => debugLogger.log('error', error));
   }
 
-  _hasCallback(id: number | undefined): boolean {
-    return id !== undefined && this._callbacks.has(id);
+  _hasCallback(id: number): boolean {
+    return this._callbacks.has(id);
   }
 
   _onMessage(object: ProtocolResponse) {

--- a/packages/playwright-core/src/server/chromium/crConnection.ts
+++ b/packages/playwright-core/src/server/chromium/crConnection.ts
@@ -42,9 +42,6 @@ export type ConnectionEventMap = {
 // should ignore.
 export const kBrowserCloseMessageId = -9999;
 
-// Error code returned by the browser for a message addressed to a closed or unknown session.
-const kSessionNotFoundErrorCode = -32001;
-
 export class CRConnection extends SdkObject {
   private _lastId = 0;
   private readonly _transport: ConnectionTransport;
@@ -82,17 +79,9 @@ export class CRConnection extends SdkObject {
     this._protocolLogger('receive', message);
     if (message.id === kBrowserCloseMessageId)
       return;
-    // Unknown session error has no sessionId, so route it by the message id.
-    const session = message.id && message.error?.code === kSessionNotFoundErrorCode ?
-      this._sessionWithCallback(message.id) : this._sessions.get(message.sessionId || '');
-    session?._onMessage(message);
-  }
-
-  private _sessionWithCallback(id: number): CRSession | undefined {
-    for (const session of this._sessions.values()) {
-      if (session._hasCallback(id))
-        return session;
-    }
+    const session = this._sessions.get(message.sessionId || '');
+    if (session)
+      session._onMessage(message);
   }
 
   _onClose(reason?: string) {
@@ -162,22 +151,18 @@ export class CRSession extends SdkObject<Protocol.EventMap & ConnectionEventMap>
     return this.send(method, params).catch((error: ProtocolError) => debugLogger.log('error', error));
   }
 
-  _hasCallback(id: number): boolean {
-    return this._callbacks.has(id);
-  }
-
   _onMessage(object: ProtocolResponse) {
     if (object.id && this._callbacks.has(object.id)) {
       const callback = this._callbacks.get(object.id)!;
       this._callbacks.delete(object.id);
       if (object.error) {
-        if (object.error.code === kSessionNotFoundErrorCode)
-          callback.error.type = 'closed';
         callback.error.setMessage(object.error.message);
         callback.reject(callback.error);
       } else {
         callback.resolve(object.result);
       }
+    } else if (object.id && object.error?.code === -32001) {
+      // Message to a closed session, just ignore it.
     } else {
       assert(!object.id, object?.error?.message || undefined);
       Promise.resolve().then(() => {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -580,6 +580,8 @@ class FrameSession {
     this._firstNonInitialNavigationCommittedReject(new TargetClosedError(this._page.closeReason()));
     for (const childSession of this._childSessions)
       childSession.dispose();
+    for (const sessionId of [...this._workerSessions.keys()])
+      this._removeWorkerSession(sessionId);
     if (this._parentSession)
       this._parentSession._childSessions.delete(this);
     eventsHelper.removeEventListeners(this._eventListeners);
@@ -780,16 +782,21 @@ class FrameSession {
     session.on('Runtime.exceptionThrown', exception => this._page.addPageError(exceptionToError(exception.exceptionDetails), stackTraceToLocation(exception.exceptionDetails.stackTrace)));
   }
 
+  private _removeWorkerSession(sessionId: string): boolean {
+    const workerSession = this._workerSessions.get(sessionId);
+    if (!workerSession)
+      return false;
+    this._workerSessions.delete(sessionId);
+    this._crPage._networkManager.removeSession(workerSession);
+    workerSession.dispose();
+    this._page.removeWorker(sessionId);
+    return true;
+  }
+
   _onDetachedFromTarget(event: Protocol.Target.detachedFromTargetPayload) {
     // This might be a worker...
-    const workerSession = this._workerSessions.get(event.sessionId);
-    if (workerSession) {
-      this._workerSessions.delete(event.sessionId);
-      this._crPage._networkManager.removeSession(workerSession);
-      workerSession.dispose();
-      this._page.removeWorker(event.sessionId);
+    if (this._removeWorkerSession(event.sessionId))
       return;
-    }
 
     // ... or an oopif.
     const childFrameSession = this._crPage._sessions.get(event.targetId!);

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -580,7 +580,7 @@ class FrameSession {
     this._firstNonInitialNavigationCommittedReject(new TargetClosedError(this._page.closeReason()));
     for (const childSession of this._childSessions)
       childSession.dispose();
-    for (const sessionId of [...this._workerSessions.keys()])
+    for (const sessionId of this._workerSessions.keys())
       this._removeWorkerSession(sessionId);
     if (this._parentSession)
       this._parentSession._childSessions.delete(this);

--- a/tests/library/chromium/oopif.spec.ts
+++ b/tests/library/chromium/oopif.spec.ts
@@ -44,12 +44,13 @@ it('should handle oopif detach', async function({ page, browser, server }) {
   expect(detachedFrame).toBe(frame);
 });
 
-it('should remove workers of a detached oopif', async function({ page, server }) {
+it('should remove workers of a detached oopif', async function({ page, browser, server }) {
   await page.goto(server.EMPTY_PAGE);
   const [worker] = await Promise.all([
     page.waitForEvent('worker'),
     attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/worker/worker.html'),
   ]);
+  await assertOOPIFCount(browser, 1);
   expect(page.workers().length).toBe(1);
   await Promise.all([
     worker.waitForEvent('close'),
@@ -58,7 +59,7 @@ it('should remove workers of a detached oopif', async function({ page, server })
   expect(page.workers().length).toBe(0);
 });
 
-it('should not hang in unrouteAll when oopif worker is gone', async function({ page, context, server }) {
+it('should not hang in unrouteAll when oopif worker is gone', async function({ page, context, browser, server }) {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42278' });
   await context.route('**/*', route => route.continue());
   await page.goto(server.EMPTY_PAGE);
@@ -66,6 +67,7 @@ it('should not hang in unrouteAll when oopif worker is gone', async function({ p
     page.waitForEvent('worker'),
     attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/worker/worker.html'),
   ]);
+  await assertOOPIFCount(browser, 1);
   await page.goto(server.CROSS_PROCESS_PREFIX + '/title.html');
   await context.unrouteAll();
 });

--- a/tests/library/chromium/oopif.spec.ts
+++ b/tests/library/chromium/oopif.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { contextTest as it, expect } from '../../config/browserTest';
+import { attachFrame } from '../../config/utils';
 import type { Frame, Browser } from '@playwright/test';
 
 it.use({
@@ -41,6 +42,32 @@ it('should handle oopif detach', async function({ page, browser, server }) {
     page.evaluate(() => document.querySelector('iframe')!.remove()),
   ]);
   expect(detachedFrame).toBe(frame);
+});
+
+it('should remove workers of a detached oopif', async function({ page, server }) {
+  await page.goto(server.EMPTY_PAGE);
+  const [worker] = await Promise.all([
+    page.waitForEvent('worker'),
+    attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/worker/worker.html'),
+  ]);
+  expect(page.workers().length).toBe(1);
+  await Promise.all([
+    worker.waitForEvent('close'),
+    page.goto(server.PREFIX + '/title.html'),
+  ]);
+  expect(page.workers().length).toBe(0);
+});
+
+it('should not hang in unrouteAll when oopif worker is gone', async function({ page, context, server }) {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42278' });
+  await context.route('**/*', route => route.continue());
+  await page.goto(server.EMPTY_PAGE);
+  await Promise.all([
+    page.waitForEvent('worker'),
+    attachFrame(page, 'frame1', server.CROSS_PROCESS_PREFIX + '/worker/worker.html'),
+  ]);
+  await page.goto(server.CROSS_PROCESS_PREFIX + '/title.html');
+  await context.unrouteAll();
 });
 
 it('should handle remote -> local -> remote transitions', async function({ page, browser, server }) {


### PR DESCRIPTION
## Summary
- A dedicated worker inside an out-of-process iframe gets a CDP session that is a child of the iframe's session. When the iframe target dies, the worker's `Target.detachedFromTarget` is delivered on the already dead iframe session and is lost, so `FrameSession.dispose()` left the worker session registered in the network manager and in `page.workers()`.
- `context.unrouteAll()` then sent `Network.setCacheDisabled` to a session the browser had forgotten. The error reply for an unknown session carries no `sessionId`, so it was routed to the root session, did not match any callback there and got dropped, and the command hung forever.
- Dispose worker sessions along with their frame session.

Fixes https://github.com/microsoft/playwright/issues/42278