### PR TITLE
fix(trace-viewer): use ToolbarButton for Show all and the console badge

### DIFF
--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -103,19 +103,8 @@
 }
 
 .action-list-show-all {
-  all: unset;
-  box-sizing: border-box;
-  display: flex;
-  cursor: pointer;
-  height: 28px;
-  align-items: center;
   align-self: flex-start;
-  border-radius: 4px;
-}
-
-.action-list-show-all:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: -1px;
+  height: 28px;
 }
 
 .action-list-container {

--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -75,6 +75,8 @@
 }
 
 .action-icons {
+  all: unset;
+  box-sizing: border-box;
   flex: none;
   display: flex;
   flex-direction: row;
@@ -87,6 +89,11 @@
 
 .action-icons:hover {
   border-bottom: 1px solid var(--vscode-sideBarTitle-foreground);
+}
+
+.action-icons:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
 }
 
 .action-error {
@@ -118,10 +125,19 @@
 }
 
 .action-list-show-all {
+  all: unset;
+  box-sizing: border-box;
   display: flex;
   cursor: pointer;
   height: 28px;
   align-items: center;
+  align-self: flex-start;
+  border-radius: 4px;
+}
+
+.action-list-show-all:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
 }
 
 .action-list-container {

--- a/packages/trace-viewer/src/ui/actionList.css
+++ b/packages/trace-viewer/src/ui/actionList.css
@@ -74,28 +74,6 @@
   padding-right: 3px;
 }
 
