### PR TITLE
feat(test-runner): add --merge-strategy flag to merge-reports

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -318,6 +318,7 @@ npx playwright merge-reports ./reports
 | :--- | :--- |
 | `-c, --config <file>` | Configuration file. Can be used to specify additional configuration for the output report |
 | `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob" (default: "list") |
+| `--merge-strategy <strategy>` | How to reconcile tests with the same id found in multiple blobs: "separate", "overwrite", or "as-retry" (default: "separate") |
 
 ### Clear Cache
 

--- a/packages/playwright/src/cli/reportActions.ts
+++ b/packages/playwright/src/cli/reportActions.ts
@@ -21,7 +21,10 @@ import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { builtInReporters, config as commonConfig, configLoader } from '../common';
 import { html, merge } from '../runner';
 
+import type { MergeStrategy } from '../reporters/merge';
 import type { ReporterDescription } from '../../types/test';
+
+const mergeStrategies: MergeStrategy[] = ['separate', 'overwrite', 'as-retry'];
 
 export async function showReport(report: string | undefined, host: string, port: number) {
   await html.showHTMLReport(report, host, port);
@@ -43,7 +46,10 @@ export async function mergeReports(reportDir: string | undefined, opts: { [key: 
   if (!reporterDescriptions)
     reporterDescriptions = [[commonConfig.defaultReporter]];
   const rootDirOverride = configFile ? config.config.rootDir : undefined;
-  const result = await merge.createMergedReport(config, dir, reporterDescriptions!, rootDirOverride);
+  const mergeStrategy: MergeStrategy = opts.mergeStrategy ?? 'separate';
+  if (!mergeStrategies.includes(mergeStrategy))
+    throw new Error(`Unsupported --merge-strategy "${mergeStrategy}", must be one of: ${mergeStrategies.join(', ')}`);
+  const result = await merge.createMergedReport(config, dir, reporterDescriptions!, rootDirOverride, mergeStrategy);
   gracefullyProcessExitDoNotHang(result === 'failed' ? 1 : 0);
 }
 

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -90,6 +90,10 @@ export type JsonTestResultStart = {
   workerIndex: number;
   parallelIndex: number;
   startTime: number;
+  // Set by report merging to discard previously-merged results for this test id
+  // right before this result is added, without affecting every onTestBegin globally
+  // (see clearPreviousResultsWhenTestBegins, which applies to all of them).
+  discardPreviousResults?: boolean;
 };
 
 export type JsonAttachment = Omit<reporterTypes.TestResult['attachments'][0], 'body'> & { base64?: string; };
@@ -363,7 +367,7 @@ export class TeleReporterReceiver {
 
   private _onTestBegin(testId: string, payload: JsonTestResultStart) {
     const test = this._tests.get(testId)!;
-    if (this._options.clearPreviousResultsWhenTestBegins)
+    if (this._options.clearPreviousResultsWhenTestBegins || payload.discardPreviousResults)
       test.results = [];
     const testResult = test._createTestResult(payload.id);
     testResult.retry = payload.retry;

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -90,9 +90,6 @@ export type JsonTestResultStart = {
   workerIndex: number;
   parallelIndex: number;
   startTime: number;
-  // Set by report merging to discard previously-merged results for this test id
-  // right before this result is added, without affecting every onTestBegin globally
-  // (see clearPreviousResultsWhenTestBegins, which applies to all of them).
   discardPreviousResults?: boolean;
 };
 

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -129,12 +129,14 @@ function addMergeReportsCommand(program: Command) {
   });
   command.option('-c, --config <file>', `Configuration file. Can be used to specify additional configuration for the output report.`);
   command.option('--reporter <reporter>', `Reporter to use, comma-separated, can be ${builtInReporters.map(name => `"${name}"`).join(', ')} (default: "${config.defaultReporter}")`);
+  command.option('--merge-strategy <strategy>', `How to reconcile tests with the same id found in multiple blobs: "separate", "overwrite", or "as-retry" (default: "separate")`);
   command.addHelpText('afterAll', `
 Arguments [dir]:
   Directory containing blob reports.
 
 Examples:
