### PR TITLE
fix(chromium): re-issue Target.closeTarget when the target survives a racing navigation commit

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -273,7 +273,42 @@ export class CRBrowser extends Browser {
   }
 
   async _closePage(crPage: CRPage) {
-    await this._session.send('Target.closeTarget', { targetId: crPage._targetId });
+    // Chromium can acknowledge Target.closeTarget with success:true without
+    // actually closing the target: when the close races a navigation commit
+    // that swaps the main RenderFrameHost, the pending close request dies with
+    // the old frame host and the target never detaches, so the page would
+    // never report closed and page.close() would hang. Re-issuing the close
+    // reliably destroys such a target.
+    // See https://issues.chromium.org/issues/536385539.
+    const page = crPage._page;
+    for (let attempt = 0; attempt < 3; ++attempt) {
+      try {
+        await this._session.send('Target.closeTarget', { targetId: crPage._targetId });
+      } catch (error) {
+        // A previous attempt may have closed the target after its timeout.
+        if (attempt)
+          break;
+        throw error;
+      }
+      const closed = await new Promise<boolean>(resolve => {
+        const timer = setTimeout(() => {
+          page.off(Page.Events.Close, onClose);
+          resolve(false);
+        }, 1000);
+        const onClose = () => {
+          clearTimeout(timer);
+          resolve(true);
+        };
+        page.once(Page.Events.Close, onClose);
+        if (page.isClosed()) {
+          clearTimeout(timer);
+          page.off(Page.Events.Close, onClose);
+          resolve(true);
+        }
+      });
+      if (closed)
+        return;
+    }
   }
 
   async newBrowserCDPSession(): Promise<CDPSession> {

--- a/tests/library/browsercontext-pages.spec.ts
+++ b/tests/library/browsercontext-pages.spec.ts
@@ -139,13 +139,14 @@ it('should not leak listeners during navigation of 20 pages', async ({ contextFa
   expect(warning).toBe(null);
 });
 
-it('should close page while a reload is committing', async ({ context, browserName }) => {
+it('should close page while a reload is committing', async ({ context }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42068' });
   it.info().annotations.push({ type: 'issue', description: 'https://issues.chromium.org/issues/536385539' });
-  it.fixme(browserName === 'chromium', 'Chromium loses the close when the reload commits into a new RenderFrameHost; fix is not rolled yet');
   // The evaluate never settles on its own, so it only rejects once the reload
   // commits. Closing right after that races the commit. Repeat a few times,
-  // since whether the close or the commit wins is timing-dependent.
+  // since whether the close or the commit wins is timing-dependent. Chromium
+  // can lose the close when the commit swaps the RenderFrameHost; the close
+  // is re-issued until the target is actually gone.
   for (let i = 0; i < 10; i++) {
     const page = await context.newPage();
     await expect(page.evaluate(() => {


### PR DESCRIPTION
Fixes #42068. References #42366 and https://issues.chromium.org/issues/536385539.

### The bug

Chromium can acknowledge `Target.closeTarget` with `success:true` without actually closing the target: when the close races a navigation commit that swaps the main RenderFrameHost, the pending close request dies with the old frame host and is never re-issued (root-caused with code pointers in the crbug, which has a pending Chromium CL). `Target.targetDestroyed` never fires, so `page.close()` awaits `closedPromise` forever — no resolution, no rejection.

### The fix

In `CRBrowser._closePage`, wait briefly (1 s) for the page to report closed after `Target.closeTarget`, and re-issue the close if the target is still alive (bounded at 3 attempts). Re-issuing reliably destroys such a target — verified over raw CDP as well as through Playwright. The normal path is unchanged: the close event resolves the wait immediately.

### Why a client-side guard when a Chromium CL is pending

- **Channel builds.** `channel: 'chrome'` / `'msedge'` users are on 151-class stable builds where the hang reproduces on **7–8 of 10 attempts** with a common real-world trigger — a page carrying `<meta http-equiv="refresh" content="0; URL=...">` closed right after the refresh commits (the W3C ACT-Rules bc659a "passed" fixtures are examples; we hit this scanning real pages, freezing long crawls for 35+ minutes with no error anywhere).
- **The bug is still present in the rolled 152.0.7977.54**: a Playwright-free raw-CDP repro (`closeTarget` → `success:true`, no `targetDestroyed`, target still in `Target.getTargets`) reproduces ~2/10 on 152 vs ~1-3/10 on 151. What changed in 152 is timing — through Playwright's call sequence the window has become hard to hit (0/10 in our runs), which is why no new test accompanies this PR: a race test that cannot reliably fail without the fix on the bundled browser would only be flaky. On 151-class builds the hang was near-deterministic through Playwright.

### Test changes

- Removed the stale `fixme` from `should close page while a reload is committing`: it passes 6/6 repeats on the bundled 152 both with and without this change (the reload trigger no longer loses the close there), and with the guard it is robust on 151-class builds too, where it previously hung.
- All of `tests/library/page-close.spec.ts`, `beforeunload.spec.ts`, and `browsercontext-pages.spec.ts` pass with the change (41/41).

### Verification matrix (10 rounds per cell, meta-refresh repro)

| | default `close()` | `close({runBeforeUnload:true})` | `context.close()` |
| --- | --- | --- | --- |
| Chromium 151 (unpatched client) | **8/10 hang** | 0/10 | 0/10 |
| Chromium 151 (this change) | 0/10 | 0/10 | 0/10 |
| Firefox / WebKit | 0/10 | 0/10 | 0/10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
