### PR TITLE
feat(tracing): allow configuring the screenshots size

### DIFF
--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -62,8 +62,11 @@ The quality of the image, between 0-100.
   - `height` <[int]> Max frame height in pixels.
 
 Specifies the dimensions of screencast frames. The actual frame is scaled to preserve the page's aspect ratio and may be smaller than these bounds.
-If a screencast is already active (e.g. started by tracing or video recording), the existing configuration takes precedence and the frame size may exceed these bounds or this option may be ignored.
 If not specified the size will be equal to page viewport scaled down to fit into 800×800.
+
+A page is captured only once, and all consumers share that single capture. Tracing captures screenshots
+this way as well, so with tracing or the `recordVideo` context option already active this option is
+ignored, and both the frames and any recorded video use the size of the running capture.
 
 ## async method: Screencast.stop
 * since: v1.59

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -139,26 +139,26 @@ given name prefix inside the [`option: BrowserType.launch.tracesDir`] directory 
 To specify the final trace zip file name, you need to pass `path` option to
 [`method: Tracing.stop`] instead.
 
-### option: Tracing.start.screenshots
-* since: v1.12
+### option: Tracing.start.screencast
+* since: v1.63
 * langs: js
-- `screenshots` <[boolean]|[Object]>
+- `screencast` <[boolean]|[Object]>
   - `size` ?<[Object]> Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's
     aspect ratio and may be smaller than these bounds. If not specified the size will be equal to `viewport` scaled
     down to fit into 800x800. Optional.
     - `width` <[int]> Max screenshot width in pixels.
     - `height` <[int]> Max screenshot height in pixels.
+  - `quality` ?<[int]> The quality of the screenshots, between 0-100. Defaults to 90. Optional.
 
-Whether to capture screenshots during tracing. Screenshots are used to build
-a timeline preview. Passing `true` is a shortcut for `{}`.
+Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
+Passing `true` is a shortcut for `{}`. Takes precedence over [`option: Tracing.start.screenshots`].
 
 A page is captured only once, and tracing shares that capture with [`method: Screencast.start`] and video recording.
-The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other consumers: set
-it to keep tracing from capping the size they receive.
+The trace viewer renders the timeline preview at a fixed size, so these settings only matter to those other
+consumers: raise them to keep tracing from capping what the others receive.
 
 ### option: Tracing.start.screenshots
 * since: v1.12
-* langs: java, python, csharp
 - `screenshots` <[boolean]>
 
 Whether to capture screenshots during tracing. Screenshots are used to build

--- a/docs/src/api/class-tracing.md
+++ b/docs/src/api/class-tracing.md
@@ -141,6 +141,24 @@ To specify the final trace zip file name, you need to pass `path` option to
 
 ### option: Tracing.start.screenshots
 * since: v1.12
