### PR TITLE
fix(html): make remaining mouse-only controls keyboard accessible

### DIFF
--- a/packages/html-reporter/src/common.css
+++ b/packages/html-reporter/src/common.css
@@ -211,6 +211,18 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   user-select: none;
 }
 
+button.subnav-item {
+  background: none;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+
+.subnav-item:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: -1px;
+}
+
 .subnav-item:hover {
   background-color: var(--color-canvas-subtle);
 }

--- a/packages/html-reporter/src/headerView.spec.ts
+++ b/packages/html-reporter/src/headerView.spec.ts
@@ -57,3 +57,13 @@ test('should toggle filters', async ({ page, mount }) => {
   await component.getByRole('textbox').fill('annot:annotation type=annotation description');
   await expect(filterText).toHaveValue('annot:annotation type=annotation description');
 });
+
+test('settings button should open with the keyboard', async ({ mount, page }) => {
+  const component = await mount<typeof Default>('headerView/Default');
+  const settings = component.getByRole('button', { name: 'Settings' });
+  await settings.focus();
+  await expect(settings).toBeFocused();
+  await expect(settings).toHaveAttribute('aria-expanded', 'false');
+  await page.keyboard.press('Enter');
+  await expect(settings).toHaveAttribute('aria-expanded', 'true');
+});

--- a/packages/html-reporter/src/headerView.tsx
+++ b/packages/html-reporter/src/headerView.tsx
@@ -128,24 +128,25 @@ const NavLink: React.FC<{
 };
 
 const SettingsButton: React.FC = () => {
-  const settingsRef = React.useRef<HTMLDivElement>(null);
+  const settingsRef = React.useRef<HTMLButtonElement>(null);
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [theme, setTheme] = useThemeSetting();
 
   return <>
-    <div
-      role='button'
+    <button
+      type='button'
       ref={settingsRef}
-      style={{ cursor: 'pointer' }}
       className='subnav-item'
       title='Settings'
+      aria-haspopup='dialog'
+      aria-expanded={settingsOpen}
       onClick={e => {
         setSettingsOpen(!settingsOpen);
         e.preventDefault();
       }}
       onMouseDown={preventDefault}>
       {icons.settings()}
-    </div>
+    </button>
 
     <Dialog
       open={settingsOpen}

--- a/packages/html-reporter/src/labels.css
+++ b/packages/html-reporter/src/labels.css
@@ -30,6 +30,15 @@
   cursor: pointer;
 }
 
