### PR TITLE
fix(mcp): do not clobber chromiumSandbox from the config file

### DIFF
--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -81,10 +81,6 @@ export function decorateMCPCommand(command: Command) {
       .option('--viewport-size <size>', 'specify browser viewport size in pixels, for example "1280x720"', resolutionParser.bind(null, '--viewport-size'))
       .addOption(new ProgramOption('--vision', 'Legacy option, use --caps=vision instead').hideHelp())
       .action(async options => {
-
-        // normalize the --no-sandbox option: sandbox = true => nothing was passed, sandbox = false => --no-sandbox was passed.
-        options.sandbox = options.sandbox === true ? undefined : false;
-
         setupExitWatchdog();
 
         if (options.vision) {

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -173,3 +173,40 @@ test('browser_get_config returns merged config from file, env and cli', async ({
   // From CLI arg (--isolated).
   expect(config.browser.isolated).toBe(true);
 });
+
+test.describe('chromiumSandbox', () => {
+  test.skip(({ mcpBrowser }) => mcpBrowser !== 'chrome', 'Channel-agnostic tests.');
+
+  test('config file value is respected', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright-mcp/issues/1716' } }, async ({ startClient }) => {
+    const { client } = await startClient({
+      config: {
+        capabilities: ['config'],
+        browser: { launchOptions: { chromiumSandbox: true } },
+      },
+    });
+    const config = JSON.parse(parseResponse(await client.callTool({ name: 'browser_get_config' })).result);
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('--no-sandbox overrides config file value', async ({ startClient }) => {
+    const { client } = await startClient({
+      config: {
+        capabilities: ['config'],
+        browser: { launchOptions: { chromiumSandbox: true } },
+      },
+      args: ['--no-sandbox'],
+    });
+    const config = JSON.parse(parseResponse(await client.callTool({ name: 'browser_get_config' })).result);
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+  });
+
+  test('--sandbox enables the sandbox', async ({ startClient }) => {
+    const { client } = await startClient({
+      config: { capabilities: ['config'] },
+      args: ['--browser=chromium', '--sandbox'],
+    });
+    const config = JSON.parse(parseResponse(await client.callTool({ name: 'browser_get_config' })).result);
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Commander leaves `sandbox` undefined when neither `--sandbox` nor `--no-sandbox` is passed (both flags are declared), so the normalization in `decorateMCPCommand` was wrong.
- It turned "no flag" into `false`, silently overriding `browser.launchOptions.chromiumSandbox` from the config file.
- It also turned an explicit `--sandbox` into `undefined`, which on Linux fell back to the platform default that disables the sandbox for the chromium channel.

Fixes https://github.com/microsoft/playwright-mcp/issues/1716