+* langs: js
+- `screenshots` <[boolean]|[Object]>
+  - `size` ?<[Object]> Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's
+    aspect ratio and may be smaller than these bounds. If not specified the size will be equal to `viewport` scaled
+    down to fit into 800x800. Optional.
+    - `width` <[int]> Max screenshot width in pixels.
+    - `height` <[int]> Max screenshot height in pixels.
+
+Whether to capture screenshots during tracing. Screenshots are used to build
+a timeline preview. Passing `true` is a shortcut for `{}`.
+
+A page is captured only once, and tracing shares that capture with [`method: Screencast.start`] and video recording.
+The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other consumers: set
+it to keep tracing from capping the size they receive.
+
+### option: Tracing.start.screenshots
+* since: v1.12
+* langs: java, python, csharp
 - `screenshots` <[boolean]>
 
 Whether to capture screenshots during tracing. Screenshots are used to build

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -683,7 +683,10 @@ export default defineConfig({
 - type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"retain-on-first-failure"|"retain-on-failure-and-retries">>
   - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
-  - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.
+  - `screenshots` ?<[boolean]|[Object]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is a shortcut for `{}`. Defaults to true. Optional.
+    - `size` ?<[Object]> Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. Optional.
+      - `width` <[int]> Max screenshot width in pixels.
+      - `height` <[int]> Max screenshot height in pixels.
   - `snapshots` ?<[boolean]|[Object]> Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`. Defaults to true. Optional.
     - `dom` ?<[boolean]> Capture DOM snapshot on every action and record network activity. Optional.
     - `aria` ?<[boolean]> Capture aria snapshot of the page on every action. Optional.

--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -683,10 +683,12 @@ export default defineConfig({
 - type: <[Object]|[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"retain-on-first-failure"|"retain-on-failure-and-retries">>
   - `mode` <[TraceMode]<"off"|"on"|"retain-on-failure"|"on-first-retry"|"on-all-retries"|"retain-on-first-failure"|"retain-on-failure-and-retries">> Trace recording mode.
   - `attachments` ?<[boolean]> Whether to include test attachments. Defaults to true. Optional.
-  - `screenshots` ?<[boolean]|[Object]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is a shortcut for `{}`. Defaults to true. Optional.
+  - `screencast` ?<[boolean]|[Object]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is a shortcut for `{}`. Takes precedence over `screenshots`. Optional.
     - `size` ?<[Object]> Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. Optional.
       - `width` <[int]> Max screenshot width in pixels.
       - `height` <[int]> Max screenshot height in pixels.
+    - `quality` ?<[int]> The quality of the screenshots, between 0-100. Defaults to 90. Optional.
+  - `screenshots` ?<[boolean]> Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Defaults to true. Optional.
   - `snapshots` ?<[boolean]|[Object]> Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`. Defaults to true. Optional.
     - `dom` ?<[boolean]> Capture DOM snapshot on every action and record network activity. Optional.
     - `aria` ?<[boolean]> Capture aria snapshot of the page on every action. Optional.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -23684,9 +23684,32 @@ export interface Tracing {
     name?: string;
 
     /**
-     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
+     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is
+     * a shortcut for `{}`.
+     *
+     * A page is captured only once, and tracing shares that capture with
+     * [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start) and video
+     * recording. The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other
+     * consumers: set it to keep tracing from capping the size they receive.
      */
-    screenshots?: boolean;
+    screenshots?: boolean|{
+      /**
+       * Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may
+       * be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into
+       * 800x800. Optional.
+       */
+      size?: {
+        /**
+         * Max screenshot width in pixels.
+         */
+        width: number;
+
+        /**
+         * Max screenshot height in pixels.
+         */
+        height: number;
+      };
+    };
 
     /**
      * Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -23685,14 +23685,15 @@ export interface Tracing {
 
     /**
      * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is
-     * a shortcut for `{}`.
+     * a shortcut for `{}`. Takes precedence over
+     * [`screenshots`](https://playwright.dev/docs/api/class-tracing#tracing-start-option-screenshots).
      *
      * A page is captured only once, and tracing shares that capture with
      * [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start) and video
-     * recording. The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other
-     * consumers: set it to keep tracing from capping the size they receive.
+     * recording. The trace viewer renders the timeline preview at a fixed size, so these settings only matter to those
+     * other consumers: raise them to keep tracing from capping what the others receive.
      */
-    screenshots?: boolean|{
+    screencast?: boolean|{
       /**
        * Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may
        * be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into
@@ -23709,7 +23710,17 @@ export interface Tracing {
          */
         height: number;
       };
+
+      /**
+       * The quality of the screenshots, between 0-100. Defaults to 90. Optional.
+       */
+      quality?: number;
     };
+
+    /**
+     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
+     */
+    screenshots?: boolean;
 
     /**
      * Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`.

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -5055,6 +5055,7 @@ export type TracingTracingStartParams = {
     width: number,
     height: number,
   },
+  screencastQuality?: number,
   live?: boolean,
 };
 export type TracingTracingStartOptions = {
@@ -5067,6 +5068,7 @@ export type TracingTracingStartOptions = {
     width: number,
     height: number,
   },
+  screencastQuality?: number,
   live?: boolean,
 };
 export type TracingTracingStartResult = void;

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -5051,6 +5051,10 @@ export type TracingTracingStartParams = {
   snapshotAria?: boolean,
   snapshotScreen?: boolean,
   screencast?: boolean,
+  screencastSize?: {
+    width: number,
+    height: number,
+  },
   live?: boolean,
 };
 export type TracingTracingStartOptions = {
@@ -5059,6 +5063,10 @@ export type TracingTracingStartOptions = {
   snapshotAria?: boolean,
   snapshotScreen?: boolean,
   screencast?: boolean,
+  screencastSize?: {
+    width: number,
+    height: number,
+  },
   live?: boolean,
 };
 export type TracingTracingStartResult = void;

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -42,17 +42,19 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     super(parent, type, guid, initializer);
   }
 
-  async start(options: { name?: string, title?: string, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean, sources?: boolean, live?: boolean } = {}) {
+  async start(options: { name?: string, title?: string, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, live?: boolean } = {}) {
     await this._wrapApiCall(async () => {
       this._includeSources = !!options.sources;
       this._isLive = !!options.live;
       const snapshots = typeof options.snapshots === 'object' ? options.snapshots : { dom: options.snapshots };
+      const screenshots = typeof options.screenshots === 'object' ? options.screenshots : {};
       await this._channel.tracingStart({
         name: options.name,
         snapshotDom: snapshots.dom,
         snapshotAria: snapshots.aria,
         snapshotScreen: snapshots.screen,
-        screencast: options.screenshots,
+        screencast: !!options.screenshots,
+        screencastSize: screenshots.size,
         live: options.live,
       }, kNoTimeout);
       const { traceName } = await this._channel.tracingStartChunk({ name: options.name, title: options.title }, kNoTimeout);

--- a/packages/playwright-core/src/client/tracing.ts
+++ b/packages/playwright-core/src/client/tracing.ts
@@ -42,19 +42,21 @@ export class Tracing extends ChannelOwner<channels.TracingChannel> implements ap
     super(parent, type, guid, initializer);
   }
 
-  async start(options: { name?: string, title?: string, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, live?: boolean } = {}) {
+  async start(options: { name?: string, title?: string, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screencast?: boolean | { size?: { width: number, height: number }, quality?: number }, screenshots?: boolean, sources?: boolean, live?: boolean } = {}) {
     await this._wrapApiCall(async () => {
       this._includeSources = !!options.sources;
       this._isLive = !!options.live;
       const snapshots = typeof options.snapshots === 'object' ? options.snapshots : { dom: options.snapshots };
-      const screenshots = typeof options.screenshots === 'object' ? options.screenshots : {};
+      const screencastOption = options.screencast ?? options.screenshots;
+      const screencast = typeof screencastOption === 'object' ? screencastOption : {};
       await this._channel.tracingStart({
         name: options.name,
         snapshotDom: snapshots.dom,
         snapshotAria: snapshots.aria,
         snapshotScreen: snapshots.screen,
-        screencast: !!options.screenshots,
-        screencastSize: screenshots.size,
+        screencast: !!screencastOption,
+        screencastSize: screencast.size,
+        screencastQuality: screencast.quality,
         live: options.live,
       }, kNoTimeout);
       const { traceName } = await this._channel.tracingStartChunk({ name: options.name, title: options.title }, kNoTimeout);

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -5052,6 +5052,10 @@ export type TracingTracingStartParams = {
   snapshotAria?: boolean,
   snapshotScreen?: boolean,
   screencast?: boolean,
+  screencastSize?: {
+    width: number,
+    height: number,
+  },
   live?: boolean,
 };
 export type TracingTracingStartOptions = {
@@ -5060,6 +5064,10 @@ export type TracingTracingStartOptions = {
   snapshotAria?: boolean,
   snapshotScreen?: boolean,
   screencast?: boolean,
+  screencastSize?: {
+    width: number,
+    height: number,
+  },
   live?: boolean,
 };
 export type TracingTracingStartResult = void;

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -5056,6 +5056,7 @@ export type TracingTracingStartParams = {
     width: number,
     height: number,
   },
+  screencastQuality?: number,
   live?: boolean,
 };
 export type TracingTracingStartOptions = {
@@ -5068,6 +5069,7 @@ export type TracingTracingStartOptions = {
     width: number,
     height: number,
   },
+  screencastQuality?: number,
   live?: boolean,
 };
 export type TracingTracingStartResult = void;

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -65,6 +65,7 @@ export type TracerOptions = {
   snapshotScreen?: boolean;
   screencast?: boolean;
   screencastSize?: types.Size;
+  screencastQuality?: number;
   live?: boolean;
 };
 
@@ -747,7 +748,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       this._appendResource(file, params.buffer);
       this._appendTraceEvent(event);
     };
-    this._pageTracingRecorders.set(page, new ScreencastTracingRecorder(page.screencast, onFrame, this._state!.options.screencastSize));
+    this._pageTracingRecorders.set(page, new ScreencastTracingRecorder(page.screencast, onFrame, this._state!.options.screencastSize, this._state!.options.screencastQuality));
   }
 
   private _appendTraceEvent(event: trace.TraceEvent) {
@@ -847,10 +848,11 @@ class ScreencastTracingRecorder {
   private _pendingAck: ManualPromise<void> | undefined;
   private _timer: NodeJS.Timeout | undefined;
 
-  constructor(screencast: Screencast, onFrame: (frame: types.ScreencastFrame) => void, size: types.Size | undefined) {
+  constructor(screencast: Screencast, onFrame: (frame: types.ScreencastFrame) => void, size: types.Size | undefined, quality: number | undefined) {
     this._screencast = screencast;
     this._client = {
       size,
+      quality,
       onFrame: (frame: types.ScreencastFrame) => {
         const time = monotonicTime();
 

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -64,6 +64,7 @@ export type TracerOptions = {
   snapshotAria?: boolean;
   snapshotScreen?: boolean;
   screencast?: boolean;
+  screencastSize?: types.Size;
   live?: boolean;
 };
 
@@ -746,7 +747,7 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       this._appendResource(file, params.buffer);
       this._appendTraceEvent(event);
     };
-    this._pageTracingRecorders.set(page, new ScreencastTracingRecorder(page.screencast, onFrame));
+    this._pageTracingRecorders.set(page, new ScreencastTracingRecorder(page.screencast, onFrame, this._state!.options.screencastSize));
   }
 
   private _appendTraceEvent(event: trace.TraceEvent) {
@@ -846,9 +847,10 @@ class ScreencastTracingRecorder {
   private _pendingAck: ManualPromise<void> | undefined;
   private _timer: NodeJS.Timeout | undefined;
 
-  constructor(screencast: Screencast, onFrame: (frame: types.ScreencastFrame) => void) {
+  constructor(screencast: Screencast, onFrame: (frame: types.ScreencastFrame) => void, size: types.Size | undefined) {
     this._screencast = screencast;
     this._client = {
+      size,
       onFrame: (frame: types.ScreencastFrame) => {
         const time = monotonicTime();
 

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -57,10 +57,11 @@ export class VideoRecorder {
       size: options.size,
     };
 
+    // Encode into the size of the running capture: it may differ from the requested one when
+    // another client (e.g. tracing) started the screencast first, and padding a smaller frame
+    // into the requested size would leave gray borders.
     const { size } = this._screencast.addClient(this._client);
-    // For video files only, prioritize encoding into the given size, regardless of the actual pixel data.
-    const videoSize = options.size ?? size;
-    this._videoRecorder = new FfmpegVideoRecorder(ffmpegPath, videoSize, outputFile, this._screencast.page.delegate);
+    this._videoRecorder = new FfmpegVideoRecorder(ffmpegPath, size, outputFile, this._screencast.page.delegate);
     this._artifact = new Artifact(this._screencast.page.browserContext, outputFile);
     return this._artifact;
   }

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -23684,9 +23684,32 @@ export interface Tracing {
     name?: string;
 
     /**
-     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
+     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is
+     * a shortcut for `{}`.
+     *
+     * A page is captured only once, and tracing shares that capture with
+     * [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start) and video
+     * recording. The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other
+     * consumers: set it to keep tracing from capping the size they receive.
      */
-    screenshots?: boolean;
+    screenshots?: boolean|{
+      /**
+       * Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may
+       * be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into
+       * 800x800. Optional.
+       */
+      size?: {
+        /**
+         * Max screenshot width in pixels.
+         */
+        width: number;
+
+        /**
+         * Max screenshot height in pixels.
+         */
+        height: number;
+      };
+    };
 
     /**
      * Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -23685,14 +23685,15 @@ export interface Tracing {
 
     /**
      * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview. Passing `true` is
-     * a shortcut for `{}`.
+     * a shortcut for `{}`. Takes precedence over
+     * [`screenshots`](https://playwright.dev/docs/api/class-tracing#tracing-start-option-screenshots).
      *
      * A page is captured only once, and tracing shares that capture with
      * [screencast.start([options])](https://playwright.dev/docs/api/class-screencast#screencast-start) and video
-     * recording. The trace viewer renders the timeline preview at a fixed size, so `size` only matters to those other
-     * consumers: set it to keep tracing from capping the size they receive.
+     * recording. The trace viewer renders the timeline preview at a fixed size, so these settings only matter to those
+     * other consumers: raise them to keep tracing from capping what the others receive.
      */
-    screenshots?: boolean|{
+    screencast?: boolean|{
       /**
        * Dimensions of the captured screenshots. Each screenshot is scaled down to preserve the page's aspect ratio and may
        * be smaller than these bounds. If not specified the size will be equal to `viewport` scaled down to fit into
@@ -23709,7 +23710,17 @@ export interface Tracing {
          */
         height: number;
       };
+
+      /**
+       * The quality of the screenshots, between 0-100. Defaults to 90. Optional.
+       */
+      quality?: number;
     };
+
+    /**
+     * Whether to capture screenshots during tracing. Screenshots are used to build a timeline preview.
+     */
+    screenshots?: boolean;
 
     /**
      * Which snapshots to capture on every action. Passing `true` is a shortcut for `{ dom: true }`.

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -38,7 +38,7 @@ const version: trace.VERSION = 8;
 let traceOrdinal = 0;
 
 type TraceFixtureValue =  PlaywrightWorkerOptions['trace'] | undefined;
-type TraceOptions = { screenshots: boolean, snapshots: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, sources: boolean, attachments: boolean, live: boolean, mode: TraceMode };
+type TraceOptions = { screenshots: boolean | { size?: { width: number, height: number } }, snapshots: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, sources: boolean, attachments: boolean, live: boolean, mode: TraceMode };
 
 export class TestTracing {
   private _testInfo: TestInfoImpl;

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -38,7 +38,7 @@ const version: trace.VERSION = 8;
 let traceOrdinal = 0;
 
 type TraceFixtureValue =  PlaywrightWorkerOptions['trace'] | undefined;
-type TraceOptions = { screenshots: boolean | { size?: { width: number, height: number } }, snapshots: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, sources: boolean, attachments: boolean, live: boolean, mode: TraceMode };
+type TraceOptions = { screencast?: boolean | { size?: { width: number, height: number }, quality?: number }, screenshots: boolean, snapshots: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, sources: boolean, attachments: boolean, live: boolean, mode: TraceMode };
 
 export class TestTracing {
   private _testInfo: TestInfoImpl;

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7191,7 +7191,7 @@ export interface PlaywrightWorkerOptions {
    *
    * Learn more about [recording trace](https://playwright.dev/docs/test-use-options#recording-options).
    */
-  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean, sources?: boolean, attachments?: boolean };
+  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, attachments?: boolean };
   /**
    * Whether to record video for each test. Defaults to `'off'`. The initial run of a test is the "first run";
    * subsequent runs caused by [retries](https://playwright.dev/docs/test-retries) are "retries".

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7191,7 +7191,7 @@ export interface PlaywrightWorkerOptions {
    *
    * Learn more about [recording trace](https://playwright.dev/docs/test-use-options#recording-options).
    */
-  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, attachments?: boolean };
+  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screencast?: boolean | { size?: { width: number, height: number }, quality?: number }, screenshots?: boolean, sources?: boolean, attachments?: boolean };
   /**
    * Whether to record video for each test. Defaults to `'off'`. The initial run of a test is the "first run";
    * subsequent runs caused by [retries](https://playwright.dev/docs/test-retries) are "retries".

--- a/packages/protocol/spec/tracing.yml
+++ b/packages/protocol/spec/tracing.yml
@@ -26,6 +26,11 @@ Tracing:
         snapshotAria: boolean?
         snapshotScreen: boolean?
         screencast: boolean?
+        screencastSize:
+          type: object?
+          properties:
+            width: int
+            height: int
         live: boolean?
 
     tracingStartChunk:

--- a/packages/protocol/spec/tracing.yml
+++ b/packages/protocol/spec/tracing.yml
@@ -31,6 +31,7 @@ Tracing:
           properties:
             width: int
             height: int
+        screencastQuality: int?
         live: boolean?
 
     tracingStartChunk:

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -3045,6 +3045,7 @@ scheme.TracingTracingStartParams = tObject({
     width: tInt,
     height: tInt,
   })),
+  screencastQuality: tOptional(tInt),
   live: tOptional(tBoolean),
 });
 scheme.TracingTracingStartResult = tOptional(tObject({}));

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -3041,6 +3041,10 @@ scheme.TracingTracingStartParams = tObject({
   snapshotAria: tOptional(tBoolean),
   snapshotScreen: tOptional(tBoolean),
   screencast: tOptional(tBoolean),
+  screencastSize: tOptional(tObject({
+    width: tInt,
+    height: tInt,
+  })),
   live: tOptional(tBoolean),
 });
 scheme.TracingTracingStartResult = tOptional(tObject({}));

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -278,6 +278,27 @@ test('start dispose stops recording', async ({ browser }, testInfo) => {
   await context.close();
 });
 
+test('start size is ignored while tracing is active', async ({ browser, trace }, testInfo) => {
+  test.skip(trace === 'on', 'the test starts its own tracing');
+  test.slow();
+
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1200 } });
+  await context.tracing.start({ screenshots: true });
+  const page = await context.newPage();
+
+  const videoPath = testInfo.outputPath('video.webm');
+  // Tracing already captures at the viewport scaled down to 800x600, so this size is ignored.
+  await page.screencast.start({ path: videoPath, size: { width: 1000, height: 750 } });
+  await page.evaluate(() => document.body.style.backgroundColor = 'red');
+  await ensureSomeFrames(page);
+  await page.screencast.stop();
+
+  await context.tracing.stop();
+  await context.close();
+  // The video must fill its frame rather than pad the smaller capture with gray.
+  expectRedFrames(videoPath, { width: 800, height: 600 });
+});
+
 type Pixel = { r: number, g: number, b: number, alpha: number };
 type PixelPredicate = (pixel: Pixel) => boolean;
 

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -307,7 +307,7 @@ test('tracing screenshots size sets the shared capture size', async ({ browser, 
   // Sizing the tracing screencast is the way to lift the cap it would otherwise put on the capture.
   const size = { width: 1000, height: 750 };
   const context = await browser.newContext({ viewport: { width: 1600, height: 1200 } });
-  await context.tracing.start({ screenshots: { size } });
+  await context.tracing.start({ screencast: { size } });
   const page = await context.newPage();
 
   const videoPath = testInfo.outputPath('video.webm');

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -253,7 +253,8 @@ test('start should finish when page is closed', async ({ browser }, testInfo) =>
   await context.close();
 });
 
-test('empty video', async ({ browser }, testInfo) => {
+test('empty video', async ({ browser, trace }, testInfo) => {
+  test.skip(trace === 'on', 'tracing keeps the capture running, so the video receives a frame and is not empty');
   const size = { width: 800, height: 800 };
   const context = await browser.newContext({ viewport: size });
   const page = await context.newPage();
@@ -297,6 +298,27 @@ test('start size is ignored while tracing is active', async ({ browser, trace },
   await context.close();
   // The video must fill its frame rather than pad the smaller capture with gray.
   expectRedFrames(videoPath, { width: 800, height: 600 });
+});
+
+test('tracing screenshots size sets the shared capture size', async ({ browser, trace }, testInfo) => {
+  test.skip(trace === 'on', 'the test starts its own tracing');
+  test.slow();
+
+  // Sizing the tracing screencast is the way to lift the cap it would otherwise put on the capture.
+  const size = { width: 1000, height: 750 };
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1200 } });
+  await context.tracing.start({ screenshots: { size } });
+  const page = await context.newPage();
+
+  const videoPath = testInfo.outputPath('video.webm');
+  await page.screencast.start({ path: videoPath });
+  await page.evaluate(() => document.body.style.backgroundColor = 'red');
+  await ensureSomeFrames(page);
+  await page.screencast.stop();
+
+  await context.tracing.stop();
+  await context.close();
+  expectRedFrames(videoPath, size);
 });
 
 type Pixel = { r: number, g: number, b: number, alpha: number };

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -539,6 +539,28 @@ for (const params of [
   });
 }
 
+browserTest('should produce screencast frames of the requested size', async ({ video, contextFactory, browserName, headless }, testInfo) => {
+  browserTest.skip(video === 'on', 'Same screencast resolution conflicts');
+  browserTest.fixme(browserName === 'firefox' && !headless, 'Image size is different');
+
+  // Without an explicit size this viewport would be captured at 800x600.
+  const size = { width: 1000, height: 750 };
+  const context = await contextFactory({ viewport: { width: 1600, height: 1200 } });
+  await context.tracing.start({ screenshots: { size } });
+  const page = await context.newPage();
+  await page.setContent(`<body style="margin: 0; background: red"></body>`);
+  for (let i = 0; i < 10; ++i)
+    await rafraf(page);
+  await context.tracing.stop({ path: testInfo.outputPath('trace.zip') });
+
+  const { events, resources } = await parseTraceRaw(testInfo.outputPath('trace.zip'));
+  const frames = events.filter(e => e.type === 'screencast-frame');
+  expect(frames.length).toBeGreaterThan(0);
+  const image = jpegjs.decode(resources.get(frames[frames.length - 1].file));
+  expect(image.width).toBe(size.width);
+  expect(image.height).toBe(size.height);
+});
+
 test('should include interrupted actions', async ({ context, page, server }, testInfo) => {
   await context.tracing.start({ screenshots: true, snapshots: true });
   await page.goto(server.EMPTY_PAGE);

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -546,7 +546,7 @@ browserTest('should produce screencast frames of the requested size', async ({ v
   // Without an explicit size this viewport would be captured at 800x600.
   const size = { width: 1000, height: 750 };
   const context = await contextFactory({ viewport: { width: 1600, height: 1200 } });
-  await context.tracing.start({ screenshots: { size } });
+  await context.tracing.start({ screencast: { size } });
   const page = await context.newPage();
   await page.setContent(`<body style="margin: 0; background: red"></body>`);
   for (let i = 0; i < 10; ++i)
@@ -559,6 +559,32 @@ browserTest('should produce screencast frames of the requested size', async ({ v
   const image = jpegjs.decode(resources.get(frames[frames.length - 1].file));
   expect(image.width).toBe(size.width);
   expect(image.height).toBe(size.height);
+});
+
+browserTest('should respect screencast quality', async ({ video, contextFactory, browserName }, testInfo) => {
+  browserTest.skip(video === 'on', 'Same screencast resolution conflicts');
+  browserTest.skip(browserName === 'webkit', 'WebKit ignores the screencast quality');
+
+  const content = `<body style="margin:0">${Array.from({ length: 400 }, (_, i) =>
+    `<div style="display:inline-block;width:40px;height:40px;background:hsl(${i * 7 % 360},80%,${30 + i % 50}%)"></div>`).join('')}</body>`;
+
+  const lastFrameSize = async (quality: number) => {
+    const context = await contextFactory({ viewport: { width: 800, height: 600 } });
+    await context.tracing.start({ screencast: { quality } });
+    const page = await context.newPage();
+    await page.setContent(content);
+    for (let i = 0; i < 10; ++i)
+      await rafraf(page);
+    const file = testInfo.outputPath(`trace-${quality}.zip`);
+    await context.tracing.stop({ path: file });
+    await context.close();
+    const { events, resources } = await parseTraceRaw(file);
+    const frames = events.filter(e => e.type === 'screencast-frame');
+    expect(frames.length).toBeGreaterThan(0);
+    return resources.get(frames[frames.length - 1].file).byteLength;
+  };
+
+  expect(await lastFrameSize(5) * 2).toBeLessThan(await lastFrameSize(95));
 });
 
 test('should include interrupted actions', async ({ context, page, server }, testInfo) => {

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -270,7 +270,7 @@ export interface PlaywrightWorkerOptions {
   connectOptions: ConnectOptions | undefined;
   reuseContext: boolean;
   screenshot: ScreenshotMode | { mode: ScreenshotMode } & Pick<PageScreenshotOptions, 'fullPage' | 'omitBackground'>;
-  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean, sources?: boolean, attachments?: boolean };
+  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, attachments?: boolean };
   video: VideoMode | /** deprecated */ 'retry-with-video' | { mode: VideoMode, size?: ViewportSize, show?: { actions?: { duration?: number, position?: 'top-left' | 'top' | 'top-right' | 'bottom-left' | 'bottom' | 'bottom-right', fontSize?: number, cursor?: 'none' | 'pointer' }, test?: { level?: 'file' | 'title' | 'step', position?: 'top-left' | 'top' | 'top-right' | 'bottom-left' | 'bottom' | 'bottom-right', fontSize?: number } } };
 }
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -270,7 +270,7 @@ export interface PlaywrightWorkerOptions {
   connectOptions: ConnectOptions | undefined;
   reuseContext: boolean;
   screenshot: ScreenshotMode | { mode: ScreenshotMode } & Pick<PageScreenshotOptions, 'fullPage' | 'omitBackground'>;
-  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screenshots?: boolean | { size?: { width: number, height: number } }, sources?: boolean, attachments?: boolean };
+  trace: TraceMode | /** deprecated */ 'retry-with-trace' | { mode: TraceMode, snapshots?: boolean | { dom?: boolean, aria?: boolean, screen?: boolean }, screencast?: boolean | { size?: { width: number, height: number }, quality?: number }, screenshots?: boolean, sources?: boolean, attachments?: boolean };
   video: VideoMode | /** deprecated */ 'retry-with-video' | { mode: VideoMode, size?: ViewportSize, show?: { actions?: { duration?: number, position?: 'top-left' | 'top' | 'top-right' | 'bottom-left' | 'bottom' | 'bottom-right', fontSize?: number, cursor?: 'none' | 'pointer' }, test?: { level?: 'file' | 'title' | 'step', position?: 'top-left' | 'top' | 'top-right' | 'bottom-left' | 'bottom' | 'bottom-right', fontSize?: number } } };
 }
 


### PR DESCRIPTION
## Summary
- Let the tracing capture be sized via `tracing.start({ screenshots: { size } })`, and the same under the `trace` test option. Tracing shares one screencast per page with `screencast.start()` and video recording, but always requested the default viewport-fit size, capping what the others could get with no way to opt out. The trace viewer renders the timeline preview at a fixed size, so this only affects those other consumers.
- The shared capture is sized by whoever attached first, so `screencast.start({ size })` encoded the video at the requested size while receiving smaller frames — ffmpeg pads rather than scales, leaving gray borders. Encode into the size the capture actually runs at instead, so `size` is plainly ignored rather than half-applied.
- Document that tracing captures screenshots through the same screencast.

Fixes https://github.com/microsoft/playwright/issues/42274