### PR TITLE
fix(web): make expandable section titles keyboard accessible

### DIFF
--- a/packages/trace-viewer/src/ui/attachmentsTab.tsx
+++ b/packages/trace-viewer/src/ui/attachmentsTab.tsx
@@ -67,16 +67,14 @@ const ExpandableAttachment: React.FunctionComponent<ExpandableAttachmentProps> =
     return Math.min(Math.max(5, lineCount), 20) * lineHeight;
   }, [attachmentText]);
 
-  const title = <span style={{ marginLeft: 5 }} ref={ref} aria-label={attachment.name}>
-    <span>{linkifyText(attachment.name)}</span>
-    {hasContent && <a style={{ marginLeft: 5 }} href={downloadURL(model, attachment)}>download</a>}
-  </span>;
+  const title = <span style={{ marginLeft: 5 }} ref={ref} aria-label={attachment.name}>{linkifyText(attachment.name)}</span>;
+  const downloadLink = hasContent && <a style={{ marginLeft: 5 }} href={downloadURL(model, attachment)}>download</a>;
 
   if (!isTextAttachment || !hasContent)
-    return <div style={{ marginLeft: 20 }}>{title}</div>;
+    return <div style={{ marginLeft: 20 }}>{title}{downloadLink}</div>;
 
   return <div className={clsx(flash && 'yellow-flash')}>
