### PR TITLE
test(mcp): cover --sandbox at the config resolution level

### DIFF
--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -18,12 +18,24 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { Command } from 'commander';
+
 import { test, expect } from './fixtures';
 
 import { tools } from '../../packages/playwright-core/lib/coreBundle';
 import type { Config } from '../../packages/playwright-core/src/tools/mcp/config.d';
 
-const { resolveCLIConfigForCLI, resolveCLIConfigForMCP, isSystemDirectory, outputDir } = tools;
+const { decorateMCPCommand, resolveCLIConfigForCLI, resolveCLIConfigForMCP, isSystemDirectory, outputDir } = tools;
+
+// Parses the command line the same way the mcp server entry point does, without starting the server.
+async function parseCLIOptions(argv: string[]): Promise<any> {
+  const command = new Command();
+  decorateMCPCommand(command);
+  let options: any;
+  command.action(o => { options = o; });
+  await command.parseAsync(argv, { from: 'user' });
+  return options;
+}
 
 // Empty env to isolate tests from the host environment.
 const emptyEnv = {};
@@ -158,6 +170,22 @@ test.describe('sandbox', () => {
   test('explicit --no-sandbox overrides default', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chrome', sandbox: false }, emptyEnv);
     expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+  });
+
+  test('--sandbox on the command line enables the sandbox', async () => {
+    const config = await resolveCLIConfigForMCP(await parseCLIOptions(['--browser=chromium', '--sandbox']), emptyEnv);
+    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('--no-sandbox on the command line disables the sandbox', async () => {
+    const config = await resolveCLIConfigForMCP(await parseCLIOptions(['--browser=chrome', '--no-sandbox']), emptyEnv);
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+  });
+
+  test('no sandbox flag on the command line leaves the value unset', async () => {
+    const options = await parseCLIOptions(['--browser=chrome']);
+    expect(options.sandbox).toBeUndefined();
   });
 });
 

--- a/tests/mcp/config.spec.ts
+++ b/tests/mcp/config.spec.ts
@@ -199,14 +199,4 @@ test.describe('chromiumSandbox', () => {
     const config = JSON.parse(parseResponse(await client.callTool({ name: 'browser_get_config' })).result);
     expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
   });
-
-  test('--sandbox enables the sandbox', async ({ startClient }) => {
-    const { client } = await startClient({
-      config: { capabilities: ['config'] },
-      args: ['--browser=chromium', '--sandbox'],
-    });
-    const config = JSON.parse(parseResponse(await client.callTool({ name: 'browser_get_config' })).result);
-    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
-    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
-  });
 });


### PR DESCRIPTION
## Summary
- `--sandbox enables the sandbox` has been failing on `ubuntu-latest - chrome` since it landed: it starts an MCP server with `--browser=chromium --sandbox`, and the server launches the browser eagerly during initialize. Chrome for Testing cannot start sandboxed on Linux (`No usable sandbox!`), so `browser_get_config` returned an error instead of a config.
- Replaced it with tests in `config-resolve.spec.ts` that drive real argv through `decorateMCPCommand` into `resolveCLIConfigForMCP`, covering `--sandbox`, `--no-sandbox` and neither flag without launching a browser.

Failing `ubuntu-latest - chrome` jobs:
- https://github.com/microsoft/playwright/actions/runs/32402013434/job/96532183849
- https://github.com/microsoft/playwright/actions/runs/32396905156/job/96515743225
- https://github.com/microsoft/playwright/actions/runs/32395156145/job/96510147300
- https://github.com/microsoft/playwright/actions/runs/32371792173/job/96433836023
- https://github.com/microsoft/playwright/actions/runs/32321251720/job/96283729180