### PR TITLE
chore(trace-viewer): show only the screencast frame on timeline hover

### DIFF
--- a/packages/trace-viewer/src/ui/filmStrip.css
+++ b/packages/trace-viewer/src/ui/filmStrip.css
@@ -52,11 +52,3 @@
   z-index: 200;
   pointer-events: none;
 }
-
-.film-strip-hover-title {
-  padding: 2px 4px;
-  display: flex;
-  align-items: center;
-  overflow: hidden;
-  line-height: 28px;
-}

--- a/packages/trace-viewer/src/ui/filmStrip.tsx
+++ b/packages/trace-viewer/src/ui/filmStrip.tsx
@@ -18,16 +18,12 @@ import './filmStrip.css';
 import type { Boundaries, Size } from './geometry';
 import * as React from 'react';
 import { useMeasure, upperBound } from '@web/uiUtils';
-import type { ActionEntry, PageEntry } from '@isomorphic/trace/entries';
-import { renderAction } from './actionList';
-import type { Language } from '@isomorphic/locatorGenerators';
+import type { PageEntry } from '@isomorphic/trace/entries';
 import { useTraceModel } from './traceModelContext';
 
 export type FilmStripPreviewPoint = {
   x: number;
   clientY: number;
-  action?: ActionEntry;
-  sdkLanguage: Language;
 };
 
 const tileSize = { width: 200, height: 45 };
@@ -70,15 +66,14 @@ export const FilmStrip: React.FunctionComponent<{
         key={index}
       /> : null)
     }</div>
-    {model && previewPoint?.x !== undefined &&
+    {model && previewPoint && previewImage && previewSize &&
       <div className='film-strip-hover' style={{
         top: measure.bottom + 5,
-        left: Math.min(previewPoint!.x, measure.width - (previewSize ? previewSize.width : 0) - 10),
+        left: Math.min(previewPoint.x, measure.width - previewSize.width - 10),
+        width: previewSize.width,
+        height: previewSize.height,
       }}>
-        {previewImage && previewSize && <div style={{ width: previewSize.width, height: previewSize.height }}>
-          <img src={model.createRelativeUrl(`file/${previewImage.file}`)} width={previewSize.width} height={previewSize.height} />
-        </div>}
-        {previewPoint.action && <div className='film-strip-hover-title'>{renderAction(previewPoint.action, previewPoint)}</div>}
+        <img src={model.createRelativeUrl(`file/${previewImage.file}`)} width={previewSize.width} height={previewSize.height} />
       </div>
     }
   </div>;

--- a/packages/trace-viewer/src/ui/timeline.tsx
+++ b/packages/trace-viewer/src/ui/timeline.tsx
@@ -24,7 +24,6 @@ import type { FilmStripPreviewPoint } from './filmStrip';
 import type { TraceModel } from '@isomorphic/trace/traceModel';
 import type { ActionEntry } from '@isomorphic/trace/entries';
 import './timeline.css';
-import type { Language } from '@isomorphic/locatorGenerators';
 import type { ActionGroup } from '@isomorphic/protocolFormatter';
 
 export const Timeline: React.FunctionComponent<{
@@ -34,9 +33,8 @@ export const Timeline: React.FunctionComponent<{
   selectedTime: Boundaries | undefined,
   setSelectedTime: (time: Boundaries | undefined) => void,
   highlightedTime?: Boundaries,
-  sdkLanguage: Language,
   scrubber?: React.ReactNode,
-}> = ({ model, boundaries, onSelected, selectedTime, setSelectedTime, highlightedTime, sdkLanguage, scrubber }) => {
+}> = ({ model, boundaries, onSelected, selectedTime, setSelectedTime, highlightedTime, scrubber }) => {
   const [measure, ref] = useMeasure<HTMLDivElement>();
   const [dragWindow, setDragWindow] = React.useState<{ startX: number, endX: number, pivot?: number, type: 'resize' | 'move' } | undefined>();
   const [previewPoint, setPreviewPoint] = React.useState<FilmStripPreviewPoint | undefined>();
@@ -156,10 +154,8 @@ export const Timeline: React.FunctionComponent<{
     if (!ref.current)
       return;
     const x = event.clientX - ref.current.getBoundingClientRect().left;
-    const time = positionToTime(measure.width, boundaries, x);
-    const action = actions?.findLast(action => action.startTime <= time);
-    setPreviewPoint({ x, clientY: event.clientY, action, sdkLanguage });
-  }, [boundaries, measure, actions, ref, sdkLanguage]);
+    setPreviewPoint({ x, clientY: event.clientY });
+  }, [ref]);
 
   const onMouseLeave = React.useCallback(() => {
     setPreviewPoint(undefined);

--- a/packages/trace-viewer/src/ui/workbench.tsx
+++ b/packages/trace-viewer/src/ui/workbench.tsx
@@ -369,7 +369,6 @@ const PartitionedWorkbench: React.FunctionComponent<WorkbenchProps & { partition
       model={model}
       boundaries={boundaries}
       onSelected={onActionSelected}
-      sdkLanguage={sdkLanguage}
       selectedTime={selectedTime}
       setSelectedTime={setSelectedTime}
       highlightedTime={highlightedTime}


### PR DESCRIPTION
## Summary
- Timeline hover popup now shows just the screencast frame; the action/locator title under it is gone.
- Popup no longer renders an empty box when there is no frame for the hovered time.