-  $ npx playwright merge-reports playwright-report`);
+  $ npx playwright merge-reports playwright-report
+  $ npx playwright merge-reports --merge-strategy as-retry playwright-report`);
 }
 
 function addTestMCPServerCommand(program: Command) {

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -245,9 +245,7 @@ async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: 
 
   const reports: ReportData[] = [];
   const globalTestIdSet = new Set<string>();
-  // Shared across all blobs so that "as-retry" keeps numbering retries
-  // consecutively for a given test id, instead of each blob restarting at 0.
-  const retryOffsets = new Map<string, number>();
+  const retryIndexByTestId = new Map<string, number>();
 
   for (let i = 0; i < blobs.length; ++i) {
     // Generate unique salt for each blob.
@@ -259,8 +257,9 @@ async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: 
         String(i),
         globalTestIdSet,
         mergeStrategy,
-        retryOffsets,
     ));
+    if (mergeStrategy !== 'separate')
+      eventPatchers.patchers.push(new MergeStrategyPatcher(mergeStrategy, retryIndexByTestId));
     // Only patch path separators if we are merging reports with explicit config.
     if (rootDirOverride)
       eventPatchers.patchers.push(new PathSeparatorPatcher(metadata.pathSeparator));
@@ -435,19 +434,6 @@ class IdsPatcher {
   private _testIdsMap: Map<string, string>;
   private _globalTestIdSet: Set<string>;
   private _mergeStrategy: MergeStrategy;
-  private _retryOffsets: Map<string, number>;
-  // Test ids that collided with an earlier blob (populated while patching this blob's
-  // "onProject" event, which always precedes its test-run events). Only these ids get the
-  // "overwrite"/"as-retry" special-casing below -- a test that only exists in this blob must
-  // pass through onTestBegin untouched, retries and all.
-  private _collidingTestIds = new Set<string>();
-  // Ensures a colliding test's previous results are discarded exactly once per blob (on its
-  // first onTestBegin), not on every one of this blob's own retries of that same test.
-  private _discardedResultsForTestIds = new Set<string>();
-  // Caches the retry offset chosen for a colliding test id so every retry within this blob is
-  // shifted by the same fixed amount, instead of re-reading (and further inflating) the shared
-  // running offset on every onTestBegin.
-  private _retryOffsetForTestId = new Map<string, number>();
 
   constructor(
     stringPool: StringInternPool,
@@ -455,7 +441,6 @@ class IdsPatcher {
     salt: string,
     globalTestIdSet: Set<string>,
     mergeStrategy: MergeStrategy,
-    retryOffsets: Map<string, number>,
   ) {
     this._stringPool = stringPool;
     this._botName = botName;
@@ -463,7 +448,6 @@ class IdsPatcher {
     this._testIdsMap = new Map();
     this._globalTestIdSet = globalTestIdSet;
     this._mergeStrategy = mergeStrategy;
-    this._retryOffsets = retryOffsets;
   }
 
   patchEvent(event: JsonEvent) {
@@ -472,20 +456,9 @@ class IdsPatcher {
       case 'onProject':
         this._onProject(params.project);
         return;
-      case 'onTestBegin': {
+      case 'onTestBegin':
         params.testId = this._mapTestId(params.testId);
-        const isCollision = this._collidingTestIds.has(params.testId);
-        if (isCollision && this._mergeStrategy === 'overwrite' && !this._discardedResultsForTestIds.has(params.testId)) {
-          params.result.discardPreviousResults = true;
-          this._discardedResultsForTestIds.add(params.testId);
-        }
-        if (this._mergeStrategy === 'as-retry') {
-          if (isCollision)
-            this._offsetRetry(params.testId, params.result);
-          this._trackRetryIndex(params.testId, params.result.retry);
-        }
         return;
-      }
       case 'onAttach':
       case 'onStepBegin':
       case 'onStepEnd':
@@ -498,38 +471,13 @@ class IdsPatcher {
     }
   }
 
-  // For "as-retry" merges, a colliding rerun's own retry numbering (0, 1, ...) would otherwise
-  // collide with retry indices the original blob already used for the same test id.
-  // Shift incoming retries to continue after the highest retry claimed so far, using one fixed
-  // offset for all of this blob's own retries of that test.
-  private _offsetRetry(testId: string, result: { retry: number }) {
-    let offset = this._retryOffsetForTestId.get(testId);
-    if (offset === undefined) {
-      offset = this._retryOffsets.get(testId) ?? 0;
-      this._retryOffsetForTestId.set(testId, offset);
-    }
-    result.retry += offset;
-  }
-
-  // Keeps the shared "highest retry index used so far" up to date for every test, colliding or
-  // not, so that a later colliding blob knows where to continue from.
-  private _trackRetryIndex(testId: string, retry: number) {
-    const highest = this._retryOffsets.get(testId) ?? 0;
-    this._retryOffsets.set(testId, Math.max(highest, retry + 1));
-  }
-
   private _onProject(project: JsonProject) {
     project.metadata ??= {};
     project.suites.forEach(suite => this._updateTestIds(suite));
   }
 
   private _updateTestIds(suite: JsonSuite) {
-    // In "overwrite"/"as-retry" mode, a colliding test reuses the id of the test case
-    // already registered from an earlier blob (see _mapTestId below). The receiver would
-    // otherwise create a second, unlinked test case for that same id (it only dedupes
-    // suite entries by title, not by id), so we drop the incoming duplicate suite entry
-    // here and let the test's later onTestBegin/onTestEnd events attach to the original
-    // test case instead.
+    // Drop duplicate suite entries for colliding test ids; the receiver only dedupes by title, not id.
     suite.entries = suite.entries.filter(entry => {
       if ('testId' in entry)
         return this._updateTestId(entry);
@@ -541,8 +489,6 @@ class IdsPatcher {
   private _updateTestId(test: JsonTestCase): boolean {
     const isDuplicate = this._mergeStrategy !== 'separate' && this._globalTestIdSet.has(this._stringPool.internString(test.testId));
     test.testId = this._mapTestId(test.testId);
-    if (isDuplicate)
-      this._collidingTestIds.add(test.testId);
     if (this._botName) {
       test.tags = test.tags || [];
       test.tags.unshift('@' + this._botName);
@@ -557,9 +503,7 @@ class IdsPatcher {
       return this._testIdsMap.get(t1)!;
     if (this._globalTestIdSet.has(t1)) {
       if (this._mergeStrategy !== 'separate') {
-        // "overwrite" and "as-retry" intentionally reuse the id from the earlier blob
-        // instead of salting, so this test's results land on the same test case rather
-        // than becoming a distinct entry.
+        // Reuse the earlier blob's id instead of salting, so results land on the same test case.
         this._testIdsMap.set(t1, t1);
         return t1;
       }
@@ -572,6 +516,29 @@ class IdsPatcher {
     this._globalTestIdSet.add(t1);
     this._testIdsMap.set(t1, t1);
     return t1;
+  }
+}
+
+// Applied after IdsPatcher, so testId is already the final (collision-resolved) id.
+class MergeStrategyPatcher {
+  constructor(
+    private _mergeStrategy: MergeStrategy,
+    private _retryIndexByTestId: Map<string, number>,
+  ) {
+  }
+
+  patchEvent(event: JsonEvent) {
+    if (event.method !== 'onTestBegin')
+      return;
+    const { testId, result } = event.params;
+    if (this._mergeStrategy === 'overwrite') {
+      if (result.retry === 0)
+        result.discardPreviousResults = true;
+    } else if (this._mergeStrategy === 'as-retry') {
+      const retry = this._retryIndexByTestId.get(testId) ?? 0;
+      this._retryIndexByTestId.set(testId, retry + 1);
+      result.retry = retry;
+    }
   }
 }
 

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -46,7 +46,9 @@ type ReportData = {
 
 export type MergeResult = 'passed' | 'failed';
 
-export async function createMergedReport(config: FullConfigInternal, dir: string, reporterDescriptions: ReporterDescription[], rootDirOverride: string | undefined): Promise<MergeResult> {
+export type MergeStrategy = 'separate' | 'overwrite' | 'as-retry';
+
+export async function createMergedReport(config: FullConfigInternal, dir: string, reporterDescriptions: ReporterDescription[], rootDirOverride: string | undefined, mergeStrategy: MergeStrategy = 'separate'): Promise<MergeResult> {
   const reporters = await createReporters(config, 'merge', reporterDescriptions);
   const multiplexer = new Multiplexer(reporters);
   const stringPool = new StringInternPool();
@@ -60,7 +62,7 @@ export async function createMergedReport(config: FullConfigInternal, dir: string
   const shardFiles = await sortedShardFiles(dir);
   if (shardFiles.length === 0)
     throw new Error(`No report files found in ${dir}`);
-  const eventData = await mergeEvents(dir, shardFiles, stringPool, printStatus, rootDirOverride);
+  const eventData = await mergeEvents(dir, shardFiles, stringPool, printStatus, rootDirOverride, mergeStrategy);
   // If explicit config is provided, use platform path separator, otherwise use the one from the report (if any).
   const pathSeparator = rootDirOverride ? path.sep : (eventData.pathSeparatorFromMetadata ?? path.sep);
   const pathPackage = pathSeparator === '/' ? path.posix : path.win32;
@@ -198,7 +200,7 @@ function findMetadata(events: JsonEvent[], file: string): BlobReportMetadata {
   return metadata;
 }
 
-async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: StringInternPool, printStatus: StatusCallback, rootDirOverride: string | undefined): Promise<{
+async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: StringInternPool, printStatus: StatusCallback, rootDirOverride: string | undefined, mergeStrategy: MergeStrategy): Promise<{
   prologue: JsonEvent[];
   reports: ReportData[];
   epilogue: JsonEvent[];
@@ -227,10 +229,25 @@ async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: 
     return a.zipFile.localeCompare(b.zipFile);
   });
 
+  if (mergeStrategy !== 'separate') {
+    // "overwrite"/"as-retry" need to know which colliding blob actually ran later, so
+    // reconcile them by each blob's own recorded run time instead of by report name/file
+    // name order (which may not reflect chronological order at all, e.g. shard/file naming).
+    const startTimeByBlob = new Map<typeof blobs[number], number>();
+    for (const blob of blobs) {
+      const onEnd = blob.parsedEvents.find(event => event.method === 'onEnd') as JsonOnEndEvent | undefined;
+      startTimeByBlob.set(blob, onEnd?.params.result.startTime ?? 0);
+    }
+    blobs.sort((a, b) => startTimeByBlob.get(a)! - startTimeByBlob.get(b)!);
+  }
+
   printStatus(`merging events`);
 
   const reports: ReportData[] = [];
   const globalTestIdSet = new Set<string>();
+  // Shared across all blobs so that "as-retry" keeps numbering retries
+  // consecutively for a given test id, instead of each blob restarting at 0.
+  const retryOffsets = new Map<string, number>();
 
   for (let i = 0; i < blobs.length; ++i) {
     // Generate unique salt for each blob.
@@ -241,6 +258,8 @@ async function mergeEvents(dir: string, shardReportFiles: string[], stringPool: 
         metadata.name,
         String(i),
         globalTestIdSet,
+        mergeStrategy,
+        retryOffsets,
     ));
     // Only patch path separators if we are merging reports with explicit config.
     if (rootDirOverride)
@@ -415,18 +434,36 @@ class IdsPatcher {
   private _salt: string;
   private _testIdsMap: Map<string, string>;
   private _globalTestIdSet: Set<string>;
+  private _mergeStrategy: MergeStrategy;
+  private _retryOffsets: Map<string, number>;
+  // Test ids that collided with an earlier blob (populated while patching this blob's
+  // "onProject" event, which always precedes its test-run events). Only these ids get the
+  // "overwrite"/"as-retry" special-casing below -- a test that only exists in this blob must
+  // pass through onTestBegin untouched, retries and all.
+  private _collidingTestIds = new Set<string>();
+  // Ensures a colliding test's previous results are discarded exactly once per blob (on its
+  // first onTestBegin), not on every one of this blob's own retries of that same test.
+  private _discardedResultsForTestIds = new Set<string>();
+  // Caches the retry offset chosen for a colliding test id so every retry within this blob is
+  // shifted by the same fixed amount, instead of re-reading (and further inflating) the shared
+  // running offset on every onTestBegin.
+  private _retryOffsetForTestId = new Map<string, number>();
 
   constructor(
     stringPool: StringInternPool,
     botName: string | undefined,
     salt: string,
     globalTestIdSet: Set<string>,
+    mergeStrategy: MergeStrategy,
+    retryOffsets: Map<string, number>,
   ) {
     this._stringPool = stringPool;
     this._botName = botName;
     this._salt = salt;
     this._testIdsMap = new Map();
     this._globalTestIdSet = globalTestIdSet;
+    this._mergeStrategy = mergeStrategy;
+    this._retryOffsets = retryOffsets;
   }
 
   patchEvent(event: JsonEvent) {
@@ -435,8 +472,21 @@ class IdsPatcher {
       case 'onProject':
         this._onProject(params.project);
         return;
+      case 'onTestBegin': {
+        params.testId = this._mapTestId(params.testId);
+        const isCollision = this._collidingTestIds.has(params.testId);
+        if (isCollision && this._mergeStrategy === 'overwrite' && !this._discardedResultsForTestIds.has(params.testId)) {
+          params.result.discardPreviousResults = true;
+          this._discardedResultsForTestIds.add(params.testId);
+        }
+        if (this._mergeStrategy === 'as-retry') {
+          if (isCollision)
+            this._offsetRetry(params.testId, params.result);
+          this._trackRetryIndex(params.testId, params.result.retry);
+        }
+        return;
+      }
       case 'onAttach':
-      case 'onTestBegin':
       case 'onStepBegin':
       case 'onStepEnd':
       case 'onStdIO':
@@ -448,26 +498,56 @@ class IdsPatcher {
     }
   }
 
+  // For "as-retry" merges, a colliding rerun's own retry numbering (0, 1, ...) would otherwise
+  // collide with retry indices the original blob already used for the same test id.
+  // Shift incoming retries to continue after the highest retry claimed so far, using one fixed
+  // offset for all of this blob's own retries of that test.
+  private _offsetRetry(testId: string, result: { retry: number }) {
+    let offset = this._retryOffsetForTestId.get(testId);
+    if (offset === undefined) {
+      offset = this._retryOffsets.get(testId) ?? 0;
+      this._retryOffsetForTestId.set(testId, offset);
+    }
+    result.retry += offset;
+  }
+
+  // Keeps the shared "highest retry index used so far" up to date for every test, colliding or
+  // not, so that a later colliding blob knows where to continue from.
+  private _trackRetryIndex(testId: string, retry: number) {
+    const highest = this._retryOffsets.get(testId) ?? 0;
+    this._retryOffsets.set(testId, Math.max(highest, retry + 1));
+  }
+
   private _onProject(project: JsonProject) {
     project.metadata ??= {};
     project.suites.forEach(suite => this._updateTestIds(suite));
   }
 
   private _updateTestIds(suite: JsonSuite) {
-    suite.entries.forEach(entry => {
+    // In "overwrite"/"as-retry" mode, a colliding test reuses the id of the test case
+    // already registered from an earlier blob (see _mapTestId below). The receiver would
+    // otherwise create a second, unlinked test case for that same id (it only dedupes
+    // suite entries by title, not by id), so we drop the incoming duplicate suite entry
+    // here and let the test's later onTestBegin/onTestEnd events attach to the original
+    // test case instead.
+    suite.entries = suite.entries.filter(entry => {
       if ('testId' in entry)
-        this._updateTestId(entry);
-      else
-        this._updateTestIds(entry);
+        return this._updateTestId(entry);
+      this._updateTestIds(entry);
+      return true;
     });
   }
 
-  private _updateTestId(test: JsonTestCase) {
+  private _updateTestId(test: JsonTestCase): boolean {
+    const isDuplicate = this._mergeStrategy !== 'separate' && this._globalTestIdSet.has(this._stringPool.internString(test.testId));
     test.testId = this._mapTestId(test.testId);
+    if (isDuplicate)
+      this._collidingTestIds.add(test.testId);
     if (this._botName) {
       test.tags = test.tags || [];
       test.tags.unshift('@' + this._botName);
     }
+    return !isDuplicate;
   }
 
   private _mapTestId(testId: string): string {
@@ -476,6 +556,13 @@ class IdsPatcher {
       // already mapped
       return this._testIdsMap.get(t1)!;
     if (this._globalTestIdSet.has(t1)) {
+      if (this._mergeStrategy !== 'separate') {
+        // "overwrite" and "as-retry" intentionally reuse the id from the earlier blob
+        // instead of salting, so this test's results land on the same test case rather
+        // than becoming a distinct entry.
+        this._testIdsMap.set(t1, t1);
+        return t1;
+      }
       // test id is used in another blob, so we need to salt it.
       const t2 = this._stringPool.internString(testId + this._salt);
       this._globalTestIdSet.add(t2);

--- a/tests/playwright-test/reporter-blob.spec.ts
+++ b/tests/playwright-test/reporter-blob.spec.ts
@@ -1425,6 +1425,199 @@ test('keep projects with same name different global tag separate', async ({ runI
   await expect(page.getByText('Errors')).not.toBeVisible();
 });
 
+test.describe('merge-strategy', () => {
+  const files = (expectValue: string) => ({
+    'playwright.config.ts': `module.exports = { reporter: 'blob' };`,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('test 1', async ({}) => { expect('${expectValue}').toBe('pass'); });
+    `,
+  });
+
+  async function mergeFailThenPassBlobs(runInlineTest, allReportsDir: string) {
+    await runInlineTest(files('fail'));
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-1-failed.zip'));
+
+    await runInlineTest(files('pass'));
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-2-passed.zip'));
+  }
+
+  test('"separate" (default) keeps a colliding test as two distinct entries', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await mergeFailThenPassBlobs(runInlineTest, allReportsDir);
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    await expect(page.locator('.subnav-item:has-text("All") .counter')).toHaveText('2');
+    await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
+    await expect(page.locator('.subnav-item:has-text("Failed") .counter')).toHaveText('1');
+    await expect(page.locator('.test-file-test .test-file-title')).toHaveText(['test 1', 'test 1']);
+  });
+
+  test('"overwrite" replaces the earlier blob\'s result with the later one', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await mergeFailThenPassBlobs(runInlineTest, allReportsDir);
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html', '--merge-strategy', 'overwrite'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    await expect(page.locator('.subnav-item:has-text("All") .counter')).toHaveText('1');
+    await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
+    await expect(page.locator('.subnav-item:has-text("Failed") .counter')).toHaveText('0');
+    await expect(page.locator('.test-file-test .test-file-title')).toHaveText(['test 1']);
+  });
+
+  test('"as-retry" treats the later blob\'s result as a retry of the earlier one', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await mergeFailThenPassBlobs(runInlineTest, allReportsDir);
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html', '--merge-strategy', 'as-retry'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    await expect(page.locator('.subnav-item:has-text("All") .counter')).toHaveText('1');
+    await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('0');
+    await expect(page.locator('.subnav-item:has-text("Failed") .counter')).toHaveText('0');
+    await expect(page.locator('.subnav-item:has-text("Flaky") .counter')).toHaveText('1');
+    await expect(page.locator('.test-file-test .test-file-title')).toHaveText(['test 1']);
+
+    await page.locator('.test-file-test a').first().click();
+    await expect(page.getByText('Retry #1')).toBeVisible();
+  });
+
+  test('invalid --merge-strategy value is rejected', async ({ runInlineTest, mergeReports }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await mergeFailThenPassBlobs(runInlineTest, allReportsDir);
+
+    const { exitCode, output } = await mergeReports(allReportsDir, {}, { additionalArgs: ['--merge-strategy', 'bogus'] });
+    expect(exitCode).toBe(1);
+    expect(output).toContain('Unsupported --merge-strategy');
+  });
+
+  test('"overwrite" does not discard a test\'s own in-blob retries when there is no cross-blob collision', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await runInlineTest({
+      'playwright.config.ts': `module.exports = { reporter: 'blob', retries: 2 };`,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('flaky', async ({}, testInfo) => { expect(testInfo.retry).toBe(2); });
+      `,
+    });
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-1.zip'));
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html', '--merge-strategy', 'overwrite'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    // The single blob's own retries (fail, fail, pass) must be preserved, not collapsed to the last attempt only.
+    await expect(page.locator('.subnav-item:has-text("Flaky") .counter')).toHaveText('1');
+  });
+
+  test('"as-retry" numbers retries correctly across multiple colliding blobs that each have their own in-blob retries', async ({ runInlineTest, mergeReports }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    // blob1: retries=1, both attempts fail (local retry 0,1).
+    // blob2 (rerun): retries=1, both attempts fail again (local retry 0,1 -> should become 2,3).
+    // blob3 (second rerun): retries=1, first attempt fails, second passes (local retry 0,1 -> should become 4,5).
+    const shouldPassOnRetryValues = [false, false, true];
+    for (let i = 0; i < shouldPassOnRetryValues.length; i++) {
+      await runInlineTest({
+        'playwright.config.ts': `module.exports = { reporter: 'blob', retries: 1 };`,
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('t', async ({}, testInfo) => {
+            expect(testInfo.retry === 1 && ${shouldPassOnRetryValues[i]}).toBe(true);
+          });
+        `,
+      });
+      await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, `report-${i}.zip`));
+    }
+    const { exitCode, output } = await mergeReports(allReportsDir, {}, { additionalArgs: ['--reporter', 'json', '--merge-strategy', 'as-retry'] });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(output.substring(output.indexOf('{')));
+    const results = json.suites[0].specs[0].tests[0].results;
+    expect(results.map((r: any) => r.retry)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(results.map((r: any) => r.status)).toEqual(['failed', 'failed', 'failed', 'failed', 'failed', 'passed']);
+    expect(json.suites[0].specs[0].tests[0].status).toBe('flaky');
+  });
+
+  test('"as-retry" keeps two independently colliding tests\' retry numbering isolated from each other', async ({ runInlineTest, mergeReports }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await runInlineTest({
+      'playwright.config.ts': `module.exports = { reporter: 'blob', retries: 1 };`,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('testA', async ({}) => { expect(1).toBe(2); });
+        test('testB', async ({}) => { expect(1).toBe(1); });
+      `,
+    });
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-1.zip'));
+
+    await runInlineTest({
+      'playwright.config.ts': `module.exports = { reporter: 'blob', retries: 1 };`,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('testA', async ({}, testInfo) => { expect(testInfo.retry).toBe(1); });
+        test('testB', async ({}) => { expect(1).toBe(2); });
+      `,
+    });
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-2.zip'));
+
+    const { exitCode, output } = await mergeReports(allReportsDir, {}, { additionalArgs: ['--reporter', 'json', '--merge-strategy', 'as-retry'] });
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(output.substring(output.indexOf('{')));
+    const specs = json.suites[0].specs;
+    const testA = specs.find((s: any) => s.title === 'testA').tests[0];
+    const testB = specs.find((s: any) => s.title === 'testB').tests[0];
+    // testA: blob1 fails twice (0,1), blob2 fails then passes (offset to 2,3).
+    expect(testA.results.map((r: any) => r.retry)).toEqual([0, 1, 2, 3]);
+    // testB: blob1 passes immediately (1 result, no retry needed), blob2 fails twice (offset to 1,2).
+    // testB's own (shorter) offset chain must not be contaminated by testA's unrelated, longer one.
+    expect(testB.results.map((r: any) => r.retry)).toEqual([0, 1, 2]);
+  });
+
+  test('"overwrite"/"as-retry" reconcile blobs by actual run time, not by filename sort order', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    // Chronologically: report-2 (FAIL) is created first (older), report-10 (PASS) is created second (newer).
+    // Alphabetically "report-10.zip" sorts BEFORE "report-2.zip" -- the opposite of chronological order.
+    await runInlineTest(files('fail'));
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-2.zip'));
+
+    await runInlineTest(files('pass'));
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-10.zip'));
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html', '--merge-strategy', 'overwrite'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    await expect(page.locator('.subnav-item:has-text("Passed") .counter')).toHaveText('1');
+    await expect(page.locator('.subnav-item:has-text("Failed") .counter')).toHaveText('0');
+  });
+
+  test('same test title under different project names is never treated as a collision', async ({ runInlineTest, mergeReports, showReport, page }) => {
+    const allReportsDir = test.info().outputPath('all-blob-reports');
+    await runInlineTest({
+      'playwright.config.ts': `module.exports = { reporter: 'blob', projects: [{ name: 'projA' }] };`,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('t', async ({}) => { expect(1).toBe(1); });
+      `,
+    });
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-1.zip'));
+
+    await runInlineTest({
+      'playwright.config.ts': `module.exports = { reporter: 'blob', projects: [{ name: 'projB' }] };`,
+      'a.test.js': `
+        import { test, expect } from '@playwright/test';
+        test('t', async ({}) => { expect(1).toBe(1); });
+      `,
+    });
+    await fs.promises.cp(test.info().outputPath('blob-report', 'report.zip'), path.join(allReportsDir, 'report-2.zip'));
+
+    const { exitCode } = await mergeReports(allReportsDir, { 'PLAYWRIGHT_HTML_OPEN': 'never' }, { additionalArgs: ['--reporter', 'html', '--merge-strategy', 'as-retry'] });
+    expect(exitCode).toBe(0);
+    await showReport();
+    await expect(page.locator('.subnav-item:has-text("All") .counter')).toHaveText('2');
+  });
+});
+
 test('no reports error', async ({ runInlineTest, mergeReports }) => {
   const reportDir = test.info().outputPath('blob-report');
   fs.mkdirSync(reportDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Adds `--merge-strategy <separate|overwrite|as-retry>` to `merge-reports`, so a test that appears in multiple blobs with the same id (e.g. a full run merged with a `--last-failed` rerun) can be reconciled instead of always showing up as a duplicate entry.
- `separate` (default) keeps existing behavior. `overwrite` keeps only the chronologically later result. `as-retry` renumbers the later result to continue the original's retry sequence, so it renders like a normal Playwright retry.
- Blobs are reconciled by each blob's own recorded run time, not by report filename, so ordering is correct regardless of how blob files happen to be named.

Fixes #33094