### PR TITLE
feat(chromium): expose tab strip metadata via page.tabInfo()

### DIFF
--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4477,6 +4477,37 @@ When `true`, includes each element's bounding box as a `box` property with `x`, 
 relative to the viewport, in CSS pixels, as returned by [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 Defaults to `false`.
 
+## async method: Page.tabInfo
+* since: v1.63
+- returns: <[null]|[Object]>
+  - `active` <[boolean]> Whether the tab is selected in its browser window. Note that this does not imply that the
+    browser window itself is focused at the OS level.
+  - `index` <[int]> Zero-based position of the tab in the tab strip of its browser window.
+  - `pinned` <[boolean]> Whether the tab is pinned.
+  - `groupId` <[null]|[string]> Id of the tab group this tab belongs to, if any.
+  - `windowId` <[int]> Id of the browser window containing the tab, matching the window id in the Chrome DevTools
+    Protocol.
+
+Returns a snapshot of the browser tab state for this page, as reflected in the browser tab strip. Unlike renderer-level
+signals such as `document.visibilityState`, this reports the real browser UI state, which is useful when a human and
+automation share the same headed browser.
+
+Returns `null` when the information is not available: in browsers other than Chromium, in Chromium versions
+below 150, in the Chromium headless shell which has no tab strip, and for pages that are not part of a tab strip.
+
+**Usage**
+
+```js
+const tabInfo = await page.tabInfo();
+if (tabInfo?.active)
+  console.log('The user is currently looking at this page');
+```
+
+:::note
+This API always returns an up-to-date snapshot and does not emit events when the tab state changes. Call it again to
+observe changes.
+:::
+
 ## async method: Page.tap
 * since: v1.8
 * discouraged: Use locator-based [`method: Locator.tap`] instead. Read more about [locators](../locators.md).

--- a/packages/isomorphic/protocolMetainfo.ts
+++ b/packages/isomorphic/protocolMetainfo.ts
@@ -287,6 +287,7 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['Page.startCSSCoverage', { title: 'Start CSS coverage', group: 'configuration', }],
   ['Page.stopCSSCoverage', { title: 'Stop CSS coverage', group: 'configuration', }],
   ['Page.bringToFront', { title: 'Bring to front', }],
+  ['Page.tabInfo', { title: 'Get tab info', }],
   ['Page.pickLocator', { title: 'Pick locator', group: 'configuration', }],
   ['Page.cancelPickLocator', { title: 'Cancel pick locator', group: 'configuration', }],
   ['Page.hideHighlight', { title: 'Hide all element highlights', group: 'configuration', }],

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -5018,6 +5018,54 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * Returns a snapshot of the browser tab state for this page, as reflected in the browser tab strip. Unlike
+   * renderer-level signals such as `document.visibilityState`, this reports the real browser UI state, which is useful
+   * when a human and automation share the same headed browser.
+   *
+   * Returns `null` when the information is not available: in browsers other than Chromium, in Chromium versions below
+   * 150, in the Chromium headless shell which has no tab strip, and for pages that are not part of a tab strip.
+   *
+   * **Usage**
+   *
+   * ```js
+   * const tabInfo = await page.tabInfo();
+   * if (tabInfo?.active)
+   *   console.log('The user is currently looking at this page');
+   * ```
+   *
+   * **NOTE** This API always returns an up-to-date snapshot and does not emit events when the tab state changes. Call
+   * it again to observe changes.
+   *
+   */
+  tabInfo(): Promise<null|{
+    /**
+     * Whether the tab is selected in its browser window. Note that this does not imply that the browser window itself is
+     * focused at the OS level.
+     */
+    active: boolean;
+
+    /**
+     * Zero-based position of the tab in the tab strip of its browser window.
+     */
+    index: number;
+
+    /**
+     * Whether the tab is pinned.
+     */
+    pinned: boolean;
+
+    /**
+     * Id of the tab group this tab belongs to, if any.
+     */
+    groupId: null|string;
+
+    /**
+     * Id of the browser window containing the tab, matching the window id in the Chrome DevTools Protocol.
+     */
+    windowId: number;
+  }>;
+
+  /**
    * **NOTE** Use locator-based [locator.tap([options])](https://playwright.dev/docs/api/class-locator#locator-tap) instead. Read
    * more about [locators](https://playwright.dev/docs/locators).
    *

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -3872,6 +3872,7 @@ export interface PageChannel extends PageEventTarget, Channel {
   startCSSCoverage(params: PageStartCSSCoverageParams, options: TimeoutOptions): Promise<PageStartCSSCoverageResult>;
   stopCSSCoverage(params: PageStopCSSCoverageParams, options: TimeoutOptions): Promise<PageStopCSSCoverageResult>;
   bringToFront(params: PageBringToFrontParams, options: TimeoutOptions): Promise<PageBringToFrontResult>;
+  tabInfo(params: PageTabInfoParams, options: TimeoutOptions): Promise<PageTabInfoResult>;
   pickLocator(params: PagePickLocatorParams, options: TimeoutOptions): Promise<PagePickLocatorResult>;
   cancelPickLocator(params: PageCancelPickLocatorParams, options: TimeoutOptions): Promise<PageCancelPickLocatorResult>;
   hideHighlight(params: PageHideHighlightParams, options: TimeoutOptions): Promise<PageHideHighlightResult>;
@@ -4401,6 +4402,17 @@ export type PageStopCSSCoverageResult = {
 export type PageBringToFrontParams = {};
 export type PageBringToFrontOptions = {};
 export type PageBringToFrontResult = void;
+export type PageTabInfoParams = {};
+export type PageTabInfoOptions = {};
+export type PageTabInfoResult = {
+  tabInfo?: {
+    active: boolean,
+    index: number,
+    pinned: boolean,
+    groupId?: string,
+    windowId: number,
+  },
+};
 export type PagePickLocatorParams = {};
 export type PagePickLocatorOptions = {};
 export type PagePickLocatorResult = {

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -688,6 +688,13 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     await this._channel.bringToFront({}, kNoTimeout);
   }
 
+  async tabInfo(): Promise<{ active: boolean, index: number, pinned: boolean, groupId: string | null, windowId: number } | null> {
+    const { tabInfo } = await this._channel.tabInfo({}, kNoTimeout);
+    if (!tabInfo)
+      return null;
+    return { ...tabInfo, groupId: tabInfo.groupId ?? null };
+  }
+
   async [Symbol.asyncDispose]() {
     await this.close();
   }

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -3873,6 +3873,7 @@ export interface PageChannel extends PageEventTarget, Channel {
   startCSSCoverage(params: PageStartCSSCoverageParams, progress: Progress): Promise<PageStartCSSCoverageResult>;
   stopCSSCoverage(params: PageStopCSSCoverageParams, progress: Progress): Promise<PageStopCSSCoverageResult>;
   bringToFront(params: PageBringToFrontParams, progress: Progress): Promise<PageBringToFrontResult>;
+  tabInfo(params: PageTabInfoParams, progress: Progress): Promise<PageTabInfoResult>;
   pickLocator(params: PagePickLocatorParams, progress: Progress): Promise<PagePickLocatorResult>;
   cancelPickLocator(params: PageCancelPickLocatorParams, progress: Progress): Promise<PageCancelPickLocatorResult>;
   hideHighlight(params: PageHideHighlightParams, progress: Progress): Promise<PageHideHighlightResult>;
@@ -4402,6 +4403,17 @@ export type PageStopCSSCoverageResult = {
 export type PageBringToFrontParams = {};
 export type PageBringToFrontOptions = {};
 export type PageBringToFrontResult = void;
+export type PageTabInfoParams = {};
+export type PageTabInfoOptions = {};
+export type PageTabInfoResult = {
+  tabInfo?: {
+    active: boolean,
+    index: number,
+    pinned: boolean,
+    groupId?: string,
+    windowId: number,
+  },
+};
 export type PagePickLocatorParams = {};
 export type PagePickLocatorOptions = {};
 export type PagePickLocatorResult = {

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -282,9 +282,6 @@ export class CRBrowser extends Browser {
     // Tab targets expose embedderData since Chromium 150.
     if (this._majorVersion && this._majorVersion < 150)
       return undefined;
-    // A single query covers the whole browser, so pages asking concurrently share one
-    // round of protocol traffic. The promise is cleared once it settles, so that each
-    // new call still observes an up-to-date tab strip.
     if (!this._tabInfoSnapshotPromise)
       this._tabInfoSnapshotPromise = this._queryTabInfos().finally(() => this._tabInfoSnapshotPromise = undefined);
     const tabInfos = await this._tabInfoSnapshotPromise;
@@ -294,7 +291,6 @@ export class CRBrowser extends Browser {
   private async _queryTabInfos(): Promise<Map<string, TabInfo>> {
     const tabInfoByPageTargetId = new Map<string, TabInfo>();
     const { targetInfos } = await this._session.send('Target.getTargets', { filter: [{ type: 'tab', exclude: false }, { exclude: true }] });
-    // Headless shell has no tab strip and embedders may not populate embedderData.
     const tabTargets = targetInfos.filter(targetInfo => !!targetInfo.embedderData);
     if (!tabTargets.length)
       return tabInfoByPageTargetId;
@@ -304,7 +300,7 @@ export class CRBrowser extends Browser {
         this._collectTabPageTargets(browserSession, targetInfo.targetId),
         browserSession.send('Browser.getWindowForTarget', { targetId: targetInfo.targetId }),
       ]);
-      // The protocol declares string values, but Chromium sends native booleans and numbers.
+      // Protocol declares string values, but Chromium sends booleans and numbers.
       const embedderData = targetInfo.embedderData as unknown as { tabActive: boolean, tabStripIndex: number, tabPinned: boolean, tabGroupId?: string };
       const tabInfo = {
         active: embedderData.tabActive,
@@ -313,15 +309,13 @@ export class CRBrowser extends Browser {
         groupId: embedderData.tabGroupId,
         windowId,
       };
-      // A tab may own several page targets, e.g. a prerendered page.
       for (const pageTargetId of pageTargetIds)
         tabInfoByPageTargetId.set(pageTargetId, tabInfo);
     }));
     return tabInfoByPageTargetId;
   }
 
-  // Use a separate browser session, so that Target.attachedToTarget events triggered
-  // by the tab attach do not interfere with the root session auto-attach handling.
+  // Separate session, so that tab attach events do not interfere with the root session auto-attach handling.
   private async _tabInfoBrowserSession(): Promise<CRSession> {
     if (!this._tabInfoBrowserSessionPromise) {
       this._tabInfoBrowserSessionPromise = this._session.send('Target.attachToBrowserTarget').then(

--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -30,7 +30,7 @@ import { CRPage } from './crPage';
 import { saveProtocolStream } from './crProtocolHelper';
 import { CRServiceWorker } from './crServiceWorker';
 
-import type { InitScript } from '../page';
+import type { InitScript, TabInfo } from '../page';
 import type { ConnectionTransport } from '../transport';
 import type * as types from '../types';
 import type { HttpCredentials } from '@protocol/structs';
@@ -56,6 +56,8 @@ export class CRBrowser extends Browser {
   private _tracingRecording = false;
   private _tracingClient: CRSession | undefined;
   private _userAgent: string = '';
+  private _tabInfoSnapshotPromise: Promise<Map<string, TabInfo>> | undefined;
+  private _tabInfoBrowserSessionPromise: Promise<CRSession> | undefined;
 
   static async connect(parent: SdkObject, transport: ConnectionTransport, options: BrowserOptions, devtools?: CRDevTools): Promise<CRBrowser> {
     // Make a copy in case we need to update `headful` property below.
@@ -274,6 +276,76 @@ export class CRBrowser extends Browser {
 
   async _closePage(crPage: CRPage) {
     await this._session.send('Target.closeTarget', { targetId: crPage._targetId });
+  }
+
+  async _tabInfoForPage(crPage: CRPage): Promise<TabInfo | undefined> {
+    // Tab targets expose embedderData since Chromium 150.
+    if (this._majorVersion && this._majorVersion < 150)
+      return undefined;
+    // A single query covers the whole browser, so pages asking concurrently share one
+    // round of protocol traffic. The promise is cleared once it settles, so that each
+    // new call still observes an up-to-date tab strip.
+    if (!this._tabInfoSnapshotPromise)
+      this._tabInfoSnapshotPromise = this._queryTabInfos().finally(() => this._tabInfoSnapshotPromise = undefined);
+    const tabInfos = await this._tabInfoSnapshotPromise;
+    return tabInfos.get(crPage._targetId);
+  }
+
+  private async _queryTabInfos(): Promise<Map<string, TabInfo>> {
+    const tabInfoByPageTargetId = new Map<string, TabInfo>();
+    const { targetInfos } = await this._session.send('Target.getTargets', { filter: [{ type: 'tab', exclude: false }, { exclude: true }] });
+    // Headless shell has no tab strip and embedders may not populate embedderData.
+    const tabTargets = targetInfos.filter(targetInfo => !!targetInfo.embedderData);
+    if (!tabTargets.length)
+      return tabInfoByPageTargetId;
+    const browserSession = await this._tabInfoBrowserSession();
+    await Promise.all(tabTargets.map(async targetInfo => {
+      const [pageTargetIds, { windowId }] = await Promise.all([
+        this._collectTabPageTargets(browserSession, targetInfo.targetId),
+        browserSession.send('Browser.getWindowForTarget', { targetId: targetInfo.targetId }),
+      ]);
+      // The protocol declares string values, but Chromium sends native booleans and numbers.
+      const embedderData = targetInfo.embedderData as unknown as { tabActive: boolean, tabStripIndex: number, tabPinned: boolean, tabGroupId?: string };
+      const tabInfo = {
+        active: embedderData.tabActive,
+        index: embedderData.tabStripIndex,
+        pinned: embedderData.tabPinned,
+        groupId: embedderData.tabGroupId,
+        windowId,
+      };
+      // A tab may own several page targets, e.g. a prerendered page.
+      for (const pageTargetId of pageTargetIds)
+        tabInfoByPageTargetId.set(pageTargetId, tabInfo);
+    }));
+    return tabInfoByPageTargetId;
+  }
+
+  // Use a separate browser session, so that Target.attachedToTarget events triggered
+  // by the tab attach do not interfere with the root session auto-attach handling.
+  private async _tabInfoBrowserSession(): Promise<CRSession> {
+    if (!this._tabInfoBrowserSessionPromise) {
+      this._tabInfoBrowserSessionPromise = this._session.send('Target.attachToBrowserTarget').then(
+          ({ sessionId }) => this._session.createChildSession(sessionId));
+      this._tabInfoBrowserSessionPromise.catch(() => this._tabInfoBrowserSessionPromise = undefined);
+    }
+    return this._tabInfoBrowserSessionPromise;
+  }
+
+  private async _collectTabPageTargets(browserSession: CRSession, tabTargetId: string): Promise<string[]> {
+    const { sessionId } = await browserSession.send('Target.attachToTarget', { targetId: tabTargetId, flatten: true });
+    const tabSession = browserSession.createChildSession(sessionId);
+    const pageTargetIds: string[] = [];
+    tabSession.on('Target.attachedToTarget', (event: Protocol.Target.attachedToTargetPayload) => {
+      pageTargetIds.push(event.targetInfo.targetId);
+    });
+    try {
+      // Existing related page targets are reported before the command acknowledgment.
+      await tabSession.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: false, flatten: true, filter: [{ type: 'page', exclude: false }, { exclude: true }] });
+    } finally {
+      browserSession.send('Target.detachFromTarget', { sessionId }).catch(() => {});
+      tabSession.dispose();
+    }
+    return pageTargetIds;
   }
 
   async newBrowserCDPSession(): Promise<CDPSession> {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -41,7 +41,7 @@ import { nullProgress } from '../progress';
 import type { CRSession } from './crConnection';
 import type { Protocol } from './protocol';
 import type { RegisteredListener } from '@utils/eventsHelper';
-import type { InitScript, PageDelegate } from '../page';
+import type { InitScript, PageDelegate, TabInfo } from '../page';
 import type { Progress } from '../progress';
 import type * as types from '../types';
 import type * as channels from '../channels';
@@ -206,6 +206,10 @@ export class CRPage implements PageDelegate {
 
   async bringToFront(): Promise<void> {
     await this._mainFrameSession._client.send('Page.bringToFront');
+  }
+
+  async tabInfo(): Promise<TabInfo | undefined> {
+    return await this._browserContext._browser._tabInfoForPage(this);
   }
 
   async updateEmulateMedia(): Promise<void> {

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -353,6 +353,10 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
     await this._page.bringToFront(progress);
   }
 
+  async tabInfo(params: channels.PageTabInfoParams, progress: Progress): Promise<channels.PageTabInfoResult> {
+    return { tabInfo: await this._page.tabInfo(progress) };
+  }
+
   async pickLocator(params: channels.PagePickLocatorParams, progress: Progress): Promise<channels.PagePickLocatorResult> {
     const recorder = await progress.race(Recorder.forContext(this._page.browserContext, { omitCallTracking: true, hideToolbar: true }));
     const selector = await recorder.pickLocator(progress, this._page);

--- a/packages/playwright-core/src/server/page.ts
+++ b/packages/playwright-core/src/server/page.ts
@@ -56,6 +56,8 @@ import type * as channels from './channels';
 import type { BindingPayload } from '@injected/bindingsController';
 import type { AriaNodeJSON, AriaSnapshotJSON } from '@isomorphic/ariaSnapshot';
 
+export type TabInfo = NonNullable<channels.PageTabInfoResult['tabInfo']>;
+
 export interface PageDelegate {
   readonly rawMouse: input.RawMouse;
   readonly rawKeyboard: input.RawKeyboard;
@@ -95,6 +97,7 @@ export interface PageDelegate {
   pdf?: (options: channels.PagePdfParams) => Promise<Buffer>;
   coverage?: () => any;
   noUtilityWorld?: () => boolean;
+  tabInfo?: () => Promise<TabInfo | undefined>;
 
   // Work around WebKit's raf issues on Windows.
   rafCountForStablePosition(): number;
@@ -669,6 +672,12 @@ export class Page extends SdkObject<PageEventMap> {
 
   async bringToFront(progress: Progress): Promise<void> {
     await progress.race(this.delegate.bringToFront());
+  }
+
+  async tabInfo(progress: Progress): Promise<TabInfo | undefined> {
+    if (!this.delegate.tabInfo)
+      return undefined;
+    return await progress.race(this.delegate.tabInfo());
   }
 
   async addInitScript(progress: Progress, source: string) {

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -357,7 +357,6 @@ export function renderTabMarkdown(tab: TabHeader): string[] {
   return lines;
 }
 
-// `foreground` marks the tab selected in the real browser tab strip, browser_tabs tool only.
 export function renderTabsMarkdown(tabs: (TabHeader & { foreground?: boolean })[]): string[] {
   if (!tabs.length)
     return ['No open tabs. Navigate to a URL to create one.'];

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -357,7 +357,8 @@ export function renderTabMarkdown(tab: TabHeader): string[] {
   return lines;
 }
 
-export function renderTabsMarkdown(tabs: TabHeader[]): string[] {
+// `foreground` marks the tab selected in the real browser tab strip, browser_tabs tool only.
+export function renderTabsMarkdown(tabs: (TabHeader & { foreground?: boolean })[]): string[] {
   if (!tabs.length)
     return ['No open tabs. Navigate to a URL to create one.'];
 
@@ -365,8 +366,9 @@ export function renderTabsMarkdown(tabs: TabHeader[]): string[] {
   for (let i = 0; i < tabs.length; i++) {
     const tab = tabs[i];
     const current = tab.current ? ' (current)' : '';
+    const foreground = tab.foreground ? ' (visible to user)' : '';
     const crashed = tab.crashed ? ' [crashed]' : '';
-    lines.push(`- ${i}:${current} [${tab.title}](${tab.url})${crashed}`);
+    lines.push(`- ${i}:${current}${foreground} [${tab.title}](${tab.url})${crashed}`);
   }
   return lines;
 }

--- a/packages/playwright-core/src/tools/backend/tabs.ts
+++ b/packages/playwright-core/src/tools/backend/tabs.ts
@@ -59,7 +59,13 @@ const browserTabs = defineTool({
         break;
       }
     }
-    const tabHeaders = await Promise.all(context.tabs().map(tab => tab.headerSnapshot()));
+    const tabHeaders = await Promise.all(context.tabs().map(async tab => {
+      const [header, tabInfo] = await Promise.all([
+        tab.headerSnapshot(),
+        tab.page.tabInfo().catch(() => null),
+      ]);
+      return { ...header, foreground: tabInfo?.active };
+    }));
     const result = renderTabsMarkdown(tabHeaders);
     response.addTextResult(result.join('\n'));
   },

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -5018,6 +5018,54 @@ export interface Page {
   }): Promise<void>;
 
   /**
+   * Returns a snapshot of the browser tab state for this page, as reflected in the browser tab strip. Unlike
+   * renderer-level signals such as `document.visibilityState`, this reports the real browser UI state, which is useful
+   * when a human and automation share the same headed browser.
+   *
+   * Returns `null` when the information is not available: in browsers other than Chromium, in Chromium versions below
+   * 150, in the Chromium headless shell which has no tab strip, and for pages that are not part of a tab strip.
+   *
+   * **Usage**
+   *
+   * ```js
+   * const tabInfo = await page.tabInfo();
+   * if (tabInfo?.active)
+   *   console.log('The user is currently looking at this page');
+   * ```
+   *
+   * **NOTE** This API always returns an up-to-date snapshot and does not emit events when the tab state changes. Call
+   * it again to observe changes.
+   *
+   */
+  tabInfo(): Promise<null|{
+    /**
+     * Whether the tab is selected in its browser window. Note that this does not imply that the browser window itself is
+     * focused at the OS level.
+     */
+    active: boolean;
+
+    /**
+     * Zero-based position of the tab in the tab strip of its browser window.
+     */
+    index: number;
+
+    /**
+     * Whether the tab is pinned.
+     */
+    pinned: boolean;
+
+    /**
+     * Id of the tab group this tab belongs to, if any.
+     */
+    groupId: null|string;
+
+    /**
+     * Id of the browser window containing the tab, matching the window id in the Chrome DevTools Protocol.
+     */
+    windowId: number;
+  }>;
+
+  /**
    * **NOTE** Use locator-based [locator.tap([options])](https://playwright.dev/docs/api/class-locator#locator-tap) instead. Read
    * more about [locators](https://playwright.dev/docs/locators).
    *

--- a/packages/protocol/spec/page.yml
+++ b/packages/protocol/spec/page.yml
@@ -518,6 +518,18 @@ Page:
     bringToFront:
       title: Bring to front
 
+    tabInfo:
+      title: Get tab info
+      returns:
+        tabInfo:
+          type: object?
+          properties:
+            active: boolean
+            index: int
+            pinned: boolean
+            groupId: string?
+            windowId: int
+
     pickLocator:
       title: Pick locator
       group: configuration

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -2553,6 +2553,16 @@ scheme.PageStopCSSCoverageResult = tObject({
 });
 scheme.PageBringToFrontParams = tOptional(tObject({}));
 scheme.PageBringToFrontResult = tOptional(tObject({}));
+scheme.PageTabInfoParams = tOptional(tObject({}));
+scheme.PageTabInfoResult = tObject({
+  tabInfo: tOptional(tObject({
+    active: tBoolean,
+    index: tInt,
+    pinned: tBoolean,
+    groupId: tOptional(tString),
+    windowId: tInt,
+  })),
+});
 scheme.PagePickLocatorParams = tOptional(tObject({}));
 scheme.PagePickLocatorResult = tObject({
   selector: tString,

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -811,3 +811,57 @@ test('should fire dialogclosed event when dialog is closed out of band', async (
   expect(await closedPromise).toBe(dialog);
   await evaluatePromise;
 });
+
+playwrightTest('page.tabInfo should report tab strip state', async ({ browserType, browserMajorVersion, channel }) => {
+  playwrightTest.skip(browserMajorVersion < 150, 'embedderData on tab targets requires Chromium 150+');
+  // Headless shell has no tab strip, opt into the full Chromium build.
+  const browser = await browserType.launch({ channel: channel || 'chromium' });
+  try {
+    const context = await browser.newContext();
+    const page1 = await context.newPage();
+    const info1 = (await page1.tabInfo())!;
+    expect(info1).toBeTruthy();
+    expect(info1.pinned).toBe(false);
+    expect(info1.groupId).toBe(null);
+
+    const page2 = await context.newPage();
+    const info2 = (await page2.tabInfo())!;
+    expect(info2).toBeTruthy();
+    expect(info2.active).toBe(true);
+
+    await page1.bringToFront();
+    await expect.poll(async () => (await page1.tabInfo())!.active).toBe(true);
+    if (info1.windowId === info2.windowId) {
+      expect((await page2.tabInfo())!.active).toBe(false);
+      expect(info1.index).not.toBe(info2.index);
+    }
+  } finally {
+    await browser.close();
+  }
+});
+
+playwrightTest('page.tabInfo should serve concurrent calls from all pages', async ({ browserType, browserMajorVersion, channel }) => {
+  playwrightTest.skip(browserMajorVersion < 150, 'embedderData on tab targets requires Chromium 150+');
+  const browser = await browserType.launch({ channel: channel || 'chromium' });
+  try {
+    const context = await browser.newContext();
+    const pages = [];
+    for (let i = 0; i < 5; i++)
+      pages.push(await context.newPage());
+
+    // Concurrent calls share a single browser-wide query, each page must still get its own tab.
+    const infos = await Promise.all(pages.map(page => page.tabInfo()));
+    expect(infos.every(info => !!info)).toBe(true);
+    expect(infos.filter(info => info!.active).length).toBe(1);
+    expect(infos.map(info => info!.index)).toEqual([0, 1, 2, 3, 4]);
+
+    // A subsequent round must observe the new state instead of reusing the shared snapshot.
+    await pages[0].bringToFront();
+    await expect.poll(async () => {
+      const updated = await Promise.all(pages.map(page => page.tabInfo()));
+      return updated.findIndex(info => info!.active);
+    }).toBe(0);
+  } finally {
+    await browser.close();
+  }
+});

--- a/tests/library/chromium/chromium.spec.ts
+++ b/tests/library/chromium/chromium.spec.ts
@@ -849,13 +849,11 @@ playwrightTest('page.tabInfo should serve concurrent calls from all pages', asyn
     for (let i = 0; i < 5; i++)
       pages.push(await context.newPage());
 
-    // Concurrent calls share a single browser-wide query, each page must still get its own tab.
     const infos = await Promise.all(pages.map(page => page.tabInfo()));
     expect(infos.every(info => !!info)).toBe(true);
     expect(infos.filter(info => info!.active).length).toBe(1);
     expect(infos.map(info => info!.index)).toEqual([0, 1, 2, 3, 4]);
 
-    // A subsequent round must observe the new state instead of reusing the shared snapshot.
     await pages[0].bringToFront();
     await expect.poll(async () => {
       const updated = await Promise.all(pages.map(page => page.tabInfo()));

--- a/tests/mcp/crash.spec.ts
+++ b/tests/mcp/crash.spec.ts
@@ -72,7 +72,7 @@ test.describe('crash recovery', () => {
       name: 'browser_tabs',
       arguments: { action: 'list' },
     })).toHaveResponse({
-      result: `- 0: (current) [](about:blank)`,
+      result: `- 0: (current) (visible to user) [](about:blank)`,
     });
   });
 
@@ -94,7 +94,7 @@ test.describe('crash recovery', () => {
       name: 'browser_tabs',
       arguments: { action: 'list' },
     })).toHaveResponse({
-      result: `- 0: (current) [Title](${server.HELLO_WORLD})\n- 1: [](about:blank) [crashed]`,
+      result: `- 0: (current) [Title](${server.HELLO_WORLD})\n- 1: (visible to user) [](about:blank) [crashed]`,
     });
   });
 });

--- a/tests/mcp/tabs.spec.ts
+++ b/tests/mcp/tabs.spec.ts
@@ -40,7 +40,7 @@ test('list initial tabs', async ({ client }) => {
       action: 'list',
     },
   })).toHaveResponse({
-    result: `- 0: (current) [](about:blank)`,
+    result: `- 0: (current) (visible to user) [](about:blank)`,
   });
 });
 
@@ -53,7 +53,7 @@ test('list first tab', async ({ client }) => {
     },
   })).toHaveResponse({
     result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+- 1: (current) (visible to user) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 
@@ -87,7 +87,7 @@ test('create new tab with url', async ({ client }) => {
     },
   })).toHaveResponse({
     result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+- 1: (current) (visible to user) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 
@@ -103,7 +103,7 @@ test('select tab', async ({ client }) => {
     },
   })).toHaveResponse({
     result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
+- 1: (current) (visible to user) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
 - 2: [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
   });
 
@@ -114,7 +114,7 @@ test('select tab', async ({ client }) => {
       index: 0,
     },
   })).toHaveResponse({
-    result: `- 0: (current) [](about:blank)
+    result: `- 0: (current) (visible to user) [](about:blank)
 - 1: [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)
 - 2: [Tab two](data:text/html,<title>Tab two</title><body>Body two</body>)`,
   });
@@ -132,7 +132,7 @@ test('close tab', async ({ client }) => {
     },
   })).toHaveResponse({
     result: `- 0: [](about:blank)
-- 1: (current) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
+- 1: (current) (visible to user) [Tab one](data:text/html,<title>Tab one</title><body>Body one</body>)`,
   });
 });
 


### PR DESCRIPTION
## Summary
- New Chromium-only `page.tabInfo()` returns the real tab strip state (`active`, `index`, `pinned`, `groupId`, `windowId`) from `Target.embedderData` (Chrome 150+). Returns `null` on other browsers, older Chromium and the headless shell.
- Concurrent calls coalesce into a single browser-wide CDP query.
- The `browser_tabs` MCP tool marks the tab that is actually visible to the user.

Fixes https://github.com/microsoft/playwright/issues/41873