### PR TITLE
fix(aria): treat searchbox as a textbox when computing embedded names

### DIFF
--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -746,7 +746,8 @@ function getTextAlternativeInternal(element: Element, options: AccessibleNameOpt
     const isOwnLabel = [...(element as (HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)).labels || []].includes(element as any);
     const isOwnLabelledBy = (labelledBy || []).includes(element);
     if (!isOwnLabel && !isOwnLabelledBy) {
-      if (role === 'textbox') {
+      // https://w3c.github.io/aria/#searchbox is a subclass of textbox.
+      if (role === 'textbox' || role === 'searchbox') {
         options.visitedElements.add(element);
         if (tagName === 'INPUT' || tagName === 'TEXTAREA')
           return compositeString((element as HTMLInputElement | HTMLTextAreaElement).value, element, options.collectElements);

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -467,8 +467,12 @@ test('control embedded in a target element', async ({ page }) => {
     <h1>
       <input type="text" value="Foo bar">
     </h1>
+    <h2>
+      <input type="search" value="Baz qux">
+    </h2>
   `);
   expect.soft(await getNameAndRole(page, 'h1')).toEqual({ role: 'heading', name: 'Foo bar' });
+  expect.soft(await getNameAndRole(page, 'h2')).toEqual({ role: 'heading', name: 'Baz qux' });
 });
 
 test('svg role=presentation', async ({ page, server }) => {


### PR DESCRIPTION
## Rationale

`<input type="search">` contributes nothing to an accessible name computed through a label or
`aria-labelledby`, while `<input type="text">` in identical markup contributes its value:

```
<button aria-labelledby="l1"></button><div id="l1"><input type="text"   value="Query"></div>  ->  button "Query"
<button aria-labelledby="l2"></button><div id="l2"><input type="search" value="Query"></div>  ->  button
```

The second button ends up with no name at all, so it cannot be found by
`getByRole('button', { name: 'Query' })`.

Step 2C of accname returns an embedded control's value when the control is a textbox, and
[searchbox](https://w3c.github.io/aria/#searchbox) is a subclass of textbox. The branch at
`roleUtils.ts:749` only matched `textbox`, while `getAriaRole` gives `<input type="search">` the
role `searchbox` (`roleUtils.ts:131`), so it fell through.

What convinced me this is an oversight rather than a deliberate deviation is that two lists in the
same file already pair the two roles: `kAriaReadonlyRoles` (line 1115) and `kAriaDisabledRoles`
(line 1175) both list `textbox` and `searchbox`. This branch was the only place treating them
differently.

One condition, plus a comment pointing at the spec.

## Test

`role-utils.spec.ts` already has `control embedded in a target element`, so the search case goes
there next to the text case rather than in a new test. On current main the added assertion fails
with the name coming back empty instead of `Baz qux`.

Green across all three browsers: `role-utils.spec.ts` 87 (which includes the w3c accname cases),
plus `selectors-role.spec.ts`, `page-aria-snapshot.spec.ts` and
`expect-to-have-accessible.spec.ts` 72 on chromium. `flint` clean.

Fixes https://github.com/microsoft/playwright/issues/42341

---

the bit I am least confident about is my reading of searchbox inheriting from textbox in the spec,
so please push back if that is wrong and I will close this myself. also worth flagging that my
previous PRs here have sat with the CLA check pending, so if that blocks this one just say and I
will get it handled. freshman in college, appreciate the patience :)