### PR TITLE
fix(cli): add .playwright-cli/ to .gitignore on workspace install

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/program.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/program.ts
@@ -93,6 +93,7 @@ export async function initWorkspace(initSkills: string | undefined, initSkillsGl
     const playwrightDir = path.join(cwd, '.playwright');
     await fs.promises.mkdir(playwrightDir, { recursive: true });
     console.log(`✅ Workspace initialized at \`${cwd}\`.`);
+    await patchGitIgnore(cwd);
   }
 
   const skills = initSkillsGlobal ?? initSkills;
@@ -109,6 +110,22 @@ export async function initWorkspace(initSkills: string | undefined, initSkillsGl
 
   if (!globalSkills)
     await ensureConfiguredBrowserInstalled();
+}
+
+async function patchGitIgnore(cwd: string) {
+  if (!fs.existsSync(path.join(cwd, '.git')))
+    return;
+  try {
+    const gitIgnorePath = path.join(cwd, '.gitignore');
+    const existing = await fs.promises.readFile(gitIgnorePath, 'utf8').catch(() => '');
+    if (existing.split('\n').some(line => line.trim() === '.playwright-cli/'))
+      return;
+    const separator = existing && !existing.endsWith('\n') ? '\n' : '';
+    await fs.promises.appendFile(gitIgnorePath, separator + '# Playwright CLI output (may contain credentials)\n.playwright-cli/\n');
+    console.log('✅ Added `.playwright-cli/` to `.gitignore`.');
+  } catch (error) {
+    console.log(`⚠️ Failed to update \`.gitignore\`: ${error instanceof Error ? error.message : error}`);
+  }
 }
 
 async function ensureConfiguredBrowserInstalled() {

--- a/tests/mcp/cli-misc.spec.ts
+++ b/tests/mcp/cli-misc.spec.ts
@@ -40,6 +40,23 @@ test('install workspace', async ({ cli }, testInfo) => {
   expect(fs.existsSync(playwrightDir)).toBe(true);
 });
 
+test('install adds .playwright-cli/ to .gitignore', async ({ cli }, testInfo) => {
+  const outsideGitRepo = await cli('install');
+  expect(outsideGitRepo.output).not.toContain('.gitignore');
+  expect(fs.existsSync(testInfo.outputPath('.gitignore'))).toBe(false);
+
+  await fs.promises.mkdir(testInfo.outputPath('.git'), { recursive: true });
+  await fs.promises.writeFile(testInfo.outputPath('.gitignore'), 'node_modules/');
+  const insideGitRepo = await cli('install');
+  expect(insideGitRepo.output).toContain('Added `.playwright-cli/` to `.gitignore`.');
+  const expectedContent = 'node_modules/\n# Playwright CLI output (may contain credentials)\n.playwright-cli/\n';
+  expect(await fs.promises.readFile(testInfo.outputPath('.gitignore'), 'utf8')).toBe(expectedContent);
+
+  const secondRun = await cli('install');
+  expect(secondRun.output).not.toContain('.gitignore');
+  expect(await fs.promises.readFile(testInfo.outputPath('.gitignore'), 'utf8')).toBe(expectedContent);
+});
+
 test('install workspace w/skills', async ({ cli }, testInfo) => {
   const { output } = await cli('install', '--skills');
   expect(output).toContain(`Skill installed to \`.claude${path.sep}skills${path.sep}playwright-cli\`.`);


### PR DESCRIPTION
## Summary
- `playwright-cli install` now appends `.playwright-cli/` to `.gitignore`, since traces and storage state saved there can contain credentials.
- Best-effort: only in a git repo, skipped if the entry is already present, a write failure warns instead of failing the install.

Fixes https://github.com/microsoft/playwright/issues/42307