### PR TITLE
feat(reporter): add chrome://tracing reporter

### DIFF
--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -101,7 +101,7 @@ See [`property: TestConfig.quiet`].
 
 ## property: FullConfig.reporter
 * since: v1.10
-- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html">>
+- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"chrome-trace">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -448,7 +448,7 @@ export default defineConfig({
 
 ## property: TestConfig.reporter
 * since: v1.10
-- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html">>
+- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"chrome-trace">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -431,6 +431,32 @@ JUnit report supports following configuration options and environment variables:
 | `PLAYWRIGHT_JUNIT_SUITE_ID` |  | Value of the `id` attribute on the root `<testsuites/>` report entry. | Empty string.
 | `PLAYWRIGHT_JUNIT_SUITE_NAME` |  | Value of the `name` attribute on the root `<testsuites/>` report entry. | Empty string.
 
+### Chrome tracing reporter
+
+Chrome tracing reporter produces a [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview) json file that can be opened in [`chrome://tracing`](chrome://tracing) or in the [Perfetto UI](https://ui.perfetto.dev). It renders the test run as a timeline with a lane per worker, where every test is a slice containing its before/after hooks, fixtures and steps as nested slices. Every slice carries the details of the test or step in its trace event arguments, including source locations, tags, annotations, errors, stdio and paths to the attachment files.
+
+```bash
+npx playwright test --reporter=chrome-trace
+```
+
+By default the report is written to `test-results/chrome-trace.json`.
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  reporter: [['chrome-trace', { outputFile: 'chrome-trace.json' }]],
+});
+```
+
+Chrome tracing report supports following configuration options and environment variables:
+
+| Environment Variable Name | Reporter Config Option| Description | Default
+|---|---|---|---|
+| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_DIR` | | Directory to save the output file. Ignored if output file is specified. | `test-results`
+| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_NAME` | | Base file name for the output, relative to the output dir. | `chrome-trace.json`
+| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE` | `outputFile` | Full path to the output file. If defined, `PLAYWRIGHT_CHROME_TRACE_OUTPUT_DIR` and `PLAYWRIGHT_CHROME_TRACE_OUTPUT_NAME` will be ignored. | `undefined`
+
 ### GitHub Actions annotations
 
 You can use the built in `github` reporter to get automatic failure annotations when running in GitHub actions.

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -289,7 +289,7 @@ export function toReporters(reporters: BuiltInReporter | ReporterDescription[] |
   return reporters;
 }
 
-export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob'] as const;
+export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob', 'chrome-trace'] as const;
 export type BuiltInReporter = typeof builtInReporters[number];
 
 export type ContextReuseMode = 'none' | 'when-possible';

--- a/packages/playwright/src/reporters/chromeTrace.ts
+++ b/packages/playwright/src/reporters/chromeTrace.ts
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { toPosixPath } from '@utils/fileUtils';
+import { getPlaywrightVersion } from 'playwright-core/lib/coreBundle';
+
+import { formatError, nonTerminalScreen, resolveOutputFile, CommonReporterOptions } from './base';
+import { stripAnsiEscapes } from '../util';
+
+import type { ReporterV2 } from './reporterV2';
+import type { ChromeTraceReporterOptions } from '../../types/test';
+import type { FullConfig, FullResult, Location, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
+
+type TraceEvent = {
+  name: string;
+  cat: string;
+  ph: 'X' | 'M' | 'i';
+  ts: number;
+  dur?: number;
+  pid: number;
+  tid: number;
+  s?: 'g';
+  cname?: string;
+  args?: Record<string, any>;
+};
+
+type Attachment = { name: string, contentType: string, path?: string };
+type Annotation = { type: string, description?: string };
+
+// Palette names understood by chrome://tracing.
+const kStatusColors: Record<string, string> = {
+  passed: 'good',
+  failed: 'bad',
+  timedOut: 'terrible',
+  interrupted: 'yellow',
+  skipped: 'grey',
+};
+
+const kProcessId = 1;
+const kRunThreadId = 0;
+
+class ChromeTraceReporter implements ReporterV2 {
+  private _config!: FullConfig;
+  private _suite!: Suite;
+  private _resolvedOutputFile: string;
+  private _events: TraceEvent[] = [];
+  private _laneEndTime = new Map<number, number>();
+  private _globalErrors: { error: TestError, timestamp: number }[] = [];
+
+  constructor(options: ChromeTraceReporterOptions & CommonReporterOptions) {
+    this._resolvedOutputFile = resolveOutputFile('CHROME_TRACE', {
+      ...options,
+      default: {
+        fileName: 'chrome-trace.json',
+        outputDir: 'test-results',
+      },
+    })!.outputFile;
+  }
+
+  version(): 'v2' {
+    return 'v2';
+  }
+
+  printsToStdio() {
+    return false;
+  }
+
+  onConfigure(config: FullConfig) {
+    this._config = config;
+  }
+
+  onBegin(suite: Suite) {
+    this._suite = suite;
+  }
+
+  onError(error: TestError) {
+    this._globalErrors.push({ error, timestamp: Date.now() });
+  }
+
+  async onEnd(result: FullResult) {
+    const entries: { test: TestCase, result: TestResult }[] = [];
+    for (const test of this._suite?.allTests() ?? []) {
+      for (const testResult of test.results)
+        entries.push({ test, result: testResult });
+    }
+    entries.sort((a, b) => a.result.startTime.getTime() - b.result.startTime.getTime());
+    for (const entry of entries)
+      this._appendTestResult(entry.test, entry.result);
+    for (const { error, timestamp } of this._globalErrors) {
+      this._events.push({
+        name: 'error',
+        cat: 'error',
+        ph: 'i',
+        s: 'g',
+        ts: timestamp,
+        pid: kProcessId,
+        tid: kRunThreadId,
+        cname: 'bad',
+        args: { error: this._formatError(error) },
+      });
+    }
+    await this._writeReport(result);
+  }
+
+  private _appendTestResult(test: TestCase, result: TestResult) {
+    const startMs = result.startTime.getTime();
+    let endMs = startMs + Math.max(0, result.duration);
+    for (const step of result.steps)
+      endMs = Math.max(endMs, stepEndTime(step));
+
+    const lane = this._allocateLane(result.parallelIndex, startMs);
+    this._laneEndTime.set(lane, endMs);
+
+    const tid = lane + 1;
+    this._events.push({
+      name: test.title,
+      cat: 'test',
+      ph: 'X',
+      ts: startMs,
+      dur: endMs - startMs,
+      pid: kProcessId,
+      tid,
+      cname: kStatusColors[result.status],
+      args: this._testArgs(test, result),
+    });
+    for (const step of result.steps)
+      this._appendStep(step, tid, startMs, endMs);
+  }
+
+  private _allocateLane(preferredLane: number, startMs: number): number {
+    const preferred = Math.max(0, preferredLane);
+    if (!(this._laneEndTime.get(preferred)! > startMs))
+      return preferred;
+    for (let lane = 0; ; ++lane) {
+      if (!(this._laneEndTime.get(lane)! > startMs))
+        return lane;
+    }
+  }
+
+  private _appendStep(step: TestStep, tid: number, parentStart: number, parentEnd: number) {
+    const stepStart = step.startTime.getTime();
+    const startMs = clamp(stepStart, parentStart, parentEnd);
+    const endMs = clamp(step.duration >= 0 ? stepStart + step.duration : parentEnd, startMs, parentEnd);
+    this._events.push({
+      name: step.title,
+      cat: step.category,
+      ph: 'X',
+      ts: startMs,
+      dur: endMs - startMs,
+      pid: kProcessId,
+      tid,
+      cname: step.error ? 'bad' : undefined,
+      args: this._stepArgs(step),
+    });
+    for (const child of step.steps)
+      this._appendStep(child, tid, startMs, endMs);
+  }
+
+  private _testArgs(test: TestCase, result: TestResult): Record<string, any> {
+    // root, project, file, ...describes, test
+    const [, projectName, , ...titles] = test.titlePath();
+    const args: Record<string, any> = {
+      status: result.status,
+      expectedStatus: test.expectedStatus,
+      testId: test.id,
+      workerIndex: result.workerIndex,
+      parallelIndex: result.parallelIndex,
+      timeout: test.timeout,
+      location: this._formatLocation(test.location),
+    };
+    if (titles.length > 1)
+      args.title = titles.join(' › ');
+    if (projectName)
+      args.project = projectName;
+    if (result.retry)
+      args.retry = result.retry;
+    if (test.tags.length)
+      args.tags = test.tags.join(' ');
+    if (result.annotations.length)
+      args.annotations = result.annotations.map(annotation => formatAnnotation(annotation));
+    if (result.attachments.length)
+      args.attachments = result.attachments.map(attachment => this._formatAttachment(attachment));
+    if (result.errors.length)
+      args.errors = result.errors.map(error => this._formatError(error));
+    const stdout = concatChunks(result.stdout);
+    if (stdout)
+      args.stdout = stdout;
+    const stderr = concatChunks(result.stderr);
+    if (stderr)
+      args.stderr = stderr;
+    return args;
+  }
+
+  private _stepArgs(step: TestStep): Record<string, any> | undefined {
+    const args: Record<string, any> = {};
+    if (step.location)
+      args.location = this._formatLocation(step.location);
+    if (step.annotations.length)
+      args.annotations = step.annotations.map(annotation => formatAnnotation(annotation));
+    if (step.attachments.length)
+      args.attachments = step.attachments.map(attachment => this._formatAttachment(attachment));
+    if (step.error)
+      args.error = this._formatError(step.error);
+    return Object.keys(args).length ? args : undefined;
+  }
+
+  private _formatAttachment(attachment: Attachment): string {
+    return attachment.path ? this._relativePath(attachment.path) : attachment.name;
+  }
+
+  private _formatLocation(location: Location | undefined): string | undefined {
+    if (!location)
+      return undefined;
+    return `${this._relativePath(location.file)}:${location.line}:${location.column}`;
+  }
+
+  private _formatError(error: TestError): string {
+    return stripAnsiEscapes(formatError(nonTerminalScreen, error).message);
+  }
+
+  private _relativePath(file: string): string {
+    return toPosixPath(path.relative(this._config.rootDir, file));
+  }
+
+  private async _writeReport(result: FullResult) {
+    let timeOrigin = result.startTime.getTime();
+    for (const event of this._events)
+      timeOrigin = Math.min(timeOrigin, event.ts);
+
+    const traceEvents: TraceEvent[] = [
+      { name: 'process_name', cat: '__metadata', ph: 'M', ts: 0, pid: kProcessId, tid: kRunThreadId, args: { name: 'Playwright Test' } },
+      { name: 'process_sort_index', cat: '__metadata', ph: 'M', ts: 0, pid: kProcessId, tid: kRunThreadId, args: { sort_index: 0 } },
+    ];
+    for (const lane of [...this._laneEndTime.keys()].sort((a, b) => a - b)) {
+      traceEvents.push({ name: 'thread_name', cat: '__metadata', ph: 'M', ts: 0, pid: kProcessId, tid: lane + 1, args: { name: `Worker ${lane}` } });
+      traceEvents.push({ name: 'thread_sort_index', cat: '__metadata', ph: 'M', ts: 0, pid: kProcessId, tid: lane + 1, args: { sort_index: lane + 1 } });
+    }
+
+    // Sort is stable, so parent slices stay ahead of their children on ties.
+    this._events.sort((a, b) => a.ts - b.ts);
+    for (const event of this._events) {
+      event.ts = Math.round((event.ts - timeOrigin) * 1000);
+      if (event.dur !== undefined)
+        event.dur = Math.round(event.dur * 1000);
+      traceEvents.push(event);
+    }
+
+    const report = {
+      traceEvents,
+      displayTimeUnit: 'ms',
+      metadata: {
+        'playwright-version': getPlaywrightVersion(),
+        'start-time': result.startTime.toISOString(),
+        'duration': result.duration,
+        'status': result.status,
+      },
+    };
+
+    await fs.promises.mkdir(path.dirname(this._resolvedOutputFile), { recursive: true });
+    await fs.promises.writeFile(this._resolvedOutputFile, JSON.stringify(report));
+  }
+}
+
+function stepEndTime(step: TestStep): number {
+  let end = step.startTime.getTime() + Math.max(0, step.duration);
+  for (const child of step.steps)
+    end = Math.max(end, stepEndTime(child));
+  return end;
+}
+
+function formatAnnotation(annotation: Annotation): string {
+  return annotation.description ? `${annotation.type}: ${annotation.description}` : annotation.type;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function concatChunks(chunks: (string | Buffer)[]): string {
+  return chunks.map(chunk => typeof chunk === 'string' ? chunk : chunk.toString('utf8')).join('');
+}
+
+export default ChromeTraceReporter;

--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -19,6 +19,7 @@ import { calculateSha1 } from '@utils/crypto';
 import { loadReporter } from './loadUtils';
 import { formatError } from '../reporters/base';
 import { BlobReporter } from '../reporters/blob';
+import ChromeTraceReporter from '../reporters/chromeTrace';
 import DotReporter from '../reporters/dot';
 import EmptyReporter from '../reporters/empty';
 import GitHubReporter from '../reporters/github';
@@ -39,15 +40,16 @@ import type { TestRunOptions } from './tasks';
 
 export async function createReporters(config: FullConfigInternal, mode: 'list' | 'test' | 'merge', descriptions?: ReporterDescription[], runOptions?: TestRunOptions): Promise<ReporterV2[]> {
   const defaultReporters: { [key in commonConfig.BuiltInReporter]: new(arg: any) => ReporterV2 } = {
-    blob: BlobReporter,
-    dot: mode === 'list' ? ListModeReporter : DotReporter,
-    line: mode === 'list' ? ListModeReporter : LineReporter,
-    list: mode === 'list' ? ListModeReporter : ListReporter,
-    github: GitHubReporter,
-    json: JSONReporter,
-    junit: JUnitReporter,
-    null: EmptyReporter,
-    html: HtmlReporter,
+    'blob': BlobReporter,
+    'chrome-trace': ChromeTraceReporter,
+    'dot': mode === 'list' ? ListModeReporter : DotReporter,
+    'line': mode === 'list' ? ListModeReporter : LineReporter,
+    'list': mode === 'list' ? ListModeReporter : ListReporter,
+    'github': GitHubReporter,
+    'json': JSONReporter,
+    'junit': JUnitReporter,
+    'null': EmptyReporter,
+    'html': HtmlReporter,
   };
   const reporters: ReporterV2[] = [];
   descriptions ??= config.config.reporter;

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -25,6 +25,7 @@ export type ListReporterOptions = { printSteps?: boolean, printFailuresInline?: 
 export type GitHubReporterOptions = { omitTags?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean, includeRetries?: boolean, omitTags?: boolean };
 export type JsonReporterOptions = { outputFile?: string };
+export type ChromeTraceReporterOptions = { outputFile?: string };
 export type HtmlReporterOptions = {
   outputFolder?: string;
   open?: 'always' | 'never' | 'on-failure';
@@ -46,6 +47,7 @@ export type ReporterDescription = Readonly<
   ['github'] | ['github', GitHubReporterOptions] |
   ['junit'] | ['junit', JUnitReporterOptions] |
   ['json'] | ['json', JsonReporterOptions] |
+  ['chrome-trace'] | ['chrome-trace', ChromeTraceReporterOptions] |
   ['html'] | ['html', HtmlReporterOptions] |
   ['null'] |
   [string] | [string, any]
@@ -917,7 +919,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    * ```
    *
    */
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'chrome-trace', string> | ReporterDescription[];
   /**
    * Global options for all tests, for example
    * [testOptions.browserName](https://playwright.dev/docs/api/class-testoptions#test-options-browser-name). Learn more

--- a/tests/playwright-test/reporter-chrome-trace.spec.ts
+++ b/tests/playwright-test/reporter-chrome-trace.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from './playwright-test-fixtures';
+
+type TraceEvent = {
+  name: string;
+  cat: string;
+  ph: 'X' | 'M' | 'i';
+  ts: number;
+  dur?: number;
+  pid: number;
+  tid: number;
+  cname?: string;
+  args?: any;
+};
+
+function readTrace(baseDir: string, fileName: string = 'test-results/chrome-trace.json') {
+  return JSON.parse(fs.readFileSync(path.join(baseDir, fileName), 'utf8')) as {
+    traceEvents: TraceEvent[],
+    displayTimeUnit: string,
+    metadata: any,
+  };
+}
+
+function slices(events: TraceEvent[]) {
+  return events.filter(e => e.ph === 'X');
+}
+
+function threadNames(events: TraceEvent[]) {
+  return events.filter(e => e.ph === 'M' && e.name === 'thread_name').map(e => e.args.name);
+}
+
+function findSlice(events: TraceEvent[], name: string) {
+  return slices(events).find(e => e.name === name);
+}
+
+const testFiles = {
+  'a.test.ts': `
+    import { test, expect } from '@playwright/test';
+    test.beforeAll(async () => {});
+    test.beforeEach(async () => {});
+    test.describe('suite', () => {
+      test('passing @smoke', { annotation: { type: 'issue', description: 'flaky' } }, async ({}) => {
+        console.log('hello from the test');
+        await test.step('outer', async () => {
+          await test.step('inner', async () => {
+            expect(1).toBe(1);
+          });
+        });
+      });
+    });
+    test('failing', async ({}) => {
+      expect(1).toBe(2);
+    });
+  `,
+};
+
+test('should write a chrome tracing report', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest(testFiles, { reporter: 'chrome-trace' });
+  expect(result.exitCode).toBe(1);
+
+  const report = readTrace(testInfo.outputPath());
+  expect(report.displayTimeUnit).toBe('ms');
+  expect(report.metadata.status).toBe('failed');
+
+  const events = report.traceEvents;
+  expect(events.filter(e => e.ph === 'M' && e.name === 'process_name')[0].args.name).toBe('Playwright Test');
+  expect(threadNames(events)).toEqual(['Worker 0']);
+
+  const passing = findSlice(events, 'passing @smoke')!;
+  expect(passing.cat).toBe('test');
+  expect(passing.cname).toBe('good');
+  expect(passing.dur).toBeGreaterThan(0);
+  expect(passing.args).toEqual(expect.objectContaining({
+    status: 'passed',
+    expectedStatus: 'passed',
+    title: 'suite › passing @smoke',
+    workerIndex: 0,
+    parallelIndex: 0,
+    timeout: 30000,
+    tags: '@smoke',
+    annotations: ['issue: flaky'],
+    stdout: 'hello from the test\n',
+  }));
+  expect(passing.args.location).toContain('a.test.ts:');
+
+  const failing = findSlice(events, 'failing')!;
+  expect(failing.cname).toBe('bad');
+  expect(failing.args.status).toBe('failed');
+  expect(failing.args.errors[0]).toContain('expect(received).toBe(expected)');
+
+  // Hooks, fixtures and steps are all rendered as slices.
+  expect(findSlice(events, 'Before Hooks')!.cat).toBe('hook');
+  expect(findSlice(events, 'beforeAll hook')!.cat).toBe('hook');
+  expect(findSlice(events, 'beforeEach hook')!.cat).toBe('hook');
+  expect(findSlice(events, 'After Hooks')!.cat).toBe('hook');
+  expect(findSlice(events, 'Expect "toBe"')!.cat).toBe('expect');
+
+  const outer = findSlice(events, 'outer')!;
+  expect(outer.cat).toBe('test.step');
+  expect(outer.args.location).toContain('a.test.ts:');
+});
+
+test('should nest steps within the test slice', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest(testFiles, { reporter: 'chrome-trace' });
+  expect(result.exitCode).toBe(1);
+
+  const events = slices(readTrace(testInfo.outputPath()).traceEvents);
+  // Complete events on the same thread must form a proper stack.
+  const byThread = new Map<number, TraceEvent[]>();
+  for (const event of events) {
+    let list = byThread.get(event.tid);
+    if (!list) {
+      list = [];
+      byThread.set(event.tid, list);
+    }
+    list.push(event);
+  }
+  for (const list of byThread.values()) {
+    list.sort((a, b) => a.ts - b.ts || b.dur! - a.dur!);
+    const stack: TraceEvent[] = [];
+    for (const event of list) {
+      while (stack.length && stack[stack.length - 1].ts + stack[stack.length - 1].dur! <= event.ts)
+        stack.pop();
+      if (stack.length) {
+        const parent = stack[stack.length - 1];
+        expect(event.ts + event.dur!, `${event.name} inside ${parent.name}`).toBeLessThanOrEqual(parent.ts + parent.dur!);
+      }
+      stack.push(event);
+    }
+  }
+
+  const outer = findSlice(events, 'outer')!;
+  const inner = findSlice(events, 'inner')!;
+  expect(inner.ts).toBeGreaterThanOrEqual(outer.ts);
+  expect(inner.ts + inner.dur!).toBeLessThanOrEqual(outer.ts + outer.dur!);
+});
+
+test('should use a lane per worker', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({}) => { await new Promise(f => setTimeout(f, 500)); });
+    `,
+    'b.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('two', async ({}) => { await new Promise(f => setTimeout(f, 500)); });
+    `,
+  }, { reporter: 'chrome-trace', workers: 2 });
+  expect(result.exitCode).toBe(0);
+
+  const events = readTrace(testInfo.outputPath()).traceEvents;
+  expect(threadNames(events)).toEqual(['Worker 0', 'Worker 1']);
+  expect(findSlice(events, 'one')!.tid).not.toBe(findSlice(events, 'two')!.tid);
+});
+
+test('should report attachment files', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import fs from 'fs';
+      import { test, expect } from '@playwright/test';
+      test('one', async ({}) => {
+        const file = test.info().outputPath('note.txt');
+        fs.writeFileSync(file, 'hello');
+        await test.info().attach('inline', { body: 'body' });
+        await test.info().attach('file', { path: file });
+      });
+    `,
+  }, { reporter: 'chrome-trace' });
+  expect(result.exitCode).toBe(0);
+
+  const one = findSlice(readTrace(testInfo.outputPath()).traceEvents, 'one')!;
+  expect(one.args.attachments).toEqual(['inline', expect.stringMatching(/^test-results\/a-one\/attachments\/file-.*\.txt$/)]);
+});
+
+test('should respect outputFile option', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { reporter: [['chrome-trace', { outputFile: 'reports/my-trace.json' }]] };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(findSlice(readTrace(testInfo.outputPath(), 'reports/my-trace.json').traceEvents, 'one')).toBeTruthy();
+});
+
+test('should respect PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({}) => {});
+    `,
+  }, { reporter: 'chrome-trace' }, { PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE: testInfo.outputPath('env-trace.json') });
+  expect(result.exitCode).toBe(0);
+  expect(findSlice(readTrace(testInfo.outputPath(), 'env-trace.json').traceEvents, 'one')).toBeTruthy();
+});
+
+test('should report retries as separate slices', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('flaky', async ({}, testInfo) => {
+        expect(testInfo.retry).toBe(1);
+      });
+    `,
+  }, { reporter: 'chrome-trace', retries: 1 });
+  expect(result.exitCode).toBe(0);
+
+  const flaky = slices(readTrace(testInfo.outputPath()).traceEvents).filter(e => e.name === 'flaky');
+  expect(flaky).toHaveLength(2);
+  expect(flaky.map(e => e.args.status)).toEqual(['failed', 'passed']);
+  expect(flaky[1].args.retry).toBe(1);
+});
+
+test('should report global errors as instant events', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('one', async ({}) => {});
+    `,
+    'b.test.ts': `
+      throw new Error('Oh my!');
+    `,
+  }, { reporter: 'chrome-trace' });
+  expect(result.exitCode).toBe(1);
+
+  const errors = readTrace(testInfo.outputPath()).traceEvents.filter(e => e.ph === 'i');
+  expect(errors).toHaveLength(1);
+  expect(errors[0].args.error).toContain('Oh my!');
+});

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -24,6 +24,7 @@ export type ListReporterOptions = { printSteps?: boolean, printFailuresInline?: 
 export type GitHubReporterOptions = { omitTags?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean, includeRetries?: boolean, omitTags?: boolean };
 export type JsonReporterOptions = { outputFile?: string };
+export type ChromeTraceReporterOptions = { outputFile?: string };
 export type HtmlReporterOptions = {
   outputFolder?: string;
   open?: 'always' | 'never' | 'on-failure';
@@ -45,6 +46,7 @@ export type ReporterDescription = Readonly<
   ['github'] | ['github', GitHubReporterOptions] |
   ['junit'] | ['junit', JUnitReporterOptions] |
   ['json'] | ['json', JsonReporterOptions] |
+  ['chrome-trace'] | ['chrome-trace', ChromeTraceReporterOptions] |
   ['html'] | ['html', HtmlReporterOptions] |
   ['null'] |
   [string] | [string, any]
@@ -67,7 +69,7 @@ type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 
 interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
   projects?: Project<TestArgs, WorkerArgs>[];
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'chrome-trace', string> | ReporterDescription[];
   use?: UseOptions<TestArgs, WorkerArgs>;
   webServer?: TestConfigWebServer | TestConfigWebServer[];
 }


### PR DESCRIPTION
## Summary
- New built-in `chrome-trace` reporter that writes a Trace Event Format json readable by `chrome://tracing` and the Perfetto UI.
- One lane per worker; each test is a slice containing its before/after hooks, fixtures, `pw:api` calls, expects and `test.step`s as nested slices, colored by status.
- Report is written to `test-results/chrome-trace.json`, overridable with `outputFile` or `PLAYWRIGHT_CHROME_TRACE_OUTPUT_{FILE,DIR,NAME}`.