### PR TITLE
fix(mcp): do not ask for roots without the event stream

### DIFF
--- a/packages/playwright-core/src/tools/utils/mcp/server.ts
+++ b/packages/playwright-core/src/tools/utils/mcp/server.ts
@@ -115,11 +115,22 @@ export function createServer(name: string, version: string, factory: ServerBacke
   return server;
 }
 
+const waitForTransportInitialized = async (transportInitialized: Promise<void>): Promise<boolean> => {
+  let timer: NodeJS.Timeout;
+  const timedOut = new Promise<boolean>(f => {
+    timer = setTimeout(() => f(false), 5000);
+  });
+  try {
+    return await Promise.race([transportInitialized.then(() => true), timedOut]);
+  } finally {
+    clearTimeout(timer!);
+  }
+};
+
 const initializeServer = async (server: ServerType, factory: ServerBackendFactory, transportInitialized: Promise<void>): Promise<ServerBackend> => {
   const capabilities = server.getClientCapabilities();
   let clientRoots: Root[] = [];
-  if (capabilities?.roots) {
-    await Promise.race([transportInitialized, new Promise<void>(f => setTimeout(f, 5000))]);
+  if (capabilities?.roots && await waitForTransportInitialized(transportInitialized)) {
     const { roots } = await server.listRoots().catch(e => {
       serverDebug(e);
       return { roots: [] };

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -511,12 +511,21 @@ function formatXml(xml: string, indent = '  ') {
   return lines.join('\n');
 }
 
+// JSON.parse turns every number into a double, which rounds integers beyond
+// Number.MAX_SAFE_INTEGER. Preserve the original source text of each number instead.
+function formatJson(json: string): string {
+  const rawJSON = (JSON as { rawJSON?(text: string): unknown }).rawJSON;
+  const preserveNumbers = rawJSON && ((key: string, value: any, context?: { source?: string }) =>
+    typeof value === 'number' && context?.source !== undefined ? rawJSON(context.source) : value);
+  return JSON.stringify(JSON.parse(json, preserveNumbers), null, 2);
+}
+
 function formatBody(body: string, contentType?: string): string {
   if (!body.trim() || !contentType)
     return body;
 
   if (isJsonMimeType(contentType))
-    return JSON.stringify(JSON.parse(body), null, 2);
+    return formatJson(body);
 
   if (isXmlMimeType(contentType))
     return formatXml(body);

--- a/tests/mcp/http.spec.ts
+++ b/tests/mcp/http.spec.ts
@@ -528,6 +528,36 @@ test('should not reap session of a client without the event stream', async ({ se
   expect(formatLog(stderr())['delete http session']).toBeUndefined();
 });
 
+test('should not stall the first tool call of a roots-capable client without the event stream', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42256' } }, async ({ serverEndpoint, server }) => {
+  const { url } = await serverEndpoint();
+
+  // A POST-only client that advertises roots but never opens the GET event stream. The server
+  // cannot deliver roots/list to it, so it must not wait for a response.
+  const endpoint = new URL('/mcp', url);
+  let lastId = 0;
+  const post = async (body: object, sessionId?: string) => {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/json, text/event-stream',
+        ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    return { status: response.status, sessionId: response.headers.get('mcp-session-id'), text: await response.text() };
+  };
+
+  const init = await post({ jsonrpc: '2.0', id: ++lastId, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: { roots: {} }, clientInfo: { name: 'post-only', version: '1.0.0' } } });
+  expect(init.status).toBe(200);
+  const sessionId = init.sessionId!;
+  await post({ jsonrpc: '2.0', method: 'notifications/initialized' }, sessionId);
+
+  const navigate = await post({ jsonrpc: '2.0', id: ++lastId, method: 'tools/call', params: { name: 'browser_navigate', arguments: { url: server.HELLO_WORLD } } }, sessionId);
+  expect(navigate.status).toBe(200);
+  expect(navigate.text).toContain('Page URL: ' + server.HELLO_WORLD);
+});
+
 test('should not run heartbeat when timeout is non-positive', async ({ serverEndpoint, server }) => {
   const { url, stderr } = await serverEndpoint({ env: { PLAYWRIGHT_MCP_PING_TIMEOUT_MS: '0' } });
 

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -283,6 +283,43 @@ test('should pretty-print response bodies and show formatting errors', async ({ 
   await expect(prettyPrintError).toBeVisible();
 });
 
+test('should pretty-print JSON without losing number precision', async ({ runUITest, server }) => {
+  server.setRoute('/response-bigint', (_, res) => res.setHeader('Content-Type', 'application/json').end('{"id":12345678901234567890,"amount":9007199254740993,"ratio":1.0,"scaled":1e3}'));
+
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test } from '@playwright/test';
+      test('network response tab', async ({ request }) => {
+        await request.get('${server.PREFIX}/response-bigint').then(res => res.text());
+      });
+    `,
+  });
+
+  await page.getByText('network response tab').dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
+  await page.getByRole('tab', { name: 'Network' }).click();
+
+  await page.getByRole('listbox', { name: 'Network requests' }).getByRole('option').filter({ hasText: 'response-bigint' }).click();
+  await page.getByRole('tabpanel', { name: 'Network' }).getByRole('tab', { name: 'Response' }).click();
+
+  const responsePanel = page.getByRole('tabpanel', { name: 'Response' });
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{',
+    '  "id": 12345678901234567890,',
+    '  "amount": 9007199254740993,',
+    '  "ratio": 1.0,',
+    '  "scaled": 1e3',
+    '}',
+  ], { useInnerText: true });
+  await expect(responsePanel.getByTitle('Formatting failed')).toBeHidden();
+
+  // Raw view keeps the exact bytes as well.
+  await responsePanel.getByRole('button', { name: 'Pretty print', exact: true }).click();
+  await expect(responsePanel.locator('.CodeMirror-code .CodeMirror-line')).toHaveText([
+    '{"id":12345678901234567890,"amount":9007199254740993,"ratio":1.0,"scaled":1e3}',
+  ], { useInnerText: true });
+});
+
 test('should display list of query parameters (only if present)', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `


### PR DESCRIPTION
## Summary
- Server-to-client requests go over the standalone GET event stream. A streamable HTTP client that advertises `roots` but never opens that stream can't be delivered `roots/list`, so the request was dropped by the transport and the first `tools/call` stalled for the SDK's 60s default timeout.
- Skip `listRoots()` when the transport never became bidirectionally ready, instead of sending a request that could only time out.

Fixes https://github.com/microsoft/playwright/issues/42256