### PR TITLE
fix(html-reporter): make tag chips keyboard accessible

### DIFF
--- a/packages/html-reporter/src/labels.css
+++ b/packages/html-reporter/src/labels.css
@@ -30,9 +30,13 @@
   cursor: pointer;
 }
 
-.label-anchor {
-  text-decoration: none;
-  color: var(--color-fg-default);
+button.label {
+  font-family: inherit;
+}
+
+.label:focus-visible {
+  outline: 1px solid var(--color-accent-fg);
+  outline-offset: 1px;
 }
 
 :root.light-mode {

--- a/packages/html-reporter/src/labels.tsx
+++ b/packages/html-reporter/src/labels.tsx
@@ -16,7 +16,7 @@
 
 import * as React from 'react';
 import { clsx } from '@web/uiUtils';
-import { formatUrl, hashStringToInt } from './utils';
+import { hashStringToInt } from './utils';
 import { navigate, ProjectLink, useSearchParams } from './links';
 import { filterWithQuery } from './filter';
 import './labels.css';
@@ -24,17 +24,14 @@ import './labels.css';
 export const Label: React.FC<{
   label: string,
   trimAtSymbolPrefix?: boolean,
-  href?: string,
   onClick?: (e: React.MouseEvent, label: string) => void,
   colorIndex?: number,
-}> = ({ label, href, onClick, colorIndex, trimAtSymbolPrefix }) => {
-  const baseLabel = <span className={clsx('label', 'label-color-' + (colorIndex !== undefined ? colorIndex : hashStringToInt(label)))} onClick={onClick ? e => onClick(e, label) : undefined}>
-    {trimAtSymbolPrefix && label.startsWith('@') ? label.slice(1) : label}
-  </span>;
-
-  return href
-    ? <a className='label-anchor' href={formatUrl(href)}>{baseLabel}</a>
-    : baseLabel;
+}> = ({ label, onClick, colorIndex, trimAtSymbolPrefix }) => {
+  const className = clsx('label', 'label-color-' + (colorIndex !== undefined ? colorIndex : hashStringToInt(label)));
+  const text = trimAtSymbolPrefix && label.startsWith('@') ? label.slice(1) : label;
+  if (!onClick)
+    return <span className={className}>{text}</span>;
+  return <button type='button' className={className} onClick={e => onClick(e, label)}>{text}</button>;
 };
 
 export const ProjectAndTagLabelsView: React.FC<{

--- a/tests/playwright-test/reporter-html.spec.ts
+++ b/tests/playwright-test/reporter-html.spec.ts
@@ -2179,6 +2179,14 @@ for (const useIntermediateMergeReport of [true, false] as const) {
         await expect(searchInput).toHaveValue('');
         await expect(page).not.toHaveURL(url => getFilter(url) === '@smoke');
 
+        // The chip is a real button, so it filters from the keyboard too.
+        await smokeLabelButton.focus();
+        await expect(smokeLabelButton).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page).toHaveURL(url => getFilter(url) === '@smoke');
+        await searchInput.clear();
+        await page.keyboard.press('Enter');
+
         const regressionLabelButton = page.locator('.test-file-test', { has: page.getByText('@regression passes', { exact: true }) }).locator('.label', { hasText: 'regression' });
         await regressionLabelButton.click();
         await expect(page).toHaveURL(url => getFilter(url) === '@regression');


### PR DESCRIPTION
## Rationale

Item 3 of #42323, which #42335 and #42336 both note is not covered by either of them.

The clickable `@tag` chips next to each test are bare `<span>`s with a click handler
(`labels.tsx:31`), so Tab walks straight past them and filtering by tag is mouse-only. They carry no
role either, so a screen reader is not told they are controls at all. `ProjectLink` sitting right
beside them already renders through `Link`, which is a real anchor, which is what makes this read as
an oversight.

They render as `<button>` now, with the same `--color-accent-fg` focus ring `chip.css` and
`tabbedPane.css` use.

While in there: `Label` had an `href` prop whose branch rendered `<a className='label-anchor'>`, and
no call site passes it. `ProjectLink` wraps a plain `Label` inside its own `Link`, and
`LabelsClickView` passes `onClick`. Removing the prop takes the dead branch, the now-unused
`formatUrl` import and the `.label-anchor` rule with it, so the net change is smaller than the fix
alone.

## Test

`reporter-html.spec.ts` already has `click label should change URL`, which even calls the element
`smokeLabelButton`, so the keyboard case goes there rather than into a new test: focus the chip,
assert focus lands, press Enter, assert the filter applies. On current main it fails at
`toBeFocused` with `Received: inactive`.

Green: `reporter-html.spec.ts` 198, html-reporter component tests 17, `flint` clean.

Fixes item 3 of https://github.com/microsoft/playwright/issues/42323

---

thanks for splitting #42323 up the way you did, the `ToolbarButton` reuse in #42336 was a better
call than the hand-rolled buttons I had, and I have taken that on board here by leaning on the
existing focus-ring convention rather than inventing styles. flagging as before that my earlier PRs
have stalled on a pending CLA check, so tell me if that is in the way again. freshman in college,
genuinely grateful for the review time :)