### PR TITLE
fix(web): make image diff mode switcher keyboard accessible

### DIFF
--- a/packages/web/src/shared/imageDiffView.css
+++ b/packages/web/src/shared/imageDiffView.css
@@ -1,0 +1,30 @@
+/*
+  Copyright (c) Microsoft Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+.image-diff-mode {
+  all: unset;
+  flex: none;
+  margin: 0 10px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 4px;
+}
+
+/* The trace viewer defines the vscode theme variables, the html reporter the color ones. */
+.image-diff-mode:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, var(--color-accent-fg));
+  outline-offset: 2px;
+}

--- a/packages/web/src/shared/imageDiffView.spec.ts
+++ b/packages/web/src/shared/imageDiffView.spec.ts
@@ -35,3 +35,19 @@ test('should show diff by default', async ({ mount }) => {
   const box = await image.boundingBox();
   expect(box).toEqual(expect.objectContaining({ width: 48, height: 48 }));
 });
+
+test('should switch mode with keyboard', async ({ mount }) => {
+  const component = await mount<typeof Default>('shared/imageDiffView/Default');
+  const sxs = component.getByRole('tab', { name: 'Side by side' });
+  await sxs.focus();
+  await expect(sxs).toBeFocused();
+  await sxs.press('Enter');
+  await expect(sxs).toHaveAttribute('aria-selected', 'true');
+  await expect(component.locator('img')).toHaveCount(2);
+
+  const diffTab = component.getByRole('tab', { name: 'Diff' });
+  await diffTab.focus();
+  await diffTab.press(' ');
+  await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+  await expect(component.locator('img')).toHaveCount(1);
+});

--- a/packages/web/src/shared/imageDiffView.tsx
+++ b/packages/web/src/shared/imageDiffView.tsx
@@ -15,6 +15,7 @@
 */
 
 import * as React from 'react';
+import './imageDiffView.css';
 import { useMeasure } from '../uiUtils';
 import { ResizeView } from './resizeView';
 
@@ -90,20 +91,20 @@ export const ImageDiffView: React.FC<{
   const fitWidth = imageWidth * scale;
   const fitHeight = imageHeight * scale;
 
-  const modeStyle: React.CSSProperties = {
-    flex: 'none',
-    margin: '0 10px',
-    cursor: 'pointer',
-    userSelect: 'none',
-  };
+  const modeTab = (m: typeof mode, title: string) => <button
+    role='tab'
+    aria-selected={mode === m}
+    className='image-diff-mode'
+    style={{ fontWeight: mode === m ? 600 : 'initial' }}
+    onClick={() => setMode(m)}>{title}</button>;
   return <div data-testid='test-result-image-mismatch' style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', flex: 'auto' }} ref={ref}>
     {isLoaded && <>
-      <div data-testid='test-result-image-mismatch-tabs' style={{ display: 'flex', margin: '10px 0 20px' }}>
-        {diff.diff && <div style={{ ...modeStyle, fontWeight: mode === 'diff' ? 600 : 'initial' }} onClick={() => setMode('diff')}>Diff</div>}
-        <div style={{ ...modeStyle, fontWeight: mode === 'actual' ? 600 : 'initial' }} onClick={() => setMode('actual')}>Actual</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'expected' ? 600 : 'initial' }} onClick={() => setMode('expected')}>{expectedImageTitle}</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'sxs' ? 600 : 'initial' }} onClick={() => setMode('sxs')}>Side by side</div>
-        <div style={{ ...modeStyle, fontWeight: mode === 'slider' ? 600 : 'initial' }} onClick={() => setMode('slider')}>Slider</div>
+      <div role='tablist' data-testid='test-result-image-mismatch-tabs' style={{ display: 'flex', margin: '10px 0 20px' }}>
+        {diff.diff && modeTab('diff', 'Diff')}
+        {modeTab('actual', 'Actual')}
+        {modeTab('expected', expectedImageTitle)}
+        {modeTab('sxs', 'Side by side')}
+        {modeTab('slider', 'Slider')}
       </div>
       <div style={{ display: 'flex', justifyContent: 'center', flex: 'auto', minHeight: fitHeight + 60 }}>
         {diff.diff && mode === 'diff' && <ImageWithSize image={diffImage} alt='Diff' hideSize={hideDetails} canvasWidth={fitWidth} canvasHeight={fitHeight} scale={scale}/>}

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -182,7 +182,7 @@ for (const useIntermediateMergeReport of [true, false] as const) {
       await expect(page.locator('text=Image mismatch')).toBeVisible();
       await expect(page.locator('text=Snapshot mismatch')).toHaveCount(0);
 
-      await expect(page.getByTestId('test-screenshot-error-view').getByTestId('test-result-image-mismatch-tabs').locator('div')).toHaveText([
+      await expect(page.getByTestId('test-screenshot-error-view').getByTestId('test-result-image-mismatch-tabs').getByRole('tab')).toHaveText([
         'Diff',
         'Actual',
         'Expected',


### PR DESCRIPTION
## Summary
- The image diff mode switchers (Diff / Actual / Expected / Side by side / Slider) were plain divs with no role or `tabIndex` — mouse-only and invisible to assistive tech. They now render as native `<button role=tab aria-selected>` in a `tablist`, following #41434.
- Static styles move to a stylesheet with an `all: unset` reset; the focus ring uses `var(--vscode-focusBorder, var(--color-accent-fg))` since the component is shared between the trace viewer and the html reporter theme systems.

Fixes https://github.com/microsoft/playwright/issues/42266