### PR TITLE
fix(chromium): deduplicate request header casing

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -662,7 +662,7 @@ class InterceptableRequest {
     if (entries && entries.length)
       postDataBuffer = Buffer.concat(entries.map(entry => Buffer.from(entry.bytes!, 'base64')));
 
-    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || headersObjectToArray(headers), requestWillBeSentEvent.wallTime * 1000);
+    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || headersObjectToArray(headersArrayToObject(headersObjectToArray(headers), true)), requestWillBeSentEvent.wallTime * 1000);
     (this.request as any)[kInterceptableRequest] = this;
   }
 }

--- a/tests/page/page-set-extra-http-headers.spec.ts
+++ b/tests/page/page-set-extra-http-headers.spec.ts
@@ -61,8 +61,7 @@ it('should throw for non-string header values', async ({ page }) => {
   expect(error2.message).toContain('Expected value of header "foo" to be String, but "boolean" is found.');
 });
 
-it('should not duplicate referer header', async ({ page, server, browserName }) => {
-  it.fail(browserName === 'chromium', 'Request has referer and Referer');
+it('should not duplicate referer header', async ({ page, server }) => {
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.ok()).toBe(true);


### PR DESCRIPTION
Fixes #42315

Chromium reports the navigation referer under two casings in the CDP request payload. Normalize that protocol header object case-insensitively before constructing the Playwright request, so `request.headers()` does not join the same value twice.

Removed the Chromium expected-failure marker from the existing regression test. On Linux x86_64 with Chromium 152.0.7977.8, I verified the test fails without the source fix and passes with it. The full Chromium spec file passed all 5 tests, and the directly relevant lint checks passed.

The complete lint pipeline could not finish because doclint requires Firefox revision 1540, which is not installed. Firefox, WebKit, Windows, and macOS were not tested.

Thanks to @ayaangazali for the report and detailed investigation.