### PR TITLE
docs(python): document that task cancellation is not supported

### DIFF
--- a/docs/src/library-python.md
+++ b/docs/src/library-python.md
@@ -202,4 +202,4 @@ Playwright's API is not thread-safe. If you are using Playwright in a multi-thre
 
 ### Cancelling `asyncio` tasks
 
-Cancelling a task that is running a Playwright call is not supported. Playwright forwards the cancellation to the driver on a best-effort basis, but it does not guarantee that the connection is left in a usable state afterwards. Cancelling a task while `async_playwright()` is still starting up can leave the driver process running. If an operation has to outlive its caller, run it in a separate task and protect it with [`asyncio.shield()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.shield).
+Cancelling a task that is running a Playwright call is not supported and results in undefined behavior. If an operation has to outlive its caller, run it in a separate task and protect it with [`asyncio.shield()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.shield).

--- a/docs/src/library-python.md
+++ b/docs/src/library-python.md
@@ -199,3 +199,7 @@ On Windows Python 3.7, Playwright sets the default event loop to `ProactorEventL
 ### Threading
 
 Playwright's API is not thread-safe. If you are using Playwright in a multi-threaded environment, you should create a playwright instance per thread. See [threading issue](https://github.com/microsoft/playwright-python/issues/623) for more details.
+
+### Cancelling `asyncio` tasks
+
+Cancelling a task that is running a Playwright call is not supported. Playwright forwards the cancellation to the driver on a best-effort basis, but it does not guarantee that the connection is left in a usable state afterwards. Cancelling a task while `async_playwright()` is still starting up can leave the driver process running. If an operation has to outlive its caller, run it in a separate task and protect it with [`asyncio.shield()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.shield).


### PR DESCRIPTION
## Summary
- add a Known issues entry stating that cancelling a task running a Playwright call is not supported and results in undefined behavior

Closes https://github.com/microsoft/playwright/issues/42296