### PR TITLE
fix(cli): correctly parse negative numbers as flag values

### DIFF
--- a/packages/playwright-core/src/tools/cli-client/minimist.ts
+++ b/packages/playwright-core/src/tools/cli-client/minimist.ts
@@ -83,7 +83,7 @@ export function minimist(args: string[], opts?: MinimistOptions): MinimistArgs {
       next = args[i + 1];
       if (
         next !== undefined
-        && !(/^(-|--)[^-]/).test(next)
+        && !isFlag(next)
         && !bools[key]
       ) {
         setArg(key, next);
@@ -135,7 +135,7 @@ export function minimist(args: string[], opts?: MinimistOptions): MinimistArgs {
       if (!broken && key !== '-') {
         if (
           args[i + 1]
-          && !(/^(-|--)[^-]/).test(args[i + 1])
+          && !isFlag(args[i + 1])
           && !bools[key]
         ) {
           setArg(key, args[i + 1]);
@@ -162,4 +162,9 @@ function toArray(value: string | string[] | undefined): string[] {
   if (!value)
     return [];
   return Array.isArray(value) ? value : [value];
+}
+
+// Short flags are letters, so negative numbers like '-100' or '-.5' are not flags.
+function isFlag(token: string): boolean {
+  return (/^--.+/).test(token) || (/^-[A-Za-z]/).test(token);
 }


### PR DESCRIPTION
## Summary

The CLI arg parser (`minimist.ts`) was treating `-100` as if it were another
flag whenever it followed `-f` or `--flag` as a separate argument, so
`--flag -100` ended up setting `flag: true` and dumping `-100` into the
positional args instead of using it as the flag's value.

This fixes that by checking whether the next token actually looks like a
number before deciding it "looks like a flag." Negative numbers passed as
a separate token now attach correctly, matching how `--flag=-100` already
behaved.

## Before / after

    minimist(['-d', '-100'])
    // before: { _: ['-100'], d: true }
    // after:  { _: [], d: '-100' }

Fixes #42345