+button.label {
+  font-family: inherit;
+}
+
+.label:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
+}
+
 .label-anchor {
   text-decoration: none;
   color: var(--color-fg-default);

--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -28,9 +28,11 @@ export const Label: React.FC<{
   onClick?: (e: React.MouseEvent, label: string) => void,
   colorIndex?: number,
 }> = ({ label, href, onClick, colorIndex, trimAtSymbolPrefix }) => {
-  const baseLabel = <span className={clsx('label', 'label-color-' + (colorIndex !== undefined ? colorIndex : hashStringToInt(label)))} onClick={onClick ? e => onClick(e, label) : undefined}>
-    {trimAtSymbolPrefix && label.startsWith('@') ? label.slice(1) : label}
-  </span>;
+  const className = clsx('label', 'label-color-' + (colorIndex !== undefined ? colorIndex : hashStringToInt(label)));
+  const text = trimAtSymbolPrefix && label.startsWith('@') ? label.slice(1) : label;
+  const baseLabel = onClick
+    ? <button type='button' className={className} onClick={e => onClick(e, label)}>{text}</button>
+    : <span className={className}>{text}</span>;
 
   return href
     ? <a className='label-anchor' href={formatUrl(href)}>{baseLabel}</a>

--- a/packages/html-reporter/src/metadataView.css
+++ b/packages/html-reporter/src/metadataView.css
@@ -18,6 +18,15 @@
   cursor: pointer;
   user-select: none;
   color: var(--color-fg-default);
+  padding: 0;
+  background: none;
+  border: none;
+  font: inherit;
+}
+
+.metadata-toggle:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
 }
 
 .metadata-toggle-second-line {

--- a/packages/html-reporter/src/testFilesView.tsx
+++ b/packages/html-reporter/src/testFilesView.tsx
@@ -81,9 +81,9 @@ export const TestFilesHeader: React.FC<{
   const isMetadataInTopLine = !showProject && !filteredStats;
 
   const metadataToggleButton = !isMetadataEmpty(report.metadata) && (
-    <div className={clsx('metadata-toggle', !isMetadataInTopLine && 'metadata-toggle-second-line')} role='button' onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
+    <button type='button' className={clsx('metadata-toggle', !isMetadataInTopLine && 'metadata-toggle-second-line')} aria-expanded={metadataVisible} onClick={toggleMetadataVisible} title={metadataVisible ? 'Hide metadata' : 'Show metadata'}>
       {metadataVisible ? icons.downArrow() : icons.rightArrow()}Metadata
-    </div>
+    </button>
   );
 
   const leftSuperHeader = <div className='test-file-header-info'>

--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -85,6 +85,20 @@
   border-bottom: 1px solid transparent;
 }
 
+button.action-list-show-all {
+  padding: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.action-list-show-all:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .action-icons:hover {
   border-bottom: 1px solid var(--vscode-sideBarTitle-foreground);
 }

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -112,7 +112,7 @@ export const ActionList: React.FC<ActionListProps> = ({
   }, [setSelectedTime]);
 
   return <div className='vbox action-list-container'>
-    {selectedTime && <div className='action-list-show-all' onClick={onShowAll}><span className='codicon codicon-triangle-left'></span>Show all</div>}
+    {selectedTime && <button type='button' className='action-list-show-all' onClick={onShowAll}><span className='codicon codicon-triangle-left'></span>Show all</button>}
     <ActionTreeView
       name='actions'
       rootItem={rootItem}


### PR DESCRIPTION
## Rationale

Four controls are still reachable only with a mouse, the same shape fixed for tabs in #41434, chips
in #42149, and expandable titles and the image diff switcher in #42310 and #42311.

| location | before | consequence |
|---|---|---|
| `headerView.tsx:136` | `<div role='button' title='Settings'>` | theme/settings dialog unreachable |
| `testFilesView.tsx:84` | `<div className='metadata-toggle' role='button'>` | metadata cannot be expanded |
| `labels.tsx:31` | bare `<span className='label' onClick>` | tag filter chips unreachable |
| `actionList.tsx:115` | bare `<div className='action-list-show-all' onClick>` | cannot clear the time-range filter |

The first two are the worse pair: they declare `role="button"` and then cannot take focus, so
assistive tech is told there is a button that cannot be operated. The other two carry no role at
all, so they are not announced as controls in the first place.

All four become native buttons with a `:focus-visible` ring, no key handlers. The html reporter
files use `--color-accent-fg`, matching `chip.css` and `tabbedPane.css`; `actionList.css` uses
`--vscode-focusBorder`, matching the rest of the trace viewer. The gear also gains
`aria-haspopup="dialog"` and `aria-expanded`, and the Metadata toggle gains `aria-expanded`, which
neither had.

`labels.tsx` only becomes a button on the clickable branch. `Label` has an `href` branch that
already renders a real anchor, but `LabelsClickView` calls it without `href`, so the tag chips
always took the bare-span path.

**One thing I deliberately did not change.** `actionList.tsx:167`, the error/warning badge that
reveals the console, is also mouse-only. I made it a button, and it broke
`ui-mode-trace.spec.ts:778`: because the badge sits inside a `treeitem`, giving it an accessible
name appends that name to every action row, `- treeitem "Evaluate 2ms Reveal console"`. That is a
regression in the accessibility tree rather than an improvement, so it needs a different approach
and is better done separately than bundled here.

## Test

`headerView.spec.ts` gets one keyboard case for the gear: focus it, assert focus lands, press Enter,
assert `aria-expanded` flips. On current main it fails at `toBeFocused` with `Received: inactive`.

Green: html-reporter component tests 18, `reporter-html.spec.ts` 198, `trace-viewer.spec.ts` 113,
`ui-mode-trace.spec.ts` 27, `flint` clean.

Fixes https://github.com/microsoft/playwright/issues/42323

---

for context, my last three PRs here were closed with the CLA check still pending, so if that is
what blocks this one too please just say so and I will get it sorted rather than have it linger.
also, reading how you structured `titleSuffix` in #42310 and the `--vscode-focusBorder` fallback in
#42311 is what made me check the token per package here instead of copying one blindly, so thanks
for that. freshman in college, learning a lot from these reviews :)