-.action-icons {
-  all: unset;
-  box-sizing: border-box;
-  flex: none;
-  display: flex;
-  flex-direction: row;
-  cursor: pointer;
-  height: 20px;
-  position: relative;
-  top: 1px;
-  border-bottom: 1px solid transparent;
-}
-
-.action-icons:hover {
-  border-bottom: 1px solid var(--vscode-sideBarTitle-foreground);
-}
-
-.action-icons:focus-visible {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: 1px;
-}
-
 .action-error {
   color: var(--vscode-errorForeground);
   position: relative;

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -112,7 +112,7 @@ export const ActionList: React.FC<ActionListProps> = ({
   }, [setSelectedTime]);
 
   return <div className='vbox action-list-container'>
-    {selectedTime && <div className='action-list-show-all' onClick={onShowAll}><span className='codicon codicon-triangle-left'></span>Show all</div>}
+    {selectedTime && <button type='button' className='action-list-show-all' onClick={onShowAll}><span className='codicon codicon-triangle-left'></span>Show all</button>}
     <ActionTreeView
       name='actions'
       rootItem={rootItem}
@@ -145,6 +145,7 @@ export const renderAction = (
   }) => {
   const { model, sdkLanguage, revealConsole, revealActionAttachment, isLive, showDuration, showBadges, showAttachments } = options;
   const { errors, warnings } = model?.stats(action) ?? { errors: 0, warnings: 0 };
+  const badgeLabel = [pluralize(errors, 'error'), pluralize(warnings, 'warning')].filter(Boolean).join(', ');
 
   const locator = action.params.selector ? asLocatorDescription(sdkLanguage || 'javascript', action.params.selector) : undefined;
 
@@ -164,10 +165,15 @@ export const renderAction = (
       {showAttachments && <ToolbarButton icon='attach' title='Open Attachment' onClick={() => revealActionAttachment?.()} />}
       {showDuration && !isSkipped && <div className='action-duration'>{time || <span className='codicon codicon-loading'></span>}</div>}
       {isSkipped && <span className={clsx('action-skipped', 'codicon', testStatusIcon('skipped'))} title='skipped'></span>}
-      {showBadges && <div className='action-icons' onClick={() => revealConsole?.()}>
+      {showBadges && !!badgeLabel && <button
+        type='button'
+        className='action-icons'
+        title='Reveal console'
+        aria-label={`Reveal console, ${badgeLabel}`}
+        onClick={() => revealConsole?.()}>
         {!!errors && <div className='action-icon'><span className='codicon codicon-error'></span><span className='action-icon-value'>{errors}</span></div>}
         {!!warnings && <div className='action-icon'><span className='codicon codicon-warning'></span><span className='action-icon-value'>{warnings}</span></div>}
-      </div>}
+      </button>}
     </div>
     {locator && <div className='action-title-selector' title={locator}>{locator}</div>}
   </div>;
@@ -216,4 +222,10 @@ export function renderTitleForCall(action: ActionTraceEvent, sdkLanguage?: Langu
     title.push(locator);
   }
   return { elements, title: title.join('') };
+}
+
+function pluralize(count: number, noun: string): string {
+  if (!count)
+    return '';
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
 }

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -165,15 +165,14 @@ export const renderAction = (
       {showAttachments && <ToolbarButton icon='attach' title='Open Attachment' onClick={() => revealActionAttachment?.()} />}
       {showDuration && !isSkipped && <div className='action-duration'>{time || <span className='codicon codicon-loading'></span>}</div>}
       {isSkipped && <span className={clsx('action-skipped', 'codicon', testStatusIcon('skipped'))} title='skipped'></span>}
-      {showBadges && !!badgeLabel && <button
-        type='button'
+      {showBadges && !!badgeLabel && <ToolbarButton
         className='action-icons'
         title='Reveal console'
-        aria-label={`Reveal console, ${badgeLabel}`}
+        ariaLabel={`Reveal console, ${badgeLabel}`}
         onClick={() => revealConsole?.()}>
-        {!!errors && <div className='action-icon'><span className='codicon codicon-error'></span><span className='action-icon-value'>{errors}</span></div>}
-        {!!warnings && <div className='action-icon'><span className='codicon codicon-warning'></span><span className='action-icon-value'>{warnings}</span></div>}
-      </button>}
+        {!!errors && <span className='action-icon'><span className='codicon codicon-error'></span><span className='action-icon-value'>{errors}</span></span>}
+        {!!warnings && <span className='action-icon'><span className='codicon codicon-warning'></span><span className='action-icon-value'>{warnings}</span></span>}
+      </ToolbarButton>}
     </div>
     {locator && <div className='action-title-selector' title={locator}>{locator}</div>}
   </div>;

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -112,7 +112,7 @@ export const ActionList: React.FC<ActionListProps> = ({
   }, [setSelectedTime]);
 
   return <div className='vbox action-list-container'>
-    {selectedTime && <button type='button' className='action-list-show-all' onClick={onShowAll}><span className='codicon codicon-triangle-left'></span>Show all</button>}
+    {selectedTime && <ToolbarButton className='action-list-show-all' icon='triangle-left' onClick={onShowAll}>Show all</ToolbarButton>}
     <ActionTreeView
       name='actions'
       rootItem={rootItem}

--- a/packages/web/src/components/treeView.tsx
+++ b/packages/web/src/components/treeView.tsx
@@ -141,7 +141,8 @@ export function TreeView<T extends TreeItem>({
       role={treeItems.size > 0 ? 'tree' : undefined}
       tabIndex={0}
       onKeyDown={event => {
-        if (selectedItem && event.key === 'Enter') {
+        // Enter is handled by the focused button inside the row, if any.
+        if (selectedItem && event.key === 'Enter' && event.target === event.currentTarget) {
           onAccepted?.(selectedItem);
           return;
         }

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -236,6 +236,22 @@ test('should keep selected action in view after Show all', async ({ runAndTrace,
   await expect(selected).toBeInViewport();
 });
 
+test('should activate Show all with keyboard', async ({ runAndTrace, page }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42323' });
+  const traceViewer = await runAndTrace(async () => {
+    await page.setContent('<div>hello</div>');
+    await page.evaluate(x => x, 1);
+  });
+
+  await traceViewer.actionsTree.getByRole('treeitem').filter({ hasText: 'Evaluate' }).dblclick();
+
+  const showAll = traceViewer.page.getByRole('button', { name: 'Show all' });
+  await showAll.focus();
+  await expect(showAll).toBeFocused();
+  await showAll.press('Enter');
+  await expect(showAll).toBeHidden();
+});
+
 test('should open uncompressed trace directory', async ({ showTraceViewer }) => {
   const traceDir = test.info().outputPath('unzipped-trace');
   await extractZip(traceFile, { dir: traceDir });
@@ -394,6 +410,18 @@ test('should open console errors on click', async ({ showTraceViewer }) => {
   await expect(traceViewer.actionIconsText('Evaluate')).toHaveText(['2', '1']);
   await expect(traceViewer.page.getByRole('tabpanel', { name: 'Console' })).toBeHidden();
   await traceViewer.actionIcons('Evaluate').click();
+  await traceViewer.page.getByRole('tabpanel', { name: 'Console' }).waitFor();
+});
+
+test('should open console errors with keyboard', async ({ showTraceViewer }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42323' });
+  const traceViewer = await showTraceViewer(traceFile);
+  const badge = traceViewer.actionIcons('Evaluate');
+  await expect(badge).toHaveAccessibleName('Reveal console, 2 errors, 1 warning');
+  await badge.focus();
+  await expect(badge).toBeFocused();
+  await expect(traceViewer.page.getByRole('tabpanel', { name: 'Console' })).toBeHidden();
+  await badge.press('Enter');
   await traceViewer.page.getByRole('tabpanel', { name: 'Console' }).waitFor();
 });
 


### PR DESCRIPTION
## Summary
- `Show all` and the error/warning badge that reveals the console were bare `div`s with a click handler — no role, no tab stop, mouse-only. Both render as `ToolbarButton` now, the same component the adjacent attachment button already uses, so the focus ring, hover background and keyboard activation come from `.toolbar-button` instead of hand-rolled styles. `.action-icons` drops out of the stylesheet entirely and `.action-list-show-all` is down to two lines.
- The badge exposes its counts through `aria-label`, and is only rendered when there is a count to show — it used to render an empty clickable div on every action row.
- `TreeView` no longer accepts the selected row on Enter when the event comes from a button inside the row, so in-row buttons (this badge, and the existing attachment button) do not double-fire.

Addresses item 4 of https://github.com/microsoft/playwright/issues/42323. Items 1 and 2 are in #42335.