### PR TITLE
fix(web): add keyboard accessibility to Expandable headers and ImageDiffView tabs

### DIFF
--- a/packages/html-reporter/playwright.config.ts
+++ b/packages/html-reporter/playwright.config.ts
@@ -45,7 +45,13 @@ export default defineConfig({
   },
   projects: [{
     name: 'chromium',
-    use: { ...devices['Desktop Chrome'] },
+    use: {
+      ...devices['Desktop Chrome'],
+      channel: process.env.PWTEST_CHANNEL as any,
+      launchOptions: {
+        executablePath: process.env.CRPATH,
+      }
+    },
   }],
   webServer: {
     command: 'npx vite --port 3101 --strictPort',

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -43,7 +43,13 @@ export default defineConfig({
   },
   projects: [{
     name: 'chromium',
-    use: { ...devices['Desktop Chrome'] },
+    use: {
+      ...devices['Desktop Chrome'],
+      channel: process.env.PWTEST_CHANNEL as any,
+      launchOptions: {
+        executablePath: process.env.CRPATH,
+      }
+    },
   }],
   webServer: {
     command: 'npx vite --config playwright/vite.config.ts',

--- a/packages/web/src/components/expandable.css
+++ b/packages/web/src/components/expandable.css
@@ -30,6 +30,11 @@
   cursor: pointer;
 }
 
+.expandable-title:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .expandable-content {
   margin-left: 25px;
 }

--- a/packages/web/src/components/expandable.spec.ts
+++ b/packages/web/src/components/expandable.spec.ts
@@ -53,3 +53,34 @@ test('title click should not expand by default', async ({ mount }) => {
   await expect(component.locator('.codicon-chevron-right')).toBeVisible();
   await expect(component.getByTestId('expanded')).toHaveValue('false');
 });
+
+test('expand collapse with keyboard', async ({ mount, page }) => {
+  const component = await mount<typeof StatefulTitleClick>('components/expandable/StatefulTitleClick');
+  const header = component.getByRole('button', { name: 'Title' });
+  await header.focus();
+  await expect(header).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
+  await expect(component.locator('text=Details')).toBeVisible();
+  await page.keyboard.press('Space');
+  await expect(component.getByTestId('expanded')).toHaveValue('false');
+  await expect(component.locator('text=Details')).toBeHidden();
+});
+
+test('expand collapse with space key', async ({ mount, page }) => {
+  const component = await mount<typeof StatefulTitleClick>('components/expandable/StatefulTitleClick');
+  const header = component.getByRole('button', { name: 'Title' });
+  await header.focus();
+  await expect(header).toBeFocused();
+  await page.keyboard.press('Space');
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
+  await expect(component.locator('text=Details')).toBeVisible();
+  await page.keyboard.press('Enter');
+  await expect(component.getByTestId('expanded')).toHaveValue('false');
+  await expect(component.locator('text=Details')).toBeHidden();
+});
+
+test('title is not a button when title click is disabled', async ({ mount }) => {
+  const component = await mount<typeof Stateful>('components/expandable/Stateful');
+  await expect(component.getByRole('button')).toHaveCount(0);
+});

--- a/packages/web/src/components/expandable.tsx
+++ b/packages/web/src/components/expandable.tsx
@@ -40,10 +40,19 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
       <div
         id={titleId}
         role='button'
+        tabIndex={0}
         aria-expanded={expanded}
         aria-controls={regionId}
         className='expandable-title'
-        onClick={onClick}>
+        onClick={onClick}
+        onKeyDown={e => {
+          if (e.target !== e.currentTarget)
+            return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick();
+          }
+        }}>
         {chevron}
         {title}
       </div> :

--- a/packages/web/src/shared/imageDiffView.css
+++ b/packages/web/src/shared/imageDiffView.css
@@ -1,0 +1,37 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+.image-diff-tab {
+  flex: none;
+  margin: 0 10px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.image-diff-tab.selected {
+  font-weight: 600;
+}
+
+.image-diff-tab:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}

--- a/packages/web/src/shared/imageDiffView.spec.ts
+++ b/packages/web/src/shared/imageDiffView.spec.ts
@@ -35,3 +35,63 @@ test('should show diff by default', async ({ mount }) => {
   const box = await image.boundingBox();
   expect(box).toEqual(expect.objectContaining({ width: 48, height: 48 }));
 });
+
+test('should render mode switcher tabs with role="tab"', async ({ mount }) => {
+  const component = await mount<typeof Default>('shared/imageDiffView/Default');
+  const tablist = component.getByRole('tablist');
+  await expect(tablist).toBeVisible();
+
+  const tabs = component.getByRole('tab');
+  await expect(tabs).toHaveText(['Diff', 'Actual', 'Expected', 'Side by side', 'Slider']);
+  await expect(component.getByRole('tab', { name: 'Diff' })).toHaveAttribute('aria-selected', 'true');
+  await expect(component.getByRole('tab', { name: 'Actual' })).toHaveAttribute('aria-selected', 'false');
+  await expect(component.getByRole('tab', { name: 'Expected' })).toHaveAttribute('aria-selected', 'false');
+  await expect(component.getByRole('tab', { name: 'Side by side' })).toHaveAttribute('aria-selected', 'false');
+  await expect(component.getByRole('tab', { name: 'Slider' })).toHaveAttribute('aria-selected', 'false');
+});
+
+test('can focus mode switcher tab and activate via keyboard', async ({ mount, page }) => {
+  const component = await mount<typeof Default>('shared/imageDiffView/Default');
+  const diffTab = component.getByRole('tab', { name: 'Diff' });
+  const actualTab = component.getByRole('tab', { name: 'Actual' });
+  const expectedTab = component.getByRole('tab', { name: 'Expected' });
+  const sxsTab = component.getByRole('tab', { name: 'Side by side' });
+  const sliderTab = component.getByRole('tab', { name: 'Slider' });
+
+  await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+
+  await actualTab.focus();
+  await expect(actualTab).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(actualTab).toHaveAttribute('aria-selected', 'true');
+  await expect(diffTab).toHaveAttribute('aria-selected', 'false');
+
+  await expectedTab.focus();
+  await expect(expectedTab).toBeFocused();
+  await page.keyboard.press('Space');
+  await expect(expectedTab).toHaveAttribute('aria-selected', 'true');
+  await expect(actualTab).toHaveAttribute('aria-selected', 'false');
+
+  await sxsTab.focus();
+  await expect(sxsTab).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(sxsTab).toHaveAttribute('aria-selected', 'true');
+  await expect(expectedTab).toHaveAttribute('aria-selected', 'false');
+
+  await sliderTab.focus();
+  await expect(sliderTab).toBeFocused();
+  await page.keyboard.press('Space');
+  await expect(sliderTab).toHaveAttribute('aria-selected', 'true');
+  await expect(sxsTab).toHaveAttribute('aria-selected', 'false');
+});
+
+test('clicking mode switcher tab changes mode and updates aria-selected', async ({ mount }) => {
+  const component = await mount<typeof Default>('shared/imageDiffView/Default');
+  const diffTab = component.getByRole('tab', { name: 'Diff' });
+  const actualTab = component.getByRole('tab', { name: 'Actual' });
+
+  await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+  await actualTab.click();
+  await expect(actualTab).toHaveAttribute('aria-selected', 'true');
+  await expect(diffTab).toHaveAttribute('aria-selected', 'false');
+});

--- a/packages/web/src/shared/imageDiffView.tsx
+++ b/packages/web/src/shared/imageDiffView.tsx
@@ -15,8 +15,9 @@
 */
 
 import * as React from 'react';
-import { useMeasure } from '../uiUtils';
+import { clsx, useMeasure } from '../uiUtils';
 import { ResizeView } from './resizeView';
+import './imageDiffView.css';
 
 type TestAttachment = {
   name: string;
@@ -90,20 +91,14 @@ export const ImageDiffView: React.FC<{
   const fitWidth = imageWidth * scale;
   const fitHeight = imageHeight * scale;
 
-  const modeStyle: React.CSSProperties = {
-    flex: 'none',
-    margin: '0 10px',
-    cursor: 'pointer',
-    userSelect: 'none',
-  };
   return <div data-testid='test-result-image-mismatch' style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 'auto' }} ref={ref}>
     {isLoaded && <>
-      <div data-testid='test-result-image-mismatch-tabs' style={{ display: 'flex', margin: '10px 0 20px' }}>
-        {diff.diff && <div style={{ ...modeStyle, fontWeight: mode === 'diff' ? 600 : 'initial' }} onClick={() => setMode('diff')}>Diff</div>}
-        <div style={{ ...modeStyle, fontWeight: mode === 'actual' ? 600 : 'initial' }} onClick={() => setMode('actual')}>Actual</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'expected' ? 600 : 'initial' }} onClick={() => setMode('expected')}>{expectedImageTitle}</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'sxs' ? 600 : 'initial' }} onClick={() => setMode('sxs')}>Side by side</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'slider' ? 600 : 'initial' }} onClick={() => setMode('slider')}>Slider</div>
+      <div role='tablist' data-testid='test-result-image-mismatch-tabs' style={{ display: 'flex', margin: '10px 0 20px' }}>
+        {diff.diff && <button type='button' role='tab' aria-selected={mode === 'diff'} className={clsx('image-diff-tab', mode === 'diff' && 'selected')} onClick={() => setMode('diff')}>Diff</button>}
+        <button type='button' role='tab' aria-selected={mode === 'actual'} className={clsx('image-diff-tab', mode === 'actual' && 'selected')} onClick={() => setMode('actual')}>Actual</button>
+        <button type='button' role='tab' aria-selected={mode === 'expected'} className={clsx('image-diff-tab', mode === 'expected' && 'selected')} onClick={() => setMode('expected')}>{expectedImageTitle}</button>
+        <button type='button' role='tab' aria-selected={mode === 'sxs'} className={clsx('image-diff-tab', mode === 'sxs' && 'selected')} onClick={() => setMode('sxs')}>Side by side</button>
+        <button type='button' role='tab' aria-selected={mode === 'slider'} className={clsx('image-diff-tab', mode === 'slider' && 'selected')} onClick={() => setMode('slider')}>Slider</button>
       </div>
       <div style={{ display: 'flex', justifyContent: 'center', flex: 'auto', minHeight: fitHeight + 60 }}>
         {diff.diff && mode === 'diff' && <ImageWithSize image={diffImage} alt='Diff' hideSize={hideDetails} canvasWidth={fitWidth} canvasHeight={fitHeight} scale={scale}/>}


