### PR TITLE
fix(test runner): match --test-list entries against the test file path

### DIFF
--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -153,6 +153,8 @@ example.spec.ts:15 › example test
 example.spec.ts:42:42 › example test
 ```
 
+File paths in the entries should point to the test files, relative to the root test directory. For a test declared in a file imported by the test file, `--list` prints the file where the test is declared — use the test file path instead when composing a test list.
+
 ### Show Report
 
 Display HTML report from previous test run. [Read more about the HTML reporter](./test-reporters#html-reporter).

--- a/packages/playwright/src/runner/loadUtils.ts
+++ b/packages/playwright/src/runner/loadUtils.ts
@@ -371,11 +371,12 @@ export async function loadTestList(config: FullConfigInternal, filePath: string)
     });
     const testFilter = (test: testNs.TestCase) => descriptions.some(d => {
       // Note: there is no root yet at the time of filtering.
-      const [projectName, , ...titles] = test.titlePath();
+      const [projectName, fileTitle, ...titles] = test.titlePath();
       if (d.project !== undefined && d.project !== projectName)
         return false;
-      const relativeFile = toPosixPath(path.relative(config.config.rootDir, test.location.file));
-      if (relativeFile !== d.file)
+      // A test can be declared in a file imported by the test file, so match either of them.
+      const declarationFile = toPosixPath(path.relative(config.config.rootDir, test.location.file));
+      if (declarationFile !== d.file && toPosixPath(fileTitle) !== d.file)
         return false;
       return d.titlePath.length <= titles.length && d.titlePath.every((_, index) => titles[index] === d.titlePath[index]);
     });

--- a/tests/playwright-test/test-list.spec.ts
+++ b/tests/playwright-test/test-list.spec.ts
@@ -246,3 +246,41 @@ test('--test-list should not load files not in the list', async ({ runInlineTest
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
 });
+
+test('--test-list should match tests declared in an imported file by test file path', async ({ runInlineTest }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42298' });
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { testDir: 'tests' };
+    `,
+    'test.list': `
+      # Entries reference the test file, not the file where the test is declared.
+      a.spec.ts
+      b.spec.ts › declared in helper
+    `,
+    'tests/helper.ts': `
+      import { test } from '@playwright/test';
+      export function defineTests() {
+        test('declared in helper', async () => { console.log('\\n%%' + test.info().titlePath[0]); });
+      }
+    `,
+    'tests/a.spec.ts': `
+      import { defineTests } from './helper';
+      defineTests();
+    `,
+    'tests/b.spec.ts': `
+      import { defineTests } from './helper';
+      defineTests();
+    `,
+    'tests/c.spec.ts': `
+      import { defineTests } from './helper';
+      defineTests();
+    `,
+  }, { 'workers': 1, 'test-list': 'test.list' });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+  expect(result.outputLines).toEqual([
+    'a.spec.ts',
+    'b.spec.ts',
+  ]);
+});


### PR DESCRIPTION
## Summary
- Tests declared in a file imported by the test file could not be selected by any `--test-list` entry: matching only considered `test.location.file`, while file-only entries and load-time file filtering use the test file path.
- Match entries against either the test file or the declaration file.
- Document that entries should use the test file path, which may differ from what `--list` prints for such tests.

Fixes https://github.com/microsoft/playwright/issues/42298