### PR TITLE
fix(chromium): do not report a navigation Referer twice

### DIFF
--- a/packages/playwright-core/src/server/chromium/crNetworkManager.ts
+++ b/packages/playwright-core/src/server/chromium/crNetworkManager.ts
@@ -662,9 +662,23 @@ class InterceptableRequest {
     if (entries && entries.length)
       postDataBuffer = Buffer.concat(entries.map(entry => Buffer.from(entry.bytes!, 'base64')));
 
-    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || headersObjectToArray(headers), requestWillBeSentEvent.wallTime * 1000);
+    this.request = new network.Request(context, frame, serviceWorker, redirectedFrom?.request || null, documentId, url, toResourceType(requestWillBeSentEvent.type || 'Other'), method, postDataBuffer,  headersOverride || dedupeHeaders(headersObjectToArray(headers)), requestWillBeSentEvent.wallTime * 1000);
     (this.request as any)[kInterceptableRequest] = this;
   }
+}
+
+// Chromium reports a navigation's Referer under two different casings when the same header also
+// comes from Network.setExtraHTTPHeaders, even though a single one is sent on the wire.
+// Header names are case-insensitive, so collapse entries that only differ by case.
+function dedupeHeaders(headers: types.HeadersArray): types.HeadersArray {
+  const seen = new Set<string>();
+  return headers.filter(header => {
+    const key = header.name.toLowerCase() + ':' + header.value;
+    if (seen.has(key))
+      return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 class RouteImpl implements network.RouteDelegate {

--- a/tests/page/page-set-extra-http-headers.spec.ts
+++ b/tests/page/page-set-extra-http-headers.spec.ts
@@ -62,7 +62,6 @@ it('should throw for non-string header values', async ({ page }) => {
 });
 
 it('should not duplicate referer header', async ({ page, server, browserName }) => {
-  it.fail(browserName === 'chromium', 'Request has referer and Referer');
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.ok()).toBe(true);


### PR DESCRIPTION
## Rationale

With `referer` set through `extraHTTPHeaders`, `request.headers()` on a Chromium navigation returns
the value twice:

```
"referer": "http://example.com/from, http://example.com/from"
```

The server only ever received it once. `allHeaders()` is correct, `document.referrer` is correct,
and Firefox and WebKit report it once. It is also navigation specific: subresources and `fetch()`
are fine.

Chromium's `Network.requestWillBeSent` reports the same header under two casings for a navigation,
canonical `Referer` plus whatever casing was passed to `setExtraHTTPHeaders`:

```
{ ..., "Referer": "http://example.com/from", "referer": "http://example.com/from" }
```

`headersObjectToArray` iterates object keys, so both entries survive, and `Request.headers()` then
lowercases and comma joins them. Header names are case-insensitive, so this collapses entries that
differ only by case.

I first assumed the cause was `frames.ts:700` lifting `referer` out of `extraHTTPHeaders` and also
passing it to `navigateFrame`, so I tried removing that. It does not help Chromium at all, and it
regresses Firefox, where `document.referrer` becomes `""` because Firefox relies on the navigate
referer to populate it. Recording that here so the dead end is not retried.

The dedupe is applied where the CDP header object is converted rather than inside
`headersObjectToArray`, because that helper has 30+ callers including client side user supplied
headers, where two casings could be deliberate.

## Test

`page-set-extra-http-headers.spec.ts` already had this case marked
`it.fail(browserName === 'chromium', 'Request has referer and Referer')`. The marker goes away and
the test passes on all three browsers, so no new test was needed. The marker's stated reason was
inaccurate, since only one Referer is ever sent.

Also green: page-event-request, page-request-intercept, page-request-continue, page-network-response,
page-network-sizes, network-post-data.

Fixes https://github.com/microsoft/playwright/issues/42315

---

heads up that my two earlier PRs were closed with the CLA still pending, so if this one is blocked
the same way please just say and I will sort it out rather than leave it sitting in your queue.
also apologies if I have misread any of the CDP side, I worked through this myself and used claude
code to challenge my reasoning, which is how I caught that my first root cause was wrong. freshman
in college, still learning :)