### PR DESCRIPTION
### Description

This PR improves keyboard navigation and accessibility across shared web components in the HTML reporter and Trace viewer:

1. **`Expandable` headers ([#42263](https://github.com/microsoft/playwright/issues/42263))**:
   - Added `tabIndex={0}` to the expandable title when `expandOnTitleClick` is true.
   - Added keyboard handlers for `Enter` and `Space` to toggle section expand/collapse while preventing unintended propagation from nested focusable elements.
   - Added focus ring styling (`:focus-visible`) matching `var(--vscode-focusBorder)`.
   - Added component tests covering keyboard focus, `Enter` / `Space` toggling, and non-button behavior when title click is disabled.

2. **`ImageDiffView` mode switchers ([#42266](https://github.com/microsoft/playwright/issues/42266))**:
   - Converted mode switcher buttons into semantic `<button type="button" role="tab">` elements within a `role="tablist"` container.
   - Added `aria-selected` attributes reflecting current selection.
   - Added stylesheet `imageDiffView.css` with clean button resets and `:focus-visible` focus ring styles.
   - Added unit tests asserting tab roles, `aria-selected` attributes, `.focus()`, and keyboard activation (`Enter` / `Space`).

### Testing Done
- `npm run test-web` (25/25 component tests passing)
- `npm run test-html-reporter` (17/17 component tests passing)
- `npm run eslint` (0 errors)
- `npm run tsc` (0 errors)
- `npm run check-deps` (passed)

Fixes #42263, Fixes #42266.