-    <Expandable title={title} expanded={expanded} setExpanded={setExpanded} expandOnTitleClick={true}>
+    <Expandable title={title} titleSuffix={downloadLink} expanded={expanded} setExpanded={setExpanded} expandOnTitleClick={true}>
       {placeholder && <i>{placeholder}</i>}
     </Expandable>
     {expanded && attachmentText !== null && <div className='vbox' style={{ height: snippetHeight }}>

--- a/packages/trace-viewer/src/ui/networkResourceDetails.tsx
+++ b/packages/trace-viewer/src/ui/networkResourceDetails.tsx
@@ -140,13 +140,11 @@ const ExpandableSection: React.FC<{
     setExpanded={setExpanded}
     expandOnTitleClick
     title={
-      <>
-        <span className='network-request-details-header'>{title}
-          {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
-        </span>
-        { titleChildren }
-      </>
+      <span className='network-request-details-header'>{title}
+        {showCount && <span className='network-request-details-header-count'> × {data?.length ?? 0}</span>}
+      </span>
     }
+    titleSuffix={titleChildren}
     className={className}
   >
     {data && <table className='network-request-details-table'>

--- a/packages/web/src/common.css
+++ b/packages/web/src/common.css
@@ -55,6 +55,12 @@ a {
   color: var(--vscode-textLink-foreground);
 }
 
+a:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 dialog {
   border: none;
   padding: 0;

--- a/packages/web/src/components/expandable.css
+++ b/packages/web/src/components/expandable.css
@@ -27,7 +27,32 @@
   align-items: center;
   white-space: nowrap;
   user-select: none;
+}
+
+.expandable-title-button {
+  display: flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0 8px 0 0;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
   cursor: pointer;
+  outline: none;
+}
+
+.expandable-title > a {
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
+/* Links are flex items here, as tall as the row; the inset ring keeps the
+   content below from covering it. */
+.expandable-title-button:focus-visible,
+.expandable-title > a:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 .expandable-content {

--- a/packages/web/src/components/expandable.css
+++ b/packages/web/src/components/expandable.css
@@ -30,16 +30,12 @@
 }
 
 .expandable-title-button {
+  all: unset;
   display: flex;
   align-items: center;
-  background: none;
-  border: none;
-  padding: 0 8px 0 0;
+  padding-right: 8px;
   border-radius: 4px;
-  color: inherit;
-  font: inherit;
   cursor: pointer;
-  outline: none;
 }
 
 .expandable-title > a {

--- a/packages/web/src/components/expandable.spec.ts
+++ b/packages/web/src/components/expandable.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect, test } from '@playwright/test';
 
-import type { Collapsed, Expanded, Stateful, StatefulTitleClick } from './expandable.story';
+import type { Collapsed, Expanded, Stateful, StatefulTitleClick, StatefulTitleSuffix } from './expandable.story';
 
 test.use({ viewport: { width: 500, height: 500 } });
 
@@ -52,4 +52,32 @@ test('title click should not expand by default', async ({ mount }) => {
   await component.getByText('Title').click();
   await expect(component.locator('.codicon-chevron-right')).toBeVisible();
   await expect(component.getByTestId('expanded')).toHaveValue('false');
+});
+
+test('keyboard should toggle when title click is enabled', async ({ mount }) => {
+  const component = await mount<typeof StatefulTitleClick>('components/expandable/StatefulTitleClick');
+  const button = component.getByRole('button', { name: 'Title' });
+  await button.focus();
+  await expect(button).toBeFocused();
+  await button.press('Enter');
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
+  await button.press(' ');
+  await expect(component.getByTestId('expanded')).toHaveValue('false');
+});
+
+test('keyboard should toggle via chevron button by default', async ({ mount }) => {
+  const component = await mount<typeof Stateful>('components/expandable/Stateful');
+  const button = component.getByRole('button', { name: 'Expand' });
+  await button.focus();
+  await button.press('Enter');
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
+  await expect(component.getByRole('button', { name: 'Collapse' })).toBeVisible();
+});
+
+test('title suffix should render outside the toggle button', async ({ mount }) => {
+  const component = await mount<typeof StatefulTitleSuffix>('components/expandable/StatefulTitleSuffix');
+  await component.getByRole('link', { name: 'download' }).click();
+  await expect(component.getByTestId('expanded')).toHaveValue('false');
+  await component.getByRole('button', { name: 'Title' }).click();
+  await expect(component.getByTestId('expanded')).toHaveValue('true');
 });

--- a/packages/web/src/components/expandable.story.tsx
+++ b/packages/web/src/components/expandable.story.tsx
@@ -26,7 +26,7 @@ export const Expanded = () =>
 export const Stateful = () => {
   const [expanded, setExpanded] = React.useState(false);
   return <>
-    <Expandable expanded={expanded} setExpanded={setExpanded} title='Title'>Details text</Expandable>
+    <Expandable expanded={expanded} setExpanded={setExpanded} title={<span>Title</span>}>Details text</Expandable>
     <form hidden><input data-testid='expanded' readOnly value={String(expanded)} /></form>
   </>;
 };
@@ -35,6 +35,14 @@ export const StatefulTitleClick = () => {
   const [expanded, setExpanded] = React.useState(false);
   return <>
     <Expandable expanded={expanded} setExpanded={setExpanded} expandOnTitleClick title='Title'>Details text</Expandable>
+    <form hidden><input data-testid='expanded' readOnly value={String(expanded)} /></form>
+  </>;
+};
+
+export const StatefulTitleSuffix = () => {
+  const [expanded, setExpanded] = React.useState(false);
+  return <>
+    <Expandable expanded={expanded} setExpanded={setExpanded} expandOnTitleClick title='Title' titleSuffix={<a href='#suffix'>download</a>}>Details text</Expandable>
     <form hidden><input data-testid='expanded' readOnly value={String(expanded)} /></form>
   </>;
 };

--- a/packages/web/src/components/expandable.tsx
+++ b/packages/web/src/components/expandable.tsx
@@ -23,8 +23,9 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
   setExpanded: (expanded: boolean) => void,
   expanded: boolean,
   expandOnTitleClick?: boolean,
+  titleSuffix?: React.ReactNode,
   className?: string;
-}>> = ({ title, children, setExpanded, expanded, expandOnTitleClick, className }) => {
+}>> = ({ title, children, setExpanded, expanded, expandOnTitleClick, titleSuffix, className }) => {
   const titleId = React.useId();
   const regionId = React.useId();
 
@@ -32,25 +33,33 @@ export const Expandable: React.FunctionComponent<React.PropsWithChildren<{
 
   const chevron = <div
     className={clsx('codicon', expanded ? 'codicon-chevron-down' : 'codicon-chevron-right')}
-    style={{ cursor: 'pointer', color: 'var(--vscode-foreground)', marginLeft: '5px' }}
-    onClick={!expandOnTitleClick ? onClick : undefined} />;
+    style={{ color: 'var(--vscode-foreground)', marginLeft: '5px' }} />;
 
   return <div className={clsx('expandable', expanded && 'expanded', className)}>
-    {expandOnTitleClick ?
-      <div
-        id={titleId}
-        role='button'
-        aria-expanded={expanded}
-        aria-controls={regionId}
-        className='expandable-title'
-        onClick={onClick}>
-        {chevron}
-        {title}
-      </div> :
-      <div className='expandable-title'>
-        {chevron}
-        {title}
-      </div>}
+    <div className='expandable-title' id={expandOnTitleClick ? undefined : titleId}>
+      {expandOnTitleClick ?
+        <button
+          id={titleId}
+          aria-expanded={expanded}
+          aria-controls={regionId}
+          className='expandable-title-button'
+          onClick={onClick}>
+          {chevron}
+          {title}
+        </button> :
+        <>
+          <button
+            aria-expanded={expanded}
+            aria-controls={regionId}
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+            className='expandable-title-button'
+            onClick={onClick}>
+            {chevron}
+          </button>
+          {title}
+        </>}
+      {titleSuffix}
+    </div>
     {expanded && <div id={regionId} aria-labelledby={titleId} role='region' className='expandable-content'>{children}</div>}
   </div>;
 };

--- a/tests/playwright-test/ui-mode-test-network-tab.spec.ts
+++ b/tests/playwright-test/ui-mode-test-network-tab.spec.ts
@@ -429,6 +429,35 @@ test('should toggle sections inside network details', async ({ runUITest, server
   await expect(headersPanel.getByRole('region', { name: 'General' })).toContainText(/Start.+Duration\d+ms/);
 });
 
+test('should toggle sections inside network details with keyboard', {
+  annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42263' },
+}, async ({ runUITest, server }) => {
+  const { page } = await runUITest({
+    'network-tab.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('network tab test', async ({ page }) => {
+        await page.goto('${server.PREFIX}/network-tab/network.html');
+        await page.evaluate(() => (window as any).donePromise);
+      });
+    `,
+  });
+
+  await page.getByRole('treeitem', { name: 'network tab test' }).dblclick();
+  await expect(page.getByTestId('workbench-run-status')).toContainText('Passed');
+
+  await page.getByRole('tab', { name: 'Network' }).click();
+  await page.getByRole('option').filter({ hasText: 'post-data-1' }).click();
+  const headersPanel = page.getByRole('tabpanel', { name: 'Headers' });
+
+  const header = headersPanel.getByRole('button', { name: 'Request Headers × 16' });
+  await header.focus();
+  await expect(header).toBeFocused();
+  await header.press('Enter');
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeHidden();
+  await header.press(' ');
+  await expect(headersPanel.getByRole('region', { name: 'Request Headers × 16' })).toBeVisible();
+});
+
 test('should copy network request', async ({ runUITest, server }) => {
   const { page } = await runUITest({
     'network-tab.test.ts': `


### PR DESCRIPTION
## Summary
- `Expandable` titles were `div`s with `role=button` but no `tabIndex` or key handler, so trace viewer section headers (network details, attachments) could not be focused or toggled with the keyboard. They now render a native `<button>`, following #41434.
- Interactive elements that cannot nest inside a button (attachment download link, payload format toggle) move to a new `titleSuffix` prop that renders them in the title row, outside the button.
- The chevron-only variant gets a button too, which makes the UI mode filters panel keyboard-operable.

Fixes https://github.com/microsoft/playwright/issues/42263