### PR TITLE
fix(trace-viewer): pretty-print JSON without losing precision

### DIFF
--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -511,12 +511,21 @@ function formatXml(xml: string, indent = '  ') {
   return lines.join('\n');
 }
 
+// JSON.parse turns every number into a double, which rounds integers beyond
+// Number.MAX_SAFE_INTEGER. Preserve the original source text of each number instead.
+function formatJson(json: string): string {
+  const rawJSON = (JSON as { rawJSON?(text: string): unknown }).rawJSON;
+  const preserveNumbers = rawJSON && ((key: string, value: any, context?: { source?: string }) =>
+    typeof value === 'number' && context?.source !== undefined ? rawJSON(context.source) : value);
+  return JSON.stringify(JSON.parse(json, preserveNumbers), null, 2);
+}
+
 function formatBody(body: string, contentType?: string): string {
   if (!body.trim() || !contentType)
     return body;
 
   if (isJsonMimeType(contentType))
-    return JSON.stringify(JSON.parse(body), null, 2);
+    return formatJson(body);
 
   if (isXmlMimeType(contentType))
     return formatXml(body);

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -283,6 +283,43 @@ test('should pretty-print response bodies and show formatting errors', async ({ 
   await expect(prettyPrintError).toBeVisible();
 });
 
+test('should pretty-print JSON without losing number precision', async ({ runUITest, server }) => {
+  server.setRoute('/response-bigint', (_, res) => res.setHeader('Content-Type', 'application/json').end('{"id":12345678901234567890,"amount":9007199254740993,"ratio":1.0,"scaled":1e3}'));
+
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test } from '@playwright/test';
+      test('network response tab', async ({ request }) => {
+        await request.get('${server.PREFIX}/response-bigint').then(res => res.text());
+      });
+    `,
+  });
+
+  await page.getByText('network response tab').dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
+  await page.getByRole('tab', { name: 'Network' }).click();
+
+  await page.getByRole('listbox', { name: 'Network requests' }).getByRole('option').filter({ hasText: 'response-bigint' }).click();
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Response' }).click();
+
+  const responsePanel = page.getByRole('tabpanel', { name: 'Response' });
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{',
+    '  "id": 12345678901234567890,',
+    '  "amount": 9007199254740993,',
+    '  "ratio": 1.0,',
+    '  "scaled": 1e3',
+    '}',
+  ], { useInnerText: true });
+  await expect(responsePanel.getByTitle('Formatting failed')).toBeHidden();
+
+  // Raw view keeps the exact bytes as well.
+  await responsePanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{"id":12345678901234567890,"amount":9007199254740993,"ratio":1.0,"scaled":1e3}',
+  ], { useInnerText: true });
+});
+
 test('should display list of query parameters (only if present)', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `


### PR DESCRIPTION
## Summary
- Pretty print in the network pane round-tripped bodies through `JSON.parse`/`JSON.stringify`, rounding integers beyond `Number.MAX_SAFE_INTEGER` (e.g. 64-bit ids) and normalizing literals like `1.0` and `1e3`.
- Preserve each number's source text via `JSON.rawJSON`, falling back to the previous behavior on engines without it (Baseline since March 2025: Chrome 114, Firefox 135, Safari 18.4).

References https://github.com/microsoft/playwright/issues/42261