### PR TITLE
docs(locator): fix C# Locator.Last example

### DIFF
--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -1884,7 +1884,7 @@ Locator banana = page.getByRole(AriaRole.LISTITEM).last();
 ```
 
 ```csharp
-var banana = await page.GetByRole(AriaRole.Listitem).Last(1);
+var banana = page.GetByRole(AriaRole.Listitem).Last;
 ```
 
 ## method: Locator.locator


### PR DESCRIPTION
## Summary
- The C# `Locator.Last` example used `.Last(1)` and `await`. `Last` is a property that returns `ILocator`, so that snippet does not compile.

Fixes https://github.com/microsoft/playwright-dotnet/issues/3310