### PR TITLE
fix(cli): parse negative numbers as arguments

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/minimist.ts
+++ b/packages/playwright-core/src/tools/cli-client/minimist.ts
@@ -94,7 +94,8 @@ export function minimist(args: string[], opts?: MinimistOptions): MinimistArgs {
       } else {
         setArg(key, strings[key] ? '' : true);
       }
-    } else if ((/^-[^-]+/).test(arg)) {
+    } else if ((/^-[A-Za-z]/).test(arg)) {
+      // Short flags are letters, so '-100' and '-.5' are arguments, not flags.
       const letters = arg.slice(1, -1).split('');
 
       let broken = false;

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -76,12 +76,13 @@ test('wrong argument type', async ({ cli, server }) => {
 test('negative number arguments', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42321' } }, async ({ cli, server }) => {
   server.setContent('/', eventsPage, 'text/html');
   await cli('open', server.PREFIX);
+  await cli('mousemove', '50', '50');
 
   expect((await cli('mousewheel', '0', '-100')).exitCode).toBe(0);
   await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel 0 -100');
 
-  expect((await cli('mousewheel', '-1.5', '-.5')).exitCode).toBe(0);
-  await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel -1.5 -0.5');
+  const { error } = await cli('mousewheel', '-.5');
+  expect(error).toContain(`error: 'dy' argument: expected number, received 'undefined'`);
 });
 
 test('should preserve leading zeros in string arguments', async ({ cli, server }) => {

--- a/tests/mcp/cli-parsing.spec.ts
+++ b/tests/mcp/cli-parsing.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { test, expect } from './cli-fixtures';
+import { test, expect, eventsPage } from './cli-fixtures';
 
 test('unknown option', async ({ cli, server }) => {
   const { error, exitCode } = await cli('open', '--some-option', 'value', 'about:blank');
@@ -71,6 +71,17 @@ test('wrong argument type', async ({ cli, server }) => {
   expect(error).toContain(`error: 'y' argument: expected number, received 'foo'`);
   const press = await cli('press', '5');
   expect(press.exitCode).toBe(0);
+});
+
+test('negative number arguments', { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42321' } }, async ({ cli, server }) => {
+  server.setContent('/', eventsPage, 'text/html');
+  await cli('open', server.PREFIX);
+
+  expect((await cli('mousewheel', '0', '-100')).exitCode).toBe(0);
+  await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel 0 -100');
+
+  expect((await cli('mousewheel', '-1.5', '-.5')).exitCode).toBe(0);
+  await expect.poll(() => cli('snapshot').then(result => result.inlineSnapshot)).toContain('wheel -1.5 -0.5');
 });
 
 test('should preserve leading zeros in string arguments', async ({ cli, server }) => {


### PR DESCRIPTION
## Summary
- `playwright-cli mousewheel 0 -100` failed with `Unknown options: --0, --1` because the vendored minimist sends everything matching `/^-[^-]+/` down the short-flag branch. Upstream minimist has the same bug.
- The CLI has no non-letter short flags, so match short flags on `/^-[A-Za-z]/` instead and let everything else fall through to positional arguments.
- Alternative to #42324.

Fixes https://github.com/microsoft/playwright/issues/42321