### PR TITLE
chore(html-reporter): render a thumbnail for every trace attachment

### DIFF
--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -164,12 +164,12 @@ export const TestResultView: React.FC<{
     </AutoChip>}
 
     {!!traces.length && <Anchor id='attachment-trace'><AutoChip header='Traces' revealOnAnchorId='attachment-trace'>
-      {<div>
-        <a href={formatUrl(generateTraceUrl(traces))}>
+      {traces.map((a, i) => <div key={`trace-${i}`}>
+        <a href={formatUrl(generateTraceUrl([a]))}>
           <img className='screenshot' src={traceImage} style={{ width: 192, height: 117, marginLeft: 20 }} />
         </a>
-        {traces.map((a, i) => <AttachmentLink key={`trace-${i}`} attachment={a} result={result} linkName={traces.length === 1 ? 'trace' : `trace-${i + 1}`}></AttachmentLink>)}
-      </div>}
+        <AttachmentLink attachment={a} result={result} linkName={traces.length === 1 ? 'trace' : `trace-${i + 1}`}></AttachmentLink>
+      </div>)}
     </AutoChip></Anchor>}
 
     {!!videos.length && <Anchor id='attachment-video'><AutoChip header='Videos' revealOnAnchorId='attachment-video'>

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -714,6 +714,45 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('.source-line-running')).toContainText('request.get');
     });
 
+    test('should show a thumbnail for every trace attachment', async ({ runInlineTest, page, server, showReport }) => {
+      const result = await runInlineTest({
+        'a.test.js': `
+          import { test, expect } from '@playwright/test';
+          test('passes', async ({ browser }, testInfo) => {
+            for (const index of [1, 2]) {
+              const context = await browser.newContext();
+              await context.tracing.start({ screenshots: true, snapshots: true });
+              const page = await context.newPage();
+              await page.goto('${server.EMPTY_PAGE}');
+              const tracePath = testInfo.outputPath('trace' + index + '.zip');
+              await context.tracing.stop({ path: tracePath });
+              await testInfo.attach('trace', { path: tracePath, contentType: 'application/zip' });
+              await context.close();
+            }
+          });
+        `,
+      }, { reporter: 'dot,html' }, { PLAYWRIGHT_HTML_OPEN: 'never' });
+      expect(result.exitCode).toBe(0);
+      expect(result.passed).toBe(1);
+
+      await showReport();
+      await page.getByRole('link', { name: 'passes' }).click();
+
+      const traces = page.locator('.chip').filter({ hasText: 'Traces' });
+      await expect(traces.locator('img')).toHaveCount(2);
+      await expect(traces.getByRole('link', { name: 'trace-1', exact: true })).toBeVisible();
+      await expect(traces.getByRole('link', { name: 'trace-2', exact: true })).toBeVisible();
+
+      const hrefs = await traces.locator('a').filter({ has: page.locator('img') }).evaluateAll(links => links.map(link => link.getAttribute('href')));
+      expect(hrefs).toHaveLength(2);
+      for (const href of hrefs)
+        expect(href!.match(/trace=/g)).toHaveLength(1);
+      expect(hrefs[0]).not.toBe(hrefs[1]);
+
+      await traces.locator('img').first().click();
+      await expect(page.locator('.action-title').first()).toBeVisible();
+    });
+
     test('trace should not hang when showing parallel api requests', async ({ runInlineTest, page, server, showReport }) => {
       const result = await runInlineTest({
         'playwright.config.js': `


### PR DESCRIPTION
## Summary
- When a result has multiple `trace` attachments, each one now gets its own thumbnail link instead of a single thumbnail followed by plain download links.
- Each thumbnail opens just that trace; the combined multi-trace view is still available via the **View Trace** button in the test header.