### PR TITLE
fix(cli): parse negative numbers as positional arguments

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/minimist.ts
+++ b/packages/playwright-core/src/tools/cli-client/minimist.ts
@@ -94,7 +94,7 @@ export function minimist(args: string[], opts?: MinimistOptions): MinimistArgs {
       } else {
         setArg(key, strings[key] ? '' : true);
       }
-    } else if ((/^-[^-]+/).test(arg)) {
+    } else if ((/^-[^-]+/).test(arg) && !(/^-\d/).test(arg)) {
       const letters = arg.slice(1, -1).split('');
 
       let broken = false;

--- a/packages/playwright-core/src/tools/cli-client/minimist.ts
+++ b/packages/playwright-core/src/tools/cli-client/minimist.ts
@@ -94,7 +94,7 @@ export function minimist(args: string[], opts?: MinimistOptions): MinimistArgs {
       } else {
         setArg(key, strings[key] ? '' : true);
       }
-    } else if ((/^-[^-]+/).test(arg) && !(/^-\d/).test(arg)) {
+    } else if ((/^-[^-]+/).test(arg) && !(/^-\.?\d/).test(arg)) {
       const letters = arg.slice(1, -1).split('');
 
       let broken = false;

--- a/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
@@ -90,6 +90,7 @@ playwright-cli mousedown right
 playwright-cli mouseup
 playwright-cli mouseup right
 playwright-cli mousewheel 0 100
+playwright-cli mousewheel 0 -100
 ```
 
 ### Save as

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -73,16 +73,11 @@ test('wrong argument type', async ({ cli, server }) => {
   expect(press.exitCode).toBe(0);
 });
 
-test('should accept negative number arguments', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42321' } }, async ({ cli, server }) => {
+test('negative number argument', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42321' } }, async ({ cli, server }) => {
   server.setContent('/', eventsPage, 'text/html');
   await cli('open', server.PREFIX);
-  await cli('mousemove', '50', '50');
-  await cli('mousedown');
-  await cli('mouseup');
-
   const { exitCode } = await cli('mousewheel', '0', '-100');
   expect(exitCode).toBe(0);
-
   await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel 0 -100');
 });
 

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './cli-fixtures';
+import { test, expect, eventsPage } from './cli-fixtures';
 
 test('unknown option', async ({ cli, server }) => {
   const { error, exitCode } = await cli('open', '--some-option', 'value', 'about:blank');
@@ -71,6 +71,19 @@ test('wrong argument type', async ({ cli, server }) => {
   expect(error).toContain(`error: 'y' argument: expected number, received 'foo'`);
   const press = await cli('press', '5');
   expect(press.exitCode).toBe(0);
+});
+
+test('should accept negative number arguments', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42321' } }, async ({ cli, server }) => {
+  server.setContent('/', eventsPage, 'text/html');
+  await cli('open', server.PREFIX);
+  await cli('mousemove', '50', '50');
+  await cli('mousedown');
+  await cli('mouseup');
+
+  const { exitCode } = await cli('mousewheel', '0', '-100');
+  expect(exitCode).toBe(0);
+
+  await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel 0 -100');
 });
 
 test('should preserve leading zeros in string arguments', async ({ cli, server }) => {


### PR DESCRIPTION
## Summary
- `playwright-cli mousewheel 0 -100` failed with `Unknown options: --0, --1`, so scrolling up was not possible. The vendored minimist sends anything matching `/^-[^-]+/` down the short-flag branch, and `-100` matches.
- Skip that branch for signed numbers so they land in `_`, like commander and yargs do.
- Added the scroll-up example to the CLI skill, which only ever showed `mousewheel 0 100`.

Fixes https://github.com/microsoft/playwright/issues/42321