### PR TITLE
feat: add reusable documentation graph and MCP server

### DIFF
--- a/agi-training-notes/API_REFERENCE.md
+++ b/agi-training-notes/API_REFERENCE.md
@@ -1,0 +1,4484 @@
+# Playwright-Core & Codegen API Reference
+
+> **Provenance**
+> - Source Commit: `b4a646a624c0b1e8e352d320cbc6684581625ff6`
+> - Commit Date: `2026-08-06`
+> - Methodology: Static-source analysis of upstream Playwright TypeScript files. Runtime/browser behavior was not exercised.
+
+Dictionary-style function reference, verified against the real upstream source
+(`packages/playwright-core/types/types.d.ts` + `src/client/*.ts`). Companion to
+NOTES.md's architecture deep-dives -- this file is for quick lookup, NOTES.md is for
+understanding mechanism. Scope: Documents the full public `playwright-core/types/types.d.ts` interface surface at the pinned revision, including Page, Locator, BrowserContext, Browser, Frame, Route, Request, Response, JSHandle, ElementHandle, Keyboard, Mouse, Download, Dialog, FileChooser, ConsoleMessage, APIRequestContext, APIResponse, WebSocket, Worker, Selectors, Touchscreen, Tracing, Video, Clock, Coverage, BrowserType, CDPSession, ElectronApplication, Electron, Android, AndroidDevice, AndroidInput, AndroidSocket, AndroidWebView, FrameLocator, APIRequest, BrowserServer, WebSocketRoute, WebError, Screencast, Debugger, ConnectOverCDPTransport, Credentials, Disposable, Logger, WebStorage, LaunchOptions, ConnectOverCDPOptions, ConnectOptions, LocatorScreenshotOptions, BrowserContextOptions, ViewportSize, HTTPCredentials, Geolocation, Cookie, PageScreenshotOptions, ChromiumBrowserContext, ChromiumBrowser, FirefoxBrowser, WebKitBrowser, and ChromiumCoverage. This reference covers interface declarations only; other exported types, namespaces, constants, and implementation internals are out of scope.
+
+> **Audit Status**
+> - Page, Locator, BrowserContext, Browser, Frame, Route, Request, and Response sections were re-audited against the pinned revision; member coverage and public signatures were checked, with descriptions retained where they matched the pinned JSDoc.
+> - JSHandle, ElementHandle, Keyboard, and Mouse were audited against the same pinned revision; inherited JSHandle members are not duplicated under ElementHandle.
+> - Download, Dialog, FileChooser, and ConsoleMessage were audited against the same pinned revision; unique members and overload totals were checked.
+> - APIRequestContext, APIResponse, WebSocket, and Worker were audited against the same pinned revision; unique members and overload totals were checked.
+> - Selectors, Touchscreen, Tracing, Video, Clock, and Coverage were audited against the same pinned revision; unique members and overload totals were checked.
+> - BrowserType, CDPSession, ElectronApplication, Electron, Android, AndroidDevice, AndroidInput, AndroidSocket, and AndroidWebView were audited against the same pinned revision; unique members and overload totals were checked.
+> - FrameLocator, APIRequest, BrowserServer, WebSocketRoute, WebError, Screencast, and Debugger were audited against the same pinned revision; unique members and overload totals were checked.
+> - ConnectOverCDPTransport, Credentials, Disposable, Logger, WebStorage, LaunchOptions, ConnectOverCDPOptions, ConnectOptions, LocatorScreenshotOptions, BrowserContextOptions, ViewportSize, HTTPCredentials, Geolocation, Cookie, PageScreenshotOptions, ChromiumBrowserContext, ChromiumBrowser, FirefoxBrowser, WebKitBrowser, and ChromiumCoverage were audited against the same pinned revision; top-level fields/methods and specialization wrappers were checked.
+
+Entry format per method:
+### `ClassName.methodName(args)`
+One-line description (Playwright's own words where accurate, tightened for brevity).
+**Returns:** return type
+**Source:** `packages/playwright-core/types/types.d.ts` (verify against
+`src/client/<file>.ts`)
+*(add a **Deprecated:** line only if the real JSDoc marks it as such)*
+
+---
+
+## Page
+
+### Navigation
+
+### `Page.goBack(options)`
+Navigates to the previous page in history.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.goForward(options)`
+Navigates to the next page in history.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.goto(url, options)`
+Navigates to the specified URL and waits for the given load state.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.reload(options)`
+Reloads the current page.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setContent(html, options)`
+Assigns HTML markup to the page.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Waiting & Delays
+
+### `Page.waitForLoadState(state, options)`
+Waits for the page to reach the specified load state (load, domcontentloaded, networkidle).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForNavigation(options)`
+Waits for the main frame to navigate to a new URL.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+**Deprecated:** inherently racy, please use `waitForURL` instead.
+
+### `Page.waitForRequest(urlOrPredicate, options)`
+Waits for a request matching the specified URL or predicate function.
+**Returns:** `Promise<Request>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForResponse(urlOrPredicate, options)`
+Waits for a response matching the specified URL or predicate function.
+**Returns:** `Promise<Response>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForTimeout(timeout)`
+Waits for the given amount of time in milliseconds.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+**Deprecated:** Note that `page.waitForTimeout()` should only be used for debugging.
+
+### `Page.waitForURL(url, options)`
+Waits for the main frame to navigate to the specified URL.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForEvent(event, optionsOrPredicate)`
+Waits for a specific event to be emitted on the page.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Locators & Element Queries
+
+### `Page.locator(selector, options)`
+Creates a locator for the specified selector.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByAltText(text, options)`
+Creates a locator that matches an element by its alt text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByLabel(text, options)`
+Creates a locator that matches an element by its associated label text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByPlaceholder(text, options)`
+Creates a locator that matches an input element by its placeholder text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByRole(role, options)`
+Creates a locator that matches an element by its ARIA role, name, and attributes.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByTestId(testId)`
+Creates a locator that matches an element by its test-id attribute.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByText(text, options)`
+Creates a locator that matches an element containing the specified text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getByTitle(text, options)`
+Creates a locator that matches an element by its title attribute.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.frameLocator(selector)`
+Creates a frame locator that matches an iframe by selector.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.pierceFrames(options)`
+Returns a frame locator resolving to all descendant frames.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.pickLocator()`
+Triggers the UI inspector to allow the user to click an element and pick a locator.
+**Returns:** `Promise<Locator>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.cancelPickLocator()`
+Cancels an ongoing `page.pickLocator()` call.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.$(selector, options)`
+Queries the page for the first matching element.
+**Returns:** `Promise<ElementHandleForTag<K> | null>` (tag-name selector) or `Promise<ElementHandle<SVGElement | HTMLElement> | null>` (general string selector)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.$$(selector)`
+Queries the page for all matching elements.
+**Returns:** `Promise<ElementHandleForTag<K>[]>` (tag-name selector) or `Promise<ElementHandle<SVGElement | HTMLElement>[]>` (general string selector)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Interactivity (Page-Level UI Actions)
+
+### `Page.check(selector, options)`
+Checks a checkbox or radio button matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.click(selector, options)`
+Clicks an element matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.dblclick(selector, options)`
+Double-clicks an element matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.dispatchEvent(selector, type, eventInit, options)`
+Dispatches an event to the element matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.dragAndDrop(source, target, options)`
+Drags the source element to the target element and drops it.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.fill(selector, value, options)`
+Fills an input, textarea, or contenteditable element with the provided value.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setInputFiles(selector, files, options)`
+Sets files on a file input matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.focus(selector, options)`
+Focuses the element matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.getAttribute(selector, name, options)`
+Returns the value of the specified attribute for the matching element.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.hover(selector, options)`
+Hovers over the element matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.innerHTML(selector, options)`
+Returns the `innerHTML` of the matching element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.innerText(selector, options)`
+Returns the `innerText` of the matching element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.inputValue(selector, options)`
+Returns the value of the matching input, textarea, or select element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isChecked(selector, options)`
+Checks if the matching checkbox or radio button is checked.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isDisabled(selector, options)`
+Checks if the matching element is disabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isEditable(selector, options)`
+Checks if the matching element is editable.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isEnabled(selector, options)`
+Checks if the matching element is enabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isHidden(selector, options)`
+Checks if the matching element is hidden.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isVisible(selector, options)`
+Checks if the matching element is visible.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.press(selector, key, options)`
+Presses a specific keyboard key on the matching element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.selectOption(selector, values, options)`
+Selects one or more options in a `<select>` element.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setChecked(selector, checked, options)`
+Sets the checked state of a checkbox or radio button.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.tap(selector, options)`
+Taps an element matching the selector (for mobile emulation).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.textContent(selector, options)`
+Returns the `textContent` of the matching element.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.type(selector, text, options)`
+Types text into the matching element, firing keydown, keypress/input, and keyup events.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+**Deprecated:** In most cases, you should use `locator.fill()` or `locator.pressSequentially()` instead.
+
+### `Page.uncheck(selector, options)`
+Unchecks a checkbox or radio button matching the selector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForSelector(selector, options)`
+Waits for an element matching the selector to satisfy state criteria.
+**Returns:** `Promise<ElementHandleForTag<K> | null>` (tag-name selector) or `Promise<ElementHandle<SVGElement | HTMLElement> | null>` (general string selector). Both are nullable when options/state permits a hidden or detached result.
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.waitForFunction(pageFunction, arg, options)`
+Waits for a function to evaluate to a truthy value in the page context.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Routing & Network
+
+### `Page.route(url, handler, options)`
+Intercepts network requests matching the URL pattern and routes them to the handler.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.requests()`
+Returns up to the currently retained last 100 requests. Note: old returned request objects may be collected as new requests arrive.
+**Returns:** `Promise<Request[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.routeFromHAR(har, options)`
+Serves network responses directly from a HAR file.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.routeWebSocket(url, handler)`
+Intercepts WebSocket connections matching the URL pattern.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.unroute(url, handler)`
+Removes a specific network routing handler.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.unrouteAll(options)`
+Removes all network routing handlers set on the page.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setExtraHTTPHeaders(headers)`
+Sets extra HTTP headers to be sent with every request from the page.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Events & Event Listeners
+
+### `Page.on(event, listener)`
+Adds an event listener for the specified page event.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.once(event, listener)`
+Adds a one-time event listener for the specified page event.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.off(event, listener)`
+Removes a specific event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.addListener(event, listener)`
+Alias for `Page.on()`. Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.removeListener(event, listener)`
+Alias for `Page.off()`. Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.removeAllListeners(type, options)`
+Removes all listeners, or those of the specified event.
+**Returns:** `this` (without options) or `Promise<void>` (with options)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Page.prependListener(event, listener)`
+Adds an event listener to the beginning of the listeners array.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/channelOwner.ts`)
+
+### Scripts & Evaluation
+
+### `Page.$eval(selector, pageFunction, arg)`
+Evaluates a function in the page context, passing the matching element as an argument.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.$$eval(selector, pageFunction, arg)`
+Evaluates a function in the page context, passing all matching elements as an argument array.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.addInitScript(script, arg)`
+Adds a script to be evaluated in every frame upon creation, before any other scripts run.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.addScriptTag(options)`
+Injects a `<script>` tag into the page.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.addStyleTag(options)`
+Injects a `<style>` tag into the page.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.evaluate(pageFunction, arg)`
+Evaluates a function in the page context and returns the result.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.evaluateHandle(pageFunction, arg)`
+Evaluates a function in the page context and returns a JSHandle to the result.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.exposeBinding(name, callback)`
+Exposes a Node.js function to the page context, optionally passing source information.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.exposeFunction(name, callback)`
+Exposes a Node.js function to the page context.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.addLocatorHandler(locator, handler, options)`
+Registers a handler that is called when a locator matches and obscures an action target.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.removeLocatorHandler(locator)`
+Removes a previously registered locator handler.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Emulation & Configuration
+
+### `Page.emulateMedia(options)`
+Emulates CSS media type, media features, or color schemes.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setDefaultNavigationTimeout(timeout)`
+Changes the default maximum navigation time for the page.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setDefaultTimeout(timeout)`
+Changes the default maximum time for all page methods awaiting conditions.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.setViewportSize(viewportSize)`
+Resizes the page's viewport to the given dimensions.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Screenshots & Output
+
+### `Page.screenshot(options)`
+Captures a screenshot of the page.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.ariaSnapshot(options)`
+Returns an ARIA snapshot representation of the page.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.ariaSnapshotJSON(options)`
+Returns a JSON-serialized ARIA snapshot representation of the page.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.pdf(options)`
+Generates a PDF of the page. (Chromium only).
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Page Lifecycle & Tabs
+
+### `Page.bringToFront()`
+Brings the page to the front (activates the tab).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.close(options)`
+Closes the page and terminates its lifecycle.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.opener()`
+Returns the page that opened this page, if any.
+**Returns:** `Promise<Page | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.isClosed()`
+Indicates whether the page has been closed.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### Accessors & State (Properties & Methods)
+
+### `Page.clock`
+Gets the `Clock` API for manipulating time and timers.
+**Returns:** `Clock`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.screencast`
+Gets the `Screencast` API to manage screencast frames and sessions.
+**Returns:** `Screencast`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.localStorage`
+Provides access to the page's `localStorage` for the current origin.
+**Returns:** `WebStorage`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.sessionStorage`
+Provides access to the page's `sessionStorage` for the current origin.
+**Returns:** `WebStorage`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.coverage`
+Gets the `Coverage` API to gather JS/CSS coverage.
+**Returns:** `Coverage`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.keyboard`
+Gets the `Keyboard` API for dispatching keyboard events.
+**Returns:** `Keyboard`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.mouse`
+Gets the `Mouse` API for dispatching mouse events.
+**Returns:** `Mouse`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.request`
+Gets the `APIRequestContext` for sending API requests from the page's network context.
+**Returns:** `APIRequestContext`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.touchscreen`
+Gets the `Touchscreen` API for dispatching touch events.
+**Returns:** `Touchscreen`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.context()`
+Returns the browser context that owns the page.
+**Returns:** `BrowserContext`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.content()`
+Gets the full HTML contents of the page, including the doctype.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.frame(frameSelector)`
+Returns a frame matching the specified name or URL.
+**Returns:** `Frame | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.frames()`
+Returns an array of all frames attached to the page.
+**Returns:** `Frame[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.mainFrame()`
+Returns the page's main frame.
+**Returns:** `Frame`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.title()`
+Returns the page's title.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.url()`
+Returns the page's current URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.video()`
+Returns the video object associated with the page if recording is enabled.
+**Returns:** `Video | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.viewportSize()`
+Returns the dimensions of the page's viewport.
+**Returns:** `Size | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.workers()`
+Returns an array of all WebWorkers associated with the page.
+**Returns:** `Worker[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.consoleMessages()`
+Returns all console messages emitted by the page.
+**Returns:** `Promise<ConsoleMessage[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.clearConsoleMessages()`
+Clears the accumulated console messages array.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.clearPageErrors()`
+Clears the accumulated page errors array.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.pageErrors(options)`
+Returns up to the currently retained last 200 page errors.
+**Returns:** `Promise<Error[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.requestGC()`
+Requests the browser to execute garbage collection.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.pause()`
+Pauses test execution for manual debugging in the Playwright Inspector.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+### `Page.hideHighlight()`
+Hides any highlights drawn by `Locator.highlight()`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/page.ts`)
+
+
+---
+
+## Locator
+
+### Filtering & Chaining
+
+### `Locator.and(locator)`
+Creates a locator that matches elements satisfying both locators simultaneously.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.filter(options)`
+Filters the current locator based on inner text or the presence of a child locator.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.first()`
+Returns a locator pointing to the first matching element.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.last()`
+Returns a locator pointing to the last matching element.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.locator(selectorOrLocator, options)`
+Returns a new locator that finds a descendant element matching the selector.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.nth(index)`
+Returns a locator pointing to the n-th matching element.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.or(locator)`
+Creates a locator that matches elements satisfying either locator.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.frameLocator(selector)`
+Returns a frame locator resolving to an iframe matching the selector inside the current locator.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Specialized Selectors
+
+### `Locator.getByAltText(text, options)`
+Creates a sub-locator that matches an element by its alt text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByLabel(text, options)`
+Creates a sub-locator that matches an element by its associated label text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByPlaceholder(text, options)`
+Creates a sub-locator that matches an input by its placeholder text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByRole(role, options)`
+Creates a sub-locator that matches an element by its ARIA role and attributes.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByTestId(testId)`
+Creates a sub-locator that matches an element by its test-id attribute.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByText(text, options)`
+Creates a sub-locator that matches an element containing the specified text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getByTitle(text, options)`
+Creates a sub-locator that matches an element by its title attribute.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Interactivity & Actions
+
+### `Locator.blur(options)`
+Removes keyboard focus from the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.check(options)`
+Checks a checkbox or radio button.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.clear(options)`
+Clears the value of an input or textarea element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.click(options)`
+Clicks the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.dblclick(options)`
+Double-clicks the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.dispatchEvent(type, eventInit, options)`
+Dispatches an event directly on the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.dragTo(target, options)`
+Drags the element to a target locator and drops it.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.drop(payload, options)`
+Programmatically drops data payloads on the element without simulating mouse drag.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.fill(value, options)`
+Fills an input, textarea, or contenteditable element with the specified value.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.focus(options)`
+Sets keyboard focus on the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.hover(options)`
+Hovers the mouse over the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.press(key, options)`
+Presses a specific keyboard key on the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.pressSequentially(text, options)`
+Types text sequentially into the element, simulating real user keystrokes.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.scrollIntoViewIfNeeded(options)`
+Scrolls the element into the viewport if it is not already visible.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.selectOption(values, options)`
+Selects one or more options in a `<select>` element.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.selectText(options)`
+Highlights/selects the text content inside the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.setChecked(checked, options)`
+Ensures the checkbox or radio button matches the specified boolean checked state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.setInputFiles(files, options)`
+Sets files on a `<input type="file">` element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.tap(options)`
+Taps the element (for mobile emulation).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.type(text, options)`
+Types text into the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+**Deprecated:** In most cases, you should use `locator.fill()` or `locator.pressSequentially()` instead.
+
+### `Locator.uncheck(options)`
+Unchecks a checkbox or radio button.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Element State & Properties
+
+### `Locator.all()`
+Returns an array of locators pointing to every matched element.
+**Returns:** `Promise<Locator[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.allInnerTexts()`
+Returns an array of `innerText` values for all matched elements.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.allTextContents()`
+Returns an array of `textContent` values for all matched elements.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.boundingBox(options)`
+Returns the bounding box (x, y, width, height) of the element.
+**Returns:** `Promise<Rect | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.count()`
+Returns the number of elements matching the locator.
+**Returns:** `Promise<number>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.getAttribute(name, options)`
+Returns the value of the specified attribute on the element.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.innerHTML(options)`
+Returns the `innerHTML` of the element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.innerText(options)`
+Returns the `innerText` of the element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.inputValue(options)`
+Returns the value of the input, textarea, or select element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isChecked(options)`
+Checks if the checkbox or radio button is checked.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isDisabled(options)`
+Checks if the element is disabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isEditable(options)`
+Checks if the element is editable.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isEnabled(options)`
+Checks if the element is enabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isHidden(options)`
+Checks if the element is hidden.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.isVisible(options)`
+Checks if the element is visible.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.textContent(options)`
+Returns the `textContent` of the element.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.contentFrame()`
+Returns a FrameLocator to the content frame of the matching iframe element.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.normalize()`
+Returns a normalized locator mapping to the exact same elements without semantic ambiguities.
+**Returns:** `Promise<Locator>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Verification & Waiting
+
+### `Locator.waitFor(options)`
+Waits for the locator to resolve to an element in the given state (attached, detached, visible, hidden).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.waitForFunction(pageFunction, arg, options)`
+Waits for a function to evaluate to a truthy value, passing the element as an argument.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Output & Handles
+
+### `Locator.ariaSnapshot(options)`
+Returns an ARIA snapshot representation of the element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.ariaSnapshotJSON(options)`
+Returns a JSON-serialized ARIA snapshot representation of the element.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.elementHandle(options)`
+Resolves the locator into an `ElementHandle`.
+**Returns:** `Promise<ElementHandle<SVGElement | HTMLElement>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.evaluate(pageFunction, arg, options)`
+Evaluates a function in the page context, passing the matching element as an argument.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.evaluateAll(pageFunction, arg)`
+Evaluates a function in the page context, passing all matching elements as an argument array.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.evaluateHandle(pageFunction, arg, options)`
+Evaluates a function in the page context, passing the matching element, and returns a JSHandle.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.elementHandles()`
+Resolves the locator into an array of `ElementHandle`s for all matching elements.
+**Returns:** `Promise<ElementHandle[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.screenshot(options)`
+Captures a screenshot of the specific element.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.highlight(options)`
+Draws a visible bounding box over the element for debugging purposes. Disposing the result removes the highlight.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.hideHighlight()`
+Hides the highlight drawn by `locator.highlight()`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### Misc & Metadata
+
+### `Locator.page()`
+Returns the Page associated with this locator.
+**Returns:** `Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.describe(description)`
+Attaches a custom description to the locator for logging/debugging.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.description()`
+Returns the custom description attached to the locator, if any.
+**Returns:** `string | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `Locator.toString()`
+Returns the string representation of the locator.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+---
+
+## BrowserContext
+
+The `BrowserContext` represents an isolated browser session, analogous to an incognito window. Each context has its own pages, cookies, cache, and storage state.
+
+### Properties & State
+
+### `BrowserContext.request`
+APIRequestContext instance for making network requests scoped to the context.
+**Returns:** `APIRequestContext`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.tracing`
+Tracing API for starting/stopping tracing for this context.
+**Returns:** `Tracing`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clock`
+Clock API for manipulating time and timers scoped to this context.
+**Returns:** `Clock`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.browser()`
+Returns the browser instance of the context. If it was launched as a persistent context, returns `null`.
+**Returns:** `Browser | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.isClosed()`
+Indicates whether the context has been closed.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Pages & Workers
+
+### `BrowserContext.newPage()`
+Creates a new page in the browser context.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.pages()`
+Returns all open pages in the context.
+**Returns:** `Page[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.backgroundPages()`
+**Deprecated:** Background pages have been removed from Chromium together with Manifest V2 extensions.
+**Returns:** `Page[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.serviceWorkers()`
+Returns all service workers currently active in the context.
+**Returns:** `Worker[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Configuration & State Management
+
+### `BrowserContext.cookies(urls)`
+Gets cookies for all or specific URLs.
+**Returns:** `Promise<Cookie[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.addCookies(cookies)`
+Adds cookies to the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clearCookies(options)`
+Clears context cookies.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.grantPermissions(permissions, options)`
+Grants specified permissions to the context or specific origins.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clearPermissions()`
+Clears all granted permissions.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setGeolocation(geolocation)`
+Sets the geolocation of the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setExtraHTTPHeaders(headers)`
+Sets extra HTTP headers to be sent with every request in the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setOffline(offline)`
+Sets the context to offline or online mode.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setHTTPCredentials(httpCredentials)`
+Sets HTTP credentials for the context.
+**Deprecated:** Browsers may cache credentials after successful authentication. Create a new browser context instead.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setDefaultNavigationTimeout(timeout)`
+Sets the default navigation timeout for the context.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setDefaultTimeout(timeout)`
+Sets the default timeout for the context.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.storageState(options)`
+Returns storage state for the context, which can be used to create a new context with the same state.
+**Returns:** `Promise<StorageState>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setStorageState(storageState)`
+Sets storage state for the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Network Routing
+
+### `BrowserContext.route(url, handler, options)`
+Intercepts and handles network requests.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.routeFromHAR(har, options)`
+Routes network requests from a HAR file.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.routeWebSocket(url, handler)`
+Intercepts WebSocket connections.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.unroute(url, handler)`
+Removes a route handler.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.unrouteAll(options)`
+Removes all routes configured for the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Scripts & Bindings
+
+### `BrowserContext.addInitScript(script, arg, options)`
+Adds a script to be evaluated in all pages upon creation.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.exposeBinding(name, callback)`
+Exposes a Node.js function as a global function on all pages, passing the source object.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.exposeFunction(name, callback)`
+Exposes a Node.js function as a global function on all pages.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Lifecycle & Events
+
+### `BrowserContext.close(options)`
+Closes the browser context. All pages in the context are also closed.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.waitForEvent(event, optionsOrPredicate)`
+Waits for an event to fire and passes its value into the predicate function.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.on(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.once(event, listener)`
+Adds a one-time event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.off(event, listener)`
+Removes an event listener. (Alias for `removeListener`).
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.addListener(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.removeListener(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.removeAllListeners(type, options)`
+Removes all listeners, or those of the specified event.
+**Returns:** `this` (without options) or `Promise<void>` (with options)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `BrowserContext.prependListener(event, listener)`
+Adds an event listener to the beginning of the listeners array.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### Misc
+
+### `BrowserContext.newCDPSession(page)`
+Creates a new CDP session linked to a specific page or frame.
+**Returns:** `Promise<CDPSession>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.credentials`
+Credentials management for the context.
+**Returns:** `Credentials`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.debugger`
+Debugger allows to pause and resume the execution.
+**Returns:** `Debugger`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+---
+
+## Browser
+
+A Browser is created via `chromium.launch()`, `firefox.launch()`, or `webkit.launch()`. It manages multiple `BrowserContext` instances.
+
+### Core Context Creation
+
+### `Browser.newContext(options)`
+Creates a new browser context.
+**Returns:** `Promise<BrowserContext>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.newPage(options)`
+Creates a new page in a new browser context.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Accessors & State
+
+### `Browser.browserType()`
+Returns the browser type (`chromium`, `firefox`, or `webkit`) that this browser belongs to.
+**Returns:** `BrowserType`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.contexts()`
+Returns an array of all open browser contexts.
+**Returns:** `BrowserContext[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.isConnected()`
+Indicates whether the browser is connected.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.version()`
+Returns the browser version.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Advanced & Tracing
+
+### `Browser.startTracing(page, options)`
+**Chromium-only.** Starts low-level Chromium tracing. (For Playwright Tracing, use `context.tracing`).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.stopTracing()`
+**Chromium-only.** Stops tracing and returns a buffer with the trace data.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.newBrowserCDPSession()`
+**Chromium-only.** Creates a new CDP session attached to the browser itself.
+**Returns:** `Promise<CDPSession>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Remote Connectivity
+
+### `Browser.bind(title, options)`
+Binds the browser to a named pipe or WebSocket, making it available for other clients to connect to, and returns the endpoint.
+**Returns:** `Promise<{ endpoint: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.unbind()`
+Unbinds and stops the browser server created by `bind()`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Lifecycle & Events
+
+### `Browser.close(options)`
+Closes the browser and all of its contexts.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.on(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.once(event, listener)`
+Adds a one-time event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.off(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.addListener(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.removeListener(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.removeAllListeners(type, options)`
+Removes all listeners, or those of the specified event.
+**Returns:** `this` (without options) or `Promise<void>` (with options)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `Browser.prependListener(event, listener)`
+Adds an event listener to the beginning of the listeners array.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+---
+
+
+
+
+## Frame
+
+A `Frame` represents a single iframe or the main frame of a page. Most `Frame` methods mirror `Page` methods, but act exclusively within the context of the frame.
+
+### Accessors & Navigation
+
+### `Frame.page()`
+Returns the page containing this frame.
+**Returns:** `Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.name()`
+Returns the frame's name attribute as specified in the tag.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.url()`
+Returns the frame's current URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.parentFrame()`
+Returns the parent frame, if any. Detached frames and main frames return `null`.
+**Returns:** `Frame | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.childFrames()`
+Returns an array of child frames.
+**Returns:** `Array<Frame>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isDetached()`
+Returns `true` if the frame has been detached from the DOM.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.title()`
+Returns the page title.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.goto(url, options)`
+Navigates the frame. (Unlike `page.goto`, this strictly targets this specific frame).
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.frameElement()`
+Returns the `iframe` or `frame` DOM element for this frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.content()`
+Gets the full HTML contents of the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setContent(html, options)`
+Sets the HTML contents of the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Locators
+
+### `Frame.locator(selector, options)`
+Returns a Locator pointing to a matching element within the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByTestId(testId)`
+Returns a Locator pointing to an element with a matching test-id inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByAltText(text, options)`
+Returns a Locator matching an element's `alt` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByLabel(text, options)`
+Returns a Locator matching a form element by its associated label inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByPlaceholder(text, options)`
+Returns a Locator matching an element's `placeholder` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByRole(role, options)`
+Returns a Locator matching an element by its ARIA role inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByText(text, options)`
+Returns a Locator matching a specific text node inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByTitle(text, options)`
+Returns a Locator matching an element's `title` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.frameLocator(selector)`
+Returns a FrameLocator pointing to a child iframe within this frame.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.pierceFrames(options)`
+Returns a FrameLocator piercing through all matching child iframes automatically.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.$(selector, options)`
+Returns the ElementHandle pointing to the frame element.
+**Returns:** `Promise<ElementHandleForTag<K> | null>` (tag-name selector) or `Promise<ElementHandle<SVGElement | HTMLElement> | null>` (general string selector)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.$$(selector)`
+Returns the ElementHandles pointing to the frame elements.
+**Returns:** `Promise<ElementHandleForTag<K>[]>` (tag-name selector) or `Promise<ElementHandle<SVGElement | HTMLElement>[]>` (general string selector)
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.$eval(selector, pageFunction, arg)`
+Returns the return value of `pageFunction`.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.$$eval(selector, pageFunction, arg)`
+Returns the return value of `pageFunction` applied to all matching elements.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Interactions & Evaluation
+
+### `Frame.click(selector, options)`
+Clicks an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dblclick(selector, options)`
+Double-clicks an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dragAndDrop(source, target, options)`
+Drags an element to a target within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.tap(selector, options)`
+Taps an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.fill(selector, value, options)`
+Fills an input element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.focus(selector, options)`
+Focuses an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.hover(selector, options)`
+Hovers an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.press(selector, key, options)`
+Focuses an element within the frame and presses a single key.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.selectOption(selector, values, options)`
+Selects options within a `<select>` element in the frame.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setInputFiles(selector, files, options)`
+Sets files on a file input within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.check(selector, options)`
+Checks a checkbox or radio button within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.uncheck(selector, options)`
+Unchecks a checkbox or radio button within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setChecked(selector, checked, options)`
+Checks or unchecks an element based on the provided state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.type(selector, text, options)`
+**Deprecated:** (Use `locator.fill()` instead). Types into an input element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.evaluate(pageFunction, arg, options)`
+Executes JavaScript inside the frame.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.evaluateHandle(pageFunction, arg, options)`
+Executes JavaScript inside the frame and returns a JSHandle to the result.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dispatchEvent(selector, type, eventInit, options)`
+Dispatches a DOM event on an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### State Queries
+
+### `Frame.textContent(selector, options)`
+Gets the text content of an element in the frame.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.innerText(selector, options)`
+Gets the rendered inner text of an element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.innerHTML(selector, options)`
+Gets the inner HTML of an element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getAttribute(selector, name, options)`
+Gets a DOM attribute of an element in the frame.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.inputValue(selector, options)`
+Gets the input value of a form element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isChecked(selector, options)`
+Returns whether a checkbox or radio is checked in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isDisabled(selector, options)`
+Returns whether an element is disabled in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isEditable(selector, options)`
+Returns whether an element is editable in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isEnabled(selector, options)`
+Returns whether an element is enabled in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isHidden(selector, options)`
+Returns whether an element is hidden in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isVisible(selector, options)`
+Returns whether an element is visible in the frame.
+**Returns:** `Promise<boolean>`
+
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Waiting & Overrides
+
+### `Frame.waitForFunction(pageFunction, arg, options)`
+Waits for a function to evaluate to a truthy value inside the frame.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForLoadState(state, options)`
+Waits for the frame to reach a specific load state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForNavigation(options)`
+**Deprecated:** (Use `waitForURL` instead). Waits for the frame to navigate.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForSelector(selector, options)`
+Waits for a selector to appear or disappear inside the frame.
+**Returns:** `Promise<null|ElementHandle<SVGElement | HTMLElement>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForTimeout(timeout)`
+**Deprecated:** (Use `page.waitForTimeout` for debugging only). Waits for a timeout.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForURL(url, options)`
+Waits for the frame to navigate to the given URL.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.addScriptTag(options)`
+Adds a `<script>` tag to the frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.addStyleTag(options)`
+Adds a `<link rel="stylesheet">` or `<style>` tag to the frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+---
+
+## Route
+
+The `Route` class represents an intercepted network request.
+
+### Methods
+
+### `Route.request()`
+Returns the intercepted request.
+**Returns:** `Request`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.abort(errorCode)`
+Aborts the route's request.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.continue(options)`
+Sends the route's request to the network with optional overrides.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fallback(options)`
+Continues the request, allowing subsequent matching handlers in the routing chain to be invoked.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fetch(options)`
+Performs the request and fetches the response without fulfilling it immediately.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fulfill(options)`
+Fulfills the route's request with a given response (e.g. mocking a 200 OK with custom body).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## Request
+
+The `Request` class represents an HTTP request sent by a page.
+
+### Methods
+
+### `Request.url()`
+Returns the URL of the request.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.resourceType()`
+Returns the resource type (e.g., `document`, `image`, `fetch`).
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.method()`
+Returns the HTTP method of the request.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postData()`
+Returns the request's post body, if any, as a string.
+**Returns:** `string | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postDataBuffer()`
+Returns the request's post body, if any, as a raw Buffer.
+**Returns:** `Buffer | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postDataJSON()`
+Returns the parsed request body for form-urlencoded data and JSON as a fallback, if any.
+**Returns:** `Serializable | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headers()`
+Returns an object containing the HTTP headers associated with the request.
+**Returns:** `{ [key: string]: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.allHeaders()`
+Returns a promise that resolves to an object with all HTTP headers.
+**Returns:** `Promise<{ [key: string]: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headersArray()`
+Returns a promise that resolves to an array of header objects (`{ name, value }`).
+**Returns:** `Promise<{ name: string, value: string }[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headerValue(name)`
+Returns the value of the specified header.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.response()`
+Returns the matching `Response` object, or `null` if the request failed.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.existingResponse()`
+Returns the `Response` object if the response has already been received, `null` otherwise. Unlike `response()`, does not wait for the response to arrive.
+**Returns:** `Response | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.frame()`
+Returns the `Frame` that initiated this request.
+**Returns:** `Frame`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.serviceWorker()`
+Returns the service worker that initiated this request, if any.
+**Returns:** `Worker | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.isNavigationRequest()`
+Returns whether this request is driving a frame navigation.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.redirectedFrom()`
+Returns the request that was redirected to this request, if any.
+**Returns:** `Request | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.redirectedTo()`
+Returns the request this request was redirected to, if any.
+**Returns:** `Request | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.failure()`
+Returns the failure message if the request failed.
+**Returns:** `{ errorText: string } | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.timing()`
+Returns resource timing information for the request.
+**Returns:** `{ startTime: number, domainLookupStart: number, domainLookupEnd: number, connectStart: number, secureConnectionStart: number, connectEnd: number, requestStart: number, responseStart: number, responseEnd: number }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.sizes()`
+Returns resource size information (e.g. body size, header size).
+**Returns:** `Promise<{ requestBodySize: number, requestHeadersSize: number, responseBodySize: number, responseHeadersSize: number }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## Response
+
+The `Response` class represents an HTTP response received by a page.
+
+### Methods
+
+### `Response.url()`
+Returns the URL of the response.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.ok()`
+Returns `true` if the status code is between 200 and 299.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.status()`
+Returns the status code of the response (e.g., 200 for a success).
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.statusText()`
+Returns the status text of the response (e.g., "OK").
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.fromServiceWorker()`
+Returns `true` if this response was served from a Service Worker.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headers()`
+Returns an object containing the HTTP headers associated with the response.
+**Returns:** `{ [key: string]: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.allHeaders()`
+Returns a promise that resolves to an object with all HTTP headers.
+**Returns:** `Promise<{ [key: string]: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headersArray()`
+Returns a promise that resolves to an array of header objects (`{ name, value }`).
+**Returns:** `Promise<{ name: string, value: string }[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headerValue(name)`
+Returns the value of the specified header.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headerValues(name)`
+Returns all values for the specified header.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.finished()`
+Waits for this response to finish; currently resolves to `null`.
+**Returns:** `Promise<Error | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.body()`
+Returns the raw body payload of the response as a Buffer.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.text()`
+Returns the text representation of the response body.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.json()`
+Returns the JSON representation of the response body.
+**Returns:** `Promise<Serializable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.request()`
+Returns the matching `Request` object.
+**Returns:** `Request`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.frame()`
+Returns the `Frame` that initiated this response.
+**Returns:** `Frame`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.serverAddr()`
+Returns the IP address and port of the server if available.
+**Returns:** `Promise<{ ipAddress: string, port: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.securityDetails()`
+Returns the security details if the response was received over a secure connection.
+**Returns:** `Promise<{ issuer?: string, protocol?: string, subjectName?: string, validFrom?: number, validTo?: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.httpVersion()`
+Returns the HTTP version of the response.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## JSHandle
+
+Represents an in-page JavaScript object, created by `page.evaluateHandle()`.
+
+### `JSHandle.evaluate(pageFunction, arg, options)`
+Evaluates a function in the page context, passing this handle as the first argument.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.evaluateHandle(pageFunction, arg, options)`
+Evaluates a function and returns its value as a `JSHandle`.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.jsonValue()`
+Returns a JSON representation of the referenced object.
+**Returns:** `Promise<T>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.asElement()`
+Returns the handle as an `ElementHandle`, or `null` when it is not an element.
+**Returns:** `ElementHandle<T> | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.dispose()`
+Stops referencing the JavaScript object so it can be garbage collected.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.getProperties()`
+Returns own property names mapped to `JSHandle` values.
+**Returns:** `Promise<Map<string, JSHandle>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.getProperty(propertyName)`
+Fetches one property from the referenced object.
+**Returns:** `Promise<JSHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+### `JSHandle.[Symbol.asyncDispose]()`
+Disposes the handle through the explicit resource-management protocol.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/jsHandle.ts`)
+
+---
+
+## ElementHandle
+
+Represents a particular in-page DOM element. Locator-based APIs are preferred for new tests.
+
+### `ElementHandle.$(selector, options)`
+Finds one matching element in this handle's subtree.
+**Returns:** `Promise<ElementHandle | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.$$(selector)`
+Finds all matching elements in this handle's subtree.
+**Returns:** `Promise<ElementHandle[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.$eval(selector, pageFunction, arg)`
+Evaluates a function with the first matching descendant as its first argument.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.$$eval(selector, pageFunction, arg)`
+Evaluates a function with all matching descendants as an array.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.boundingBox()`
+Returns the element bounding box, or `null` when it is not visible.
+**Returns:** `Promise<{ x: number, y: number, width: number, height: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.check(options)`
+Checks a checkbox or radio input.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.click(options)`
+Clicks the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.contentFrame()`
+Returns the content frame for an iframe/frame element, or `null` otherwise.
+**Returns:** `Promise<Frame | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.dblclick(options)`
+Double-clicks the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.dispatchEvent(type, eventInit)`
+Dispatches an event directly on the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.fill(value, options)`
+Fills an input or textarea with the specified value.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.focus()`
+Focuses the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.getAttribute(name)`
+Returns an attribute value, or `null` when absent.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.hover(options)`
+Hovers over the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.innerHTML()`
+Returns `element.innerHTML`.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.innerText()`
+Returns `element.innerText`.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.inputValue(options)`
+Returns the value of an input, textarea, or select element.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+**Deprecated:** The `options.timeout` option is ignored; the value is returned immediately.
+
+### `ElementHandle.isChecked()`
+Returns whether a checkbox or radio input is checked.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.isDisabled()`
+Returns whether the element is disabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.isEditable()`
+Returns whether the element is editable.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.isEnabled()`
+Returns whether the element is enabled.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.isHidden()`
+Returns whether the element is hidden.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.isVisible()`
+Returns whether the element is visible.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.ownerFrame()`
+Returns the frame containing this element.
+**Returns:** `Promise<Frame | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.press(key, options)`
+Focuses the element and presses a key.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.screenshot(options)`
+Takes a screenshot of the element.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.scrollIntoViewIfNeeded(options)`
+Scrolls the element into view when needed.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.selectOption(values, options)`
+Selects one or more options in a select element.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.selectText(options)`
+Selects the element text.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.setChecked(checked, options)`
+Sets a checkbox or radio element's checked state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.setInputFiles(files, options)`
+Sets the value of a file input.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.tap(options)`
+Performs a tap gesture on the element.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.textContent()`
+Returns the node text content.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.type(text, options)`
+Types text character by character. Prefer `Locator.fill()` or `Locator.pressSequentially()`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+**Deprecated:** Use locator-based typing instead.
+
+### `ElementHandle.uncheck(options)`
+Unchecks a checkbox or radio input.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.waitForElementState(state, options)`
+Waits for an element state such as visible, hidden, stable, enabled, disabled, or editable.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+### `ElementHandle.waitForSelector(selector, options)`
+Waits for a matching descendant to satisfy the requested state.
+**Returns:** `Promise<ElementHandle | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/elementHandle.ts`)
+
+---
+
+## Keyboard
+
+Provides low-level keyboard input through `page.keyboard`.
+
+### `Keyboard.down(key)`
+Dispatches a `keydown` event.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Keyboard.insertText(text)`
+Dispatches an input event without keydown, keyup, or keypress events.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Keyboard.press(key, options)`
+Runs `keyboard.down()` followed by `keyboard.up()`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Keyboard.type(text, options)`
+Sends keyboard events for each character.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Keyboard.up(key)`
+Dispatches a `keyup` event.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+---
+
+## Mouse
+
+Provides low-level mouse input and cursor positioning through `page.mouse`.
+
+### `Mouse.click(x, y, options)`
+Moves, presses, and releases the mouse.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Mouse.dblclick(x, y, options)`
+Moves the mouse and clicks twice.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Mouse.down(options)`
+Dispatches a `mousedown` event.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Mouse.move(x, y, options)`
+Moves to coordinates, optionally emitting interpolated steps.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Mouse.up(options)`
+Dispatches a `mouseup` event.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+### `Mouse.wheel(deltaX, deltaY)`
+Dispatches a wheel event.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| JSHandle | 8 | 10 |
+| ElementHandle | 37 | 48 |
+| Keyboard | 5 | 5 |
+| Mouse | 6 | 6 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`. ElementHandle inherits JSHandle members; inherited members are documented only under JSHandle.
+
+---
+
+## Download
+
+Represents a file download dispatched by a page through the `page.on('download')` event.
+
+### `Download.cancel()`
+Cancels the download; `failure()` resolves to `canceled` after successful cancellation.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.createReadStream()`
+Returns a readable stream for a successful download.
+**Returns:** `Promise<Readable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.delete()`
+Deletes the downloaded file, waiting for completion when necessary.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.failure()`
+Returns an error message, or `null` for a successful download.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.page()`
+Returns the page that owns the download.
+**Returns:** `Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.path()`
+Returns the downloaded file path; throws for failed/canceled downloads or remote connections.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.saveAs(path)`
+Copies the download to a user-specified path, waiting for completion as needed.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.suggestedFilename()`
+Returns the browser-computed suggested filename.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+### `Download.url()`
+Returns the downloaded URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/download.ts`)
+
+---
+
+## Dialog
+
+Represents a JavaScript `alert`, `beforeunload`, `confirm`, or `prompt` dialog.
+
+### `Dialog.accept(promptText)`
+Accepts the dialog, optionally supplying prompt text.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+### `Dialog.defaultValue()`
+Returns the default prompt value, or an empty string for other dialog types.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+### `Dialog.dismiss()`
+Dismisses the dialog.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+### `Dialog.message()`
+Returns the dialog message.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+### `Dialog.page()`
+Returns the page that initiated the dialog, when available.
+**Returns:** `Page | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+### `Dialog.type()`
+Returns the dialog type: `alert`, `beforeunload`, `confirm`, or `prompt`.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/dialog.ts`)
+
+---
+
+## FileChooser
+
+Represents a file input chooser dispatched through `page.on('filechooser')`.
+
+### `FileChooser.element()`
+Returns the associated input element handle.
+**Returns:** `ElementHandle`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fileChooser.ts`)
+
+### `FileChooser.isMultiple()`
+Returns whether the input accepts multiple files.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fileChooser.ts`)
+
+### `FileChooser.page()`
+Returns the page that owns this chooser.
+**Returns:** `Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fileChooser.ts`)
+
+### `FileChooser.setFiles(files, options)`
+Sets or clears the associated file input value.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fileChooser.ts`)
+**Deprecated:** `options.noWaitAfter` has no effect.
+
+---
+
+## ConsoleMessage
+
+Represents a `console.*` message dispatched through `page.on('console')`.
+
+### `ConsoleMessage.args()`
+Returns arguments passed to the console call as `JSHandle` instances.
+**Returns:** `JSHandle[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+### `ConsoleMessage.location()`
+Returns the call-site URL and zero-based line and column information.
+**Returns:** `{ url: string, line: number, column: number, lineNumber: number, columnNumber: number }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+**Deprecated:** `lineNumber` and `columnNumber`; use `line` and `column` instead.
+
+### `ConsoleMessage.page()`
+Returns the page that produced the message, when available.
+**Returns:** `Page | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+### `ConsoleMessage.text()`
+Returns the console message text.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+### `ConsoleMessage.timestamp()`
+Returns the message timestamp in milliseconds since the Unix epoch.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+### `ConsoleMessage.type()`
+Returns the console message type.
+**Returns:** `"log" | "debug" | "info" | "error" | "warning" | "dir" | "dirxml" | "table" | "trace" | "clear" | "startGroup" | "startGroupCollapsed" | "endGroup" | "assert" | "profile" | "profileEnd" | "count" | "time" | "timeEnd"`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+### `ConsoleMessage.worker()`
+Returns the web worker or service worker that produced the message, when available.
+**Returns:** `Worker | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/consoleMessage.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| Download | 9 | 9 |
+| Dialog | 6 | 6 |
+| FileChooser | 4 | 4 |
+| ConsoleMessage | 7 | 7 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.
+
+---
+
+## APIRequestContext
+
+Performs HTTP(S) requests with isolated cookie storage and optional tracing.
+
+### `APIRequestContext.delete(url, options)`
+Sends an HTTP DELETE request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.dispose(options)`
+Discards resources held by this request context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.fetch(urlOrRequest, options)`
+Sends an HTTP request and manages cookies for the context.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.get(url, options)`
+Sends an HTTP GET request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.head(url, options)`
+Sends an HTTP HEAD request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.patch(url, options)`
+Sends an HTTP PATCH request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.post(url, options)`
+Sends an HTTP POST request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.put(url, options)`
+Sends an HTTP PUT request.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.storageState(options)`
+Returns cookies and local-storage state for the request context.
+**Returns:** `Promise<StorageState>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.tracing`
+Returns the tracing API associated with this request context.
+**Returns:** `Tracing`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIRequestContext.[Symbol.asyncDispose]()`
+Disposes the request context asynchronously.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+---
+
+## APIResponse
+
+Represents a response returned by an `APIRequestContext` request.
+
+### `APIResponse.body()`
+Returns the response body as a buffer.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.dispose()`
+Disposes the response body held in memory.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.headers()`
+Returns all response headers as an object.
+**Returns:** `{ [key: string]: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.headersArray()`
+Returns response headers while preserving casing and duplicates.
+**Returns:** `Array<{ name: string, value: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.json()`
+Parses and returns the response body as JSON.
+**Returns:** `Promise<Serializable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.ok()`
+Returns whether the status code is in the 200–299 range.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.securityDetails()`
+Returns HTTPS security details, or `null` when unavailable.
+**Returns:** `Promise<{ issuer?: string, protocol?: string, subjectName?: string, validFrom?: number, validTo?: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.serverAddr()`
+Returns the server IP address and port, or `null` when unavailable.
+**Returns:** `Promise<{ ipAddress: string, port: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.status()`
+Returns the HTTP status code.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.statusText()`
+Returns the HTTP status text.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.text()`
+Returns the response body as text.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.timing()`
+Returns resource timing information.
+**Returns:** `ResourceTiming`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.url()`
+Returns the response URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+### `APIResponse.[Symbol.asyncDispose]()`
+Disposes the response body asynchronously.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+---
+
+## WebSocket
+
+Represents a WebSocket connection created within a page.
+
+### `WebSocket.isClosed()`
+Returns whether the WebSocket is closed.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocket.url()`
+Returns the WebSocket URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocket.waitForEvent(event, optionsOrPredicate)`
+Waits for a close, frame, or socket-error event.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocket.on(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `WebSocket.once(event, listener)`
+Adds a one-time event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `WebSocket.off(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `WebSocket.addListener(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `WebSocket.removeListener(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+### `WebSocket.prependListener(event, listener)`
+Adds an event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/eventEmitter.ts`)
+
+---
+
+## Worker
+
+Represents a dedicated WebWorker or service worker.
+
+### `Worker.evaluate(pageFunction, arg)`
+Evaluates a function or expression in the worker context.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.evaluateHandle(pageFunction, arg)`
+Evaluates a function and returns its value as a `JSHandle`.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.on(event, listener)`
+Adds a worker event listener for `close` or `console`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.once(event, listener)`
+Adds a one-time worker event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.addListener(event, listener)`
+Adds a worker event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.removeListener(event, listener)`
+Removes a worker event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.off(event, listener)`
+Removes a worker event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.prependListener(event, listener)`
+Adds a worker listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.url()`
+Returns the worker URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+### `Worker.waitForEvent(event, optionsOrPredicate)`
+Waits for a worker `close` or `console` event.
+**Returns:** `Promise<Worker | ConsoleMessage>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/worker.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| APIRequestContext | 11 | 11 |
+| APIResponse | 14 | 14 |
+| WebSocket | 9 | 27 |
+| Worker | 10 | 14 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.
+
+---
+
+## Selectors
+
+Installs custom selector engines and configures the attribute used by `getByTestId`.
+
+### `Selectors.register(name, script, options)`
+Registers a custom selector engine before pages are created.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/selectors.ts`)
+
+### `Selectors.setTestIdAttribute(attributeName)`
+Defines the attribute name used by `page.getByTestId(testId)`.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/selectors.ts`)
+
+---
+
+## Touchscreen
+
+Simulates touchscreen input in main-frame CSS pixels.
+
+### `Touchscreen.tap(x, y)`
+Dispatches `touchstart` and `touchend` for a single touch at the specified coordinates.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/input.ts`)
+
+---
+
+## Tracing
+
+Controls trace and HAR recording for a browser context.
+
+### `Tracing.group(name, options)`
+Creates a trace group and assigns subsequent API calls to it until `groupEnd()` is called.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.groupEnd()`
+Closes the most recently opened trace group.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.start(options)`
+Starts tracing for the browser context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.startChunk(options)`
+Starts a new trace chunk within an active tracing session.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.startHar(path, options)`
+Starts HAR recording for network activity in the browser context.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.stop(options)`
+Stops tracing and optionally exports the collected trace.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.stopChunk(options)`
+Stops the current trace chunk and optionally exports it.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+### `Tracing.stopHar()`
+Stops HAR recording and saves the HAR file.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/tracing.ts`)
+
+---
+
+## Video
+
+Represents the recorded video associated with a page in a video-enabled context.
+
+### `Video.delete()`
+Deletes the video file, waiting for recording to finish if necessary.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/video.ts`)
+
+### `Video.path()`
+Returns the recorded video's filesystem path.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/video.ts`)
+
+### `Video.saveAs(path)`
+Saves the video to a user-specified destination path.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/video.ts`)
+
+---
+
+## Clock
+
+Controls fake time and timer progression for an entire browser context.
+
+### `Clock.fastForward(ticks)`
+Advances the clock by the specified duration and fires due timers at most once.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.install(options)`
+Installs fake implementations for time-related APIs in the browser context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.pauseAt(time)`
+Advances the clock to the specified time and pauses further automatic progression.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.resume()`
+Resumes normal timer execution after the clock has been paused.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.runFor(ticks)`
+Advances the clock while firing all scheduled time-related callbacks.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.setFixedTime(time)`
+Makes `Date.now()` and `new Date()` return a fixed fake time while timers continue running.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+### `Clock.setSystemTime(time)`
+Sets system time without triggering timers.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/clock.ts`)
+
+---
+
+## Coverage
+
+Collects JavaScript and CSS coverage information on Chromium-based browsers.
+
+### `Coverage.startCSSCoverage(options)`
+Starts CSS coverage collection.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/coverage.ts`)
+
+### `Coverage.startJSCoverage(options)`
+Starts JavaScript coverage collection.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/coverage.ts`)
+
+### `Coverage.stopCSSCoverage()`
+Stops CSS coverage collection and returns stylesheet coverage data.
+**Returns:** `Promise<Array<{...}>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/coverage.ts`)
+
+### `Coverage.stopJSCoverage()`
+Stops JavaScript coverage collection and returns script coverage data.
+**Returns:** `Promise<Array<{...}>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/coverage.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| Selectors | 2 | 2 |
+| Touchscreen | 1 | 1 |
+| Tracing | 8 | 8 |
+| Video | 3 | 3 |
+| Clock | 7 | 7 |
+| Coverage | 4 | 4 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.
+
+---
+
+## BrowserType
+
+Launches new browser instances or connects to existing ones for a specific engine.
+
+### `BrowserType.connectOverCDP(endpointURL, options)`
+Attaches Playwright to an existing Chromium-based browser over the Chrome DevTools Protocol.
+**Returns:** `Promise<Browser>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.connect(wsEndpoint, options)`
+Attaches Playwright to an existing browser launched by `launchServer()`.
+**Returns:** `Promise<Browser>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.executablePath()`
+Returns the path where Playwright expects the bundled browser executable.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.launch(options)`
+Launches a new browser process.
+**Returns:** `Promise<Browser>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.launchPersistentContext(userDataDir, options)`
+Launches a browser with persistent storage and returns its only context.
+**Returns:** `Promise<BrowserContext>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.launchServer(options)`
+Launches a browser server that accepts later Playwright connections.
+**Returns:** `Promise<BrowserServer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `BrowserType.name()`
+Returns the browser engine name, such as `chromium`, `webkit`, or `firefox`.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+---
+
+## CDPSession
+
+Provides raw access to the Chrome DevTools Protocol for a specific target.
+
+### `CDPSession.on(event, listener)`
+Adds a CDP event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.addListener(event, listener)`
+Adds a CDP event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.off(event, listener)`
+Removes a CDP event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.removeListener(event, listener)`
+Removes a CDP event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.once(event, listener)`
+Adds a one-time CDP event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.send(method, params)`
+Sends a raw DevTools Protocol command through the session.
+**Returns:** `Promise<Protocol.CommandReturnValues[T]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.prependListener(event, listener)`
+Adds a CDP event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+### `CDPSession.detach()`
+Detaches the session from its target.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/cdpSession.ts`)
+
+---
+
+## ElectronApplication
+
+Controls an Electron application process and its windows.
+
+### `ElectronApplication.evaluate(pageFunction, arg)`
+Evaluates a function in the Electron main process and returns its value.
+**Returns:** `Promise<R>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.evaluateHandle(pageFunction, arg)`
+Evaluates a function in the Electron main process and returns its value as a `JSHandle`.
+**Returns:** `Promise<SmartHandle<R>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.on(event, listener)`
+Adds an Electron application event listener for `close`, `console`, or `window`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.once(event, listener)`
+Adds a one-time Electron application event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.addListener(event, listener)`
+Adds an Electron application event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.removeListener(event, listener)`
+Removes an Electron application event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.off(event, listener)`
+Removes an Electron application event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.prependListener(event, listener)`
+Adds an Electron application event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.browserWindow(page)`
+Returns the `BrowserWindow` object handle corresponding to a Playwright page.
+**Returns:** `Promise<JSHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.close()`
+Closes the Electron application.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.context()`
+Returns the browser context backing the Electron application.
+**Returns:** `BrowserContext`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.firstWindow(options)`
+Waits for and returns the first opened application window.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.process()`
+Returns the main process child process for the Electron application.
+**Returns:** `ChildProcess`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.waitForEvent(event, optionsOrPredicate)`
+Waits for an Electron application event and returns its payload.
+**Returns:** `Promise<void | ConsoleMessage | Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.windows()`
+Returns all currently opened application windows.
+**Returns:** `Array<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+### `ElectronApplication.[Symbol.asyncDispose]()`
+Asynchronously closes the Electron application when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+---
+
+## Electron
+
+Launches Electron applications for automation.
+
+### `Electron.launch(options)`
+Launches an Electron application and returns its controller object.
+**Returns:** `Promise<ElectronApplication>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/electron.ts`)
+
+---
+
+## Android
+
+Provides experimental Android automation entry points.
+
+### `Android.connect(endpoint, options)`
+Connects to an existing Android automation server endpoint.
+**Returns:** `Promise<AndroidDevice>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `Android.devices(options)`
+Returns the list of detected Android devices available through ADB.
+**Returns:** `Promise<Array<AndroidDevice>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `Android.launchServer(options)`
+Launches an Android automation server that clients can connect to.
+**Returns:** `Promise<BrowserServer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `Android.setDefaultTimeout(timeout)`
+Sets the default timeout for Android operations.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+---
+
+## AndroidDevice
+
+Represents a connected Android device or emulator.
+
+### `AndroidDevice.on(event, listener)`
+Adds a device event listener for `close` or `webview`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.once(event, listener)`
+Adds a one-time device event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.addListener(event, listener)`
+Adds a device event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.removeListener(event, listener)`
+Removes a device event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.off(event, listener)`
+Removes a device event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.prependListener(event, listener)`
+Adds a device event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.close()`
+Disconnects from the device.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.drag(selector, dest, options)`
+Drags the matched widget toward the specified point.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.fill(selector, text, options)`
+Fills the matched input widget with text.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.fling(selector, direction, options)`
+Performs a fast fling gesture on the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.info(selector)`
+Returns element metadata for the matched widget.
+**Returns:** `Promise<AndroidElementInfo>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.installApk(file, options)`
+Installs an APK on the device.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.launchBrowser(options)`
+Launches a browser on the device and returns its browser context.
+**Returns:** `Promise<BrowserContext>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.longTap(selector, options)`
+Performs a long tap on the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.model()`
+Returns the device model name.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.open(command)`
+Launches a shell process on the device and returns a socket for communicating with it.
+**Returns:** `Promise<AndroidSocket>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.pinchClose(selector, percent, options)`
+Performs a pinch-close gesture on the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.pinchOpen(selector, percent, options)`
+Performs a pinch-open gesture on the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.press(selector, key, options)`
+Presses a key in the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.push(file, path, options)`
+Copies a file or buffer to a path on the device.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.screenshot(options)`
+Captures a screenshot of the device.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.scroll(selector, direction, percent, options)`
+Scrolls the matched widget in the specified direction.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.serial()`
+Returns the device serial number.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.setDefaultTimeout(timeout)`
+Sets the default timeout for device operations.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.shell(command)`
+Executes a shell command on the device and returns its output.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.swipe(selector, direction, percent, options)`
+Swipes the matched widget in the specified direction.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.tap(selector, options)`
+Taps the matched widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.wait(selector, options)`
+Waits for the matched widget to appear or disappear.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.waitForEvent(event, optionsOrPredicate)`
+Waits for a device event and returns its payload.
+**Returns:** `Promise<AndroidDevice | AndroidWebView>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.webView(selector, options)`
+Waits for and returns an Android WebView matching the selector.
+**Returns:** `Promise<AndroidWebView>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.webViews()`
+Returns all currently open WebViews.
+**Returns:** `Array<AndroidWebView>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.input`
+Exposes low-level input primitives for the device.
+**Returns:** `AndroidInput`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidDevice.[Symbol.asyncDispose]()`
+Asynchronously closes the device when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+---
+
+## AndroidInput
+
+Provides low-level input primitives for an Android device.
+
+### `AndroidInput.drag(from, to, steps)`
+Performs a drag gesture between two points.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidInput.press(key)`
+Presses the specified Android key.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidInput.swipe(from, segments, steps)`
+Performs a swipe gesture following the specified path segments.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidInput.tap(point)`
+Taps the specified point on the device screen.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidInput.type(text)`
+Types text into the currently focused widget.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+---
+
+## AndroidSocket
+
+Represents a socket connected to a process running on the Android device.
+
+### `AndroidSocket.on(event, listener)`
+Adds a socket event listener for `close` or `data`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.once(event, listener)`
+Adds a one-time socket event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.addListener(event, listener)`
+Adds a socket event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.removeListener(event, listener)`
+Removes a socket event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.off(event, listener)`
+Removes a socket event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.prependListener(event, listener)`
+Adds a socket event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.close()`
+Closes the socket.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.write(data)`
+Writes data to the socket.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidSocket.[Symbol.asyncDispose]()`
+Asynchronously closes the socket when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+---
+
+## AndroidWebView
+
+Represents an inspectable WebView exposed by an Android application.
+
+### `AndroidWebView.on(event, listener)`
+Adds a WebView close-event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.once(event, listener)`
+Adds a one-time WebView close-event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.addListener(event, listener)`
+Adds a WebView close-event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.removeListener(event, listener)`
+Removes a WebView close-event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.off(event, listener)`
+Removes a WebView close-event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.prependListener(event, listener)`
+Adds a WebView close-event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.page()`
+Connects to the WebView and returns a Playwright page for interacting with it.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.pid()`
+Returns the WebView process identifier.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+### `AndroidWebView.pkg()`
+Returns the WebView package identifier.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/android.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| BrowserType | 7 | 10 |
+| CDPSession | 8 | 19 |
+| ElectronApplication | 16 | 32 |
+| Electron | 1 | 1 |
+| Android | 4 | 4 |
+| AndroidDevice | 33 | 40 |
+| AndroidInput | 5 | 5 |
+| AndroidSocket | 9 | 15 |
+| AndroidWebView | 9 | 9 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.
+
+---
+
+## FrameLocator
+
+Enters iframe contexts and creates locators scoped inside them.
+
+### `FrameLocator.first()`
+Returns a frame locator for the first matching frame.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+**Deprecated:** use `locator.first().contentFrame()` instead.
+
+### `FrameLocator.frameLocator(selector)`
+Creates a child frame locator inside the current frame locator.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByAltText(text, options)`
+Locates elements inside the frame by alt text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByLabel(text, options)`
+Locates form controls inside the frame by associated label text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByPlaceholder(text, options)`
+Locates input elements inside the frame by placeholder text.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByRole(role, options)`
+Locates elements inside the frame by ARIA role, name, and related attributes.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByTestId(testId)`
+Locates elements inside the frame by test id.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByText(text, options)`
+Locates elements inside the frame by text content.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.getByTitle(text, options)`
+Locates elements inside the frame by title attribute.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.last()`
+Returns a frame locator for the last matching frame.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+**Deprecated:** use `locator.last().contentFrame()` instead.
+
+### `FrameLocator.locator(selectorOrLocator, options)`
+Creates a locator for an element inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+### `FrameLocator.nth(index)`
+Returns a frame locator for the n-th matching frame.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+**Deprecated:** use `locator.nth(index).contentFrame()` instead.
+
+### `FrameLocator.owner()`
+Returns a locator pointing to the same `iframe` element as this frame locator.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/locator.ts`)
+
+---
+
+## APIRequest
+
+Creates standalone API request contexts for Web API testing.
+
+### `APIRequest.newContext(options)`
+Creates a new `APIRequestContext` instance with its own request configuration and cookie storage.
+**Returns:** `Promise<APIRequestContext>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/fetch.ts`)
+
+---
+
+## BrowserServer
+
+Represents a running browser server launched for later Playwright connections.
+
+### `BrowserServer.on(event, listener)`
+Adds a browser server event listener for `close`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.once(event, listener)`
+Adds a one-time browser server event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.addListener(event, listener)`
+Adds a browser server event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.removeListener(event, listener)`
+Removes a browser server event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.off(event, listener)`
+Removes a browser server event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.prependListener(event, listener)`
+Adds a browser server event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.close()`
+Closes the browser gracefully and terminates its process.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.kill()`
+Kills the browser process and waits for it to exit.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.process()`
+Returns the spawned browser process.
+**Returns:** `ChildProcess`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.wsEndpoint()`
+Returns the browser WebSocket endpoint for `browserType.connect()`.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+### `BrowserServer.[Symbol.asyncDispose]()`
+Asynchronously closes the browser server when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/server/browser.ts`)
+
+---
+
+## WebSocketRoute
+
+Intercepts and controls a routed WebSocket connection.
+
+### `WebSocketRoute.onMessage(handler)`
+Registers a handler for messages on this side of the WebSocket route.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.onClose(handler)`
+Registers a handler for WebSocket close events on this side of the route.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.close(options)`
+Closes one side of the WebSocket connection.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.connectToServer()`
+Connects the routed WebSocket to the actual server and returns the server-side route.
+**Returns:** `WebSocketRoute`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.protocols()`
+Returns the subprotocols requested by the page.
+**Returns:** `Array<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.send(message)`
+Sends a message to the page or the server, depending on which side this route represents.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.url()`
+Returns the WebSocket URL created in the page.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `WebSocketRoute.[Symbol.asyncDispose]()`
+Asynchronously closes the WebSocket route when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## WebError
+
+Represents an unhandled exception thrown in a page.
+
+### `WebError.error()`
+Returns the unhandled error that was thrown.
+**Returns:** `Error`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webError.ts`)
+
+### `WebError.location()`
+Returns the source location of the unhandled error.
+**Returns:** `{ url: string, line: number, column: number }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webError.ts`)
+
+### `WebError.page()`
+Returns the page that produced the unhandled exception, if any.
+**Returns:** `null | Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webError.ts`)
+
+---
+
+## Screencast
+
+Captures screencast output and manages recording overlays and annotations.
+
+### `Screencast.start(options)`
+Starts the screencast and optionally records video or delivers frames to a callback.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.hideActions()`
+Removes action decorations from the screencast.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.hideOverlays()`
+Hides overlays without removing them.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.showActions(options)`
+Enables visual annotations on interacted elements and returns a disposable that disables them.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.showChapter(title, options)`
+Shows a chapter overlay with a title and optional description.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.showOverlay(html, options)`
+Adds an overlay with the given HTML content and returns a disposable that removes it.
+**Returns:** `Promise<Disposable>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.showOverlays()`
+Shows previously hidden overlays.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+### `Screencast.stop()`
+Stops the screencast and saves the video if recording was active.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/screencast.ts`)
+
+---
+
+## Debugger
+
+Controls Playwright debugger pause, resume, and stepping behavior.
+
+### `Debugger.on(event, listener)`
+Adds a debugger event listener for `pausedstatechanged`.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.once(event, listener)`
+Adds a one-time debugger event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.addListener(event, listener)`
+Adds a debugger event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.removeListener(event, listener)`
+Removes a debugger event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.off(event, listener)`
+Removes a debugger event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.prependListener(event, listener)`
+Adds a debugger event listener at the beginning of the listener list.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.next()`
+Resumes execution and pauses again before the next action.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.pausedDetails()`
+Returns details about the current paused call, or `null` if the debugger is not paused.
+**Returns:** `null | { location: { file: string, line?: number, column?: number }, title: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.requestPause()`
+Configures the debugger to pause before the next action is executed.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.resume()`
+Resumes script execution.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+### `Debugger.runTo(location)`
+Resumes execution and pauses when an action originates from the specified source location.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/debugger.ts`)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| FrameLocator | 13 | 13 |
+| APIRequest | 1 | 1 |
+| BrowserServer | 11 | 11 |
+| WebSocketRoute | 8 | 8 |
+| WebError | 3 | 3 |
+| Screencast | 8 | 8 |
+| Debugger | 11 | 11 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.
+
+---
+
+## ConnectOverCDPTransport
+
+Defines a custom transport used when connecting over Chrome DevTools Protocol.
+
+### `ConnectOverCDPTransport.open()`
+Optionally opens and initializes the transport.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPTransport.send(message)`
+Sends a protocol message through the transport.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPTransport.close()`
+Closes the transport.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPTransport.onmessage`
+Callback invoked when a protocol message is received.
+**Returns:** `((message: object) => void) | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPTransport.onclose`
+Callback invoked when the transport closes.
+**Returns:** `((reason?: string) => void) | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+---
+
+## Credentials
+
+Manages virtual WebAuthn credentials scoped to a browser context.
+
+### `Credentials.create(rpId, options)`
+Seeds a virtual WebAuthn credential and returns it.
+**Returns:** `Promise<{ id: string, rpId: string, userHandle: string, privateKey: string, publicKey: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/credentials.ts`)
+
+### `Credentials.delete(id)`
+Removes a credential from the authenticator by credential id.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/credentials.ts`)
+
+### `Credentials.get(options)`
+Returns the credentials currently held by the authenticator, optionally filtered.
+**Returns:** `Promise<Array<{ id: string, rpId: string, userHandle: string, privateKey: string, publicKey: string }>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/credentials.ts`)
+
+### `Credentials.install()`
+Installs the virtual WebAuthn authenticator into the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/credentials.ts`)
+
+---
+
+## Disposable
+
+Represents a reversible resource that can be removed or undone later.
+
+### `Disposable.dispose()`
+Removes the associated resource.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/disposable.ts`)
+
+### `Disposable.[Symbol.asyncDispose]()`
+Asynchronously disposes the resource when used with `await using`.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/disposable.ts`)
+
+---
+
+## Logger
+
+Defines a pluggable sink for Playwright log output.
+
+### `Logger.isEnabled(name, severity)`
+Determines whether the sink is interested in a logger name and severity.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Logger.log(name, severity, message, args, hints)`
+Receives a log entry with message arguments and optional formatting hints.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## WebStorage
+
+Exposes the page's `localStorage` or `sessionStorage` through an async API.
+
+### `WebStorage.clear()`
+Removes all items from the storage.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webStorage.ts`)
+
+### `WebStorage.getItem(name)`
+Returns the value for the given item name if present.
+**Returns:** `Promise<null | string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webStorage.ts`)
+
+### `WebStorage.items()`
+Returns all items in storage as name/value pairs.
+**Returns:** `Promise<Array<{ name: string, value: string }>>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webStorage.ts`)
+
+### `WebStorage.removeItem(name)`
+Removes the item with the given name.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webStorage.ts`)
+
+### `WebStorage.setItem(name, value)`
+Sets the value for the given item name.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/webStorage.ts`)
+
+---
+
+## LaunchOptions
+
+Option schema for `browserType.launch()`.
+
+### `LaunchOptions.args`
+Additional browser command-line arguments.
+**Returns:** `Array<string> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.artifactsDir`
+Directory where artifacts such as traces and downloads are stored.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.channel`
+Browser distribution channel to launch.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.chromiumSandbox`
+Whether Chromium sandboxing is enabled.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.downloadsPath`
+Directory where accepted downloads are saved.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.env`
+Environment variables visible to the browser process.
+**Returns:** `{ [key: string]: string | undefined } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.executablePath`
+Path to a custom browser executable.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.firefoxUserPrefs`
+Custom Firefox user preferences.
+**Returns:** `{ [key: string]: string | number | boolean } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.handleSIGHUP`
+Whether the browser closes on `SIGHUP`.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.handleSIGINT`
+Whether the browser closes on `SIGINT`.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.handleSIGTERM`
+Whether the browser closes on `SIGTERM`.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.headless`
+Whether the browser runs in headless mode.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.ignoreDefaultArgs`
+Whether to ignore Playwright's default launch arguments, or which ones to filter out.
+**Returns:** `boolean | Array<string> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.logger`
+Logger sink for Playwright logging.
+**Returns:** `Logger | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+**Deprecated:** the logs received by the logger are incomplete; use tracing instead.
+
+### `LaunchOptions.proxy`
+Network proxy settings for the browser instance.
+**Returns:** `{ server: string, bypass?: string, username?: string, password?: string } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.slowMo`
+Artificial delay applied to Playwright operations.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.timeout`
+Maximum time to wait for browser launch.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `LaunchOptions.tracesDir`
+Directory where traces are saved.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+---
+
+## ConnectOverCDPOptions
+
+Option schema for `browserType.connectOverCDP()`.
+
+### `ConnectOverCDPOptions.artifactsDir`
+Directory where browser artifacts are saved.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPOptions.endpointURL`
+Deprecated endpoint URL field; use the first argument instead.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+**Deprecated:** use the first argument instead.
+
+### `ConnectOverCDPOptions.headers`
+Additional HTTP headers sent with the connect request.
+**Returns:** `{ [key: string]: string } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPOptions.isLocal`
+Whether Playwright and the CDP server run on the same host.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPOptions.noDefaults`
+Whether Playwright skips applying its default overrides to the existing default context.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPOptions.slowMo`
+Artificial delay applied to Playwright operations.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOverCDPOptions.timeout`
+Maximum time to wait for the connection to be established.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+---
+
+## ConnectOptions
+
+Option schema for `browserType.connect()`.
+
+### `ConnectOptions.exposeNetwork`
+Rules describing which client-side network resources are exposed to the browser.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOptions.headers`
+Additional HTTP headers sent with the WebSocket connect request.
+**Returns:** `{ [key: string]: string } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOptions.slowMo`
+Artificial delay applied to Playwright operations.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+### `ConnectOptions.timeout`
+Maximum time to wait for the connection to be established.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserType.ts`)
+
+---
+
+## LocatorScreenshotOptions
+
+Option schema for `locator.screenshot()`.
+
+### `LocatorScreenshotOptions.animations`
+How CSS animations and transitions are handled during screenshot capture.
+**Returns:** `"disabled" | "allow" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.caret`
+How the text caret is handled during screenshot capture.
+**Returns:** `"hide" | "initial" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.mask`
+Locators to mask in the screenshot.
+**Returns:** `Array<Locator> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.maskColor`
+Mask overlay color.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.omitBackground`
+Whether to hide the default white background.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.path`
+Path where the screenshot image is written.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.quality`
+Image quality for lossy formats.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.scale`
+Pixel scaling mode for the screenshot.
+**Returns:** `"css" | "device" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.signal`
+Abort signal for canceling screenshot capture.
+**Returns:** `AbortSignal | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.style`
+Stylesheet text applied while taking the screenshot.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.timeout`
+Maximum time to wait for screenshot capture.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `LocatorScreenshotOptions.type`
+Screenshot image format.
+**Returns:** `"png" | "jpeg" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## BrowserContextOptions
+
+Option schema for `browser.newContext()` and related APIs.
+
+### `BrowserContextOptions.acceptDownloads`
+Whether downloads are automatically accepted.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.baseURL`
+Base URL used to resolve relative URLs.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.bypassCSP`
+Whether Content Security Policy is bypassed.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.clientCertificates`
+Client certificates used for mutual TLS authentication.
+**Returns:** `Array<object> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.colorScheme`
+Emulated `prefers-color-scheme` value.
+**Returns:** `null | "light" | "dark" | "no-preference" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.contrast`
+Emulated `prefers-contrast` value.
+**Returns:** `null | "no-preference" | "more" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.deviceScaleFactor`
+Emulated device scale factor.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.extraHTTPHeaders`
+Additional headers sent with every request.
+**Returns:** `{ [key: string]: string } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.forcedColors`
+Emulated `forced-colors` value.
+**Returns:** `null | "active" | "none" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.geolocation`
+Emulated geolocation coordinates.
+**Returns:** `Geolocation | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.hasTouch`
+Whether the viewport supports touch events.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.httpCredentials`
+HTTP authentication credentials.
+**Returns:** `HTTPCredentials | Array<HTTPCredentials> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.ignoreHTTPSErrors`
+Whether HTTPS errors are ignored.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.isMobile`
+Whether mobile emulation is enabled.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.javaScriptEnabled`
+Whether JavaScript execution is enabled.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.locale`
+Emulated user locale.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.logger`
+Logger sink for context logging.
+**Returns:** `Logger | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.offline`
+Whether network offline mode is enabled.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.permissions`
+Permissions granted to all pages in the context.
+**Returns:** `Array<string> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.pierceFrames`
+Whether selectors pierce frames by default.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.proxy`
+Network proxy settings for the context.
+**Returns:** `{ server: string, bypass?: string, username?: string, password?: string } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.recordHar`
+HAR recording configuration.
+**Returns:** `object | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.recordVideo`
+Video recording configuration.
+**Returns:** `object | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.reducedMotion`
+Emulated `prefers-reduced-motion` value.
+**Returns:** `null | "reduce" | "no-preference" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.screen`
+Emulated screen size.
+**Returns:** `{ width: number, height: number } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.serviceWorkers`
+Service worker policy for the context.
+**Returns:** `"allow" | "block" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.storageState`
+Initial storage state for cookies and local storage.
+**Returns:** `string | object | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.strictSelectors`
+Whether strict selector mode is enabled.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.timezoneId`
+Emulated timezone identifier.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.userAgent`
+Custom user agent string.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContextOptions.viewport`
+Emulated viewport size, or `null` to disable viewport emulation.
+**Returns:** `null | ViewportSize | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+---
+
+## ViewportSize
+
+Represents viewport dimensions in CSS pixels.
+
+### `ViewportSize.width`
+Viewport width in pixels.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `ViewportSize.height`
+Viewport height in pixels.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## HTTPCredentials
+
+Represents HTTP authentication credentials and send policy.
+
+### `HTTPCredentials.username`
+Authentication username.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `HTTPCredentials.password`
+Authentication password.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `HTTPCredentials.origin`
+Optional origin restriction for sending credentials.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `HTTPCredentials.send`
+Whether credentials are sent only after challenge or always.
+**Returns:** `"unauthorized" | "always" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## Geolocation
+
+Represents latitude, longitude, and optional accuracy for emulation.
+
+### `Geolocation.latitude`
+Latitude between -90 and 90.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Geolocation.longitude`
+Longitude between -180 and 180.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Geolocation.accuracy`
+Optional non-negative accuracy value.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## Cookie
+
+Represents a browser cookie in storage state and cookie APIs.
+
+### `Cookie.name`
+Cookie name.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.value`
+Cookie value.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.domain`
+Cookie domain.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.path`
+Cookie path.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.expires`
+Cookie expiration time as Unix seconds.
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.httpOnly`
+Whether the cookie is HTTP-only.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.secure`
+Whether the cookie requires a secure connection.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.sameSite`
+SameSite policy.
+**Returns:** `"Strict" | "Lax" | "None"`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `Cookie.partitionKey`
+Optional partition key for partitioned cookie storage.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## PageScreenshotOptions
+
+Option schema for `page.screenshot()`.
+
+### `PageScreenshotOptions.animations`
+How CSS animations and transitions are handled during screenshot capture.
+**Returns:** `"disabled" | "allow" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.caret`
+How the text caret is handled during screenshot capture.
+**Returns:** `"hide" | "initial" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.clip`
+Rectangular clip area for the screenshot.
+**Returns:** `{ x: number, y: number, width: number, height: number } | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.fullPage`
+Whether to capture the full scrollable page.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.mask`
+Locators to mask in the screenshot.
+**Returns:** `Array<Locator> | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.maskColor`
+Mask overlay color.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.omitBackground`
+Whether to hide the default white background.
+**Returns:** `boolean | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.path`
+Path where the screenshot image is written.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.quality`
+Image quality for lossy formats.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.scale`
+Pixel scaling mode for the screenshot.
+**Returns:** `"css" | "device" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.signal`
+Abort signal for canceling screenshot capture.
+**Returns:** `AbortSignal | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.style`
+Stylesheet text applied while taking the screenshot.
+**Returns:** `string | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.timeout`
+Maximum time to wait for screenshot capture.
+**Returns:** `number | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+### `PageScreenshotOptions.type`
+Screenshot image format.
+**Returns:** `"png" | "jpeg" | "webp" | undefined`
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## ChromiumBrowserContext
+
+Type wrapper extending `BrowserContext` without adding new members.
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## ChromiumBrowser
+
+Type wrapper extending `Browser` without adding new members.
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## FirefoxBrowser
+
+Type wrapper extending `Browser` without adding new members.
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## WebKitBrowser
+
+Type wrapper extending `Browser` without adding new members.
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+## ChromiumCoverage
+
+Type wrapper extending `Coverage` without adding new members.
+**Source:** `packages/playwright-core/types/types.d.ts` (documented from the public type schema only)
+
+---
+
+### Batch audit summary
+
+| Class | Declared members | Overload declarations |
+| --- | ---: | ---: |
+| ConnectOverCDPTransport | 5 | 5 |
+| Credentials | 4 | 4 |
+| Disposable | 2 | 2 |
+| Logger | 2 | 2 |
+| WebStorage | 5 | 5 |
+| LaunchOptions | 18 | 18 |
+| ConnectOverCDPOptions | 7 | 7 |
+| ConnectOptions | 4 | 4 |
+| LocatorScreenshotOptions | 12 | 12 |
+| BrowserContextOptions | 31 | 31 |
+| ViewportSize | 2 | 2 |
+| HTTPCredentials | 4 | 4 |
+| Geolocation | 3 | 3 |
+| Cookie | 9 | 9 |
+| PageScreenshotOptions | 14 | 14 |
+| ChromiumBrowserContext | 0 | 0 |
+| ChromiumBrowser | 0 | 0 |
+| FirefoxBrowser | 0 | 0 |
+| WebKitBrowser | 0 | 0 |
+| ChromiumCoverage | 0 | 0 |
+
+Verified against source commit `b4a646a624c0b1e8e352d320cbc6684581625ff6`.

--- a/agi-training-notes/DOCUMENTATION_GRAPH_ARCHITECTURE.md
+++ b/agi-training-notes/DOCUMENTATION_GRAPH_ARCHITECTURE.md
@@ -1,0 +1,178 @@
+# Documentation Graph and Model Access Architecture
+
+This project uses a small retrieval layer so coding questions can access precise documentation without loading the entire documentation set into model context. The same architecture is intended to support Playwright, other programming languages, and other frameworks.
+
+## 1. System overview
+
+```text
+Source documentation
+  NOTES.md · API_REFERENCE.md · examples/
+                 │
+                 ▼
+       Graphify indexer
+       tools/graphify-docs.mjs
+                 │
+                 ▼
+          DOC_GRAPH.json
+   documents · sections · topics · examples
+                 │
+                 ▼
+        Graph query / routing
+       tools/query-doc-graph.mjs
+                 │
+                 ▼
+       Targeted source excerpts
+                 │
+                 ▼
+       AGY model invocation
+       Gemini 3.7 Flash
+                 │
+                 ▼
+        Grounded coding answer
+```
+
+`DOC_GRAPH.json` is an index, not a replacement for the source documents. The source Markdown and examples remain authoritative.
+
+## 2. Graph contents
+
+The graph currently contains four node types:
+
+| Node type | Purpose |
+| --- | --- |
+| `document` | Identifies `NOTES.md` or `API_REFERENCE.md`. |
+| `section` | Stores the heading, source file, and exact line number. |
+| `topic` | Provides keyword routing for concepts and API names. |
+| `example` | Identifies a runnable example and its topic words. |
+
+Edges currently express:
+
+| Edge | Meaning |
+| --- | --- |
+| `document → contains → section` | A source document contains a section. |
+| `section → about → topic` | A section is relevant to a topic. |
+| `example → illustrates → topic` | An example demonstrates a topic. |
+
+The current index contains 1,700 nodes and 3,840 relationships across 2 documents and 38 examples (949 sections and 711 topics).
+
+## 3. Retrieval workflow
+
+For each question:
+
+1. Search the graph for matching topics.
+2. Resolve topic edges to source sections and examples.
+3. Read only the selected source ranges.
+4. Build a grounded prompt containing those excerpts and their file/line references.
+5. Ask AGY to answer with citations and to identify uncertainty.
+
+The complete documentation is used only when targeted retrieval is insufficient. A normal question should use hundreds or a few thousand tokens, not the 17–21k tokens required to load both primary documents.
+
+Example:
+
+```sh
+node tools/query-doc-graph.mjs agi-training-notes multi-tab
+```
+
+## 4. Model boundary
+
+AGY is the model-access boundary for this project. The selected model is:
+
+```text
+gemini-3.7-flash-medium
+```
+
+The graph and retrieval layer must remain model-independent. A future model can receive the same selected excerpts and source references without changing the graph format.
+
+The model must not be given the graph as a substitute for source text. The graph chooses the context; the source excerpts support the answer.
+
+## 5. Documentation API
+
+The command-line tools were the original prototype. The reusable service wrapper
+(`../doc-graph/`) now exposes the same operations:
+
+```text
+GET  /search?q=shadow+dom
+GET  /context?q=shadow+dom
+GET  /health
+```
+
+Responsibilities:
+
+```text
+/search  → graph matches and source references only
+/context → graph matches plus bounded source excerpts
+/health  → service liveness and project name
+```
+
+The API returns source file names, line numbers, selected node IDs, matched
+topics, and provenance so answers remain auditable. Model invocation is out of
+scope for the service; it returns excerpts for an external model to consume.
+
+## 6. Extending to other languages
+
+Each language or framework should have its own documentation bundle and graph, while sharing the schema and retrieval protocol:
+
+```text
+docs/
+├── playwright/
+│   ├── NOTES.md
+│   ├── API_REFERENCE.md
+│   ├── DOC_GRAPH.json
+│   └── examples/
+├── python/
+│   ├── NOTES.md
+│   ├── API_REFERENCE.md
+│   ├── DOC_GRAPH.json
+│   └── examples/
+└── rust/
+    ├── NOTES.md
+    ├── API_REFERENCE.md
+    ├── DOC_GRAPH.json
+    └── examples/
+```
+
+The shared contract is:
+
+```text
+question
+  → graph routing
+  → bounded source excerpts
+  → model answer
+  → exact references and uncertainty
+```
+
+Language-specific indexers may add richer nodes—classes, functions, modules, traits, packages, error types, or version constraints—but should preserve the common `document`, `section`, `topic`, and `example` concepts.
+
+## 7. Versioning and trust rules
+
+- Source documents are authoritative; generated graph files are rebuildable artifacts.
+- The graph must be rebuilt whenever headings or examples change.
+- API answers should include the documentation version or pinned source revision when available.
+- Examples marked documentation-only must not be presented as executable proof.
+- If the graph finds no strong match, the model must say so rather than inventing an API.
+- External web documentation is a fallback, not the first source, when local project notes exist.
+
+## 8. Rebuild commands
+
+From `agi-training-notes`:
+
+```sh
+# Prototype (retained for reference).
+node tools/graphify-docs.mjs
+node tools/query-doc-graph.mjs agi-training-notes <topic words>
+
+# Reusable package (recommended).
+node ../doc-graph/bin/doc-graph.mjs build --root .
+node ../doc-graph/bin/doc-graph.mjs search <query> --root .
+node ../doc-graph/bin/doc-graph.mjs context <query> --root .
+node ../doc-graph/bin/doc-graph.mjs serve --root . --port 8080
+```
+
+## 9. Reusable package
+
+The indexer, query engine, CLI, and HTTP API are extracted into `../doc-graph/`,
+a dependency-free, model-independent Node package. Projects opt in with a
+`doc-graph.config.json` that declares document globs, example globs, a project
+name, and an output path, so a project with a different documentation layout
+indexes without source changes. A minimal second-project fixture lives at
+`../doc-graph/test/fixtures/second-project/`. Generated graphs remain
+rebuildable artifacts, kept separate from source documentation.

--- a/agi-training-notes/DOC_GRAPH.json
+++ b/agi-training-notes/DOC_GRAPH.json
@@ -1,0 +1,31602 @@
+{
+  "schema": 2,
+  "generated_at": "2026-08-23T17:17:36.602Z",
+  "project": "playwright",
+  "pinned_commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+  "pinned_commit_date": "2026-08-06",
+  "source": "NOTES.md, API_REFERENCE.md, examples/*.js",
+  "source_documents": [
+    {
+      "file": "API_REFERENCE.md",
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "file": "NOTES.md",
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    }
+  ],
+  "source_examples": [
+    "examples/01-launch-browser.js",
+    "examples/02-context-and-page.js",
+    "examples/03-locator-basics.js",
+    "examples/04-network-interception.js",
+    "examples/05-codegen-invocation.js",
+    "examples/06-codegen-language-targets.js",
+    "examples/07-codegen-selector-scoring.js",
+    "examples/08-codegen-storage-and-session.js",
+    "examples/09-test-runner-and-config.js",
+    "examples/10-fixtures-and-dependency-graph.js",
+    "examples/11-reporters-and-events.js",
+    "examples/12-tracing.js",
+    "examples/13-frames-and-oopif.js",
+    "examples/14-downloads-and-dialogs.js",
+    "examples/15-api-testing.js",
+    "examples/16-page-load-and-lifecycle.js",
+    "examples/17-multi-tab-and-pages.js",
+    "examples/18-targeted-network-interception.js",
+    "examples/19-browser-side-polling.js",
+    "examples/20-network-stubbing.js",
+    "examples/21-click-and-retry-loop.js",
+    "examples/22-video-recording-pipeline.js",
+    "examples/23-environmental-settings.js",
+    "examples/24-stability-and-opacity.js",
+    "examples/25-video-cursor-overlay.js",
+    "examples/26-automation-detection.js",
+    "examples/27-custom-selector-engines.js",
+    "examples/28-slowmo-dispatcher-delay.js",
+    "examples/29-emulation-scope.js",
+    "examples/30-screenshot-masking.js",
+    "examples/31-accessibility-tree.js",
+    "examples/32-worker-websocket-hooks.js",
+    "examples/33-cdp-session-access.js",
+    "examples/34-code-coverage.js",
+    "examples/35-automation-evasion-initscript.js",
+    "examples/36-video-fragmentation.js",
+    "examples/37-tracing-tab-correlation.js",
+    "examples/38-programmatic-pause.js"
+  ],
+  "nodes": [
+    {
+      "id": "doc:API_REFERENCE.md",
+      "type": "document",
+      "file": "API_REFERENCE.md",
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1",
+      "type": "section",
+      "title": "Playwright-Core & Codegen API Reference",
+      "file": "API_REFERENCE.md",
+      "line": 1,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:playwright-core",
+      "type": "topic",
+      "name": "playwright-core"
+    },
+    {
+      "id": "topic:codegen",
+      "type": "topic",
+      "name": "codegen"
+    },
+    {
+      "id": "topic:api",
+      "type": "topic",
+      "name": "api"
+    },
+    {
+      "id": "topic:reference",
+      "type": "topic",
+      "name": "reference"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#24",
+      "type": "section",
+      "title": "`ClassName.methodName(args)`",
+      "file": "API_REFERENCE.md",
+      "line": 24,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:classname",
+      "type": "topic",
+      "name": "classname"
+    },
+    {
+      "id": "topic:methodname",
+      "type": "topic",
+      "name": "methodname"
+    },
+    {
+      "id": "topic:args",
+      "type": "topic",
+      "name": "args"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#33",
+      "type": "section",
+      "title": "Page",
+      "file": "API_REFERENCE.md",
+      "line": 33,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:page",
+      "type": "topic",
+      "name": "page"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#35",
+      "type": "section",
+      "title": "Navigation",
+      "file": "API_REFERENCE.md",
+      "line": 35,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:navigation",
+      "type": "topic",
+      "name": "navigation"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#37",
+      "type": "section",
+      "title": "`Page.goBack(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 37,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:goback",
+      "type": "topic",
+      "name": "goback"
+    },
+    {
+      "id": "topic:options",
+      "type": "topic",
+      "name": "options"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#42",
+      "type": "section",
+      "title": "`Page.goForward(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 42,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:goforward",
+      "type": "topic",
+      "name": "goforward"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#47",
+      "type": "section",
+      "title": "`Page.goto(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 47,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:goto",
+      "type": "topic",
+      "name": "goto"
+    },
+    {
+      "id": "topic:url",
+      "type": "topic",
+      "name": "url"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#52",
+      "type": "section",
+      "title": "`Page.reload(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 52,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:reload",
+      "type": "topic",
+      "name": "reload"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#57",
+      "type": "section",
+      "title": "`Page.setContent(html, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 57,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setcontent",
+      "type": "topic",
+      "name": "setcontent"
+    },
+    {
+      "id": "topic:html",
+      "type": "topic",
+      "name": "html"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#62",
+      "type": "section",
+      "title": "Waiting & Delays",
+      "file": "API_REFERENCE.md",
+      "line": 62,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waiting",
+      "type": "topic",
+      "name": "waiting"
+    },
+    {
+      "id": "topic:delays",
+      "type": "topic",
+      "name": "delays"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#64",
+      "type": "section",
+      "title": "`Page.waitForLoadState(state, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 64,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforloadstate",
+      "type": "topic",
+      "name": "waitforloadstate"
+    },
+    {
+      "id": "topic:state",
+      "type": "topic",
+      "name": "state"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#69",
+      "type": "section",
+      "title": "`Page.waitForNavigation(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 69,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitfornavigation",
+      "type": "topic",
+      "name": "waitfornavigation"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#75",
+      "type": "section",
+      "title": "`Page.waitForRequest(urlOrPredicate, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 75,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforrequest",
+      "type": "topic",
+      "name": "waitforrequest"
+    },
+    {
+      "id": "topic:urlorpredicate",
+      "type": "topic",
+      "name": "urlorpredicate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#80",
+      "type": "section",
+      "title": "`Page.waitForResponse(urlOrPredicate, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 80,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforresponse",
+      "type": "topic",
+      "name": "waitforresponse"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#85",
+      "type": "section",
+      "title": "`Page.waitForTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 85,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitfortimeout",
+      "type": "topic",
+      "name": "waitfortimeout"
+    },
+    {
+      "id": "topic:timeout",
+      "type": "topic",
+      "name": "timeout"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#91",
+      "type": "section",
+      "title": "`Page.waitForURL(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 91,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforurl",
+      "type": "topic",
+      "name": "waitforurl"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#96",
+      "type": "section",
+      "title": "`Page.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 96,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforevent",
+      "type": "topic",
+      "name": "waitforevent"
+    },
+    {
+      "id": "topic:event",
+      "type": "topic",
+      "name": "event"
+    },
+    {
+      "id": "topic:optionsorpredicate",
+      "type": "topic",
+      "name": "optionsorpredicate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#101",
+      "type": "section",
+      "title": "Locators & Element Queries",
+      "file": "API_REFERENCE.md",
+      "line": 101,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:locators",
+      "type": "topic",
+      "name": "locators"
+    },
+    {
+      "id": "topic:element",
+      "type": "topic",
+      "name": "element"
+    },
+    {
+      "id": "topic:queries",
+      "type": "topic",
+      "name": "queries"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#103",
+      "type": "section",
+      "title": "`Page.locator(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 103,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:locator",
+      "type": "topic",
+      "name": "locator"
+    },
+    {
+      "id": "topic:selector",
+      "type": "topic",
+      "name": "selector"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#108",
+      "type": "section",
+      "title": "`Page.getByAltText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 108,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbyalttext",
+      "type": "topic",
+      "name": "getbyalttext"
+    },
+    {
+      "id": "topic:text",
+      "type": "topic",
+      "name": "text"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#113",
+      "type": "section",
+      "title": "`Page.getByLabel(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 113,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbylabel",
+      "type": "topic",
+      "name": "getbylabel"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#118",
+      "type": "section",
+      "title": "`Page.getByPlaceholder(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 118,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbyplaceholder",
+      "type": "topic",
+      "name": "getbyplaceholder"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#123",
+      "type": "section",
+      "title": "`Page.getByRole(role, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 123,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbyrole",
+      "type": "topic",
+      "name": "getbyrole"
+    },
+    {
+      "id": "topic:role",
+      "type": "topic",
+      "name": "role"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#128",
+      "type": "section",
+      "title": "`Page.getByTestId(testId)`",
+      "file": "API_REFERENCE.md",
+      "line": 128,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbytestid",
+      "type": "topic",
+      "name": "getbytestid"
+    },
+    {
+      "id": "topic:testid",
+      "type": "topic",
+      "name": "testid"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#133",
+      "type": "section",
+      "title": "`Page.getByText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 133,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbytext",
+      "type": "topic",
+      "name": "getbytext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#138",
+      "type": "section",
+      "title": "`Page.getByTitle(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 138,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getbytitle",
+      "type": "topic",
+      "name": "getbytitle"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#143",
+      "type": "section",
+      "title": "`Page.frameLocator(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 143,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:framelocator",
+      "type": "topic",
+      "name": "framelocator"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#148",
+      "type": "section",
+      "title": "`Page.pierceFrames(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 148,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pierceframes",
+      "type": "topic",
+      "name": "pierceframes"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#153",
+      "type": "section",
+      "title": "`Page.pickLocator()`",
+      "file": "API_REFERENCE.md",
+      "line": 153,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:picklocator",
+      "type": "topic",
+      "name": "picklocator"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#158",
+      "type": "section",
+      "title": "`Page.cancelPickLocator()`",
+      "file": "API_REFERENCE.md",
+      "line": 158,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cancelpicklocator",
+      "type": "topic",
+      "name": "cancelpicklocator"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#163",
+      "type": "section",
+      "title": "`Page.$(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 163,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#168",
+      "type": "section",
+      "title": "`Page.$$(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 168,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#173",
+      "type": "section",
+      "title": "Interactivity (Page-Level UI Actions)",
+      "file": "API_REFERENCE.md",
+      "line": 173,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:interactivity",
+      "type": "topic",
+      "name": "interactivity"
+    },
+    {
+      "id": "topic:page-level",
+      "type": "topic",
+      "name": "page-level"
+    },
+    {
+      "id": "topic:actions",
+      "type": "topic",
+      "name": "actions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#175",
+      "type": "section",
+      "title": "`Page.check(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 175,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:check",
+      "type": "topic",
+      "name": "check"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#180",
+      "type": "section",
+      "title": "`Page.click(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 180,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:click",
+      "type": "topic",
+      "name": "click"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#185",
+      "type": "section",
+      "title": "`Page.dblclick(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 185,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dblclick",
+      "type": "topic",
+      "name": "dblclick"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#190",
+      "type": "section",
+      "title": "`Page.dispatchEvent(selector, type, eventInit, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 190,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dispatchevent",
+      "type": "topic",
+      "name": "dispatchevent"
+    },
+    {
+      "id": "topic:type",
+      "type": "topic",
+      "name": "type"
+    },
+    {
+      "id": "topic:eventinit",
+      "type": "topic",
+      "name": "eventinit"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#195",
+      "type": "section",
+      "title": "`Page.dragAndDrop(source, target, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 195,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:draganddrop",
+      "type": "topic",
+      "name": "draganddrop"
+    },
+    {
+      "id": "topic:source",
+      "type": "topic",
+      "name": "source"
+    },
+    {
+      "id": "topic:target",
+      "type": "topic",
+      "name": "target"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#200",
+      "type": "section",
+      "title": "`Page.fill(selector, value, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 200,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fill",
+      "type": "topic",
+      "name": "fill"
+    },
+    {
+      "id": "topic:value",
+      "type": "topic",
+      "name": "value"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#205",
+      "type": "section",
+      "title": "`Page.setInputFiles(selector, files, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 205,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setinputfiles",
+      "type": "topic",
+      "name": "setinputfiles"
+    },
+    {
+      "id": "topic:files",
+      "type": "topic",
+      "name": "files"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#210",
+      "type": "section",
+      "title": "`Page.focus(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 210,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:focus",
+      "type": "topic",
+      "name": "focus"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#215",
+      "type": "section",
+      "title": "`Page.getAttribute(selector, name, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 215,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getattribute",
+      "type": "topic",
+      "name": "getattribute"
+    },
+    {
+      "id": "topic:name",
+      "type": "topic",
+      "name": "name"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#220",
+      "type": "section",
+      "title": "`Page.hover(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 220,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hover",
+      "type": "topic",
+      "name": "hover"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#225",
+      "type": "section",
+      "title": "`Page.innerHTML(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 225,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:innerhtml",
+      "type": "topic",
+      "name": "innerhtml"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#230",
+      "type": "section",
+      "title": "`Page.innerText(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 230,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:innertext",
+      "type": "topic",
+      "name": "innertext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#235",
+      "type": "section",
+      "title": "`Page.inputValue(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 235,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:inputvalue",
+      "type": "topic",
+      "name": "inputvalue"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#240",
+      "type": "section",
+      "title": "`Page.isChecked(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 240,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ischecked",
+      "type": "topic",
+      "name": "ischecked"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#245",
+      "type": "section",
+      "title": "`Page.isDisabled(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 245,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isdisabled",
+      "type": "topic",
+      "name": "isdisabled"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#250",
+      "type": "section",
+      "title": "`Page.isEditable(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 250,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:iseditable",
+      "type": "topic",
+      "name": "iseditable"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#255",
+      "type": "section",
+      "title": "`Page.isEnabled(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 255,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isenabled",
+      "type": "topic",
+      "name": "isenabled"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#260",
+      "type": "section",
+      "title": "`Page.isHidden(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 260,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ishidden",
+      "type": "topic",
+      "name": "ishidden"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#265",
+      "type": "section",
+      "title": "`Page.isVisible(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 265,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isvisible",
+      "type": "topic",
+      "name": "isvisible"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#270",
+      "type": "section",
+      "title": "`Page.press(selector, key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 270,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:press",
+      "type": "topic",
+      "name": "press"
+    },
+    {
+      "id": "topic:key",
+      "type": "topic",
+      "name": "key"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#275",
+      "type": "section",
+      "title": "`Page.selectOption(selector, values, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 275,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:selectoption",
+      "type": "topic",
+      "name": "selectoption"
+    },
+    {
+      "id": "topic:values",
+      "type": "topic",
+      "name": "values"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#280",
+      "type": "section",
+      "title": "`Page.setChecked(selector, checked, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 280,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setchecked",
+      "type": "topic",
+      "name": "setchecked"
+    },
+    {
+      "id": "topic:checked",
+      "type": "topic",
+      "name": "checked"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#285",
+      "type": "section",
+      "title": "`Page.tap(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 285,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:tap",
+      "type": "topic",
+      "name": "tap"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#290",
+      "type": "section",
+      "title": "`Page.textContent(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 290,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:textcontent",
+      "type": "topic",
+      "name": "textcontent"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#295",
+      "type": "section",
+      "title": "`Page.type(selector, text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 295,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#301",
+      "type": "section",
+      "title": "`Page.uncheck(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 301,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:uncheck",
+      "type": "topic",
+      "name": "uncheck"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#306",
+      "type": "section",
+      "title": "`Page.waitForSelector(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 306,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforselector",
+      "type": "topic",
+      "name": "waitforselector"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#311",
+      "type": "section",
+      "title": "`Page.waitForFunction(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 311,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforfunction",
+      "type": "topic",
+      "name": "waitforfunction"
+    },
+    {
+      "id": "topic:pagefunction",
+      "type": "topic",
+      "name": "pagefunction"
+    },
+    {
+      "id": "topic:arg",
+      "type": "topic",
+      "name": "arg"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#316",
+      "type": "section",
+      "title": "Routing & Network",
+      "file": "API_REFERENCE.md",
+      "line": 316,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:routing",
+      "type": "topic",
+      "name": "routing"
+    },
+    {
+      "id": "topic:network",
+      "type": "topic",
+      "name": "network"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#318",
+      "type": "section",
+      "title": "`Page.route(url, handler, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 318,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:route",
+      "type": "topic",
+      "name": "route"
+    },
+    {
+      "id": "topic:handler",
+      "type": "topic",
+      "name": "handler"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#323",
+      "type": "section",
+      "title": "`Page.requests()`",
+      "file": "API_REFERENCE.md",
+      "line": 323,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:requests",
+      "type": "topic",
+      "name": "requests"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#328",
+      "type": "section",
+      "title": "`Page.routeFromHAR(har, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 328,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:routefromhar",
+      "type": "topic",
+      "name": "routefromhar"
+    },
+    {
+      "id": "topic:har",
+      "type": "topic",
+      "name": "har"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#333",
+      "type": "section",
+      "title": "`Page.routeWebSocket(url, handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 333,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:routewebsocket",
+      "type": "topic",
+      "name": "routewebsocket"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#338",
+      "type": "section",
+      "title": "`Page.unroute(url, handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 338,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:unroute",
+      "type": "topic",
+      "name": "unroute"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#343",
+      "type": "section",
+      "title": "`Page.unrouteAll(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 343,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:unrouteall",
+      "type": "topic",
+      "name": "unrouteall"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#348",
+      "type": "section",
+      "title": "`Page.setExtraHTTPHeaders(headers)`",
+      "file": "API_REFERENCE.md",
+      "line": 348,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setextrahttpheaders",
+      "type": "topic",
+      "name": "setextrahttpheaders"
+    },
+    {
+      "id": "topic:headers",
+      "type": "topic",
+      "name": "headers"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#353",
+      "type": "section",
+      "title": "Events & Event Listeners",
+      "file": "API_REFERENCE.md",
+      "line": 353,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:events",
+      "type": "topic",
+      "name": "events"
+    },
+    {
+      "id": "topic:listeners",
+      "type": "topic",
+      "name": "listeners"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#355",
+      "type": "section",
+      "title": "`Page.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 355,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:listener",
+      "type": "topic",
+      "name": "listener"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#360",
+      "type": "section",
+      "title": "`Page.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 360,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:once",
+      "type": "topic",
+      "name": "once"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#365",
+      "type": "section",
+      "title": "`Page.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 365,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:off",
+      "type": "topic",
+      "name": "off"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#370",
+      "type": "section",
+      "title": "`Page.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 370,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addlistener",
+      "type": "topic",
+      "name": "addlistener"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#375",
+      "type": "section",
+      "title": "`Page.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 375,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:removelistener",
+      "type": "topic",
+      "name": "removelistener"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#380",
+      "type": "section",
+      "title": "`Page.removeAllListeners(type, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 380,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:removealllisteners",
+      "type": "topic",
+      "name": "removealllisteners"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#385",
+      "type": "section",
+      "title": "`Page.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 385,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:prependlistener",
+      "type": "topic",
+      "name": "prependlistener"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#390",
+      "type": "section",
+      "title": "Scripts & Evaluation",
+      "file": "API_REFERENCE.md",
+      "line": 390,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:scripts",
+      "type": "topic",
+      "name": "scripts"
+    },
+    {
+      "id": "topic:evaluation",
+      "type": "topic",
+      "name": "evaluation"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#392",
+      "type": "section",
+      "title": "`Page.$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 392,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:eval",
+      "type": "topic",
+      "name": "eval"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#397",
+      "type": "section",
+      "title": "`Page.$$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 397,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#402",
+      "type": "section",
+      "title": "`Page.addInitScript(script, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 402,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addinitscript",
+      "type": "topic",
+      "name": "addinitscript"
+    },
+    {
+      "id": "topic:script",
+      "type": "topic",
+      "name": "script"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#407",
+      "type": "section",
+      "title": "`Page.addScriptTag(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 407,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addscripttag",
+      "type": "topic",
+      "name": "addscripttag"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#412",
+      "type": "section",
+      "title": "`Page.addStyleTag(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 412,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addstyletag",
+      "type": "topic",
+      "name": "addstyletag"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#417",
+      "type": "section",
+      "title": "`Page.evaluate(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 417,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:evaluate",
+      "type": "topic",
+      "name": "evaluate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#422",
+      "type": "section",
+      "title": "`Page.evaluateHandle(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 422,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:evaluatehandle",
+      "type": "topic",
+      "name": "evaluatehandle"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#427",
+      "type": "section",
+      "title": "`Page.exposeBinding(name, callback)`",
+      "file": "API_REFERENCE.md",
+      "line": 427,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:exposebinding",
+      "type": "topic",
+      "name": "exposebinding"
+    },
+    {
+      "id": "topic:callback",
+      "type": "topic",
+      "name": "callback"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#432",
+      "type": "section",
+      "title": "`Page.exposeFunction(name, callback)`",
+      "file": "API_REFERENCE.md",
+      "line": 432,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:exposefunction",
+      "type": "topic",
+      "name": "exposefunction"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#437",
+      "type": "section",
+      "title": "`Page.addLocatorHandler(locator, handler, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 437,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addlocatorhandler",
+      "type": "topic",
+      "name": "addlocatorhandler"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#442",
+      "type": "section",
+      "title": "`Page.removeLocatorHandler(locator)`",
+      "file": "API_REFERENCE.md",
+      "line": 442,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:removelocatorhandler",
+      "type": "topic",
+      "name": "removelocatorhandler"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#447",
+      "type": "section",
+      "title": "Emulation & Configuration",
+      "file": "API_REFERENCE.md",
+      "line": 447,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:emulation",
+      "type": "topic",
+      "name": "emulation"
+    },
+    {
+      "id": "topic:configuration",
+      "type": "topic",
+      "name": "configuration"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#449",
+      "type": "section",
+      "title": "`Page.emulateMedia(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 449,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:emulatemedia",
+      "type": "topic",
+      "name": "emulatemedia"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#454",
+      "type": "section",
+      "title": "`Page.setDefaultNavigationTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 454,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setdefaultnavigationtimeout",
+      "type": "topic",
+      "name": "setdefaultnavigationtimeout"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#459",
+      "type": "section",
+      "title": "`Page.setDefaultTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 459,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setdefaulttimeout",
+      "type": "topic",
+      "name": "setdefaulttimeout"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#464",
+      "type": "section",
+      "title": "`Page.setViewportSize(viewportSize)`",
+      "file": "API_REFERENCE.md",
+      "line": 464,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setviewportsize",
+      "type": "topic",
+      "name": "setviewportsize"
+    },
+    {
+      "id": "topic:viewportsize",
+      "type": "topic",
+      "name": "viewportsize"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#469",
+      "type": "section",
+      "title": "Screenshots & Output",
+      "file": "API_REFERENCE.md",
+      "line": 469,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:screenshots",
+      "type": "topic",
+      "name": "screenshots"
+    },
+    {
+      "id": "topic:output",
+      "type": "topic",
+      "name": "output"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#471",
+      "type": "section",
+      "title": "`Page.screenshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 471,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:screenshot",
+      "type": "topic",
+      "name": "screenshot"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#476",
+      "type": "section",
+      "title": "`Page.ariaSnapshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 476,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ariasnapshot",
+      "type": "topic",
+      "name": "ariasnapshot"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#481",
+      "type": "section",
+      "title": "`Page.ariaSnapshotJSON(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 481,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ariasnapshotjson",
+      "type": "topic",
+      "name": "ariasnapshotjson"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#486",
+      "type": "section",
+      "title": "`Page.pdf(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 486,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pdf",
+      "type": "topic",
+      "name": "pdf"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#491",
+      "type": "section",
+      "title": "Page Lifecycle & Tabs",
+      "file": "API_REFERENCE.md",
+      "line": 491,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:lifecycle",
+      "type": "topic",
+      "name": "lifecycle"
+    },
+    {
+      "id": "topic:tabs",
+      "type": "topic",
+      "name": "tabs"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#493",
+      "type": "section",
+      "title": "`Page.bringToFront()`",
+      "file": "API_REFERENCE.md",
+      "line": 493,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:bringtofront",
+      "type": "topic",
+      "name": "bringtofront"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#498",
+      "type": "section",
+      "title": "`Page.close(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 498,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:close",
+      "type": "topic",
+      "name": "close"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#503",
+      "type": "section",
+      "title": "`Page.opener()`",
+      "file": "API_REFERENCE.md",
+      "line": 503,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:opener",
+      "type": "topic",
+      "name": "opener"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#508",
+      "type": "section",
+      "title": "`Page.isClosed()`",
+      "file": "API_REFERENCE.md",
+      "line": 508,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isclosed",
+      "type": "topic",
+      "name": "isclosed"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#513",
+      "type": "section",
+      "title": "Accessors & State (Properties & Methods)",
+      "file": "API_REFERENCE.md",
+      "line": 513,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:accessors",
+      "type": "topic",
+      "name": "accessors"
+    },
+    {
+      "id": "topic:properties",
+      "type": "topic",
+      "name": "properties"
+    },
+    {
+      "id": "topic:methods",
+      "type": "topic",
+      "name": "methods"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#515",
+      "type": "section",
+      "title": "`Page.clock`",
+      "file": "API_REFERENCE.md",
+      "line": 515,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clock",
+      "type": "topic",
+      "name": "clock"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#520",
+      "type": "section",
+      "title": "`Page.screencast`",
+      "file": "API_REFERENCE.md",
+      "line": 520,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:screencast",
+      "type": "topic",
+      "name": "screencast"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#525",
+      "type": "section",
+      "title": "`Page.localStorage`",
+      "file": "API_REFERENCE.md",
+      "line": 525,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:localstorage",
+      "type": "topic",
+      "name": "localstorage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#530",
+      "type": "section",
+      "title": "`Page.sessionStorage`",
+      "file": "API_REFERENCE.md",
+      "line": 530,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:sessionstorage",
+      "type": "topic",
+      "name": "sessionstorage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#535",
+      "type": "section",
+      "title": "`Page.coverage`",
+      "file": "API_REFERENCE.md",
+      "line": 535,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:coverage",
+      "type": "topic",
+      "name": "coverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#540",
+      "type": "section",
+      "title": "`Page.keyboard`",
+      "file": "API_REFERENCE.md",
+      "line": 540,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:keyboard",
+      "type": "topic",
+      "name": "keyboard"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#545",
+      "type": "section",
+      "title": "`Page.mouse`",
+      "file": "API_REFERENCE.md",
+      "line": 545,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:mouse",
+      "type": "topic",
+      "name": "mouse"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#550",
+      "type": "section",
+      "title": "`Page.request`",
+      "file": "API_REFERENCE.md",
+      "line": 550,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:request",
+      "type": "topic",
+      "name": "request"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#555",
+      "type": "section",
+      "title": "`Page.touchscreen`",
+      "file": "API_REFERENCE.md",
+      "line": 555,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:touchscreen",
+      "type": "topic",
+      "name": "touchscreen"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#560",
+      "type": "section",
+      "title": "`Page.context()`",
+      "file": "API_REFERENCE.md",
+      "line": 560,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:context",
+      "type": "topic",
+      "name": "context"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#565",
+      "type": "section",
+      "title": "`Page.content()`",
+      "file": "API_REFERENCE.md",
+      "line": 565,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:content",
+      "type": "topic",
+      "name": "content"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#570",
+      "type": "section",
+      "title": "`Page.frame(frameSelector)`",
+      "file": "API_REFERENCE.md",
+      "line": 570,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:frame",
+      "type": "topic",
+      "name": "frame"
+    },
+    {
+      "id": "topic:frameselector",
+      "type": "topic",
+      "name": "frameselector"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#575",
+      "type": "section",
+      "title": "`Page.frames()`",
+      "file": "API_REFERENCE.md",
+      "line": 575,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:frames",
+      "type": "topic",
+      "name": "frames"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#580",
+      "type": "section",
+      "title": "`Page.mainFrame()`",
+      "file": "API_REFERENCE.md",
+      "line": 580,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:mainframe",
+      "type": "topic",
+      "name": "mainframe"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#585",
+      "type": "section",
+      "title": "`Page.title()`",
+      "file": "API_REFERENCE.md",
+      "line": 585,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:title",
+      "type": "topic",
+      "name": "title"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#590",
+      "type": "section",
+      "title": "`Page.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 590,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#595",
+      "type": "section",
+      "title": "`Page.video()`",
+      "file": "API_REFERENCE.md",
+      "line": 595,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:video",
+      "type": "topic",
+      "name": "video"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#600",
+      "type": "section",
+      "title": "`Page.viewportSize()`",
+      "file": "API_REFERENCE.md",
+      "line": 600,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#605",
+      "type": "section",
+      "title": "`Page.workers()`",
+      "file": "API_REFERENCE.md",
+      "line": 605,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:workers",
+      "type": "topic",
+      "name": "workers"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#610",
+      "type": "section",
+      "title": "`Page.consoleMessages()`",
+      "file": "API_REFERENCE.md",
+      "line": 610,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:consolemessages",
+      "type": "topic",
+      "name": "consolemessages"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#615",
+      "type": "section",
+      "title": "`Page.clearConsoleMessages()`",
+      "file": "API_REFERENCE.md",
+      "line": 615,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clearconsolemessages",
+      "type": "topic",
+      "name": "clearconsolemessages"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#620",
+      "type": "section",
+      "title": "`Page.clearPageErrors()`",
+      "file": "API_REFERENCE.md",
+      "line": 620,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clearpageerrors",
+      "type": "topic",
+      "name": "clearpageerrors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#625",
+      "type": "section",
+      "title": "`Page.pageErrors(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 625,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pageerrors",
+      "type": "topic",
+      "name": "pageerrors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#630",
+      "type": "section",
+      "title": "`Page.requestGC()`",
+      "file": "API_REFERENCE.md",
+      "line": 630,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:requestgc",
+      "type": "topic",
+      "name": "requestgc"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#635",
+      "type": "section",
+      "title": "`Page.pause()`",
+      "file": "API_REFERENCE.md",
+      "line": 635,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pause",
+      "type": "topic",
+      "name": "pause"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#640",
+      "type": "section",
+      "title": "`Page.hideHighlight()`",
+      "file": "API_REFERENCE.md",
+      "line": 640,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hidehighlight",
+      "type": "topic",
+      "name": "hidehighlight"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#648",
+      "type": "section",
+      "title": "Locator",
+      "file": "API_REFERENCE.md",
+      "line": 648,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#650",
+      "type": "section",
+      "title": "Filtering & Chaining",
+      "file": "API_REFERENCE.md",
+      "line": 650,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:filtering",
+      "type": "topic",
+      "name": "filtering"
+    },
+    {
+      "id": "topic:chaining",
+      "type": "topic",
+      "name": "chaining"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#652",
+      "type": "section",
+      "title": "`Locator.and(locator)`",
+      "file": "API_REFERENCE.md",
+      "line": 652,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:and",
+      "type": "topic",
+      "name": "and"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#657",
+      "type": "section",
+      "title": "`Locator.filter(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 657,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:filter",
+      "type": "topic",
+      "name": "filter"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#662",
+      "type": "section",
+      "title": "`Locator.first()`",
+      "file": "API_REFERENCE.md",
+      "line": 662,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:first",
+      "type": "topic",
+      "name": "first"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#667",
+      "type": "section",
+      "title": "`Locator.last()`",
+      "file": "API_REFERENCE.md",
+      "line": 667,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:last",
+      "type": "topic",
+      "name": "last"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#672",
+      "type": "section",
+      "title": "`Locator.locator(selectorOrLocator, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 672,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:selectororlocator",
+      "type": "topic",
+      "name": "selectororlocator"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#677",
+      "type": "section",
+      "title": "`Locator.nth(index)`",
+      "file": "API_REFERENCE.md",
+      "line": 677,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:nth",
+      "type": "topic",
+      "name": "nth"
+    },
+    {
+      "id": "topic:index",
+      "type": "topic",
+      "name": "index"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#682",
+      "type": "section",
+      "title": "`Locator.or(locator)`",
+      "file": "API_REFERENCE.md",
+      "line": 682,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#687",
+      "type": "section",
+      "title": "`Locator.frameLocator(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 687,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#692",
+      "type": "section",
+      "title": "Specialized Selectors",
+      "file": "API_REFERENCE.md",
+      "line": 692,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:specialized",
+      "type": "topic",
+      "name": "specialized"
+    },
+    {
+      "id": "topic:selectors",
+      "type": "topic",
+      "name": "selectors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#694",
+      "type": "section",
+      "title": "`Locator.getByAltText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 694,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#699",
+      "type": "section",
+      "title": "`Locator.getByLabel(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 699,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#704",
+      "type": "section",
+      "title": "`Locator.getByPlaceholder(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 704,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#709",
+      "type": "section",
+      "title": "`Locator.getByRole(role, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 709,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#714",
+      "type": "section",
+      "title": "`Locator.getByTestId(testId)`",
+      "file": "API_REFERENCE.md",
+      "line": 714,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#719",
+      "type": "section",
+      "title": "`Locator.getByText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 719,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#724",
+      "type": "section",
+      "title": "`Locator.getByTitle(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 724,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#729",
+      "type": "section",
+      "title": "Interactivity & Actions",
+      "file": "API_REFERENCE.md",
+      "line": 729,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#731",
+      "type": "section",
+      "title": "`Locator.blur(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 731,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:blur",
+      "type": "topic",
+      "name": "blur"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#736",
+      "type": "section",
+      "title": "`Locator.check(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 736,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#741",
+      "type": "section",
+      "title": "`Locator.clear(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 741,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clear",
+      "type": "topic",
+      "name": "clear"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#746",
+      "type": "section",
+      "title": "`Locator.click(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 746,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#751",
+      "type": "section",
+      "title": "`Locator.dblclick(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 751,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#756",
+      "type": "section",
+      "title": "`Locator.dispatchEvent(type, eventInit, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 756,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#761",
+      "type": "section",
+      "title": "`Locator.dragTo(target, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 761,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dragto",
+      "type": "topic",
+      "name": "dragto"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#766",
+      "type": "section",
+      "title": "`Locator.drop(payload, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 766,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:drop",
+      "type": "topic",
+      "name": "drop"
+    },
+    {
+      "id": "topic:payload",
+      "type": "topic",
+      "name": "payload"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#771",
+      "type": "section",
+      "title": "`Locator.fill(value, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 771,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#776",
+      "type": "section",
+      "title": "`Locator.focus(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 776,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#781",
+      "type": "section",
+      "title": "`Locator.hover(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 781,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#786",
+      "type": "section",
+      "title": "`Locator.press(key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 786,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#791",
+      "type": "section",
+      "title": "`Locator.pressSequentially(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 791,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:presssequentially",
+      "type": "topic",
+      "name": "presssequentially"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#796",
+      "type": "section",
+      "title": "`Locator.scrollIntoViewIfNeeded(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 796,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:scrollintoviewifneeded",
+      "type": "topic",
+      "name": "scrollintoviewifneeded"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#801",
+      "type": "section",
+      "title": "`Locator.selectOption(values, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 801,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#806",
+      "type": "section",
+      "title": "`Locator.selectText(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 806,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:selecttext",
+      "type": "topic",
+      "name": "selecttext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#811",
+      "type": "section",
+      "title": "`Locator.setChecked(checked, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 811,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#816",
+      "type": "section",
+      "title": "`Locator.setInputFiles(files, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 816,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#821",
+      "type": "section",
+      "title": "`Locator.tap(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 821,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#826",
+      "type": "section",
+      "title": "`Locator.type(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 826,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#832",
+      "type": "section",
+      "title": "`Locator.uncheck(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 832,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#837",
+      "type": "section",
+      "title": "Element State & Properties",
+      "file": "API_REFERENCE.md",
+      "line": 837,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#839",
+      "type": "section",
+      "title": "`Locator.all()`",
+      "file": "API_REFERENCE.md",
+      "line": 839,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:all",
+      "type": "topic",
+      "name": "all"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#844",
+      "type": "section",
+      "title": "`Locator.allInnerTexts()`",
+      "file": "API_REFERENCE.md",
+      "line": 844,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:allinnertexts",
+      "type": "topic",
+      "name": "allinnertexts"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#849",
+      "type": "section",
+      "title": "`Locator.allTextContents()`",
+      "file": "API_REFERENCE.md",
+      "line": 849,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:alltextcontents",
+      "type": "topic",
+      "name": "alltextcontents"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#854",
+      "type": "section",
+      "title": "`Locator.boundingBox(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 854,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:boundingbox",
+      "type": "topic",
+      "name": "boundingbox"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#859",
+      "type": "section",
+      "title": "`Locator.count()`",
+      "file": "API_REFERENCE.md",
+      "line": 859,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:count",
+      "type": "topic",
+      "name": "count"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#864",
+      "type": "section",
+      "title": "`Locator.getAttribute(name, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 864,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#869",
+      "type": "section",
+      "title": "`Locator.innerHTML(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 869,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#874",
+      "type": "section",
+      "title": "`Locator.innerText(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 874,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#879",
+      "type": "section",
+      "title": "`Locator.inputValue(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 879,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#884",
+      "type": "section",
+      "title": "`Locator.isChecked(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 884,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#889",
+      "type": "section",
+      "title": "`Locator.isDisabled(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 889,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#894",
+      "type": "section",
+      "title": "`Locator.isEditable(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 894,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#899",
+      "type": "section",
+      "title": "`Locator.isEnabled(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 899,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#904",
+      "type": "section",
+      "title": "`Locator.isHidden(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 904,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#909",
+      "type": "section",
+      "title": "`Locator.isVisible(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 909,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#914",
+      "type": "section",
+      "title": "`Locator.textContent(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 914,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#919",
+      "type": "section",
+      "title": "`Locator.contentFrame()`",
+      "file": "API_REFERENCE.md",
+      "line": 919,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:contentframe",
+      "type": "topic",
+      "name": "contentframe"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#924",
+      "type": "section",
+      "title": "`Locator.normalize()`",
+      "file": "API_REFERENCE.md",
+      "line": 924,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:normalize",
+      "type": "topic",
+      "name": "normalize"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#929",
+      "type": "section",
+      "title": "Verification & Waiting",
+      "file": "API_REFERENCE.md",
+      "line": 929,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:verification",
+      "type": "topic",
+      "name": "verification"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#931",
+      "type": "section",
+      "title": "`Locator.waitFor(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 931,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitfor",
+      "type": "topic",
+      "name": "waitfor"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#936",
+      "type": "section",
+      "title": "`Locator.waitForFunction(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 936,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#941",
+      "type": "section",
+      "title": "Output & Handles",
+      "file": "API_REFERENCE.md",
+      "line": 941,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:handles",
+      "type": "topic",
+      "name": "handles"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#943",
+      "type": "section",
+      "title": "`Locator.ariaSnapshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 943,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#948",
+      "type": "section",
+      "title": "`Locator.ariaSnapshotJSON(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 948,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#953",
+      "type": "section",
+      "title": "`Locator.elementHandle(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 953,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:elementhandle",
+      "type": "topic",
+      "name": "elementhandle"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#958",
+      "type": "section",
+      "title": "`Locator.evaluate(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 958,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#963",
+      "type": "section",
+      "title": "`Locator.evaluateAll(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 963,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:evaluateall",
+      "type": "topic",
+      "name": "evaluateall"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#968",
+      "type": "section",
+      "title": "`Locator.evaluateHandle(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 968,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#973",
+      "type": "section",
+      "title": "`Locator.elementHandles()`",
+      "file": "API_REFERENCE.md",
+      "line": 973,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:elementhandles",
+      "type": "topic",
+      "name": "elementhandles"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#978",
+      "type": "section",
+      "title": "`Locator.screenshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 978,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#983",
+      "type": "section",
+      "title": "`Locator.highlight(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 983,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:highlight",
+      "type": "topic",
+      "name": "highlight"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#988",
+      "type": "section",
+      "title": "`Locator.hideHighlight()`",
+      "file": "API_REFERENCE.md",
+      "line": 988,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#993",
+      "type": "section",
+      "title": "Misc & Metadata",
+      "file": "API_REFERENCE.md",
+      "line": 993,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:misc",
+      "type": "topic",
+      "name": "misc"
+    },
+    {
+      "id": "topic:metadata",
+      "type": "topic",
+      "name": "metadata"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#995",
+      "type": "section",
+      "title": "`Locator.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 995,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1000",
+      "type": "section",
+      "title": "`Locator.describe(description)`",
+      "file": "API_REFERENCE.md",
+      "line": 1000,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:describe",
+      "type": "topic",
+      "name": "describe"
+    },
+    {
+      "id": "topic:description",
+      "type": "topic",
+      "name": "description"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1005",
+      "type": "section",
+      "title": "`Locator.description()`",
+      "file": "API_REFERENCE.md",
+      "line": 1005,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1010",
+      "type": "section",
+      "title": "`Locator.toString()`",
+      "file": "API_REFERENCE.md",
+      "line": 1010,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:tostring",
+      "type": "topic",
+      "name": "tostring"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1017",
+      "type": "section",
+      "title": "BrowserContext",
+      "file": "API_REFERENCE.md",
+      "line": 1017,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browsercontext",
+      "type": "topic",
+      "name": "browsercontext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1021",
+      "type": "section",
+      "title": "Properties & State",
+      "file": "API_REFERENCE.md",
+      "line": 1021,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1023",
+      "type": "section",
+      "title": "`BrowserContext.request`",
+      "file": "API_REFERENCE.md",
+      "line": 1023,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1028",
+      "type": "section",
+      "title": "`BrowserContext.tracing`",
+      "file": "API_REFERENCE.md",
+      "line": 1028,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:tracing",
+      "type": "topic",
+      "name": "tracing"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1033",
+      "type": "section",
+      "title": "`BrowserContext.clock`",
+      "file": "API_REFERENCE.md",
+      "line": 1033,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1038",
+      "type": "section",
+      "title": "`BrowserContext.browser()`",
+      "file": "API_REFERENCE.md",
+      "line": 1038,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browser",
+      "type": "topic",
+      "name": "browser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1043",
+      "type": "section",
+      "title": "`BrowserContext.isClosed()`",
+      "file": "API_REFERENCE.md",
+      "line": 1043,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1048",
+      "type": "section",
+      "title": "Pages & Workers",
+      "file": "API_REFERENCE.md",
+      "line": 1048,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pages",
+      "type": "topic",
+      "name": "pages"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1050",
+      "type": "section",
+      "title": "`BrowserContext.newPage()`",
+      "file": "API_REFERENCE.md",
+      "line": 1050,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:newpage",
+      "type": "topic",
+      "name": "newpage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1055",
+      "type": "section",
+      "title": "`BrowserContext.pages()`",
+      "file": "API_REFERENCE.md",
+      "line": 1055,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1060",
+      "type": "section",
+      "title": "`BrowserContext.backgroundPages()`",
+      "file": "API_REFERENCE.md",
+      "line": 1060,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:backgroundpages",
+      "type": "topic",
+      "name": "backgroundpages"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1065",
+      "type": "section",
+      "title": "`BrowserContext.serviceWorkers()`",
+      "file": "API_REFERENCE.md",
+      "line": 1065,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:serviceworkers",
+      "type": "topic",
+      "name": "serviceworkers"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1070",
+      "type": "section",
+      "title": "Configuration & State Management",
+      "file": "API_REFERENCE.md",
+      "line": 1070,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:management",
+      "type": "topic",
+      "name": "management"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1072",
+      "type": "section",
+      "title": "`BrowserContext.cookies(urls)`",
+      "file": "API_REFERENCE.md",
+      "line": 1072,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cookies",
+      "type": "topic",
+      "name": "cookies"
+    },
+    {
+      "id": "topic:urls",
+      "type": "topic",
+      "name": "urls"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1077",
+      "type": "section",
+      "title": "`BrowserContext.addCookies(cookies)`",
+      "file": "API_REFERENCE.md",
+      "line": 1077,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:addcookies",
+      "type": "topic",
+      "name": "addcookies"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1082",
+      "type": "section",
+      "title": "`BrowserContext.clearCookies(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1082,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clearcookies",
+      "type": "topic",
+      "name": "clearcookies"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1087",
+      "type": "section",
+      "title": "`BrowserContext.grantPermissions(permissions, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1087,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:grantpermissions",
+      "type": "topic",
+      "name": "grantpermissions"
+    },
+    {
+      "id": "topic:permissions",
+      "type": "topic",
+      "name": "permissions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1092",
+      "type": "section",
+      "title": "`BrowserContext.clearPermissions()`",
+      "file": "API_REFERENCE.md",
+      "line": 1092,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clearpermissions",
+      "type": "topic",
+      "name": "clearpermissions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1097",
+      "type": "section",
+      "title": "`BrowserContext.setGeolocation(geolocation)`",
+      "file": "API_REFERENCE.md",
+      "line": 1097,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setgeolocation",
+      "type": "topic",
+      "name": "setgeolocation"
+    },
+    {
+      "id": "topic:geolocation",
+      "type": "topic",
+      "name": "geolocation"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1102",
+      "type": "section",
+      "title": "`BrowserContext.setExtraHTTPHeaders(headers)`",
+      "file": "API_REFERENCE.md",
+      "line": 1102,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1107",
+      "type": "section",
+      "title": "`BrowserContext.setOffline(offline)`",
+      "file": "API_REFERENCE.md",
+      "line": 1107,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setoffline",
+      "type": "topic",
+      "name": "setoffline"
+    },
+    {
+      "id": "topic:offline",
+      "type": "topic",
+      "name": "offline"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1112",
+      "type": "section",
+      "title": "`BrowserContext.setHTTPCredentials(httpCredentials)`",
+      "file": "API_REFERENCE.md",
+      "line": 1112,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:sethttpcredentials",
+      "type": "topic",
+      "name": "sethttpcredentials"
+    },
+    {
+      "id": "topic:httpcredentials",
+      "type": "topic",
+      "name": "httpcredentials"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1118",
+      "type": "section",
+      "title": "`BrowserContext.setDefaultNavigationTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 1118,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1123",
+      "type": "section",
+      "title": "`BrowserContext.setDefaultTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 1123,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1128",
+      "type": "section",
+      "title": "`BrowserContext.storageState(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1128,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:storagestate",
+      "type": "topic",
+      "name": "storagestate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1133",
+      "type": "section",
+      "title": "`BrowserContext.setStorageState(storageState)`",
+      "file": "API_REFERENCE.md",
+      "line": 1133,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setstoragestate",
+      "type": "topic",
+      "name": "setstoragestate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1138",
+      "type": "section",
+      "title": "Network Routing",
+      "file": "API_REFERENCE.md",
+      "line": 1138,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1140",
+      "type": "section",
+      "title": "`BrowserContext.route(url, handler, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1140,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1145",
+      "type": "section",
+      "title": "`BrowserContext.routeFromHAR(har, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1145,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1150",
+      "type": "section",
+      "title": "`BrowserContext.routeWebSocket(url, handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 1150,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1155",
+      "type": "section",
+      "title": "`BrowserContext.unroute(url, handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 1155,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1160",
+      "type": "section",
+      "title": "`BrowserContext.unrouteAll(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1160,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1165",
+      "type": "section",
+      "title": "Scripts & Bindings",
+      "file": "API_REFERENCE.md",
+      "line": 1165,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:bindings",
+      "type": "topic",
+      "name": "bindings"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1167",
+      "type": "section",
+      "title": "`BrowserContext.addInitScript(script, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1167,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1172",
+      "type": "section",
+      "title": "`BrowserContext.exposeBinding(name, callback)`",
+      "file": "API_REFERENCE.md",
+      "line": 1172,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1177",
+      "type": "section",
+      "title": "`BrowserContext.exposeFunction(name, callback)`",
+      "file": "API_REFERENCE.md",
+      "line": 1177,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1182",
+      "type": "section",
+      "title": "Lifecycle & Events",
+      "file": "API_REFERENCE.md",
+      "line": 1182,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1184",
+      "type": "section",
+      "title": "`BrowserContext.close(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1184,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1189",
+      "type": "section",
+      "title": "`BrowserContext.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 1189,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1194",
+      "type": "section",
+      "title": "`BrowserContext.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1194,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1199",
+      "type": "section",
+      "title": "`BrowserContext.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1199,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1204",
+      "type": "section",
+      "title": "`BrowserContext.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1204,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1209",
+      "type": "section",
+      "title": "`BrowserContext.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1209,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1214",
+      "type": "section",
+      "title": "`BrowserContext.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1214,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1219",
+      "type": "section",
+      "title": "`BrowserContext.removeAllListeners(type, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1219,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1224",
+      "type": "section",
+      "title": "`BrowserContext.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1224,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1229",
+      "type": "section",
+      "title": "Misc",
+      "file": "API_REFERENCE.md",
+      "line": 1229,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1231",
+      "type": "section",
+      "title": "`BrowserContext.newCDPSession(page)`",
+      "file": "API_REFERENCE.md",
+      "line": 1231,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:newcdpsession",
+      "type": "topic",
+      "name": "newcdpsession"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1236",
+      "type": "section",
+      "title": "`BrowserContext.credentials`",
+      "file": "API_REFERENCE.md",
+      "line": 1236,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:credentials",
+      "type": "topic",
+      "name": "credentials"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1241",
+      "type": "section",
+      "title": "`BrowserContext.debugger`",
+      "file": "API_REFERENCE.md",
+      "line": 1241,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:debugger",
+      "type": "topic",
+      "name": "debugger"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1248",
+      "type": "section",
+      "title": "Browser",
+      "file": "API_REFERENCE.md",
+      "line": 1248,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1252",
+      "type": "section",
+      "title": "Core Context Creation",
+      "file": "API_REFERENCE.md",
+      "line": 1252,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:core",
+      "type": "topic",
+      "name": "core"
+    },
+    {
+      "id": "topic:creation",
+      "type": "topic",
+      "name": "creation"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1254",
+      "type": "section",
+      "title": "`Browser.newContext(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1254,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:newcontext",
+      "type": "topic",
+      "name": "newcontext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1259",
+      "type": "section",
+      "title": "`Browser.newPage(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1259,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1264",
+      "type": "section",
+      "title": "Accessors & State",
+      "file": "API_REFERENCE.md",
+      "line": 1264,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1266",
+      "type": "section",
+      "title": "`Browser.browserType()`",
+      "file": "API_REFERENCE.md",
+      "line": 1266,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browsertype",
+      "type": "topic",
+      "name": "browsertype"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1271",
+      "type": "section",
+      "title": "`Browser.contexts()`",
+      "file": "API_REFERENCE.md",
+      "line": 1271,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:contexts",
+      "type": "topic",
+      "name": "contexts"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1276",
+      "type": "section",
+      "title": "`Browser.isConnected()`",
+      "file": "API_REFERENCE.md",
+      "line": 1276,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isconnected",
+      "type": "topic",
+      "name": "isconnected"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1281",
+      "type": "section",
+      "title": "`Browser.version()`",
+      "file": "API_REFERENCE.md",
+      "line": 1281,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:version",
+      "type": "topic",
+      "name": "version"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1286",
+      "type": "section",
+      "title": "Advanced & Tracing",
+      "file": "API_REFERENCE.md",
+      "line": 1286,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:advanced",
+      "type": "topic",
+      "name": "advanced"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1288",
+      "type": "section",
+      "title": "`Browser.startTracing(page, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1288,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:starttracing",
+      "type": "topic",
+      "name": "starttracing"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1293",
+      "type": "section",
+      "title": "`Browser.stopTracing()`",
+      "file": "API_REFERENCE.md",
+      "line": 1293,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stoptracing",
+      "type": "topic",
+      "name": "stoptracing"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1298",
+      "type": "section",
+      "title": "`Browser.newBrowserCDPSession()`",
+      "file": "API_REFERENCE.md",
+      "line": 1298,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:newbrowsercdpsession",
+      "type": "topic",
+      "name": "newbrowsercdpsession"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1303",
+      "type": "section",
+      "title": "Remote Connectivity",
+      "file": "API_REFERENCE.md",
+      "line": 1303,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:remote",
+      "type": "topic",
+      "name": "remote"
+    },
+    {
+      "id": "topic:connectivity",
+      "type": "topic",
+      "name": "connectivity"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1305",
+      "type": "section",
+      "title": "`Browser.bind(title, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1305,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:bind",
+      "type": "topic",
+      "name": "bind"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1310",
+      "type": "section",
+      "title": "`Browser.unbind()`",
+      "file": "API_REFERENCE.md",
+      "line": 1310,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:unbind",
+      "type": "topic",
+      "name": "unbind"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1315",
+      "type": "section",
+      "title": "Lifecycle & Events",
+      "file": "API_REFERENCE.md",
+      "line": 1315,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1317",
+      "type": "section",
+      "title": "`Browser.close(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1317,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1322",
+      "type": "section",
+      "title": "`Browser.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1322,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1327",
+      "type": "section",
+      "title": "`Browser.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1327,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1332",
+      "type": "section",
+      "title": "`Browser.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1332,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1337",
+      "type": "section",
+      "title": "`Browser.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1337,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1342",
+      "type": "section",
+      "title": "`Browser.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1342,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1347",
+      "type": "section",
+      "title": "`Browser.removeAllListeners(type, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1347,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1352",
+      "type": "section",
+      "title": "`Browser.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 1352,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1362",
+      "type": "section",
+      "title": "Frame",
+      "file": "API_REFERENCE.md",
+      "line": 1362,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1366",
+      "type": "section",
+      "title": "Accessors & Navigation",
+      "file": "API_REFERENCE.md",
+      "line": 1366,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1368",
+      "type": "section",
+      "title": "`Frame.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 1368,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1373",
+      "type": "section",
+      "title": "`Frame.name()`",
+      "file": "API_REFERENCE.md",
+      "line": 1373,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1378",
+      "type": "section",
+      "title": "`Frame.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 1378,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1383",
+      "type": "section",
+      "title": "`Frame.parentFrame()`",
+      "file": "API_REFERENCE.md",
+      "line": 1383,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:parentframe",
+      "type": "topic",
+      "name": "parentframe"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1388",
+      "type": "section",
+      "title": "`Frame.childFrames()`",
+      "file": "API_REFERENCE.md",
+      "line": 1388,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:childframes",
+      "type": "topic",
+      "name": "childframes"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1393",
+      "type": "section",
+      "title": "`Frame.isDetached()`",
+      "file": "API_REFERENCE.md",
+      "line": 1393,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isdetached",
+      "type": "topic",
+      "name": "isdetached"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1398",
+      "type": "section",
+      "title": "`Frame.title()`",
+      "file": "API_REFERENCE.md",
+      "line": 1398,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1403",
+      "type": "section",
+      "title": "`Frame.goto(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1403,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1408",
+      "type": "section",
+      "title": "`Frame.frameElement()`",
+      "file": "API_REFERENCE.md",
+      "line": 1408,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:frameelement",
+      "type": "topic",
+      "name": "frameelement"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1413",
+      "type": "section",
+      "title": "`Frame.content()`",
+      "file": "API_REFERENCE.md",
+      "line": 1413,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1418",
+      "type": "section",
+      "title": "`Frame.setContent(html, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1418,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1423",
+      "type": "section",
+      "title": "Locators",
+      "file": "API_REFERENCE.md",
+      "line": 1423,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1425",
+      "type": "section",
+      "title": "`Frame.locator(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1425,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1430",
+      "type": "section",
+      "title": "`Frame.getByTestId(testId)`",
+      "file": "API_REFERENCE.md",
+      "line": 1430,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1435",
+      "type": "section",
+      "title": "`Frame.getByAltText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1435,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1440",
+      "type": "section",
+      "title": "`Frame.getByLabel(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1440,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1445",
+      "type": "section",
+      "title": "`Frame.getByPlaceholder(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1445,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1450",
+      "type": "section",
+      "title": "`Frame.getByRole(role, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1450,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1455",
+      "type": "section",
+      "title": "`Frame.getByText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1455,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1460",
+      "type": "section",
+      "title": "`Frame.getByTitle(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1460,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1465",
+      "type": "section",
+      "title": "`Frame.frameLocator(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 1465,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1470",
+      "type": "section",
+      "title": "`Frame.pierceFrames(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1470,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1475",
+      "type": "section",
+      "title": "`Frame.$(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1475,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1480",
+      "type": "section",
+      "title": "`Frame.$$(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 1480,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1485",
+      "type": "section",
+      "title": "`Frame.$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 1485,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1490",
+      "type": "section",
+      "title": "`Frame.$$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 1490,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1495",
+      "type": "section",
+      "title": "Interactions & Evaluation",
+      "file": "API_REFERENCE.md",
+      "line": 1495,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:interactions",
+      "type": "topic",
+      "name": "interactions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1497",
+      "type": "section",
+      "title": "`Frame.click(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1497,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1502",
+      "type": "section",
+      "title": "`Frame.dblclick(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1502,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1507",
+      "type": "section",
+      "title": "`Frame.dragAndDrop(source, target, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1507,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1512",
+      "type": "section",
+      "title": "`Frame.tap(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1512,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1517",
+      "type": "section",
+      "title": "`Frame.fill(selector, value, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1517,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1522",
+      "type": "section",
+      "title": "`Frame.focus(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1522,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1527",
+      "type": "section",
+      "title": "`Frame.hover(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1527,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1532",
+      "type": "section",
+      "title": "`Frame.press(selector, key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1532,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1537",
+      "type": "section",
+      "title": "`Frame.selectOption(selector, values, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1537,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1542",
+      "type": "section",
+      "title": "`Frame.setInputFiles(selector, files, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1542,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1547",
+      "type": "section",
+      "title": "`Frame.check(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1547,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1552",
+      "type": "section",
+      "title": "`Frame.uncheck(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1552,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1557",
+      "type": "section",
+      "title": "`Frame.setChecked(selector, checked, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1557,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1562",
+      "type": "section",
+      "title": "`Frame.type(selector, text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1562,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1567",
+      "type": "section",
+      "title": "`Frame.evaluate(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1567,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1572",
+      "type": "section",
+      "title": "`Frame.evaluateHandle(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1572,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1577",
+      "type": "section",
+      "title": "`Frame.dispatchEvent(selector, type, eventInit, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1577,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1582",
+      "type": "section",
+      "title": "State Queries",
+      "file": "API_REFERENCE.md",
+      "line": 1582,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1584",
+      "type": "section",
+      "title": "`Frame.textContent(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1584,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1589",
+      "type": "section",
+      "title": "`Frame.innerText(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1589,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1594",
+      "type": "section",
+      "title": "`Frame.innerHTML(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1594,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1599",
+      "type": "section",
+      "title": "`Frame.getAttribute(selector, name, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1599,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1604",
+      "type": "section",
+      "title": "`Frame.inputValue(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1604,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1609",
+      "type": "section",
+      "title": "`Frame.isChecked(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1609,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1614",
+      "type": "section",
+      "title": "`Frame.isDisabled(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1614,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1619",
+      "type": "section",
+      "title": "`Frame.isEditable(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1619,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1624",
+      "type": "section",
+      "title": "`Frame.isEnabled(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1624,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1629",
+      "type": "section",
+      "title": "`Frame.isHidden(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1629,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1634",
+      "type": "section",
+      "title": "`Frame.isVisible(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1634,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1640",
+      "type": "section",
+      "title": "Waiting & Overrides",
+      "file": "API_REFERENCE.md",
+      "line": 1640,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:overrides",
+      "type": "topic",
+      "name": "overrides"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1642",
+      "type": "section",
+      "title": "`Frame.waitForFunction(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1642,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1647",
+      "type": "section",
+      "title": "`Frame.waitForLoadState(state, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1647,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1652",
+      "type": "section",
+      "title": "`Frame.waitForNavigation(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1652,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1657",
+      "type": "section",
+      "title": "`Frame.waitForSelector(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1657,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1662",
+      "type": "section",
+      "title": "`Frame.waitForTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 1662,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1667",
+      "type": "section",
+      "title": "`Frame.waitForURL(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1667,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1672",
+      "type": "section",
+      "title": "`Frame.addScriptTag(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1672,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1677",
+      "type": "section",
+      "title": "`Frame.addStyleTag(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1677,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1684",
+      "type": "section",
+      "title": "Route",
+      "file": "API_REFERENCE.md",
+      "line": 1684,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1688",
+      "type": "section",
+      "title": "Methods",
+      "file": "API_REFERENCE.md",
+      "line": 1688,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1690",
+      "type": "section",
+      "title": "`Route.request()`",
+      "file": "API_REFERENCE.md",
+      "line": 1690,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1695",
+      "type": "section",
+      "title": "`Route.abort(errorCode)`",
+      "file": "API_REFERENCE.md",
+      "line": 1695,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:abort",
+      "type": "topic",
+      "name": "abort"
+    },
+    {
+      "id": "topic:errorcode",
+      "type": "topic",
+      "name": "errorcode"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1700",
+      "type": "section",
+      "title": "`Route.continue(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1700,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:continue",
+      "type": "topic",
+      "name": "continue"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1705",
+      "type": "section",
+      "title": "`Route.fallback(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1705,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fallback",
+      "type": "topic",
+      "name": "fallback"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1710",
+      "type": "section",
+      "title": "`Route.fetch(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1710,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fetch",
+      "type": "topic",
+      "name": "fetch"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1715",
+      "type": "section",
+      "title": "`Route.fulfill(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1715,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fulfill",
+      "type": "topic",
+      "name": "fulfill"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1722",
+      "type": "section",
+      "title": "Request",
+      "file": "API_REFERENCE.md",
+      "line": 1722,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1726",
+      "type": "section",
+      "title": "Methods",
+      "file": "API_REFERENCE.md",
+      "line": 1726,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1728",
+      "type": "section",
+      "title": "`Request.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 1728,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1733",
+      "type": "section",
+      "title": "`Request.resourceType()`",
+      "file": "API_REFERENCE.md",
+      "line": 1733,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:resourcetype",
+      "type": "topic",
+      "name": "resourcetype"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1738",
+      "type": "section",
+      "title": "`Request.method()`",
+      "file": "API_REFERENCE.md",
+      "line": 1738,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:method",
+      "type": "topic",
+      "name": "method"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1743",
+      "type": "section",
+      "title": "`Request.postData()`",
+      "file": "API_REFERENCE.md",
+      "line": 1743,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:postdata",
+      "type": "topic",
+      "name": "postdata"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1748",
+      "type": "section",
+      "title": "`Request.postDataBuffer()`",
+      "file": "API_REFERENCE.md",
+      "line": 1748,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:postdatabuffer",
+      "type": "topic",
+      "name": "postdatabuffer"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1753",
+      "type": "section",
+      "title": "`Request.postDataJSON()`",
+      "file": "API_REFERENCE.md",
+      "line": 1753,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:postdatajson",
+      "type": "topic",
+      "name": "postdatajson"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1758",
+      "type": "section",
+      "title": "`Request.headers()`",
+      "file": "API_REFERENCE.md",
+      "line": 1758,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1763",
+      "type": "section",
+      "title": "`Request.allHeaders()`",
+      "file": "API_REFERENCE.md",
+      "line": 1763,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:allheaders",
+      "type": "topic",
+      "name": "allheaders"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1768",
+      "type": "section",
+      "title": "`Request.headersArray()`",
+      "file": "API_REFERENCE.md",
+      "line": 1768,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:headersarray",
+      "type": "topic",
+      "name": "headersarray"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1773",
+      "type": "section",
+      "title": "`Request.headerValue(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 1773,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:headervalue",
+      "type": "topic",
+      "name": "headervalue"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1778",
+      "type": "section",
+      "title": "`Request.response()`",
+      "file": "API_REFERENCE.md",
+      "line": 1778,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:response",
+      "type": "topic",
+      "name": "response"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1783",
+      "type": "section",
+      "title": "`Request.existingResponse()`",
+      "file": "API_REFERENCE.md",
+      "line": 1783,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:existingresponse",
+      "type": "topic",
+      "name": "existingresponse"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1788",
+      "type": "section",
+      "title": "`Request.frame()`",
+      "file": "API_REFERENCE.md",
+      "line": 1788,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1793",
+      "type": "section",
+      "title": "`Request.serviceWorker()`",
+      "file": "API_REFERENCE.md",
+      "line": 1793,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:serviceworker",
+      "type": "topic",
+      "name": "serviceworker"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1798",
+      "type": "section",
+      "title": "`Request.isNavigationRequest()`",
+      "file": "API_REFERENCE.md",
+      "line": 1798,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isnavigationrequest",
+      "type": "topic",
+      "name": "isnavigationrequest"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1803",
+      "type": "section",
+      "title": "`Request.redirectedFrom()`",
+      "file": "API_REFERENCE.md",
+      "line": 1803,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:redirectedfrom",
+      "type": "topic",
+      "name": "redirectedfrom"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1808",
+      "type": "section",
+      "title": "`Request.redirectedTo()`",
+      "file": "API_REFERENCE.md",
+      "line": 1808,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:redirectedto",
+      "type": "topic",
+      "name": "redirectedto"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1813",
+      "type": "section",
+      "title": "`Request.failure()`",
+      "file": "API_REFERENCE.md",
+      "line": 1813,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:failure",
+      "type": "topic",
+      "name": "failure"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1818",
+      "type": "section",
+      "title": "`Request.timing()`",
+      "file": "API_REFERENCE.md",
+      "line": 1818,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:timing",
+      "type": "topic",
+      "name": "timing"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1823",
+      "type": "section",
+      "title": "`Request.sizes()`",
+      "file": "API_REFERENCE.md",
+      "line": 1823,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:sizes",
+      "type": "topic",
+      "name": "sizes"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1830",
+      "type": "section",
+      "title": "Response",
+      "file": "API_REFERENCE.md",
+      "line": 1830,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1834",
+      "type": "section",
+      "title": "Methods",
+      "file": "API_REFERENCE.md",
+      "line": 1834,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1836",
+      "type": "section",
+      "title": "`Response.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 1836,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1841",
+      "type": "section",
+      "title": "`Response.ok()`",
+      "file": "API_REFERENCE.md",
+      "line": 1841,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1846",
+      "type": "section",
+      "title": "`Response.status()`",
+      "file": "API_REFERENCE.md",
+      "line": 1846,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:status",
+      "type": "topic",
+      "name": "status"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1851",
+      "type": "section",
+      "title": "`Response.statusText()`",
+      "file": "API_REFERENCE.md",
+      "line": 1851,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:statustext",
+      "type": "topic",
+      "name": "statustext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1856",
+      "type": "section",
+      "title": "`Response.fromServiceWorker()`",
+      "file": "API_REFERENCE.md",
+      "line": 1856,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fromserviceworker",
+      "type": "topic",
+      "name": "fromserviceworker"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1861",
+      "type": "section",
+      "title": "`Response.headers()`",
+      "file": "API_REFERENCE.md",
+      "line": 1861,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1866",
+      "type": "section",
+      "title": "`Response.allHeaders()`",
+      "file": "API_REFERENCE.md",
+      "line": 1866,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1871",
+      "type": "section",
+      "title": "`Response.headersArray()`",
+      "file": "API_REFERENCE.md",
+      "line": 1871,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1876",
+      "type": "section",
+      "title": "`Response.headerValue(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 1876,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1881",
+      "type": "section",
+      "title": "`Response.headerValues(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 1881,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:headervalues",
+      "type": "topic",
+      "name": "headervalues"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1886",
+      "type": "section",
+      "title": "`Response.finished()`",
+      "file": "API_REFERENCE.md",
+      "line": 1886,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:finished",
+      "type": "topic",
+      "name": "finished"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1891",
+      "type": "section",
+      "title": "`Response.body()`",
+      "file": "API_REFERENCE.md",
+      "line": 1891,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:body",
+      "type": "topic",
+      "name": "body"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1896",
+      "type": "section",
+      "title": "`Response.text()`",
+      "file": "API_REFERENCE.md",
+      "line": 1896,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1901",
+      "type": "section",
+      "title": "`Response.json()`",
+      "file": "API_REFERENCE.md",
+      "line": 1901,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:json",
+      "type": "topic",
+      "name": "json"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1906",
+      "type": "section",
+      "title": "`Response.request()`",
+      "file": "API_REFERENCE.md",
+      "line": 1906,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1911",
+      "type": "section",
+      "title": "`Response.frame()`",
+      "file": "API_REFERENCE.md",
+      "line": 1911,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1916",
+      "type": "section",
+      "title": "`Response.serverAddr()`",
+      "file": "API_REFERENCE.md",
+      "line": 1916,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:serveraddr",
+      "type": "topic",
+      "name": "serveraddr"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1921",
+      "type": "section",
+      "title": "`Response.securityDetails()`",
+      "file": "API_REFERENCE.md",
+      "line": 1921,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:securitydetails",
+      "type": "topic",
+      "name": "securitydetails"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1926",
+      "type": "section",
+      "title": "`Response.httpVersion()`",
+      "file": "API_REFERENCE.md",
+      "line": 1926,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:httpversion",
+      "type": "topic",
+      "name": "httpversion"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1933",
+      "type": "section",
+      "title": "JSHandle",
+      "file": "API_REFERENCE.md",
+      "line": 1933,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:jshandle",
+      "type": "topic",
+      "name": "jshandle"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1937",
+      "type": "section",
+      "title": "`JSHandle.evaluate(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1937,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1942",
+      "type": "section",
+      "title": "`JSHandle.evaluateHandle(pageFunction, arg, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1942,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1947",
+      "type": "section",
+      "title": "`JSHandle.jsonValue()`",
+      "file": "API_REFERENCE.md",
+      "line": 1947,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:jsonvalue",
+      "type": "topic",
+      "name": "jsonvalue"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1952",
+      "type": "section",
+      "title": "`JSHandle.asElement()`",
+      "file": "API_REFERENCE.md",
+      "line": 1952,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:aselement",
+      "type": "topic",
+      "name": "aselement"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1957",
+      "type": "section",
+      "title": "`JSHandle.dispose()`",
+      "file": "API_REFERENCE.md",
+      "line": 1957,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dispose",
+      "type": "topic",
+      "name": "dispose"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1962",
+      "type": "section",
+      "title": "`JSHandle.getProperties()`",
+      "file": "API_REFERENCE.md",
+      "line": 1962,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getproperties",
+      "type": "topic",
+      "name": "getproperties"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1967",
+      "type": "section",
+      "title": "`JSHandle.getProperty(propertyName)`",
+      "file": "API_REFERENCE.md",
+      "line": 1967,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getproperty",
+      "type": "topic",
+      "name": "getproperty"
+    },
+    {
+      "id": "topic:propertyname",
+      "type": "topic",
+      "name": "propertyname"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1972",
+      "type": "section",
+      "title": "`JSHandle.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 1972,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:symbol",
+      "type": "topic",
+      "name": "symbol"
+    },
+    {
+      "id": "topic:asyncdispose",
+      "type": "topic",
+      "name": "asyncdispose"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1979",
+      "type": "section",
+      "title": "ElementHandle",
+      "file": "API_REFERENCE.md",
+      "line": 1979,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1983",
+      "type": "section",
+      "title": "`ElementHandle.$(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 1983,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1988",
+      "type": "section",
+      "title": "`ElementHandle.$$(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 1988,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1993",
+      "type": "section",
+      "title": "`ElementHandle.$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 1993,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#1998",
+      "type": "section",
+      "title": "`ElementHandle.$$eval(selector, pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 1998,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2003",
+      "type": "section",
+      "title": "`ElementHandle.boundingBox()`",
+      "file": "API_REFERENCE.md",
+      "line": 2003,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2008",
+      "type": "section",
+      "title": "`ElementHandle.check(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2008,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2013",
+      "type": "section",
+      "title": "`ElementHandle.click(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2013,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2018",
+      "type": "section",
+      "title": "`ElementHandle.contentFrame()`",
+      "file": "API_REFERENCE.md",
+      "line": 2018,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2023",
+      "type": "section",
+      "title": "`ElementHandle.dblclick(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2023,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2028",
+      "type": "section",
+      "title": "`ElementHandle.dispatchEvent(type, eventInit)`",
+      "file": "API_REFERENCE.md",
+      "line": 2028,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2033",
+      "type": "section",
+      "title": "`ElementHandle.fill(value, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2033,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2038",
+      "type": "section",
+      "title": "`ElementHandle.focus()`",
+      "file": "API_REFERENCE.md",
+      "line": 2038,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2043",
+      "type": "section",
+      "title": "`ElementHandle.getAttribute(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 2043,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2048",
+      "type": "section",
+      "title": "`ElementHandle.hover(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2048,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2053",
+      "type": "section",
+      "title": "`ElementHandle.innerHTML()`",
+      "file": "API_REFERENCE.md",
+      "line": 2053,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2058",
+      "type": "section",
+      "title": "`ElementHandle.innerText()`",
+      "file": "API_REFERENCE.md",
+      "line": 2058,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2063",
+      "type": "section",
+      "title": "`ElementHandle.inputValue(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2063,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2069",
+      "type": "section",
+      "title": "`ElementHandle.isChecked()`",
+      "file": "API_REFERENCE.md",
+      "line": 2069,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2074",
+      "type": "section",
+      "title": "`ElementHandle.isDisabled()`",
+      "file": "API_REFERENCE.md",
+      "line": 2074,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2079",
+      "type": "section",
+      "title": "`ElementHandle.isEditable()`",
+      "file": "API_REFERENCE.md",
+      "line": 2079,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2084",
+      "type": "section",
+      "title": "`ElementHandle.isEnabled()`",
+      "file": "API_REFERENCE.md",
+      "line": 2084,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2089",
+      "type": "section",
+      "title": "`ElementHandle.isHidden()`",
+      "file": "API_REFERENCE.md",
+      "line": 2089,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2094",
+      "type": "section",
+      "title": "`ElementHandle.isVisible()`",
+      "file": "API_REFERENCE.md",
+      "line": 2094,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2099",
+      "type": "section",
+      "title": "`ElementHandle.ownerFrame()`",
+      "file": "API_REFERENCE.md",
+      "line": 2099,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ownerframe",
+      "type": "topic",
+      "name": "ownerframe"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2104",
+      "type": "section",
+      "title": "`ElementHandle.press(key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2104,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2109",
+      "type": "section",
+      "title": "`ElementHandle.screenshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2109,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2114",
+      "type": "section",
+      "title": "`ElementHandle.scrollIntoViewIfNeeded(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2114,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2119",
+      "type": "section",
+      "title": "`ElementHandle.selectOption(values, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2119,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2124",
+      "type": "section",
+      "title": "`ElementHandle.selectText(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2124,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2129",
+      "type": "section",
+      "title": "`ElementHandle.setChecked(checked, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2129,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2134",
+      "type": "section",
+      "title": "`ElementHandle.setInputFiles(files, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2134,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2139",
+      "type": "section",
+      "title": "`ElementHandle.tap(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2139,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2144",
+      "type": "section",
+      "title": "`ElementHandle.textContent()`",
+      "file": "API_REFERENCE.md",
+      "line": 2144,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2149",
+      "type": "section",
+      "title": "`ElementHandle.type(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2149,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2155",
+      "type": "section",
+      "title": "`ElementHandle.uncheck(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2155,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2160",
+      "type": "section",
+      "title": "`ElementHandle.waitForElementState(state, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2160,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:waitforelementstate",
+      "type": "topic",
+      "name": "waitforelementstate"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2165",
+      "type": "section",
+      "title": "`ElementHandle.waitForSelector(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2165,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2172",
+      "type": "section",
+      "title": "Keyboard",
+      "file": "API_REFERENCE.md",
+      "line": 2172,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2176",
+      "type": "section",
+      "title": "`Keyboard.down(key)`",
+      "file": "API_REFERENCE.md",
+      "line": 2176,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:down",
+      "type": "topic",
+      "name": "down"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2181",
+      "type": "section",
+      "title": "`Keyboard.insertText(text)`",
+      "file": "API_REFERENCE.md",
+      "line": 2181,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:inserttext",
+      "type": "topic",
+      "name": "inserttext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2186",
+      "type": "section",
+      "title": "`Keyboard.press(key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2186,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2191",
+      "type": "section",
+      "title": "`Keyboard.type(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2191,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2196",
+      "type": "section",
+      "title": "`Keyboard.up(key)`",
+      "file": "API_REFERENCE.md",
+      "line": 2196,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2203",
+      "type": "section",
+      "title": "Mouse",
+      "file": "API_REFERENCE.md",
+      "line": 2203,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2207",
+      "type": "section",
+      "title": "`Mouse.click(x, y, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2207,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2212",
+      "type": "section",
+      "title": "`Mouse.dblclick(x, y, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2212,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2217",
+      "type": "section",
+      "title": "`Mouse.down(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2217,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2222",
+      "type": "section",
+      "title": "`Mouse.move(x, y, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2222,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:move",
+      "type": "topic",
+      "name": "move"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2227",
+      "type": "section",
+      "title": "`Mouse.up(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2227,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2232",
+      "type": "section",
+      "title": "`Mouse.wheel(deltaX, deltaY)`",
+      "file": "API_REFERENCE.md",
+      "line": 2232,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:wheel",
+      "type": "topic",
+      "name": "wheel"
+    },
+    {
+      "id": "topic:deltax",
+      "type": "topic",
+      "name": "deltax"
+    },
+    {
+      "id": "topic:deltay",
+      "type": "topic",
+      "name": "deltay"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2239",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 2239,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:batch",
+      "type": "topic",
+      "name": "batch"
+    },
+    {
+      "id": "topic:audit",
+      "type": "topic",
+      "name": "audit"
+    },
+    {
+      "id": "topic:summary",
+      "type": "topic",
+      "name": "summary"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2252",
+      "type": "section",
+      "title": "Download",
+      "file": "API_REFERENCE.md",
+      "line": 2252,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:download",
+      "type": "topic",
+      "name": "download"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2256",
+      "type": "section",
+      "title": "`Download.cancel()`",
+      "file": "API_REFERENCE.md",
+      "line": 2256,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cancel",
+      "type": "topic",
+      "name": "cancel"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2261",
+      "type": "section",
+      "title": "`Download.createReadStream()`",
+      "file": "API_REFERENCE.md",
+      "line": 2261,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:createreadstream",
+      "type": "topic",
+      "name": "createreadstream"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2266",
+      "type": "section",
+      "title": "`Download.delete()`",
+      "file": "API_REFERENCE.md",
+      "line": 2266,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:delete",
+      "type": "topic",
+      "name": "delete"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2271",
+      "type": "section",
+      "title": "`Download.failure()`",
+      "file": "API_REFERENCE.md",
+      "line": 2271,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2276",
+      "type": "section",
+      "title": "`Download.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 2276,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2281",
+      "type": "section",
+      "title": "`Download.path()`",
+      "file": "API_REFERENCE.md",
+      "line": 2281,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:path",
+      "type": "topic",
+      "name": "path"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2286",
+      "type": "section",
+      "title": "`Download.saveAs(path)`",
+      "file": "API_REFERENCE.md",
+      "line": 2286,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:saveas",
+      "type": "topic",
+      "name": "saveas"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2291",
+      "type": "section",
+      "title": "`Download.suggestedFilename()`",
+      "file": "API_REFERENCE.md",
+      "line": 2291,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:suggestedfilename",
+      "type": "topic",
+      "name": "suggestedfilename"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2296",
+      "type": "section",
+      "title": "`Download.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 2296,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2303",
+      "type": "section",
+      "title": "Dialog",
+      "file": "API_REFERENCE.md",
+      "line": 2303,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dialog",
+      "type": "topic",
+      "name": "dialog"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2307",
+      "type": "section",
+      "title": "`Dialog.accept(promptText)`",
+      "file": "API_REFERENCE.md",
+      "line": 2307,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:accept",
+      "type": "topic",
+      "name": "accept"
+    },
+    {
+      "id": "topic:prompttext",
+      "type": "topic",
+      "name": "prompttext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2312",
+      "type": "section",
+      "title": "`Dialog.defaultValue()`",
+      "file": "API_REFERENCE.md",
+      "line": 2312,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:defaultvalue",
+      "type": "topic",
+      "name": "defaultvalue"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2317",
+      "type": "section",
+      "title": "`Dialog.dismiss()`",
+      "file": "API_REFERENCE.md",
+      "line": 2317,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:dismiss",
+      "type": "topic",
+      "name": "dismiss"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2322",
+      "type": "section",
+      "title": "`Dialog.message()`",
+      "file": "API_REFERENCE.md",
+      "line": 2322,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:message",
+      "type": "topic",
+      "name": "message"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2327",
+      "type": "section",
+      "title": "`Dialog.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 2327,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2332",
+      "type": "section",
+      "title": "`Dialog.type()`",
+      "file": "API_REFERENCE.md",
+      "line": 2332,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2339",
+      "type": "section",
+      "title": "FileChooser",
+      "file": "API_REFERENCE.md",
+      "line": 2339,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:filechooser",
+      "type": "topic",
+      "name": "filechooser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2343",
+      "type": "section",
+      "title": "`FileChooser.element()`",
+      "file": "API_REFERENCE.md",
+      "line": 2343,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2348",
+      "type": "section",
+      "title": "`FileChooser.isMultiple()`",
+      "file": "API_REFERENCE.md",
+      "line": 2348,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ismultiple",
+      "type": "topic",
+      "name": "ismultiple"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2353",
+      "type": "section",
+      "title": "`FileChooser.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 2353,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2358",
+      "type": "section",
+      "title": "`FileChooser.setFiles(files, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2358,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setfiles",
+      "type": "topic",
+      "name": "setfiles"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2366",
+      "type": "section",
+      "title": "ConsoleMessage",
+      "file": "API_REFERENCE.md",
+      "line": 2366,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:consolemessage",
+      "type": "topic",
+      "name": "consolemessage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2370",
+      "type": "section",
+      "title": "`ConsoleMessage.args()`",
+      "file": "API_REFERENCE.md",
+      "line": 2370,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2375",
+      "type": "section",
+      "title": "`ConsoleMessage.location()`",
+      "file": "API_REFERENCE.md",
+      "line": 2375,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:location",
+      "type": "topic",
+      "name": "location"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2381",
+      "type": "section",
+      "title": "`ConsoleMessage.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 2381,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2386",
+      "type": "section",
+      "title": "`ConsoleMessage.text()`",
+      "file": "API_REFERENCE.md",
+      "line": 2386,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2391",
+      "type": "section",
+      "title": "`ConsoleMessage.timestamp()`",
+      "file": "API_REFERENCE.md",
+      "line": 2391,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:timestamp",
+      "type": "topic",
+      "name": "timestamp"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2396",
+      "type": "section",
+      "title": "`ConsoleMessage.type()`",
+      "file": "API_REFERENCE.md",
+      "line": 2396,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2401",
+      "type": "section",
+      "title": "`ConsoleMessage.worker()`",
+      "file": "API_REFERENCE.md",
+      "line": 2401,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:worker",
+      "type": "topic",
+      "name": "worker"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2408",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 2408,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2421",
+      "type": "section",
+      "title": "APIRequestContext",
+      "file": "API_REFERENCE.md",
+      "line": 2421,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:apirequestcontext",
+      "type": "topic",
+      "name": "apirequestcontext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2425",
+      "type": "section",
+      "title": "`APIRequestContext.delete(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2425,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2430",
+      "type": "section",
+      "title": "`APIRequestContext.dispose(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2430,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2435",
+      "type": "section",
+      "title": "`APIRequestContext.fetch(urlOrRequest, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2435,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:urlorrequest",
+      "type": "topic",
+      "name": "urlorrequest"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2440",
+      "type": "section",
+      "title": "`APIRequestContext.get(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2440,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:get",
+      "type": "topic",
+      "name": "get"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2445",
+      "type": "section",
+      "title": "`APIRequestContext.head(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2445,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:head",
+      "type": "topic",
+      "name": "head"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2450",
+      "type": "section",
+      "title": "`APIRequestContext.patch(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2450,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:patch",
+      "type": "topic",
+      "name": "patch"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2455",
+      "type": "section",
+      "title": "`APIRequestContext.post(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2455,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:post",
+      "type": "topic",
+      "name": "post"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2460",
+      "type": "section",
+      "title": "`APIRequestContext.put(url, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2460,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:put",
+      "type": "topic",
+      "name": "put"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2465",
+      "type": "section",
+      "title": "`APIRequestContext.storageState(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2465,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2470",
+      "type": "section",
+      "title": "`APIRequestContext.tracing`",
+      "file": "API_REFERENCE.md",
+      "line": 2470,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2475",
+      "type": "section",
+      "title": "`APIRequestContext.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 2475,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2482",
+      "type": "section",
+      "title": "APIResponse",
+      "file": "API_REFERENCE.md",
+      "line": 2482,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:apiresponse",
+      "type": "topic",
+      "name": "apiresponse"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2486",
+      "type": "section",
+      "title": "`APIResponse.body()`",
+      "file": "API_REFERENCE.md",
+      "line": 2486,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2491",
+      "type": "section",
+      "title": "`APIResponse.dispose()`",
+      "file": "API_REFERENCE.md",
+      "line": 2491,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2496",
+      "type": "section",
+      "title": "`APIResponse.headers()`",
+      "file": "API_REFERENCE.md",
+      "line": 2496,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2501",
+      "type": "section",
+      "title": "`APIResponse.headersArray()`",
+      "file": "API_REFERENCE.md",
+      "line": 2501,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2506",
+      "type": "section",
+      "title": "`APIResponse.json()`",
+      "file": "API_REFERENCE.md",
+      "line": 2506,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2511",
+      "type": "section",
+      "title": "`APIResponse.ok()`",
+      "file": "API_REFERENCE.md",
+      "line": 2511,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2516",
+      "type": "section",
+      "title": "`APIResponse.securityDetails()`",
+      "file": "API_REFERENCE.md",
+      "line": 2516,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2521",
+      "type": "section",
+      "title": "`APIResponse.serverAddr()`",
+      "file": "API_REFERENCE.md",
+      "line": 2521,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2526",
+      "type": "section",
+      "title": "`APIResponse.status()`",
+      "file": "API_REFERENCE.md",
+      "line": 2526,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2531",
+      "type": "section",
+      "title": "`APIResponse.statusText()`",
+      "file": "API_REFERENCE.md",
+      "line": 2531,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2536",
+      "type": "section",
+      "title": "`APIResponse.text()`",
+      "file": "API_REFERENCE.md",
+      "line": 2536,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2541",
+      "type": "section",
+      "title": "`APIResponse.timing()`",
+      "file": "API_REFERENCE.md",
+      "line": 2541,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2546",
+      "type": "section",
+      "title": "`APIResponse.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 2546,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2551",
+      "type": "section",
+      "title": "`APIResponse.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 2551,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2558",
+      "type": "section",
+      "title": "WebSocket",
+      "file": "API_REFERENCE.md",
+      "line": 2558,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:websocket",
+      "type": "topic",
+      "name": "websocket"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2562",
+      "type": "section",
+      "title": "`WebSocket.isClosed()`",
+      "file": "API_REFERENCE.md",
+      "line": 2562,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2567",
+      "type": "section",
+      "title": "`WebSocket.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 2567,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2572",
+      "type": "section",
+      "title": "`WebSocket.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 2572,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2577",
+      "type": "section",
+      "title": "`WebSocket.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2577,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2582",
+      "type": "section",
+      "title": "`WebSocket.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2582,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2587",
+      "type": "section",
+      "title": "`WebSocket.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2587,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2592",
+      "type": "section",
+      "title": "`WebSocket.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2592,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2597",
+      "type": "section",
+      "title": "`WebSocket.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2597,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2602",
+      "type": "section",
+      "title": "`WebSocket.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2602,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2609",
+      "type": "section",
+      "title": "Worker",
+      "file": "API_REFERENCE.md",
+      "line": 2609,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2613",
+      "type": "section",
+      "title": "`Worker.evaluate(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 2613,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2618",
+      "type": "section",
+      "title": "`Worker.evaluateHandle(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 2618,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2623",
+      "type": "section",
+      "title": "`Worker.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2623,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2628",
+      "type": "section",
+      "title": "`Worker.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2628,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2633",
+      "type": "section",
+      "title": "`Worker.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2633,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2638",
+      "type": "section",
+      "title": "`Worker.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2638,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2643",
+      "type": "section",
+      "title": "`Worker.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2643,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2648",
+      "type": "section",
+      "title": "`Worker.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2648,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2653",
+      "type": "section",
+      "title": "`Worker.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 2653,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2658",
+      "type": "section",
+      "title": "`Worker.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 2658,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2665",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 2665,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2678",
+      "type": "section",
+      "title": "Selectors",
+      "file": "API_REFERENCE.md",
+      "line": 2678,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2682",
+      "type": "section",
+      "title": "`Selectors.register(name, script, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2682,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:register",
+      "type": "topic",
+      "name": "register"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2687",
+      "type": "section",
+      "title": "`Selectors.setTestIdAttribute(attributeName)`",
+      "file": "API_REFERENCE.md",
+      "line": 2687,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:settestidattribute",
+      "type": "topic",
+      "name": "settestidattribute"
+    },
+    {
+      "id": "topic:attributename",
+      "type": "topic",
+      "name": "attributename"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2694",
+      "type": "section",
+      "title": "Touchscreen",
+      "file": "API_REFERENCE.md",
+      "line": 2694,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2698",
+      "type": "section",
+      "title": "`Touchscreen.tap(x, y)`",
+      "file": "API_REFERENCE.md",
+      "line": 2698,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2705",
+      "type": "section",
+      "title": "Tracing",
+      "file": "API_REFERENCE.md",
+      "line": 2705,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2709",
+      "type": "section",
+      "title": "`Tracing.group(name, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2709,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:group",
+      "type": "topic",
+      "name": "group"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2714",
+      "type": "section",
+      "title": "`Tracing.groupEnd()`",
+      "file": "API_REFERENCE.md",
+      "line": 2714,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:groupend",
+      "type": "topic",
+      "name": "groupend"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2719",
+      "type": "section",
+      "title": "`Tracing.start(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2719,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:start",
+      "type": "topic",
+      "name": "start"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2724",
+      "type": "section",
+      "title": "`Tracing.startChunk(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2724,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:startchunk",
+      "type": "topic",
+      "name": "startchunk"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2729",
+      "type": "section",
+      "title": "`Tracing.startHar(path, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2729,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:starthar",
+      "type": "topic",
+      "name": "starthar"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2734",
+      "type": "section",
+      "title": "`Tracing.stop(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2734,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stop",
+      "type": "topic",
+      "name": "stop"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2739",
+      "type": "section",
+      "title": "`Tracing.stopChunk(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2739,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stopchunk",
+      "type": "topic",
+      "name": "stopchunk"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2744",
+      "type": "section",
+      "title": "`Tracing.stopHar()`",
+      "file": "API_REFERENCE.md",
+      "line": 2744,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stophar",
+      "type": "topic",
+      "name": "stophar"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2751",
+      "type": "section",
+      "title": "Video",
+      "file": "API_REFERENCE.md",
+      "line": 2751,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2755",
+      "type": "section",
+      "title": "`Video.delete()`",
+      "file": "API_REFERENCE.md",
+      "line": 2755,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2760",
+      "type": "section",
+      "title": "`Video.path()`",
+      "file": "API_REFERENCE.md",
+      "line": 2760,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2765",
+      "type": "section",
+      "title": "`Video.saveAs(path)`",
+      "file": "API_REFERENCE.md",
+      "line": 2765,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2772",
+      "type": "section",
+      "title": "Clock",
+      "file": "API_REFERENCE.md",
+      "line": 2772,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2776",
+      "type": "section",
+      "title": "`Clock.fastForward(ticks)`",
+      "file": "API_REFERENCE.md",
+      "line": 2776,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fastforward",
+      "type": "topic",
+      "name": "fastforward"
+    },
+    {
+      "id": "topic:ticks",
+      "type": "topic",
+      "name": "ticks"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2781",
+      "type": "section",
+      "title": "`Clock.install(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2781,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:install",
+      "type": "topic",
+      "name": "install"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2786",
+      "type": "section",
+      "title": "`Clock.pauseAt(time)`",
+      "file": "API_REFERENCE.md",
+      "line": 2786,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pauseat",
+      "type": "topic",
+      "name": "pauseat"
+    },
+    {
+      "id": "topic:time",
+      "type": "topic",
+      "name": "time"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2791",
+      "type": "section",
+      "title": "`Clock.resume()`",
+      "file": "API_REFERENCE.md",
+      "line": 2791,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:resume",
+      "type": "topic",
+      "name": "resume"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2796",
+      "type": "section",
+      "title": "`Clock.runFor(ticks)`",
+      "file": "API_REFERENCE.md",
+      "line": 2796,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:runfor",
+      "type": "topic",
+      "name": "runfor"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2801",
+      "type": "section",
+      "title": "`Clock.setFixedTime(time)`",
+      "file": "API_REFERENCE.md",
+      "line": 2801,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setfixedtime",
+      "type": "topic",
+      "name": "setfixedtime"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2806",
+      "type": "section",
+      "title": "`Clock.setSystemTime(time)`",
+      "file": "API_REFERENCE.md",
+      "line": 2806,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setsystemtime",
+      "type": "topic",
+      "name": "setsystemtime"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2813",
+      "type": "section",
+      "title": "Coverage",
+      "file": "API_REFERENCE.md",
+      "line": 2813,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2817",
+      "type": "section",
+      "title": "`Coverage.startCSSCoverage(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2817,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:startcsscoverage",
+      "type": "topic",
+      "name": "startcsscoverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2822",
+      "type": "section",
+      "title": "`Coverage.startJSCoverage(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2822,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:startjscoverage",
+      "type": "topic",
+      "name": "startjscoverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2827",
+      "type": "section",
+      "title": "`Coverage.stopCSSCoverage()`",
+      "file": "API_REFERENCE.md",
+      "line": 2827,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stopcsscoverage",
+      "type": "topic",
+      "name": "stopcsscoverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2832",
+      "type": "section",
+      "title": "`Coverage.stopJSCoverage()`",
+      "file": "API_REFERENCE.md",
+      "line": 2832,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stopjscoverage",
+      "type": "topic",
+      "name": "stopjscoverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2839",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 2839,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2854",
+      "type": "section",
+      "title": "BrowserType",
+      "file": "API_REFERENCE.md",
+      "line": 2854,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2858",
+      "type": "section",
+      "title": "`BrowserType.connectOverCDP(endpointURL, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2858,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connectovercdp",
+      "type": "topic",
+      "name": "connectovercdp"
+    },
+    {
+      "id": "topic:endpointurl",
+      "type": "topic",
+      "name": "endpointurl"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2863",
+      "type": "section",
+      "title": "`BrowserType.connect(wsEndpoint, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2863,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connect",
+      "type": "topic",
+      "name": "connect"
+    },
+    {
+      "id": "topic:wsendpoint",
+      "type": "topic",
+      "name": "wsendpoint"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2868",
+      "type": "section",
+      "title": "`BrowserType.executablePath()`",
+      "file": "API_REFERENCE.md",
+      "line": 2868,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:executablepath",
+      "type": "topic",
+      "name": "executablepath"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2873",
+      "type": "section",
+      "title": "`BrowserType.launch(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2873,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:launch",
+      "type": "topic",
+      "name": "launch"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2878",
+      "type": "section",
+      "title": "`BrowserType.launchPersistentContext(userDataDir, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2878,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:launchpersistentcontext",
+      "type": "topic",
+      "name": "launchpersistentcontext"
+    },
+    {
+      "id": "topic:userdatadir",
+      "type": "topic",
+      "name": "userdatadir"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2883",
+      "type": "section",
+      "title": "`BrowserType.launchServer(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 2883,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:launchserver",
+      "type": "topic",
+      "name": "launchserver"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2888",
+      "type": "section",
+      "title": "`BrowserType.name()`",
+      "file": "API_REFERENCE.md",
+      "line": 2888,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2895",
+      "type": "section",
+      "title": "CDPSession",
+      "file": "API_REFERENCE.md",
+      "line": 2895,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cdpsession",
+      "type": "topic",
+      "name": "cdpsession"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2899",
+      "type": "section",
+      "title": "`CDPSession.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2899,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2904",
+      "type": "section",
+      "title": "`CDPSession.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2904,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2909",
+      "type": "section",
+      "title": "`CDPSession.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2909,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2914",
+      "type": "section",
+      "title": "`CDPSession.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2914,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2919",
+      "type": "section",
+      "title": "`CDPSession.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2919,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2924",
+      "type": "section",
+      "title": "`CDPSession.send(method, params)`",
+      "file": "API_REFERENCE.md",
+      "line": 2924,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:send",
+      "type": "topic",
+      "name": "send"
+    },
+    {
+      "id": "topic:params",
+      "type": "topic",
+      "name": "params"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2929",
+      "type": "section",
+      "title": "`CDPSession.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2929,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2934",
+      "type": "section",
+      "title": "`CDPSession.detach()`",
+      "file": "API_REFERENCE.md",
+      "line": 2934,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:detach",
+      "type": "topic",
+      "name": "detach"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2941",
+      "type": "section",
+      "title": "ElectronApplication",
+      "file": "API_REFERENCE.md",
+      "line": 2941,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:electronapplication",
+      "type": "topic",
+      "name": "electronapplication"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2945",
+      "type": "section",
+      "title": "`ElectronApplication.evaluate(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 2945,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2950",
+      "type": "section",
+      "title": "`ElectronApplication.evaluateHandle(pageFunction, arg)`",
+      "file": "API_REFERENCE.md",
+      "line": 2950,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2955",
+      "type": "section",
+      "title": "`ElectronApplication.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2955,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2960",
+      "type": "section",
+      "title": "`ElectronApplication.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2960,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2965",
+      "type": "section",
+      "title": "`ElectronApplication.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2965,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2970",
+      "type": "section",
+      "title": "`ElectronApplication.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2970,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2975",
+      "type": "section",
+      "title": "`ElectronApplication.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2975,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2980",
+      "type": "section",
+      "title": "`ElectronApplication.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 2980,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2985",
+      "type": "section",
+      "title": "`ElectronApplication.browserWindow(page)`",
+      "file": "API_REFERENCE.md",
+      "line": 2985,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browserwindow",
+      "type": "topic",
+      "name": "browserwindow"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2990",
+      "type": "section",
+      "title": "`ElectronApplication.close()`",
+      "file": "API_REFERENCE.md",
+      "line": 2990,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#2995",
+      "type": "section",
+      "title": "`ElectronApplication.context()`",
+      "file": "API_REFERENCE.md",
+      "line": 2995,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3000",
+      "type": "section",
+      "title": "`ElectronApplication.firstWindow(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3000,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:firstwindow",
+      "type": "topic",
+      "name": "firstwindow"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3005",
+      "type": "section",
+      "title": "`ElectronApplication.process()`",
+      "file": "API_REFERENCE.md",
+      "line": 3005,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:process",
+      "type": "topic",
+      "name": "process"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3010",
+      "type": "section",
+      "title": "`ElectronApplication.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 3010,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3015",
+      "type": "section",
+      "title": "`ElectronApplication.windows()`",
+      "file": "API_REFERENCE.md",
+      "line": 3015,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:windows",
+      "type": "topic",
+      "name": "windows"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3020",
+      "type": "section",
+      "title": "`ElectronApplication.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3020,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3027",
+      "type": "section",
+      "title": "Electron",
+      "file": "API_REFERENCE.md",
+      "line": 3027,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:electron",
+      "type": "topic",
+      "name": "electron"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3031",
+      "type": "section",
+      "title": "`Electron.launch(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3031,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3038",
+      "type": "section",
+      "title": "Android",
+      "file": "API_REFERENCE.md",
+      "line": 3038,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:android",
+      "type": "topic",
+      "name": "android"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3042",
+      "type": "section",
+      "title": "`Android.connect(endpoint, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3042,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:endpoint",
+      "type": "topic",
+      "name": "endpoint"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3047",
+      "type": "section",
+      "title": "`Android.devices(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3047,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:devices",
+      "type": "topic",
+      "name": "devices"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3052",
+      "type": "section",
+      "title": "`Android.launchServer(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3052,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3057",
+      "type": "section",
+      "title": "`Android.setDefaultTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 3057,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3064",
+      "type": "section",
+      "title": "AndroidDevice",
+      "file": "API_REFERENCE.md",
+      "line": 3064,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:androiddevice",
+      "type": "topic",
+      "name": "androiddevice"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3068",
+      "type": "section",
+      "title": "`AndroidDevice.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3068,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3073",
+      "type": "section",
+      "title": "`AndroidDevice.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3073,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3078",
+      "type": "section",
+      "title": "`AndroidDevice.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3078,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3083",
+      "type": "section",
+      "title": "`AndroidDevice.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3083,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3088",
+      "type": "section",
+      "title": "`AndroidDevice.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3088,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3093",
+      "type": "section",
+      "title": "`AndroidDevice.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3093,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3098",
+      "type": "section",
+      "title": "`AndroidDevice.close()`",
+      "file": "API_REFERENCE.md",
+      "line": 3098,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3103",
+      "type": "section",
+      "title": "`AndroidDevice.drag(selector, dest, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3103,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:drag",
+      "type": "topic",
+      "name": "drag"
+    },
+    {
+      "id": "topic:dest",
+      "type": "topic",
+      "name": "dest"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3108",
+      "type": "section",
+      "title": "`AndroidDevice.fill(selector, text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3108,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3113",
+      "type": "section",
+      "title": "`AndroidDevice.fling(selector, direction, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3113,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fling",
+      "type": "topic",
+      "name": "fling"
+    },
+    {
+      "id": "topic:direction",
+      "type": "topic",
+      "name": "direction"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3118",
+      "type": "section",
+      "title": "`AndroidDevice.info(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 3118,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:info",
+      "type": "topic",
+      "name": "info"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3123",
+      "type": "section",
+      "title": "`AndroidDevice.installApk(file, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3123,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:installapk",
+      "type": "topic",
+      "name": "installapk"
+    },
+    {
+      "id": "topic:file",
+      "type": "topic",
+      "name": "file"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3128",
+      "type": "section",
+      "title": "`AndroidDevice.launchBrowser(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3128,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:launchbrowser",
+      "type": "topic",
+      "name": "launchbrowser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3133",
+      "type": "section",
+      "title": "`AndroidDevice.longTap(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3133,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:longtap",
+      "type": "topic",
+      "name": "longtap"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3138",
+      "type": "section",
+      "title": "`AndroidDevice.model()`",
+      "file": "API_REFERENCE.md",
+      "line": 3138,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:model",
+      "type": "topic",
+      "name": "model"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3143",
+      "type": "section",
+      "title": "`AndroidDevice.open(command)`",
+      "file": "API_REFERENCE.md",
+      "line": 3143,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:open",
+      "type": "topic",
+      "name": "open"
+    },
+    {
+      "id": "topic:command",
+      "type": "topic",
+      "name": "command"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3148",
+      "type": "section",
+      "title": "`AndroidDevice.pinchClose(selector, percent, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3148,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pinchclose",
+      "type": "topic",
+      "name": "pinchclose"
+    },
+    {
+      "id": "topic:percent",
+      "type": "topic",
+      "name": "percent"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3153",
+      "type": "section",
+      "title": "`AndroidDevice.pinchOpen(selector, percent, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3153,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pinchopen",
+      "type": "topic",
+      "name": "pinchopen"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3158",
+      "type": "section",
+      "title": "`AndroidDevice.press(selector, key, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3158,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3163",
+      "type": "section",
+      "title": "`AndroidDevice.push(file, path, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3163,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:push",
+      "type": "topic",
+      "name": "push"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3168",
+      "type": "section",
+      "title": "`AndroidDevice.screenshot(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3168,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3173",
+      "type": "section",
+      "title": "`AndroidDevice.scroll(selector, direction, percent, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3173,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:scroll",
+      "type": "topic",
+      "name": "scroll"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3178",
+      "type": "section",
+      "title": "`AndroidDevice.serial()`",
+      "file": "API_REFERENCE.md",
+      "line": 3178,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:serial",
+      "type": "topic",
+      "name": "serial"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3183",
+      "type": "section",
+      "title": "`AndroidDevice.setDefaultTimeout(timeout)`",
+      "file": "API_REFERENCE.md",
+      "line": 3183,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3188",
+      "type": "section",
+      "title": "`AndroidDevice.shell(command)`",
+      "file": "API_REFERENCE.md",
+      "line": 3188,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:shell",
+      "type": "topic",
+      "name": "shell"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3193",
+      "type": "section",
+      "title": "`AndroidDevice.swipe(selector, direction, percent, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3193,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:swipe",
+      "type": "topic",
+      "name": "swipe"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3198",
+      "type": "section",
+      "title": "`AndroidDevice.tap(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3198,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3203",
+      "type": "section",
+      "title": "`AndroidDevice.wait(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3203,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:wait",
+      "type": "topic",
+      "name": "wait"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3208",
+      "type": "section",
+      "title": "`AndroidDevice.waitForEvent(event, optionsOrPredicate)`",
+      "file": "API_REFERENCE.md",
+      "line": 3208,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3213",
+      "type": "section",
+      "title": "`AndroidDevice.webView(selector, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3213,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:webview",
+      "type": "topic",
+      "name": "webview"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3218",
+      "type": "section",
+      "title": "`AndroidDevice.webViews()`",
+      "file": "API_REFERENCE.md",
+      "line": 3218,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:webviews",
+      "type": "topic",
+      "name": "webviews"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3223",
+      "type": "section",
+      "title": "`AndroidDevice.input`",
+      "file": "API_REFERENCE.md",
+      "line": 3223,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:input",
+      "type": "topic",
+      "name": "input"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3228",
+      "type": "section",
+      "title": "`AndroidDevice.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3228,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3235",
+      "type": "section",
+      "title": "AndroidInput",
+      "file": "API_REFERENCE.md",
+      "line": 3235,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:androidinput",
+      "type": "topic",
+      "name": "androidinput"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3239",
+      "type": "section",
+      "title": "`AndroidInput.drag(from, to, steps)`",
+      "file": "API_REFERENCE.md",
+      "line": 3239,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:from",
+      "type": "topic",
+      "name": "from"
+    },
+    {
+      "id": "topic:steps",
+      "type": "topic",
+      "name": "steps"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3244",
+      "type": "section",
+      "title": "`AndroidInput.press(key)`",
+      "file": "API_REFERENCE.md",
+      "line": 3244,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3249",
+      "type": "section",
+      "title": "`AndroidInput.swipe(from, segments, steps)`",
+      "file": "API_REFERENCE.md",
+      "line": 3249,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:segments",
+      "type": "topic",
+      "name": "segments"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3254",
+      "type": "section",
+      "title": "`AndroidInput.tap(point)`",
+      "file": "API_REFERENCE.md",
+      "line": 3254,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:point",
+      "type": "topic",
+      "name": "point"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3259",
+      "type": "section",
+      "title": "`AndroidInput.type(text)`",
+      "file": "API_REFERENCE.md",
+      "line": 3259,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3266",
+      "type": "section",
+      "title": "AndroidSocket",
+      "file": "API_REFERENCE.md",
+      "line": 3266,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:androidsocket",
+      "type": "topic",
+      "name": "androidsocket"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3270",
+      "type": "section",
+      "title": "`AndroidSocket.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3270,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3275",
+      "type": "section",
+      "title": "`AndroidSocket.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3275,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3280",
+      "type": "section",
+      "title": "`AndroidSocket.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3280,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3285",
+      "type": "section",
+      "title": "`AndroidSocket.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3285,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3290",
+      "type": "section",
+      "title": "`AndroidSocket.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3290,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3295",
+      "type": "section",
+      "title": "`AndroidSocket.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3295,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3300",
+      "type": "section",
+      "title": "`AndroidSocket.close()`",
+      "file": "API_REFERENCE.md",
+      "line": 3300,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3305",
+      "type": "section",
+      "title": "`AndroidSocket.write(data)`",
+      "file": "API_REFERENCE.md",
+      "line": 3305,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:write",
+      "type": "topic",
+      "name": "write"
+    },
+    {
+      "id": "topic:data",
+      "type": "topic",
+      "name": "data"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3310",
+      "type": "section",
+      "title": "`AndroidSocket.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3310,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3317",
+      "type": "section",
+      "title": "AndroidWebView",
+      "file": "API_REFERENCE.md",
+      "line": 3317,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:androidwebview",
+      "type": "topic",
+      "name": "androidwebview"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3321",
+      "type": "section",
+      "title": "`AndroidWebView.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3321,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3326",
+      "type": "section",
+      "title": "`AndroidWebView.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3326,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3331",
+      "type": "section",
+      "title": "`AndroidWebView.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3331,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3336",
+      "type": "section",
+      "title": "`AndroidWebView.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3336,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3341",
+      "type": "section",
+      "title": "`AndroidWebView.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3341,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3346",
+      "type": "section",
+      "title": "`AndroidWebView.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3346,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3351",
+      "type": "section",
+      "title": "`AndroidWebView.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 3351,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3356",
+      "type": "section",
+      "title": "`AndroidWebView.pid()`",
+      "file": "API_REFERENCE.md",
+      "line": 3356,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pid",
+      "type": "topic",
+      "name": "pid"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3361",
+      "type": "section",
+      "title": "`AndroidWebView.pkg()`",
+      "file": "API_REFERENCE.md",
+      "line": 3361,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pkg",
+      "type": "topic",
+      "name": "pkg"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3368",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 3368,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3386",
+      "type": "section",
+      "title": "FrameLocator",
+      "file": "API_REFERENCE.md",
+      "line": 3386,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3390",
+      "type": "section",
+      "title": "`FrameLocator.first()`",
+      "file": "API_REFERENCE.md",
+      "line": 3390,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3396",
+      "type": "section",
+      "title": "`FrameLocator.frameLocator(selector)`",
+      "file": "API_REFERENCE.md",
+      "line": 3396,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3401",
+      "type": "section",
+      "title": "`FrameLocator.getByAltText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3401,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3406",
+      "type": "section",
+      "title": "`FrameLocator.getByLabel(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3406,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3411",
+      "type": "section",
+      "title": "`FrameLocator.getByPlaceholder(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3411,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3416",
+      "type": "section",
+      "title": "`FrameLocator.getByRole(role, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3416,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3421",
+      "type": "section",
+      "title": "`FrameLocator.getByTestId(testId)`",
+      "file": "API_REFERENCE.md",
+      "line": 3421,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3426",
+      "type": "section",
+      "title": "`FrameLocator.getByText(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3426,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3431",
+      "type": "section",
+      "title": "`FrameLocator.getByTitle(text, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3431,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3436",
+      "type": "section",
+      "title": "`FrameLocator.last()`",
+      "file": "API_REFERENCE.md",
+      "line": 3436,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3442",
+      "type": "section",
+      "title": "`FrameLocator.locator(selectorOrLocator, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3442,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3447",
+      "type": "section",
+      "title": "`FrameLocator.nth(index)`",
+      "file": "API_REFERENCE.md",
+      "line": 3447,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3453",
+      "type": "section",
+      "title": "`FrameLocator.owner()`",
+      "file": "API_REFERENCE.md",
+      "line": 3453,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:owner",
+      "type": "topic",
+      "name": "owner"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3460",
+      "type": "section",
+      "title": "APIRequest",
+      "file": "API_REFERENCE.md",
+      "line": 3460,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:apirequest",
+      "type": "topic",
+      "name": "apirequest"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3464",
+      "type": "section",
+      "title": "`APIRequest.newContext(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3464,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3471",
+      "type": "section",
+      "title": "BrowserServer",
+      "file": "API_REFERENCE.md",
+      "line": 3471,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browserserver",
+      "type": "topic",
+      "name": "browserserver"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3475",
+      "type": "section",
+      "title": "`BrowserServer.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3475,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3480",
+      "type": "section",
+      "title": "`BrowserServer.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3480,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3485",
+      "type": "section",
+      "title": "`BrowserServer.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3485,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3490",
+      "type": "section",
+      "title": "`BrowserServer.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3490,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3495",
+      "type": "section",
+      "title": "`BrowserServer.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3495,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3500",
+      "type": "section",
+      "title": "`BrowserServer.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3500,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3505",
+      "type": "section",
+      "title": "`BrowserServer.close()`",
+      "file": "API_REFERENCE.md",
+      "line": 3505,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3510",
+      "type": "section",
+      "title": "`BrowserServer.kill()`",
+      "file": "API_REFERENCE.md",
+      "line": 3510,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:kill",
+      "type": "topic",
+      "name": "kill"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3515",
+      "type": "section",
+      "title": "`BrowserServer.process()`",
+      "file": "API_REFERENCE.md",
+      "line": 3515,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3520",
+      "type": "section",
+      "title": "`BrowserServer.wsEndpoint()`",
+      "file": "API_REFERENCE.md",
+      "line": 3520,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3525",
+      "type": "section",
+      "title": "`BrowserServer.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3525,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3532",
+      "type": "section",
+      "title": "WebSocketRoute",
+      "file": "API_REFERENCE.md",
+      "line": 3532,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:websocketroute",
+      "type": "topic",
+      "name": "websocketroute"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3536",
+      "type": "section",
+      "title": "`WebSocketRoute.onMessage(handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 3536,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:onmessage",
+      "type": "topic",
+      "name": "onmessage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3541",
+      "type": "section",
+      "title": "`WebSocketRoute.onClose(handler)`",
+      "file": "API_REFERENCE.md",
+      "line": 3541,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:onclose",
+      "type": "topic",
+      "name": "onclose"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3546",
+      "type": "section",
+      "title": "`WebSocketRoute.close(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3546,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3551",
+      "type": "section",
+      "title": "`WebSocketRoute.connectToServer()`",
+      "file": "API_REFERENCE.md",
+      "line": 3551,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connecttoserver",
+      "type": "topic",
+      "name": "connecttoserver"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3556",
+      "type": "section",
+      "title": "`WebSocketRoute.protocols()`",
+      "file": "API_REFERENCE.md",
+      "line": 3556,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:protocols",
+      "type": "topic",
+      "name": "protocols"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3561",
+      "type": "section",
+      "title": "`WebSocketRoute.send(message)`",
+      "file": "API_REFERENCE.md",
+      "line": 3561,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3566",
+      "type": "section",
+      "title": "`WebSocketRoute.url()`",
+      "file": "API_REFERENCE.md",
+      "line": 3566,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3571",
+      "type": "section",
+      "title": "`WebSocketRoute.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3571,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3578",
+      "type": "section",
+      "title": "WebError",
+      "file": "API_REFERENCE.md",
+      "line": 3578,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:weberror",
+      "type": "topic",
+      "name": "weberror"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3582",
+      "type": "section",
+      "title": "`WebError.error()`",
+      "file": "API_REFERENCE.md",
+      "line": 3582,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:error",
+      "type": "topic",
+      "name": "error"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3587",
+      "type": "section",
+      "title": "`WebError.location()`",
+      "file": "API_REFERENCE.md",
+      "line": 3587,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3592",
+      "type": "section",
+      "title": "`WebError.page()`",
+      "file": "API_REFERENCE.md",
+      "line": 3592,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3599",
+      "type": "section",
+      "title": "Screencast",
+      "file": "API_REFERENCE.md",
+      "line": 3599,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3603",
+      "type": "section",
+      "title": "`Screencast.start(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3603,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3608",
+      "type": "section",
+      "title": "`Screencast.hideActions()`",
+      "file": "API_REFERENCE.md",
+      "line": 3608,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hideactions",
+      "type": "topic",
+      "name": "hideactions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3613",
+      "type": "section",
+      "title": "`Screencast.hideOverlays()`",
+      "file": "API_REFERENCE.md",
+      "line": 3613,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hideoverlays",
+      "type": "topic",
+      "name": "hideoverlays"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3618",
+      "type": "section",
+      "title": "`Screencast.showActions(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3618,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:showactions",
+      "type": "topic",
+      "name": "showactions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3623",
+      "type": "section",
+      "title": "`Screencast.showChapter(title, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3623,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:showchapter",
+      "type": "topic",
+      "name": "showchapter"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3628",
+      "type": "section",
+      "title": "`Screencast.showOverlay(html, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3628,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:showoverlay",
+      "type": "topic",
+      "name": "showoverlay"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3633",
+      "type": "section",
+      "title": "`Screencast.showOverlays()`",
+      "file": "API_REFERENCE.md",
+      "line": 3633,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:showoverlays",
+      "type": "topic",
+      "name": "showoverlays"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3638",
+      "type": "section",
+      "title": "`Screencast.stop()`",
+      "file": "API_REFERENCE.md",
+      "line": 3638,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3645",
+      "type": "section",
+      "title": "Debugger",
+      "file": "API_REFERENCE.md",
+      "line": 3645,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3649",
+      "type": "section",
+      "title": "`Debugger.on(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3649,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3654",
+      "type": "section",
+      "title": "`Debugger.once(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3654,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3659",
+      "type": "section",
+      "title": "`Debugger.addListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3659,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3664",
+      "type": "section",
+      "title": "`Debugger.removeListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3664,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3669",
+      "type": "section",
+      "title": "`Debugger.off(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3669,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3674",
+      "type": "section",
+      "title": "`Debugger.prependListener(event, listener)`",
+      "file": "API_REFERENCE.md",
+      "line": 3674,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3679",
+      "type": "section",
+      "title": "`Debugger.next()`",
+      "file": "API_REFERENCE.md",
+      "line": 3679,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:next",
+      "type": "topic",
+      "name": "next"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3684",
+      "type": "section",
+      "title": "`Debugger.pausedDetails()`",
+      "file": "API_REFERENCE.md",
+      "line": 3684,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pauseddetails",
+      "type": "topic",
+      "name": "pauseddetails"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3689",
+      "type": "section",
+      "title": "`Debugger.requestPause()`",
+      "file": "API_REFERENCE.md",
+      "line": 3689,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:requestpause",
+      "type": "topic",
+      "name": "requestpause"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3694",
+      "type": "section",
+      "title": "`Debugger.resume()`",
+      "file": "API_REFERENCE.md",
+      "line": 3694,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3699",
+      "type": "section",
+      "title": "`Debugger.runTo(location)`",
+      "file": "API_REFERENCE.md",
+      "line": 3699,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:runto",
+      "type": "topic",
+      "name": "runto"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3706",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 3706,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3722",
+      "type": "section",
+      "title": "ConnectOverCDPTransport",
+      "file": "API_REFERENCE.md",
+      "line": 3722,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connectovercdptransport",
+      "type": "topic",
+      "name": "connectovercdptransport"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3726",
+      "type": "section",
+      "title": "`ConnectOverCDPTransport.open()`",
+      "file": "API_REFERENCE.md",
+      "line": 3726,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3731",
+      "type": "section",
+      "title": "`ConnectOverCDPTransport.send(message)`",
+      "file": "API_REFERENCE.md",
+      "line": 3731,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3736",
+      "type": "section",
+      "title": "`ConnectOverCDPTransport.close()`",
+      "file": "API_REFERENCE.md",
+      "line": 3736,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3741",
+      "type": "section",
+      "title": "`ConnectOverCDPTransport.onmessage`",
+      "file": "API_REFERENCE.md",
+      "line": 3741,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3746",
+      "type": "section",
+      "title": "`ConnectOverCDPTransport.onclose`",
+      "file": "API_REFERENCE.md",
+      "line": 3746,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3753",
+      "type": "section",
+      "title": "Credentials",
+      "file": "API_REFERENCE.md",
+      "line": 3753,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3757",
+      "type": "section",
+      "title": "`Credentials.create(rpId, options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3757,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:create",
+      "type": "topic",
+      "name": "create"
+    },
+    {
+      "id": "topic:rpid",
+      "type": "topic",
+      "name": "rpid"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3762",
+      "type": "section",
+      "title": "`Credentials.delete(id)`",
+      "file": "API_REFERENCE.md",
+      "line": 3762,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3767",
+      "type": "section",
+      "title": "`Credentials.get(options)`",
+      "file": "API_REFERENCE.md",
+      "line": 3767,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3772",
+      "type": "section",
+      "title": "`Credentials.install()`",
+      "file": "API_REFERENCE.md",
+      "line": 3772,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3779",
+      "type": "section",
+      "title": "Disposable",
+      "file": "API_REFERENCE.md",
+      "line": 3779,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:disposable",
+      "type": "topic",
+      "name": "disposable"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3783",
+      "type": "section",
+      "title": "`Disposable.dispose()`",
+      "file": "API_REFERENCE.md",
+      "line": 3783,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3788",
+      "type": "section",
+      "title": "`Disposable.[Symbol.asyncDispose]()`",
+      "file": "API_REFERENCE.md",
+      "line": 3788,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3795",
+      "type": "section",
+      "title": "Logger",
+      "file": "API_REFERENCE.md",
+      "line": 3795,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:logger",
+      "type": "topic",
+      "name": "logger"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3799",
+      "type": "section",
+      "title": "`Logger.isEnabled(name, severity)`",
+      "file": "API_REFERENCE.md",
+      "line": 3799,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:severity",
+      "type": "topic",
+      "name": "severity"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3804",
+      "type": "section",
+      "title": "`Logger.log(name, severity, message, args, hints)`",
+      "file": "API_REFERENCE.md",
+      "line": 3804,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:log",
+      "type": "topic",
+      "name": "log"
+    },
+    {
+      "id": "topic:hints",
+      "type": "topic",
+      "name": "hints"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3811",
+      "type": "section",
+      "title": "WebStorage",
+      "file": "API_REFERENCE.md",
+      "line": 3811,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:webstorage",
+      "type": "topic",
+      "name": "webstorage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3815",
+      "type": "section",
+      "title": "`WebStorage.clear()`",
+      "file": "API_REFERENCE.md",
+      "line": 3815,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3820",
+      "type": "section",
+      "title": "`WebStorage.getItem(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 3820,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:getitem",
+      "type": "topic",
+      "name": "getitem"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3825",
+      "type": "section",
+      "title": "`WebStorage.items()`",
+      "file": "API_REFERENCE.md",
+      "line": 3825,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:items",
+      "type": "topic",
+      "name": "items"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3830",
+      "type": "section",
+      "title": "`WebStorage.removeItem(name)`",
+      "file": "API_REFERENCE.md",
+      "line": 3830,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:removeitem",
+      "type": "topic",
+      "name": "removeitem"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3835",
+      "type": "section",
+      "title": "`WebStorage.setItem(name, value)`",
+      "file": "API_REFERENCE.md",
+      "line": 3835,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:setitem",
+      "type": "topic",
+      "name": "setitem"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3842",
+      "type": "section",
+      "title": "LaunchOptions",
+      "file": "API_REFERENCE.md",
+      "line": 3842,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:launchoptions",
+      "type": "topic",
+      "name": "launchoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3846",
+      "type": "section",
+      "title": "`LaunchOptions.args`",
+      "file": "API_REFERENCE.md",
+      "line": 3846,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3851",
+      "type": "section",
+      "title": "`LaunchOptions.artifactsDir`",
+      "file": "API_REFERENCE.md",
+      "line": 3851,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:artifactsdir",
+      "type": "topic",
+      "name": "artifactsdir"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3856",
+      "type": "section",
+      "title": "`LaunchOptions.channel`",
+      "file": "API_REFERENCE.md",
+      "line": 3856,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:channel",
+      "type": "topic",
+      "name": "channel"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3861",
+      "type": "section",
+      "title": "`LaunchOptions.chromiumSandbox`",
+      "file": "API_REFERENCE.md",
+      "line": 3861,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:chromiumsandbox",
+      "type": "topic",
+      "name": "chromiumsandbox"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3866",
+      "type": "section",
+      "title": "`LaunchOptions.downloadsPath`",
+      "file": "API_REFERENCE.md",
+      "line": 3866,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:downloadspath",
+      "type": "topic",
+      "name": "downloadspath"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3871",
+      "type": "section",
+      "title": "`LaunchOptions.env`",
+      "file": "API_REFERENCE.md",
+      "line": 3871,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:env",
+      "type": "topic",
+      "name": "env"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3876",
+      "type": "section",
+      "title": "`LaunchOptions.executablePath`",
+      "file": "API_REFERENCE.md",
+      "line": 3876,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3881",
+      "type": "section",
+      "title": "`LaunchOptions.firefoxUserPrefs`",
+      "file": "API_REFERENCE.md",
+      "line": 3881,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:firefoxuserprefs",
+      "type": "topic",
+      "name": "firefoxuserprefs"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3886",
+      "type": "section",
+      "title": "`LaunchOptions.handleSIGHUP`",
+      "file": "API_REFERENCE.md",
+      "line": 3886,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:handlesighup",
+      "type": "topic",
+      "name": "handlesighup"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3891",
+      "type": "section",
+      "title": "`LaunchOptions.handleSIGINT`",
+      "file": "API_REFERENCE.md",
+      "line": 3891,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:handlesigint",
+      "type": "topic",
+      "name": "handlesigint"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3896",
+      "type": "section",
+      "title": "`LaunchOptions.handleSIGTERM`",
+      "file": "API_REFERENCE.md",
+      "line": 3896,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:handlesigterm",
+      "type": "topic",
+      "name": "handlesigterm"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3901",
+      "type": "section",
+      "title": "`LaunchOptions.headless`",
+      "file": "API_REFERENCE.md",
+      "line": 3901,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:headless",
+      "type": "topic",
+      "name": "headless"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3906",
+      "type": "section",
+      "title": "`LaunchOptions.ignoreDefaultArgs`",
+      "file": "API_REFERENCE.md",
+      "line": 3906,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ignoredefaultargs",
+      "type": "topic",
+      "name": "ignoredefaultargs"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3911",
+      "type": "section",
+      "title": "`LaunchOptions.logger`",
+      "file": "API_REFERENCE.md",
+      "line": 3911,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3917",
+      "type": "section",
+      "title": "`LaunchOptions.proxy`",
+      "file": "API_REFERENCE.md",
+      "line": 3917,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:proxy",
+      "type": "topic",
+      "name": "proxy"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3922",
+      "type": "section",
+      "title": "`LaunchOptions.slowMo`",
+      "file": "API_REFERENCE.md",
+      "line": 3922,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:slowmo",
+      "type": "topic",
+      "name": "slowmo"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3927",
+      "type": "section",
+      "title": "`LaunchOptions.timeout`",
+      "file": "API_REFERENCE.md",
+      "line": 3927,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3932",
+      "type": "section",
+      "title": "`LaunchOptions.tracesDir`",
+      "file": "API_REFERENCE.md",
+      "line": 3932,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:tracesdir",
+      "type": "topic",
+      "name": "tracesdir"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3939",
+      "type": "section",
+      "title": "ConnectOverCDPOptions",
+      "file": "API_REFERENCE.md",
+      "line": 3939,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connectovercdpoptions",
+      "type": "topic",
+      "name": "connectovercdpoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3943",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.artifactsDir`",
+      "file": "API_REFERENCE.md",
+      "line": 3943,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3948",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.endpointURL`",
+      "file": "API_REFERENCE.md",
+      "line": 3948,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3954",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.headers`",
+      "file": "API_REFERENCE.md",
+      "line": 3954,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3959",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.isLocal`",
+      "file": "API_REFERENCE.md",
+      "line": 3959,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:islocal",
+      "type": "topic",
+      "name": "islocal"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3964",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.noDefaults`",
+      "file": "API_REFERENCE.md",
+      "line": 3964,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:nodefaults",
+      "type": "topic",
+      "name": "nodefaults"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3969",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.slowMo`",
+      "file": "API_REFERENCE.md",
+      "line": 3969,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3974",
+      "type": "section",
+      "title": "`ConnectOverCDPOptions.timeout`",
+      "file": "API_REFERENCE.md",
+      "line": 3974,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3981",
+      "type": "section",
+      "title": "ConnectOptions",
+      "file": "API_REFERENCE.md",
+      "line": 3981,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:connectoptions",
+      "type": "topic",
+      "name": "connectoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3985",
+      "type": "section",
+      "title": "`ConnectOptions.exposeNetwork`",
+      "file": "API_REFERENCE.md",
+      "line": 3985,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:exposenetwork",
+      "type": "topic",
+      "name": "exposenetwork"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3990",
+      "type": "section",
+      "title": "`ConnectOptions.headers`",
+      "file": "API_REFERENCE.md",
+      "line": 3990,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#3995",
+      "type": "section",
+      "title": "`ConnectOptions.slowMo`",
+      "file": "API_REFERENCE.md",
+      "line": 3995,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4000",
+      "type": "section",
+      "title": "`ConnectOptions.timeout`",
+      "file": "API_REFERENCE.md",
+      "line": 4000,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4007",
+      "type": "section",
+      "title": "LocatorScreenshotOptions",
+      "file": "API_REFERENCE.md",
+      "line": 4007,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:locatorscreenshotoptions",
+      "type": "topic",
+      "name": "locatorscreenshotoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4011",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.animations`",
+      "file": "API_REFERENCE.md",
+      "line": 4011,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:animations",
+      "type": "topic",
+      "name": "animations"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4016",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.caret`",
+      "file": "API_REFERENCE.md",
+      "line": 4016,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:caret",
+      "type": "topic",
+      "name": "caret"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4021",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.mask`",
+      "file": "API_REFERENCE.md",
+      "line": 4021,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:mask",
+      "type": "topic",
+      "name": "mask"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4026",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.maskColor`",
+      "file": "API_REFERENCE.md",
+      "line": 4026,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:maskcolor",
+      "type": "topic",
+      "name": "maskcolor"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4031",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.omitBackground`",
+      "file": "API_REFERENCE.md",
+      "line": 4031,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:omitbackground",
+      "type": "topic",
+      "name": "omitbackground"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4036",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.path`",
+      "file": "API_REFERENCE.md",
+      "line": 4036,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4041",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.quality`",
+      "file": "API_REFERENCE.md",
+      "line": 4041,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:quality",
+      "type": "topic",
+      "name": "quality"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4046",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.scale`",
+      "file": "API_REFERENCE.md",
+      "line": 4046,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:scale",
+      "type": "topic",
+      "name": "scale"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4051",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.signal`",
+      "file": "API_REFERENCE.md",
+      "line": 4051,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:signal",
+      "type": "topic",
+      "name": "signal"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4056",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.style`",
+      "file": "API_REFERENCE.md",
+      "line": 4056,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:style",
+      "type": "topic",
+      "name": "style"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4061",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.timeout`",
+      "file": "API_REFERENCE.md",
+      "line": 4061,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4066",
+      "type": "section",
+      "title": "`LocatorScreenshotOptions.type`",
+      "file": "API_REFERENCE.md",
+      "line": 4066,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4073",
+      "type": "section",
+      "title": "BrowserContextOptions",
+      "file": "API_REFERENCE.md",
+      "line": 4073,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browsercontextoptions",
+      "type": "topic",
+      "name": "browsercontextoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4077",
+      "type": "section",
+      "title": "`BrowserContextOptions.acceptDownloads`",
+      "file": "API_REFERENCE.md",
+      "line": 4077,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:acceptdownloads",
+      "type": "topic",
+      "name": "acceptdownloads"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4082",
+      "type": "section",
+      "title": "`BrowserContextOptions.baseURL`",
+      "file": "API_REFERENCE.md",
+      "line": 4082,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:baseurl",
+      "type": "topic",
+      "name": "baseurl"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4087",
+      "type": "section",
+      "title": "`BrowserContextOptions.bypassCSP`",
+      "file": "API_REFERENCE.md",
+      "line": 4087,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:bypasscsp",
+      "type": "topic",
+      "name": "bypasscsp"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4092",
+      "type": "section",
+      "title": "`BrowserContextOptions.clientCertificates`",
+      "file": "API_REFERENCE.md",
+      "line": 4092,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clientcertificates",
+      "type": "topic",
+      "name": "clientcertificates"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4097",
+      "type": "section",
+      "title": "`BrowserContextOptions.colorScheme`",
+      "file": "API_REFERENCE.md",
+      "line": 4097,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:colorscheme",
+      "type": "topic",
+      "name": "colorscheme"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4102",
+      "type": "section",
+      "title": "`BrowserContextOptions.contrast`",
+      "file": "API_REFERENCE.md",
+      "line": 4102,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:contrast",
+      "type": "topic",
+      "name": "contrast"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4107",
+      "type": "section",
+      "title": "`BrowserContextOptions.deviceScaleFactor`",
+      "file": "API_REFERENCE.md",
+      "line": 4107,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:devicescalefactor",
+      "type": "topic",
+      "name": "devicescalefactor"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4112",
+      "type": "section",
+      "title": "`BrowserContextOptions.extraHTTPHeaders`",
+      "file": "API_REFERENCE.md",
+      "line": 4112,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:extrahttpheaders",
+      "type": "topic",
+      "name": "extrahttpheaders"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4117",
+      "type": "section",
+      "title": "`BrowserContextOptions.forcedColors`",
+      "file": "API_REFERENCE.md",
+      "line": 4117,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:forcedcolors",
+      "type": "topic",
+      "name": "forcedcolors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4122",
+      "type": "section",
+      "title": "`BrowserContextOptions.geolocation`",
+      "file": "API_REFERENCE.md",
+      "line": 4122,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4127",
+      "type": "section",
+      "title": "`BrowserContextOptions.hasTouch`",
+      "file": "API_REFERENCE.md",
+      "line": 4127,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hastouch",
+      "type": "topic",
+      "name": "hastouch"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4132",
+      "type": "section",
+      "title": "`BrowserContextOptions.httpCredentials`",
+      "file": "API_REFERENCE.md",
+      "line": 4132,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4137",
+      "type": "section",
+      "title": "`BrowserContextOptions.ignoreHTTPSErrors`",
+      "file": "API_REFERENCE.md",
+      "line": 4137,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ignorehttpserrors",
+      "type": "topic",
+      "name": "ignorehttpserrors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4142",
+      "type": "section",
+      "title": "`BrowserContextOptions.isMobile`",
+      "file": "API_REFERENCE.md",
+      "line": 4142,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ismobile",
+      "type": "topic",
+      "name": "ismobile"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4147",
+      "type": "section",
+      "title": "`BrowserContextOptions.javaScriptEnabled`",
+      "file": "API_REFERENCE.md",
+      "line": 4147,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:javascriptenabled",
+      "type": "topic",
+      "name": "javascriptenabled"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4152",
+      "type": "section",
+      "title": "`BrowserContextOptions.locale`",
+      "file": "API_REFERENCE.md",
+      "line": 4152,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:locale",
+      "type": "topic",
+      "name": "locale"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4157",
+      "type": "section",
+      "title": "`BrowserContextOptions.logger`",
+      "file": "API_REFERENCE.md",
+      "line": 4157,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4162",
+      "type": "section",
+      "title": "`BrowserContextOptions.offline`",
+      "file": "API_REFERENCE.md",
+      "line": 4162,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4167",
+      "type": "section",
+      "title": "`BrowserContextOptions.permissions`",
+      "file": "API_REFERENCE.md",
+      "line": 4167,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4172",
+      "type": "section",
+      "title": "`BrowserContextOptions.pierceFrames`",
+      "file": "API_REFERENCE.md",
+      "line": 4172,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4177",
+      "type": "section",
+      "title": "`BrowserContextOptions.proxy`",
+      "file": "API_REFERENCE.md",
+      "line": 4177,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4182",
+      "type": "section",
+      "title": "`BrowserContextOptions.recordHar`",
+      "file": "API_REFERENCE.md",
+      "line": 4182,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:recordhar",
+      "type": "topic",
+      "name": "recordhar"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4187",
+      "type": "section",
+      "title": "`BrowserContextOptions.recordVideo`",
+      "file": "API_REFERENCE.md",
+      "line": 4187,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:recordvideo",
+      "type": "topic",
+      "name": "recordvideo"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4192",
+      "type": "section",
+      "title": "`BrowserContextOptions.reducedMotion`",
+      "file": "API_REFERENCE.md",
+      "line": 4192,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:reducedmotion",
+      "type": "topic",
+      "name": "reducedmotion"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4197",
+      "type": "section",
+      "title": "`BrowserContextOptions.screen`",
+      "file": "API_REFERENCE.md",
+      "line": 4197,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:screen",
+      "type": "topic",
+      "name": "screen"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4202",
+      "type": "section",
+      "title": "`BrowserContextOptions.serviceWorkers`",
+      "file": "API_REFERENCE.md",
+      "line": 4202,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4207",
+      "type": "section",
+      "title": "`BrowserContextOptions.storageState`",
+      "file": "API_REFERENCE.md",
+      "line": 4207,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4212",
+      "type": "section",
+      "title": "`BrowserContextOptions.strictSelectors`",
+      "file": "API_REFERENCE.md",
+      "line": 4212,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:strictselectors",
+      "type": "topic",
+      "name": "strictselectors"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4217",
+      "type": "section",
+      "title": "`BrowserContextOptions.timezoneId`",
+      "file": "API_REFERENCE.md",
+      "line": 4217,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:timezoneid",
+      "type": "topic",
+      "name": "timezoneid"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4222",
+      "type": "section",
+      "title": "`BrowserContextOptions.userAgent`",
+      "file": "API_REFERENCE.md",
+      "line": 4222,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:useragent",
+      "type": "topic",
+      "name": "useragent"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4227",
+      "type": "section",
+      "title": "`BrowserContextOptions.viewport`",
+      "file": "API_REFERENCE.md",
+      "line": 4227,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:viewport",
+      "type": "topic",
+      "name": "viewport"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4234",
+      "type": "section",
+      "title": "ViewportSize",
+      "file": "API_REFERENCE.md",
+      "line": 4234,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4238",
+      "type": "section",
+      "title": "`ViewportSize.width`",
+      "file": "API_REFERENCE.md",
+      "line": 4238,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:width",
+      "type": "topic",
+      "name": "width"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4243",
+      "type": "section",
+      "title": "`ViewportSize.height`",
+      "file": "API_REFERENCE.md",
+      "line": 4243,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:height",
+      "type": "topic",
+      "name": "height"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4250",
+      "type": "section",
+      "title": "HTTPCredentials",
+      "file": "API_REFERENCE.md",
+      "line": 4250,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4254",
+      "type": "section",
+      "title": "`HTTPCredentials.username`",
+      "file": "API_REFERENCE.md",
+      "line": 4254,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:username",
+      "type": "topic",
+      "name": "username"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4259",
+      "type": "section",
+      "title": "`HTTPCredentials.password`",
+      "file": "API_REFERENCE.md",
+      "line": 4259,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:password",
+      "type": "topic",
+      "name": "password"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4264",
+      "type": "section",
+      "title": "`HTTPCredentials.origin`",
+      "file": "API_REFERENCE.md",
+      "line": 4264,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:origin",
+      "type": "topic",
+      "name": "origin"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4269",
+      "type": "section",
+      "title": "`HTTPCredentials.send`",
+      "file": "API_REFERENCE.md",
+      "line": 4269,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4276",
+      "type": "section",
+      "title": "Geolocation",
+      "file": "API_REFERENCE.md",
+      "line": 4276,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4280",
+      "type": "section",
+      "title": "`Geolocation.latitude`",
+      "file": "API_REFERENCE.md",
+      "line": 4280,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:latitude",
+      "type": "topic",
+      "name": "latitude"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4285",
+      "type": "section",
+      "title": "`Geolocation.longitude`",
+      "file": "API_REFERENCE.md",
+      "line": 4285,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:longitude",
+      "type": "topic",
+      "name": "longitude"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4290",
+      "type": "section",
+      "title": "`Geolocation.accuracy`",
+      "file": "API_REFERENCE.md",
+      "line": 4290,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:accuracy",
+      "type": "topic",
+      "name": "accuracy"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4297",
+      "type": "section",
+      "title": "Cookie",
+      "file": "API_REFERENCE.md",
+      "line": 4297,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cookie",
+      "type": "topic",
+      "name": "cookie"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4301",
+      "type": "section",
+      "title": "`Cookie.name`",
+      "file": "API_REFERENCE.md",
+      "line": 4301,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4306",
+      "type": "section",
+      "title": "`Cookie.value`",
+      "file": "API_REFERENCE.md",
+      "line": 4306,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4311",
+      "type": "section",
+      "title": "`Cookie.domain`",
+      "file": "API_REFERENCE.md",
+      "line": 4311,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:domain",
+      "type": "topic",
+      "name": "domain"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4316",
+      "type": "section",
+      "title": "`Cookie.path`",
+      "file": "API_REFERENCE.md",
+      "line": 4316,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4321",
+      "type": "section",
+      "title": "`Cookie.expires`",
+      "file": "API_REFERENCE.md",
+      "line": 4321,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:expires",
+      "type": "topic",
+      "name": "expires"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4326",
+      "type": "section",
+      "title": "`Cookie.httpOnly`",
+      "file": "API_REFERENCE.md",
+      "line": 4326,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:httponly",
+      "type": "topic",
+      "name": "httponly"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4331",
+      "type": "section",
+      "title": "`Cookie.secure`",
+      "file": "API_REFERENCE.md",
+      "line": 4331,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:secure",
+      "type": "topic",
+      "name": "secure"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4336",
+      "type": "section",
+      "title": "`Cookie.sameSite`",
+      "file": "API_REFERENCE.md",
+      "line": 4336,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:samesite",
+      "type": "topic",
+      "name": "samesite"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4341",
+      "type": "section",
+      "title": "`Cookie.partitionKey`",
+      "file": "API_REFERENCE.md",
+      "line": 4341,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:partitionkey",
+      "type": "topic",
+      "name": "partitionkey"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4348",
+      "type": "section",
+      "title": "PageScreenshotOptions",
+      "file": "API_REFERENCE.md",
+      "line": 4348,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:pagescreenshotoptions",
+      "type": "topic",
+      "name": "pagescreenshotoptions"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4352",
+      "type": "section",
+      "title": "`PageScreenshotOptions.animations`",
+      "file": "API_REFERENCE.md",
+      "line": 4352,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4357",
+      "type": "section",
+      "title": "`PageScreenshotOptions.caret`",
+      "file": "API_REFERENCE.md",
+      "line": 4357,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4362",
+      "type": "section",
+      "title": "`PageScreenshotOptions.clip`",
+      "file": "API_REFERENCE.md",
+      "line": 4362,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:clip",
+      "type": "topic",
+      "name": "clip"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4367",
+      "type": "section",
+      "title": "`PageScreenshotOptions.fullPage`",
+      "file": "API_REFERENCE.md",
+      "line": 4367,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fullpage",
+      "type": "topic",
+      "name": "fullpage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4372",
+      "type": "section",
+      "title": "`PageScreenshotOptions.mask`",
+      "file": "API_REFERENCE.md",
+      "line": 4372,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4377",
+      "type": "section",
+      "title": "`PageScreenshotOptions.maskColor`",
+      "file": "API_REFERENCE.md",
+      "line": 4377,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4382",
+      "type": "section",
+      "title": "`PageScreenshotOptions.omitBackground`",
+      "file": "API_REFERENCE.md",
+      "line": 4382,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4387",
+      "type": "section",
+      "title": "`PageScreenshotOptions.path`",
+      "file": "API_REFERENCE.md",
+      "line": 4387,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4392",
+      "type": "section",
+      "title": "`PageScreenshotOptions.quality`",
+      "file": "API_REFERENCE.md",
+      "line": 4392,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4397",
+      "type": "section",
+      "title": "`PageScreenshotOptions.scale`",
+      "file": "API_REFERENCE.md",
+      "line": 4397,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4402",
+      "type": "section",
+      "title": "`PageScreenshotOptions.signal`",
+      "file": "API_REFERENCE.md",
+      "line": 4402,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4407",
+      "type": "section",
+      "title": "`PageScreenshotOptions.style`",
+      "file": "API_REFERENCE.md",
+      "line": 4407,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4412",
+      "type": "section",
+      "title": "`PageScreenshotOptions.timeout`",
+      "file": "API_REFERENCE.md",
+      "line": 4412,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4417",
+      "type": "section",
+      "title": "`PageScreenshotOptions.type`",
+      "file": "API_REFERENCE.md",
+      "line": 4417,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4424",
+      "type": "section",
+      "title": "ChromiumBrowserContext",
+      "file": "API_REFERENCE.md",
+      "line": 4424,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:chromiumbrowsercontext",
+      "type": "topic",
+      "name": "chromiumbrowsercontext"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4431",
+      "type": "section",
+      "title": "ChromiumBrowser",
+      "file": "API_REFERENCE.md",
+      "line": 4431,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:chromiumbrowser",
+      "type": "topic",
+      "name": "chromiumbrowser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4438",
+      "type": "section",
+      "title": "FirefoxBrowser",
+      "file": "API_REFERENCE.md",
+      "line": 4438,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:firefoxbrowser",
+      "type": "topic",
+      "name": "firefoxbrowser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4445",
+      "type": "section",
+      "title": "WebKitBrowser",
+      "file": "API_REFERENCE.md",
+      "line": 4445,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:webkitbrowser",
+      "type": "topic",
+      "name": "webkitbrowser"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4452",
+      "type": "section",
+      "title": "ChromiumCoverage",
+      "file": "API_REFERENCE.md",
+      "line": 4452,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:chromiumcoverage",
+      "type": "topic",
+      "name": "chromiumcoverage"
+    },
+    {
+      "id": "doc:API_REFERENCE.md#4459",
+      "type": "section",
+      "title": "Batch audit summary",
+      "file": "API_REFERENCE.md",
+      "line": 4459,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md",
+      "type": "document",
+      "file": "NOTES.md",
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#1",
+      "type": "section",
+      "title": "Playwright & Playwright-Core Architecture Notes",
+      "file": "NOTES.md",
+      "line": 1,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:playwright",
+      "type": "topic",
+      "name": "playwright"
+    },
+    {
+      "id": "topic:architecture",
+      "type": "topic",
+      "name": "architecture"
+    },
+    {
+      "id": "topic:notes",
+      "type": "topic",
+      "name": "notes"
+    },
+    {
+      "id": "doc:NOTES.md#12",
+      "type": "section",
+      "title": "1. Browser Launch Mechanism",
+      "file": "NOTES.md",
+      "line": 12,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:mechanism",
+      "type": "topic",
+      "name": "mechanism"
+    },
+    {
+      "id": "doc:NOTES.md#14",
+      "type": "section",
+      "title": "Architecture & Flow",
+      "file": "NOTES.md",
+      "line": 14,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:flow",
+      "type": "topic",
+      "name": "flow"
+    },
+    {
+      "id": "doc:NOTES.md#30",
+      "type": "section",
+      "title": "2. BrowserContext and Page Ownership & Relationships",
+      "file": "NOTES.md",
+      "line": 30,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ownership",
+      "type": "topic",
+      "name": "ownership"
+    },
+    {
+      "id": "topic:relationships",
+      "type": "topic",
+      "name": "relationships"
+    },
+    {
+      "id": "doc:NOTES.md#32",
+      "type": "section",
+      "title": "BrowserContext",
+      "file": "NOTES.md",
+      "line": 32,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#42",
+      "type": "section",
+      "title": "Page",
+      "file": "NOTES.md",
+      "line": 42,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#54",
+      "type": "section",
+      "title": "3. Locator Architecture, Selector Resolution, and Auto-Waiting",
+      "file": "NOTES.md",
+      "line": 54,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:resolution",
+      "type": "topic",
+      "name": "resolution"
+    },
+    {
+      "id": "topic:auto-waiting",
+      "type": "topic",
+      "name": "auto-waiting"
+    },
+    {
+      "id": "doc:NOTES.md#56",
+      "type": "section",
+      "title": "Locator Definition",
+      "file": "NOTES.md",
+      "line": 56,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:definition",
+      "type": "topic",
+      "name": "definition"
+    },
+    {
+      "id": "doc:NOTES.md#61",
+      "type": "section",
+      "title": "Auto-Waiting Mechanism",
+      "file": "NOTES.md",
+      "line": 61,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#72",
+      "type": "section",
+      "title": "4. End-to-End Action Call Trace (`Locator.click`)",
+      "file": "NOTES.md",
+      "line": 72,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:end-to-end",
+      "type": "topic",
+      "name": "end-to-end"
+    },
+    {
+      "id": "topic:action",
+      "type": "topic",
+      "name": "action"
+    },
+    {
+      "id": "topic:call",
+      "type": "topic",
+      "name": "call"
+    },
+    {
+      "id": "topic:trace",
+      "type": "topic",
+      "name": "trace"
+    },
+    {
+      "id": "doc:NOTES.md#109",
+      "type": "section",
+      "title": "5. Network Interception Architecture",
+      "file": "NOTES.md",
+      "line": 109,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:interception",
+      "type": "topic",
+      "name": "interception"
+    },
+    {
+      "id": "doc:NOTES.md#111",
+      "type": "section",
+      "title": "Client Routing API",
+      "file": "NOTES.md",
+      "line": 111,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:client",
+      "type": "topic",
+      "name": "client"
+    },
+    {
+      "id": "doc:NOTES.md#119",
+      "type": "section",
+      "title": "Server Network Engine",
+      "file": "NOTES.md",
+      "line": 119,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:server",
+      "type": "topic",
+      "name": "server"
+    },
+    {
+      "id": "topic:engine",
+      "type": "topic",
+      "name": "engine"
+    },
+    {
+      "id": "doc:NOTES.md#125",
+      "type": "section",
+      "title": "6. Codegen / Recorder Architecture (Expanded Deep Dive)",
+      "file": "NOTES.md",
+      "line": 125,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:recorder",
+      "type": "topic",
+      "name": "recorder"
+    },
+    {
+      "id": "topic:expanded",
+      "type": "topic",
+      "name": "expanded"
+    },
+    {
+      "id": "topic:deep",
+      "type": "topic",
+      "name": "deep"
+    },
+    {
+      "id": "topic:dive",
+      "type": "topic",
+      "name": "dive"
+    },
+    {
+      "id": "doc:NOTES.md#154",
+      "type": "section",
+      "title": "6.1 Recorder Overlay, Toolbar UI, and Client-Server Bridge",
+      "file": "NOTES.md",
+      "line": 154,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:overlay",
+      "type": "topic",
+      "name": "overlay"
+    },
+    {
+      "id": "topic:toolbar",
+      "type": "topic",
+      "name": "toolbar"
+    },
+    {
+      "id": "topic:client-server",
+      "type": "topic",
+      "name": "client-server"
+    },
+    {
+      "id": "topic:bridge",
+      "type": "topic",
+      "name": "bridge"
+    },
+    {
+      "id": "doc:NOTES.md#172",
+      "type": "section",
+      "title": "6.2 Storage State Capture (`--save-storage` and `--load-storage`)",
+      "file": "NOTES.md",
+      "line": 172,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:storage",
+      "type": "topic",
+      "name": "storage"
+    },
+    {
+      "id": "topic:capture",
+      "type": "topic",
+      "name": "capture"
+    },
+    {
+      "id": "topic:save-storage",
+      "type": "topic",
+      "name": "save-storage"
+    },
+    {
+      "id": "topic:load-storage",
+      "type": "topic",
+      "name": "load-storage"
+    },
+    {
+      "id": "doc:NOTES.md#188",
+      "type": "section",
+      "title": "6.3 Multi-Language Code Generation (`--target`)",
+      "file": "NOTES.md",
+      "line": 188,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:multi-language",
+      "type": "topic",
+      "name": "multi-language"
+    },
+    {
+      "id": "topic:code",
+      "type": "topic",
+      "name": "code"
+    },
+    {
+      "id": "topic:generation",
+      "type": "topic",
+      "name": "generation"
+    },
+    {
+      "id": "doc:NOTES.md#203",
+      "type": "section",
+      "title": "6.4 Selector Generator Ranking Algorithm (`generateSelector`)",
+      "file": "NOTES.md",
+      "line": 203,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:generator",
+      "type": "topic",
+      "name": "generator"
+    },
+    {
+      "id": "topic:ranking",
+      "type": "topic",
+      "name": "ranking"
+    },
+    {
+      "id": "topic:algorithm",
+      "type": "topic",
+      "name": "algorithm"
+    },
+    {
+      "id": "topic:generateselector",
+      "type": "topic",
+      "name": "generateselector"
+    },
+    {
+      "id": "doc:NOTES.md#225",
+      "type": "section",
+      "title": "6.5 Action Recording Lifecycle: Fresh Session vs. Attaching to Existing Context",
+      "file": "NOTES.md",
+      "line": 225,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:recording",
+      "type": "topic",
+      "name": "recording"
+    },
+    {
+      "id": "topic:fresh",
+      "type": "topic",
+      "name": "fresh"
+    },
+    {
+      "id": "topic:session",
+      "type": "topic",
+      "name": "session"
+    },
+    {
+      "id": "topic:attaching",
+      "type": "topic",
+      "name": "attaching"
+    },
+    {
+      "id": "topic:existing",
+      "type": "topic",
+      "name": "existing"
+    },
+    {
+      "id": "doc:NOTES.md#237",
+      "type": "section",
+      "title": "6.6 Verification Sources & Documentation Alignment",
+      "file": "NOTES.md",
+      "line": 237,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:sources",
+      "type": "topic",
+      "name": "sources"
+    },
+    {
+      "id": "topic:documentation",
+      "type": "topic",
+      "name": "documentation"
+    },
+    {
+      "id": "topic:alignment",
+      "type": "topic",
+      "name": "alignment"
+    },
+    {
+      "id": "doc:NOTES.md#248",
+      "type": "section",
+      "title": "6.7 Programmatic Initiation and Termination Signals (`page.pause()`)",
+      "file": "NOTES.md",
+      "line": 248,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:programmatic",
+      "type": "topic",
+      "name": "programmatic"
+    },
+    {
+      "id": "topic:initiation",
+      "type": "topic",
+      "name": "initiation"
+    },
+    {
+      "id": "topic:termination",
+      "type": "topic",
+      "name": "termination"
+    },
+    {
+      "id": "topic:signals",
+      "type": "topic",
+      "name": "signals"
+    },
+    {
+      "id": "doc:NOTES.md#267",
+      "type": "section",
+      "title": "7. @playwright/test Test Runner Architecture",
+      "file": "NOTES.md",
+      "line": 267,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:test",
+      "type": "topic",
+      "name": "test"
+    },
+    {
+      "id": "topic:runner",
+      "type": "topic",
+      "name": "runner"
+    },
+    {
+      "id": "doc:NOTES.md#293",
+      "type": "section",
+      "title": "7.1 Test Runner Core Loop: Discovery, Suite Building & Dispatch",
+      "file": "NOTES.md",
+      "line": 293,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:loop",
+      "type": "topic",
+      "name": "loop"
+    },
+    {
+      "id": "topic:discovery",
+      "type": "topic",
+      "name": "discovery"
+    },
+    {
+      "id": "topic:suite",
+      "type": "topic",
+      "name": "suite"
+    },
+    {
+      "id": "topic:building",
+      "type": "topic",
+      "name": "building"
+    },
+    {
+      "id": "topic:dispatch",
+      "type": "topic",
+      "name": "dispatch"
+    },
+    {
+      "id": "doc:NOTES.md#313",
+      "type": "section",
+      "title": "7.2 Fixtures System (`test.extend()`, Scoping, and Dependency DAG)",
+      "file": "NOTES.md",
+      "line": 313,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fixtures",
+      "type": "topic",
+      "name": "fixtures"
+    },
+    {
+      "id": "topic:system",
+      "type": "topic",
+      "name": "system"
+    },
+    {
+      "id": "topic:extend",
+      "type": "topic",
+      "name": "extend"
+    },
+    {
+      "id": "topic:scoping",
+      "type": "topic",
+      "name": "scoping"
+    },
+    {
+      "id": "topic:dependency",
+      "type": "topic",
+      "name": "dependency"
+    },
+    {
+      "id": "topic:dag",
+      "type": "topic",
+      "name": "dag"
+    },
+    {
+      "id": "doc:NOTES.md#328",
+      "type": "section",
+      "title": "7.3 Worker Process Architecture & Test Isolation",
+      "file": "NOTES.md",
+      "line": 328,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:isolation",
+      "type": "topic",
+      "name": "isolation"
+    },
+    {
+      "id": "doc:NOTES.md#343",
+      "type": "section",
+      "title": "7.4 Auto-Retrying Assertions (`expect(locator).toBeVisible()`)",
+      "file": "NOTES.md",
+      "line": 343,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:auto-retrying",
+      "type": "topic",
+      "name": "auto-retrying"
+    },
+    {
+      "id": "topic:assertions",
+      "type": "topic",
+      "name": "assertions"
+    },
+    {
+      "id": "topic:expect",
+      "type": "topic",
+      "name": "expect"
+    },
+    {
+      "id": "topic:tobevisible",
+      "type": "topic",
+      "name": "tobevisible"
+    },
+    {
+      "id": "doc:NOTES.md#357",
+      "type": "section",
+      "title": "7.5 Reporters & Event Multiplexing",
+      "file": "NOTES.md",
+      "line": 357,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:reporters",
+      "type": "topic",
+      "name": "reporters"
+    },
+    {
+      "id": "topic:multiplexing",
+      "type": "topic",
+      "name": "multiplexing"
+    },
+    {
+      "id": "doc:NOTES.md#380",
+      "type": "section",
+      "title": "8. Tracing, Trace Viewer, and Cross-Origin Frame Architecture",
+      "file": "NOTES.md",
+      "line": 380,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:viewer",
+      "type": "topic",
+      "name": "viewer"
+    },
+    {
+      "id": "topic:cross-origin",
+      "type": "topic",
+      "name": "cross-origin"
+    },
+    {
+      "id": "doc:NOTES.md#382",
+      "type": "section",
+      "title": "8.1 Tracing Recording Architecture (`context.tracing.start()` / `stop()`)",
+      "file": "NOTES.md",
+      "line": 382,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#394",
+      "type": "section",
+      "title": "8.2 Trace Archive Zip Structure",
+      "file": "NOTES.md",
+      "line": 394,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:archive",
+      "type": "topic",
+      "name": "archive"
+    },
+    {
+      "id": "topic:zip",
+      "type": "topic",
+      "name": "zip"
+    },
+    {
+      "id": "topic:structure",
+      "type": "topic",
+      "name": "structure"
+    },
+    {
+      "id": "doc:NOTES.md#410",
+      "type": "section",
+      "title": "8.3 Trace Viewer Architecture",
+      "file": "NOTES.md",
+      "line": 410,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#422",
+      "type": "section",
+      "title": "8.4 Frame Hierarchy & Ownership",
+      "file": "NOTES.md",
+      "line": 422,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:hierarchy",
+      "type": "topic",
+      "name": "hierarchy"
+    },
+    {
+      "id": "doc:NOTES.md#432",
+      "type": "section",
+      "title": "8.5 Cross-Origin IFrames & OOPIF Architecture",
+      "file": "NOTES.md",
+      "line": 432,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:iframes",
+      "type": "topic",
+      "name": "iframes"
+    },
+    {
+      "id": "topic:oopif",
+      "type": "topic",
+      "name": "oopif"
+    },
+    {
+      "id": "doc:NOTES.md#444",
+      "type": "section",
+      "title": "8.6 Frame Lifecycle & Navigation Event Propagation",
+      "file": "NOTES.md",
+      "line": 444,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:propagation",
+      "type": "topic",
+      "name": "propagation"
+    },
+    {
+      "id": "doc:NOTES.md#464",
+      "type": "section",
+      "title": "9. Downloads, API Testing, and Time Mocking",
+      "file": "NOTES.md",
+      "line": 464,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:downloads",
+      "type": "topic",
+      "name": "downloads"
+    },
+    {
+      "id": "topic:testing",
+      "type": "topic",
+      "name": "testing"
+    },
+    {
+      "id": "topic:mocking",
+      "type": "topic",
+      "name": "mocking"
+    },
+    {
+      "id": "doc:NOTES.md#466",
+      "type": "section",
+      "title": "9.1 Downloads, Uploads, and Dialog Handling",
+      "file": "NOTES.md",
+      "line": 466,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:uploads",
+      "type": "topic",
+      "name": "uploads"
+    },
+    {
+      "id": "topic:handling",
+      "type": "topic",
+      "name": "handling"
+    },
+    {
+      "id": "doc:NOTES.md#477",
+      "type": "section",
+      "title": "9.2 API Testing (`APIRequestContext`)",
+      "file": "NOTES.md",
+      "line": 477,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#482",
+      "type": "section",
+      "title": "9.3 Clock & Time Mocking",
+      "file": "NOTES.md",
+      "line": 482,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#489",
+      "type": "section",
+      "title": "10. Page Load Detection and Multi-Tab Architecture",
+      "file": "NOTES.md",
+      "line": 489,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:load",
+      "type": "topic",
+      "name": "load"
+    },
+    {
+      "id": "topic:detection",
+      "type": "topic",
+      "name": "detection"
+    },
+    {
+      "id": "topic:multi-tab",
+      "type": "topic",
+      "name": "multi-tab"
+    },
+    {
+      "id": "doc:NOTES.md#491",
+      "type": "section",
+      "title": "10.1 Page Load Detection -- Visual Readiness vs. Data Readiness",
+      "file": "NOTES.md",
+      "line": 491,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:visual",
+      "type": "topic",
+      "name": "visual"
+    },
+    {
+      "id": "topic:readiness",
+      "type": "topic",
+      "name": "readiness"
+    },
+    {
+      "id": "doc:NOTES.md#502",
+      "type": "section",
+      "title": "10.2 Multi-Tab / Multi-Page Switching Logic",
+      "file": "NOTES.md",
+      "line": 502,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:multi-page",
+      "type": "topic",
+      "name": "multi-page"
+    },
+    {
+      "id": "topic:switching",
+      "type": "topic",
+      "name": "switching"
+    },
+    {
+      "id": "topic:logic",
+      "type": "topic",
+      "name": "logic"
+    },
+    {
+      "id": "doc:NOTES.md#514",
+      "type": "section",
+      "title": "11. Deterministic Readiness Patterns for Dynamic UI Elements (Dropdowns & Beyond)",
+      "file": "NOTES.md",
+      "line": 514,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:deterministic",
+      "type": "topic",
+      "name": "deterministic"
+    },
+    {
+      "id": "topic:patterns",
+      "type": "topic",
+      "name": "patterns"
+    },
+    {
+      "id": "topic:for",
+      "type": "topic",
+      "name": "for"
+    },
+    {
+      "id": "topic:dynamic",
+      "type": "topic",
+      "name": "dynamic"
+    },
+    {
+      "id": "topic:elements",
+      "type": "topic",
+      "name": "elements"
+    },
+    {
+      "id": "topic:dropdowns",
+      "type": "topic",
+      "name": "dropdowns"
+    },
+    {
+      "id": "topic:beyond",
+      "type": "topic",
+      "name": "beyond"
+    },
+    {
+      "id": "doc:NOTES.md#518",
+      "type": "section",
+      "title": "11.1 Targeted Network Interception (\"wait for the one response that matters\")",
+      "file": "NOTES.md",
+      "line": 518,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:targeted",
+      "type": "topic",
+      "name": "targeted"
+    },
+    {
+      "id": "topic:the",
+      "type": "topic",
+      "name": "the"
+    },
+    {
+      "id": "topic:one",
+      "type": "topic",
+      "name": "one"
+    },
+    {
+      "id": "topic:that",
+      "type": "topic",
+      "name": "that"
+    },
+    {
+      "id": "topic:matters",
+      "type": "topic",
+      "name": "matters"
+    },
+    {
+      "id": "doc:NOTES.md#523",
+      "type": "section",
+      "title": "11.2 Browser-Side Predicate Polling (\"wait for the DOM to say so\")",
+      "file": "NOTES.md",
+      "line": 523,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:browser-side",
+      "type": "topic",
+      "name": "browser-side"
+    },
+    {
+      "id": "topic:predicate",
+      "type": "topic",
+      "name": "predicate"
+    },
+    {
+      "id": "topic:polling",
+      "type": "topic",
+      "name": "polling"
+    },
+    {
+      "id": "topic:dom",
+      "type": "topic",
+      "name": "dom"
+    },
+    {
+      "id": "topic:say",
+      "type": "topic",
+      "name": "say"
+    },
+    {
+      "id": "doc:NOTES.md#528",
+      "type": "section",
+      "title": "11.3 Network Stubbing / Mocking (\"skip the network entirely\")",
+      "file": "NOTES.md",
+      "line": 528,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stubbing",
+      "type": "topic",
+      "name": "stubbing"
+    },
+    {
+      "id": "topic:skip",
+      "type": "topic",
+      "name": "skip"
+    },
+    {
+      "id": "topic:entirely",
+      "type": "topic",
+      "name": "entirely"
+    },
+    {
+      "id": "doc:NOTES.md#533",
+      "type": "section",
+      "title": "11.4 \"Click and Retry\" Loop (brute-force fallback)",
+      "file": "NOTES.md",
+      "line": 533,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:retry",
+      "type": "topic",
+      "name": "retry"
+    },
+    {
+      "id": "topic:brute-force",
+      "type": "topic",
+      "name": "brute-force"
+    },
+    {
+      "id": "doc:NOTES.md#538",
+      "type": "section",
+      "title": "12. Video Recording Architecture (`recordVideo`) and Its Hard Constraints",
+      "file": "NOTES.md",
+      "line": 538,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:its",
+      "type": "topic",
+      "name": "its"
+    },
+    {
+      "id": "topic:hard",
+      "type": "topic",
+      "name": "hard"
+    },
+    {
+      "id": "topic:constraints",
+      "type": "topic",
+      "name": "constraints"
+    },
+    {
+      "id": "doc:NOTES.md#540",
+      "type": "section",
+      "title": "12.1 FFmpeg Encoding Pipeline",
+      "file": "NOTES.md",
+      "line": 540,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:ffmpeg",
+      "type": "topic",
+      "name": "ffmpeg"
+    },
+    {
+      "id": "topic:encoding",
+      "type": "topic",
+      "name": "encoding"
+    },
+    {
+      "id": "topic:pipeline",
+      "type": "topic",
+      "name": "pipeline"
+    },
+    {
+      "id": "doc:NOTES.md#552",
+      "type": "section",
+      "title": "12.2 Default Environmental Settings",
+      "file": "NOTES.md",
+      "line": 552,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:default",
+      "type": "topic",
+      "name": "default"
+    },
+    {
+      "id": "topic:environmental",
+      "type": "topic",
+      "name": "environmental"
+    },
+    {
+      "id": "topic:settings",
+      "type": "topic",
+      "name": "settings"
+    },
+    {
+      "id": "doc:NOTES.md#557",
+      "type": "section",
+      "title": "12.3 Auto-Waiting \"Stable\" Check Scope",
+      "file": "NOTES.md",
+      "line": 557,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:stable",
+      "type": "topic",
+      "name": "stable"
+    },
+    {
+      "id": "topic:scope",
+      "type": "topic",
+      "name": "scope"
+    },
+    {
+      "id": "doc:NOTES.md#561",
+      "type": "section",
+      "title": "12.4 Cursor Visibility in Recorded Video",
+      "file": "NOTES.md",
+      "line": 561,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:cursor",
+      "type": "topic",
+      "name": "cursor"
+    },
+    {
+      "id": "topic:visibility",
+      "type": "topic",
+      "name": "visibility"
+    },
+    {
+      "id": "topic:recorded",
+      "type": "topic",
+      "name": "recorded"
+    },
+    {
+      "id": "doc:NOTES.md#566",
+      "type": "section",
+      "title": "12.5 `navigator.webdriver` / Automation Detection Surface",
+      "file": "NOTES.md",
+      "line": 566,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:navigator",
+      "type": "topic",
+      "name": "navigator"
+    },
+    {
+      "id": "topic:webdriver",
+      "type": "topic",
+      "name": "webdriver"
+    },
+    {
+      "id": "topic:automation",
+      "type": "topic",
+      "name": "automation"
+    },
+    {
+      "id": "topic:surface",
+      "type": "topic",
+      "name": "surface"
+    },
+    {
+      "id": "doc:NOTES.md#572",
+      "type": "section",
+      "title": "13. Custom Engines, Emulation, Observability, and Automation Detection Surface",
+      "file": "NOTES.md",
+      "line": 572,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:custom",
+      "type": "topic",
+      "name": "custom"
+    },
+    {
+      "id": "topic:engines",
+      "type": "topic",
+      "name": "engines"
+    },
+    {
+      "id": "topic:observability",
+      "type": "topic",
+      "name": "observability"
+    },
+    {
+      "id": "doc:NOTES.md#574",
+      "type": "section",
+      "title": "13.1 Custom Selector Engines",
+      "file": "NOTES.md",
+      "line": 574,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#578",
+      "type": "section",
+      "title": "13.2 `slowMo` Launch Option",
+      "file": "NOTES.md",
+      "line": 578,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:option",
+      "type": "topic",
+      "name": "option"
+    },
+    {
+      "id": "doc:NOTES.md#582",
+      "type": "section",
+      "title": "13.3 Device Emulation Scope",
+      "file": "NOTES.md",
+      "line": 582,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:device",
+      "type": "topic",
+      "name": "device"
+    },
+    {
+      "id": "doc:NOTES.md#586",
+      "type": "section",
+      "title": "13.4 Visual Regression -- Masking & Animation Freezing",
+      "file": "NOTES.md",
+      "line": 586,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:regression",
+      "type": "topic",
+      "name": "regression"
+    },
+    {
+      "id": "topic:masking",
+      "type": "topic",
+      "name": "masking"
+    },
+    {
+      "id": "topic:animation",
+      "type": "topic",
+      "name": "animation"
+    },
+    {
+      "id": "topic:freezing",
+      "type": "topic",
+      "name": "freezing"
+    },
+    {
+      "id": "doc:NOTES.md#590",
+      "type": "section",
+      "title": "13.5 Accessibility Tree Access",
+      "file": "NOTES.md",
+      "line": 590,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:accessibility",
+      "type": "topic",
+      "name": "accessibility"
+    },
+    {
+      "id": "topic:tree",
+      "type": "topic",
+      "name": "tree"
+    },
+    {
+      "id": "topic:access",
+      "type": "topic",
+      "name": "access"
+    },
+    {
+      "id": "doc:NOTES.md#593",
+      "type": "section",
+      "title": "13.6 Worker / Service Worker / WebSocket Hooks",
+      "file": "NOTES.md",
+      "line": 593,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:service",
+      "type": "topic",
+      "name": "service"
+    },
+    {
+      "id": "topic:hooks",
+      "type": "topic",
+      "name": "hooks"
+    },
+    {
+      "id": "doc:NOTES.md#598",
+      "type": "section",
+      "title": "13.7 Low-Level CDP Session Access",
+      "file": "NOTES.md",
+      "line": 598,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:low-level",
+      "type": "topic",
+      "name": "low-level"
+    },
+    {
+      "id": "topic:cdp",
+      "type": "topic",
+      "name": "cdp"
+    },
+    {
+      "id": "doc:NOTES.md#602",
+      "type": "section",
+      "title": "13.8 Code Coverage",
+      "file": "NOTES.md",
+      "line": 602,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "doc:NOTES.md#606",
+      "type": "section",
+      "title": "13.9 Automation Detection Surface -- Correction Pass",
+      "file": "NOTES.md",
+      "line": 606,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:correction",
+      "type": "topic",
+      "name": "correction"
+    },
+    {
+      "id": "topic:pass",
+      "type": "topic",
+      "name": "pass"
+    },
+    {
+      "id": "doc:NOTES.md#613",
+      "type": "section",
+      "title": "14. Multi-Tab Recording: Video Fragmentation vs. Tracing Correlation",
+      "file": "NOTES.md",
+      "line": 613,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:fragmentation",
+      "type": "topic",
+      "name": "fragmentation"
+    },
+    {
+      "id": "topic:correlation",
+      "type": "topic",
+      "name": "correlation"
+    },
+    {
+      "id": "doc:NOTES.md#615",
+      "type": "section",
+      "title": "14.1 `recordVideo` Produces Independent, Uncorrelated Files Per Tab",
+      "file": "NOTES.md",
+      "line": 615,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:produces",
+      "type": "topic",
+      "name": "produces"
+    },
+    {
+      "id": "topic:independent",
+      "type": "topic",
+      "name": "independent"
+    },
+    {
+      "id": "topic:uncorrelated",
+      "type": "topic",
+      "name": "uncorrelated"
+    },
+    {
+      "id": "topic:per",
+      "type": "topic",
+      "name": "per"
+    },
+    {
+      "id": "topic:tab",
+      "type": "topic",
+      "name": "tab"
+    },
+    {
+      "id": "doc:NOTES.md#621",
+      "type": "section",
+      "title": "14.2 `context.tracing` Is the Actual Cross-Tab Correlation Mechanism",
+      "file": "NOTES.md",
+      "line": 621,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:actual",
+      "type": "topic",
+      "name": "actual"
+    },
+    {
+      "id": "topic:cross-tab",
+      "type": "topic",
+      "name": "cross-tab"
+    },
+    {
+      "id": "doc:NOTES.md#631",
+      "type": "section",
+      "title": "15. Unverified Claims & Caveats",
+      "file": "NOTES.md",
+      "line": 631,
+      "commit": "b4a646a624c0b1e8e352d320cbc6684581625ff6",
+      "commit_date": "2026-08-06"
+    },
+    {
+      "id": "topic:unverified",
+      "type": "topic",
+      "name": "unverified"
+    },
+    {
+      "id": "topic:claims",
+      "type": "topic",
+      "name": "claims"
+    },
+    {
+      "id": "topic:caveats",
+      "type": "topic",
+      "name": "caveats"
+    },
+    {
+      "id": "example:examples/01-launch-browser.js",
+      "type": "example",
+      "file": "examples/01-launch-browser.js",
+      "title": "launch browser"
+    },
+    {
+      "id": "example:examples/02-context-and-page.js",
+      "type": "example",
+      "file": "examples/02-context-and-page.js",
+      "title": "context and page"
+    },
+    {
+      "id": "example:examples/03-locator-basics.js",
+      "type": "example",
+      "file": "examples/03-locator-basics.js",
+      "title": "locator basics"
+    },
+    {
+      "id": "topic:basics",
+      "type": "topic",
+      "name": "basics"
+    },
+    {
+      "id": "example:examples/04-network-interception.js",
+      "type": "example",
+      "file": "examples/04-network-interception.js",
+      "title": "network interception"
+    },
+    {
+      "id": "example:examples/05-codegen-invocation.js",
+      "type": "example",
+      "file": "examples/05-codegen-invocation.js",
+      "title": "codegen invocation"
+    },
+    {
+      "id": "topic:invocation",
+      "type": "topic",
+      "name": "invocation"
+    },
+    {
+      "id": "example:examples/06-codegen-language-targets.js",
+      "type": "example",
+      "file": "examples/06-codegen-language-targets.js",
+      "title": "codegen language targets"
+    },
+    {
+      "id": "topic:language",
+      "type": "topic",
+      "name": "language"
+    },
+    {
+      "id": "topic:targets",
+      "type": "topic",
+      "name": "targets"
+    },
+    {
+      "id": "example:examples/07-codegen-selector-scoring.js",
+      "type": "example",
+      "file": "examples/07-codegen-selector-scoring.js",
+      "title": "codegen selector scoring"
+    },
+    {
+      "id": "topic:scoring",
+      "type": "topic",
+      "name": "scoring"
+    },
+    {
+      "id": "example:examples/08-codegen-storage-and-session.js",
+      "type": "example",
+      "file": "examples/08-codegen-storage-and-session.js",
+      "title": "codegen storage and session"
+    },
+    {
+      "id": "example:examples/09-test-runner-and-config.js",
+      "type": "example",
+      "file": "examples/09-test-runner-and-config.js",
+      "title": "test runner and config"
+    },
+    {
+      "id": "topic:config",
+      "type": "topic",
+      "name": "config"
+    },
+    {
+      "id": "example:examples/10-fixtures-and-dependency-graph.js",
+      "type": "example",
+      "file": "examples/10-fixtures-and-dependency-graph.js",
+      "title": "fixtures and dependency graph"
+    },
+    {
+      "id": "topic:graph",
+      "type": "topic",
+      "name": "graph"
+    },
+    {
+      "id": "example:examples/11-reporters-and-events.js",
+      "type": "example",
+      "file": "examples/11-reporters-and-events.js",
+      "title": "reporters and events"
+    },
+    {
+      "id": "example:examples/12-tracing.js",
+      "type": "example",
+      "file": "examples/12-tracing.js",
+      "title": "tracing"
+    },
+    {
+      "id": "example:examples/13-frames-and-oopif.js",
+      "type": "example",
+      "file": "examples/13-frames-and-oopif.js",
+      "title": "frames and oopif"
+    },
+    {
+      "id": "example:examples/14-downloads-and-dialogs.js",
+      "type": "example",
+      "file": "examples/14-downloads-and-dialogs.js",
+      "title": "downloads and dialogs"
+    },
+    {
+      "id": "topic:dialogs",
+      "type": "topic",
+      "name": "dialogs"
+    },
+    {
+      "id": "example:examples/15-api-testing.js",
+      "type": "example",
+      "file": "examples/15-api-testing.js",
+      "title": "api testing"
+    },
+    {
+      "id": "example:examples/16-page-load-and-lifecycle.js",
+      "type": "example",
+      "file": "examples/16-page-load-and-lifecycle.js",
+      "title": "page load and lifecycle"
+    },
+    {
+      "id": "example:examples/17-multi-tab-and-pages.js",
+      "type": "example",
+      "file": "examples/17-multi-tab-and-pages.js",
+      "title": "multi tab and pages"
+    },
+    {
+      "id": "topic:multi",
+      "type": "topic",
+      "name": "multi"
+    },
+    {
+      "id": "example:examples/18-targeted-network-interception.js",
+      "type": "example",
+      "file": "examples/18-targeted-network-interception.js",
+      "title": "targeted network interception"
+    },
+    {
+      "id": "example:examples/19-browser-side-polling.js",
+      "type": "example",
+      "file": "examples/19-browser-side-polling.js",
+      "title": "browser side polling"
+    },
+    {
+      "id": "topic:side",
+      "type": "topic",
+      "name": "side"
+    },
+    {
+      "id": "example:examples/20-network-stubbing.js",
+      "type": "example",
+      "file": "examples/20-network-stubbing.js",
+      "title": "network stubbing"
+    },
+    {
+      "id": "example:examples/21-click-and-retry-loop.js",
+      "type": "example",
+      "file": "examples/21-click-and-retry-loop.js",
+      "title": "click and retry loop"
+    },
+    {
+      "id": "example:examples/22-video-recording-pipeline.js",
+      "type": "example",
+      "file": "examples/22-video-recording-pipeline.js",
+      "title": "video recording pipeline"
+    },
+    {
+      "id": "example:examples/23-environmental-settings.js",
+      "type": "example",
+      "file": "examples/23-environmental-settings.js",
+      "title": "environmental settings"
+    },
+    {
+      "id": "example:examples/24-stability-and-opacity.js",
+      "type": "example",
+      "file": "examples/24-stability-and-opacity.js",
+      "title": "stability and opacity"
+    },
+    {
+      "id": "topic:stability",
+      "type": "topic",
+      "name": "stability"
+    },
+    {
+      "id": "topic:opacity",
+      "type": "topic",
+      "name": "opacity"
+    },
+    {
+      "id": "example:examples/25-video-cursor-overlay.js",
+      "type": "example",
+      "file": "examples/25-video-cursor-overlay.js",
+      "title": "video cursor overlay"
+    },
+    {
+      "id": "example:examples/26-automation-detection.js",
+      "type": "example",
+      "file": "examples/26-automation-detection.js",
+      "title": "automation detection"
+    },
+    {
+      "id": "example:examples/27-custom-selector-engines.js",
+      "type": "example",
+      "file": "examples/27-custom-selector-engines.js",
+      "title": "custom selector engines"
+    },
+    {
+      "id": "example:examples/28-slowmo-dispatcher-delay.js",
+      "type": "example",
+      "file": "examples/28-slowmo-dispatcher-delay.js",
+      "title": "slowmo dispatcher delay"
+    },
+    {
+      "id": "topic:dispatcher",
+      "type": "topic",
+      "name": "dispatcher"
+    },
+    {
+      "id": "topic:delay",
+      "type": "topic",
+      "name": "delay"
+    },
+    {
+      "id": "example:examples/29-emulation-scope.js",
+      "type": "example",
+      "file": "examples/29-emulation-scope.js",
+      "title": "emulation scope"
+    },
+    {
+      "id": "example:examples/30-screenshot-masking.js",
+      "type": "example",
+      "file": "examples/30-screenshot-masking.js",
+      "title": "screenshot masking"
+    },
+    {
+      "id": "example:examples/31-accessibility-tree.js",
+      "type": "example",
+      "file": "examples/31-accessibility-tree.js",
+      "title": "accessibility tree"
+    },
+    {
+      "id": "example:examples/32-worker-websocket-hooks.js",
+      "type": "example",
+      "file": "examples/32-worker-websocket-hooks.js",
+      "title": "worker websocket hooks"
+    },
+    {
+      "id": "example:examples/33-cdp-session-access.js",
+      "type": "example",
+      "file": "examples/33-cdp-session-access.js",
+      "title": "cdp session access"
+    },
+    {
+      "id": "example:examples/34-code-coverage.js",
+      "type": "example",
+      "file": "examples/34-code-coverage.js",
+      "title": "code coverage"
+    },
+    {
+      "id": "example:examples/35-automation-evasion-initscript.js",
+      "type": "example",
+      "file": "examples/35-automation-evasion-initscript.js",
+      "title": "automation evasion initscript"
+    },
+    {
+      "id": "topic:evasion",
+      "type": "topic",
+      "name": "evasion"
+    },
+    {
+      "id": "topic:initscript",
+      "type": "topic",
+      "name": "initscript"
+    },
+    {
+      "id": "example:examples/36-video-fragmentation.js",
+      "type": "example",
+      "file": "examples/36-video-fragmentation.js",
+      "title": "video fragmentation"
+    },
+    {
+      "id": "example:examples/37-tracing-tab-correlation.js",
+      "type": "example",
+      "file": "examples/37-tracing-tab-correlation.js",
+      "title": "tracing tab correlation"
+    },
+    {
+      "id": "example:examples/38-programmatic-pause.js",
+      "type": "example",
+      "file": "examples/38-programmatic-pause.js",
+      "title": "programmatic pause"
+    }
+  ],
+  "edges": [
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1",
+      "relation": "about",
+      "to": "topic:playwright-core"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1",
+      "relation": "about",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1",
+      "relation": "about",
+      "to": "topic:api"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1",
+      "relation": "about",
+      "to": "topic:reference"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#24"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#24",
+      "relation": "about",
+      "to": "topic:classname"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#24",
+      "relation": "about",
+      "to": "topic:methodname"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#24",
+      "relation": "about",
+      "to": "topic:args"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#33"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#33",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#35"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#35",
+      "relation": "about",
+      "to": "topic:navigation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#37"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#37",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#37",
+      "relation": "about",
+      "to": "topic:goback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#37",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#42"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#42",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#42",
+      "relation": "about",
+      "to": "topic:goforward"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#42",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#47"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#47",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#47",
+      "relation": "about",
+      "to": "topic:goto"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#47",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#47",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#52"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#52",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#52",
+      "relation": "about",
+      "to": "topic:reload"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#52",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#57"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#57",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#57",
+      "relation": "about",
+      "to": "topic:setcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#57",
+      "relation": "about",
+      "to": "topic:html"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#57",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#62"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#62",
+      "relation": "about",
+      "to": "topic:waiting"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#62",
+      "relation": "about",
+      "to": "topic:delays"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#64"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#64",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#64",
+      "relation": "about",
+      "to": "topic:waitforloadstate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#64",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#64",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#69"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#69",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#69",
+      "relation": "about",
+      "to": "topic:waitfornavigation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#69",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#75"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#75",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#75",
+      "relation": "about",
+      "to": "topic:waitforrequest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#75",
+      "relation": "about",
+      "to": "topic:urlorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#75",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#80"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#80",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#80",
+      "relation": "about",
+      "to": "topic:waitforresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#80",
+      "relation": "about",
+      "to": "topic:urlorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#80",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#85"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#85",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#85",
+      "relation": "about",
+      "to": "topic:waitfortimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#85",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#91"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#91",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#91",
+      "relation": "about",
+      "to": "topic:waitforurl"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#91",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#91",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#96"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#96",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#96",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#96",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#96",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#101"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#101",
+      "relation": "about",
+      "to": "topic:locators"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#101",
+      "relation": "about",
+      "to": "topic:element"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#101",
+      "relation": "about",
+      "to": "topic:queries"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#103"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#103",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#103",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#103",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#103",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#108"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#108",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#108",
+      "relation": "about",
+      "to": "topic:getbyalttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#108",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#108",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#113"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#113",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#113",
+      "relation": "about",
+      "to": "topic:getbylabel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#113",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#113",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#118"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#118",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#118",
+      "relation": "about",
+      "to": "topic:getbyplaceholder"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#118",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#118",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#123"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#123",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#123",
+      "relation": "about",
+      "to": "topic:getbyrole"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#123",
+      "relation": "about",
+      "to": "topic:role"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#123",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#128"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#128",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#128",
+      "relation": "about",
+      "to": "topic:getbytestid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#128",
+      "relation": "about",
+      "to": "topic:testid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#133"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#133",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#133",
+      "relation": "about",
+      "to": "topic:getbytext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#133",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#133",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#138"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#138",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#138",
+      "relation": "about",
+      "to": "topic:getbytitle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#138",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#138",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#143"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#143",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#143",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#143",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#148"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#148",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#148",
+      "relation": "about",
+      "to": "topic:pierceframes"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#148",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#153"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#153",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#153",
+      "relation": "about",
+      "to": "topic:picklocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#158"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#158",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#158",
+      "relation": "about",
+      "to": "topic:cancelpicklocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#163"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#163",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#163",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#163",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#168"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#168",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#168",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#173"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#173",
+      "relation": "about",
+      "to": "topic:interactivity"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#173",
+      "relation": "about",
+      "to": "topic:page-level"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#173",
+      "relation": "about",
+      "to": "topic:actions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#175"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#175",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#175",
+      "relation": "about",
+      "to": "topic:check"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#175",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#175",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#180"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#180",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#180",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#180",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#180",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#185"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#185",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#185",
+      "relation": "about",
+      "to": "topic:dblclick"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#185",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#185",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#190"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:dispatchevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:eventinit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#190",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#195"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#195",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#195",
+      "relation": "about",
+      "to": "topic:draganddrop"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#195",
+      "relation": "about",
+      "to": "topic:source"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#195",
+      "relation": "about",
+      "to": "topic:target"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#195",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#200"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#200",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#200",
+      "relation": "about",
+      "to": "topic:fill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#200",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#200",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#200",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#205"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#205",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#205",
+      "relation": "about",
+      "to": "topic:setinputfiles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#205",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#205",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#205",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#210"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#210",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#210",
+      "relation": "about",
+      "to": "topic:focus"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#210",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#210",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#215"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#215",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#215",
+      "relation": "about",
+      "to": "topic:getattribute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#215",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#215",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#215",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#220"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#220",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#220",
+      "relation": "about",
+      "to": "topic:hover"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#220",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#220",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#225"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#225",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#225",
+      "relation": "about",
+      "to": "topic:innerhtml"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#225",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#225",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#230"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#230",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#230",
+      "relation": "about",
+      "to": "topic:innertext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#230",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#230",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#235"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#235",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#235",
+      "relation": "about",
+      "to": "topic:inputvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#235",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#235",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#240"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#240",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#240",
+      "relation": "about",
+      "to": "topic:ischecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#240",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#240",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#245"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#245",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#245",
+      "relation": "about",
+      "to": "topic:isdisabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#245",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#245",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#250"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#250",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#250",
+      "relation": "about",
+      "to": "topic:iseditable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#250",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#250",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#255"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#255",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#255",
+      "relation": "about",
+      "to": "topic:isenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#255",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#255",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#260"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#260",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#260",
+      "relation": "about",
+      "to": "topic:ishidden"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#260",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#260",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#265"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#265",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#265",
+      "relation": "about",
+      "to": "topic:isvisible"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#265",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#265",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#270"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#270",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#270",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#270",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#270",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#270",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#275"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#275",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#275",
+      "relation": "about",
+      "to": "topic:selectoption"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#275",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#275",
+      "relation": "about",
+      "to": "topic:values"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#275",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#280"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#280",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#280",
+      "relation": "about",
+      "to": "topic:setchecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#280",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#280",
+      "relation": "about",
+      "to": "topic:checked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#280",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#285"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#285",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#285",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#285",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#285",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#290"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#290",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#290",
+      "relation": "about",
+      "to": "topic:textcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#290",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#290",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#295"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#295",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#295",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#295",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#295",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#295",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#301"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#301",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#301",
+      "relation": "about",
+      "to": "topic:uncheck"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#301",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#301",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#306"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#306",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#306",
+      "relation": "about",
+      "to": "topic:waitforselector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#306",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#306",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#311"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#311",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#311",
+      "relation": "about",
+      "to": "topic:waitforfunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#311",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#311",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#311",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#316"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#316",
+      "relation": "about",
+      "to": "topic:routing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#316",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#318"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#318",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#318",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#318",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#318",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#318",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#323"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#323",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#323",
+      "relation": "about",
+      "to": "topic:requests"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#328"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#328",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#328",
+      "relation": "about",
+      "to": "topic:routefromhar"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#328",
+      "relation": "about",
+      "to": "topic:har"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#328",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#333"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#333",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#333",
+      "relation": "about",
+      "to": "topic:routewebsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#333",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#333",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#338"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#338",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#338",
+      "relation": "about",
+      "to": "topic:unroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#338",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#338",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#343"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#343",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#343",
+      "relation": "about",
+      "to": "topic:unrouteall"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#343",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#348"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#348",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#348",
+      "relation": "about",
+      "to": "topic:setextrahttpheaders"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#348",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#353"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#353",
+      "relation": "about",
+      "to": "topic:events"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#353",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#353",
+      "relation": "about",
+      "to": "topic:listeners"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#355"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#355",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#355",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#355",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#360"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#360",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#360",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#360",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#360",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#365"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#365",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#365",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#365",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#365",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#370"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#370",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#370",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#370",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#370",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#375"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#375",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#375",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#375",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#375",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#380"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#380",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#380",
+      "relation": "about",
+      "to": "topic:removealllisteners"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#380",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#380",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#385"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#385",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#385",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#385",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#385",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#390"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#390",
+      "relation": "about",
+      "to": "topic:scripts"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#390",
+      "relation": "about",
+      "to": "topic:evaluation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#392"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#392",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#392",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#392",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#392",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#392",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#397"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#397",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#397",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#397",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#397",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#397",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#402"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#402",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#402",
+      "relation": "about",
+      "to": "topic:addinitscript"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#402",
+      "relation": "about",
+      "to": "topic:script"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#402",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#407"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#407",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#407",
+      "relation": "about",
+      "to": "topic:addscripttag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#407",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#412"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#412",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#412",
+      "relation": "about",
+      "to": "topic:addstyletag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#412",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#417"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#417",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#417",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#417",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#417",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#422"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#422",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#422",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#422",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#422",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#427"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#427",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#427",
+      "relation": "about",
+      "to": "topic:exposebinding"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#427",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#427",
+      "relation": "about",
+      "to": "topic:callback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#432"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#432",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#432",
+      "relation": "about",
+      "to": "topic:exposefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#432",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#432",
+      "relation": "about",
+      "to": "topic:callback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#437"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#437",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#437",
+      "relation": "about",
+      "to": "topic:addlocatorhandler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#437",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#437",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#437",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#442"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#442",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#442",
+      "relation": "about",
+      "to": "topic:removelocatorhandler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#442",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#447"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#447",
+      "relation": "about",
+      "to": "topic:emulation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#447",
+      "relation": "about",
+      "to": "topic:configuration"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#449"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#449",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#449",
+      "relation": "about",
+      "to": "topic:emulatemedia"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#449",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#454"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#454",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#454",
+      "relation": "about",
+      "to": "topic:setdefaultnavigationtimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#454",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#459"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#459",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#459",
+      "relation": "about",
+      "to": "topic:setdefaulttimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#459",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#464"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#464",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#464",
+      "relation": "about",
+      "to": "topic:setviewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#464",
+      "relation": "about",
+      "to": "topic:viewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#469"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#469",
+      "relation": "about",
+      "to": "topic:screenshots"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#469",
+      "relation": "about",
+      "to": "topic:output"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#471"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#471",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#471",
+      "relation": "about",
+      "to": "topic:screenshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#471",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#476"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#476",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#476",
+      "relation": "about",
+      "to": "topic:ariasnapshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#476",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#481"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#481",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#481",
+      "relation": "about",
+      "to": "topic:ariasnapshotjson"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#481",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#486"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#486",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#486",
+      "relation": "about",
+      "to": "topic:pdf"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#486",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#491"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#491",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#491",
+      "relation": "about",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#491",
+      "relation": "about",
+      "to": "topic:tabs"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#493"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#493",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#493",
+      "relation": "about",
+      "to": "topic:bringtofront"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#498"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#498",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#498",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#498",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#503"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#503",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#503",
+      "relation": "about",
+      "to": "topic:opener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#508"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#508",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#508",
+      "relation": "about",
+      "to": "topic:isclosed"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#513"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#513",
+      "relation": "about",
+      "to": "topic:accessors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#513",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#513",
+      "relation": "about",
+      "to": "topic:properties"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#513",
+      "relation": "about",
+      "to": "topic:methods"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#515"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#515",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#515",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#520"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#520",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#520",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#525"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#525",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#525",
+      "relation": "about",
+      "to": "topic:localstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#530"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#530",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#530",
+      "relation": "about",
+      "to": "topic:sessionstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#535"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#535",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#535",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#540"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#540",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#540",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#545"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#545",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#545",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#550"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#550",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#550",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#555"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#555",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#555",
+      "relation": "about",
+      "to": "topic:touchscreen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#560"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#560",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#560",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#565"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#565",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#565",
+      "relation": "about",
+      "to": "topic:content"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#570"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#570",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#570",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#570",
+      "relation": "about",
+      "to": "topic:frameselector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#575"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#575",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#575",
+      "relation": "about",
+      "to": "topic:frames"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#580"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#580",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#580",
+      "relation": "about",
+      "to": "topic:mainframe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#585"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#585",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#585",
+      "relation": "about",
+      "to": "topic:title"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#590"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#590",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#590",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#595"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#595",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#595",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#600"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#600",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#600",
+      "relation": "about",
+      "to": "topic:viewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#605"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#605",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#605",
+      "relation": "about",
+      "to": "topic:workers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#610"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#610",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#610",
+      "relation": "about",
+      "to": "topic:consolemessages"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#615"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#615",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#615",
+      "relation": "about",
+      "to": "topic:clearconsolemessages"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#620"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#620",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#620",
+      "relation": "about",
+      "to": "topic:clearpageerrors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#625"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#625",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#625",
+      "relation": "about",
+      "to": "topic:pageerrors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#625",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#630"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#630",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#630",
+      "relation": "about",
+      "to": "topic:requestgc"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#635"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#635",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#635",
+      "relation": "about",
+      "to": "topic:pause"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#640"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#640",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#640",
+      "relation": "about",
+      "to": "topic:hidehighlight"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#648"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#648",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#650"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#650",
+      "relation": "about",
+      "to": "topic:filtering"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#650",
+      "relation": "about",
+      "to": "topic:chaining"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#652"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#652",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#652",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#657"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#657",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#657",
+      "relation": "about",
+      "to": "topic:filter"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#657",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#662"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#662",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#662",
+      "relation": "about",
+      "to": "topic:first"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#667"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#667",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#667",
+      "relation": "about",
+      "to": "topic:last"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#672"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#672",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#672",
+      "relation": "about",
+      "to": "topic:selectororlocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#672",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#677"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#677",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#677",
+      "relation": "about",
+      "to": "topic:nth"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#677",
+      "relation": "about",
+      "to": "topic:index"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#682"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#682",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#687"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#687",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#687",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#687",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#692"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#692",
+      "relation": "about",
+      "to": "topic:specialized"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#692",
+      "relation": "about",
+      "to": "topic:selectors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#694"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#694",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#694",
+      "relation": "about",
+      "to": "topic:getbyalttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#694",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#694",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#699"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#699",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#699",
+      "relation": "about",
+      "to": "topic:getbylabel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#699",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#699",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#704"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#704",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#704",
+      "relation": "about",
+      "to": "topic:getbyplaceholder"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#704",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#704",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#709"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#709",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#709",
+      "relation": "about",
+      "to": "topic:getbyrole"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#709",
+      "relation": "about",
+      "to": "topic:role"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#709",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#714"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#714",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#714",
+      "relation": "about",
+      "to": "topic:getbytestid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#714",
+      "relation": "about",
+      "to": "topic:testid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#719"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#719",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#719",
+      "relation": "about",
+      "to": "topic:getbytext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#719",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#719",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#724"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#724",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#724",
+      "relation": "about",
+      "to": "topic:getbytitle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#724",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#724",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#729"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#729",
+      "relation": "about",
+      "to": "topic:interactivity"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#729",
+      "relation": "about",
+      "to": "topic:actions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#731"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#731",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#731",
+      "relation": "about",
+      "to": "topic:blur"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#731",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#736"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#736",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#736",
+      "relation": "about",
+      "to": "topic:check"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#736",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#741"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#741",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#741",
+      "relation": "about",
+      "to": "topic:clear"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#741",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#746"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#746",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#746",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#746",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#751"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#751",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#751",
+      "relation": "about",
+      "to": "topic:dblclick"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#751",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#756"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#756",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#756",
+      "relation": "about",
+      "to": "topic:dispatchevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#756",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#756",
+      "relation": "about",
+      "to": "topic:eventinit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#756",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#761"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#761",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#761",
+      "relation": "about",
+      "to": "topic:dragto"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#761",
+      "relation": "about",
+      "to": "topic:target"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#761",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#766"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#766",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#766",
+      "relation": "about",
+      "to": "topic:drop"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#766",
+      "relation": "about",
+      "to": "topic:payload"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#766",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#771"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#771",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#771",
+      "relation": "about",
+      "to": "topic:fill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#771",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#771",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#776"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#776",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#776",
+      "relation": "about",
+      "to": "topic:focus"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#776",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#781"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#781",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#781",
+      "relation": "about",
+      "to": "topic:hover"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#781",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#786"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#786",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#786",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#786",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#786",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#791"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#791",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#791",
+      "relation": "about",
+      "to": "topic:presssequentially"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#791",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#791",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#796"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#796",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#796",
+      "relation": "about",
+      "to": "topic:scrollintoviewifneeded"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#796",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#801"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#801",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#801",
+      "relation": "about",
+      "to": "topic:selectoption"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#801",
+      "relation": "about",
+      "to": "topic:values"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#801",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#806"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#806",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#806",
+      "relation": "about",
+      "to": "topic:selecttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#806",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#811"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#811",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#811",
+      "relation": "about",
+      "to": "topic:setchecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#811",
+      "relation": "about",
+      "to": "topic:checked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#811",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#816"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#816",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#816",
+      "relation": "about",
+      "to": "topic:setinputfiles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#816",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#816",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#821"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#821",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#821",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#821",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#826"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#826",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#826",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#826",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#826",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#832"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#832",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#832",
+      "relation": "about",
+      "to": "topic:uncheck"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#832",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#837"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#837",
+      "relation": "about",
+      "to": "topic:element"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#837",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#837",
+      "relation": "about",
+      "to": "topic:properties"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#839"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#839",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#839",
+      "relation": "about",
+      "to": "topic:all"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#844"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#844",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#844",
+      "relation": "about",
+      "to": "topic:allinnertexts"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#849"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#849",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#849",
+      "relation": "about",
+      "to": "topic:alltextcontents"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#854"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#854",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#854",
+      "relation": "about",
+      "to": "topic:boundingbox"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#854",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#859"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#859",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#859",
+      "relation": "about",
+      "to": "topic:count"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#864"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#864",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#864",
+      "relation": "about",
+      "to": "topic:getattribute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#864",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#864",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#869"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#869",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#869",
+      "relation": "about",
+      "to": "topic:innerhtml"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#869",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#874"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#874",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#874",
+      "relation": "about",
+      "to": "topic:innertext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#874",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#879"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#879",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#879",
+      "relation": "about",
+      "to": "topic:inputvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#879",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#884"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#884",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#884",
+      "relation": "about",
+      "to": "topic:ischecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#884",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#889"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#889",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#889",
+      "relation": "about",
+      "to": "topic:isdisabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#889",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#894"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#894",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#894",
+      "relation": "about",
+      "to": "topic:iseditable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#894",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#899"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#899",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#899",
+      "relation": "about",
+      "to": "topic:isenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#899",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#904"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#904",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#904",
+      "relation": "about",
+      "to": "topic:ishidden"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#904",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#909"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#909",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#909",
+      "relation": "about",
+      "to": "topic:isvisible"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#909",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#914"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#914",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#914",
+      "relation": "about",
+      "to": "topic:textcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#914",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#919"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#919",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#919",
+      "relation": "about",
+      "to": "topic:contentframe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#924"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#924",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#924",
+      "relation": "about",
+      "to": "topic:normalize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#929"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#929",
+      "relation": "about",
+      "to": "topic:verification"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#929",
+      "relation": "about",
+      "to": "topic:waiting"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#931"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#931",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#931",
+      "relation": "about",
+      "to": "topic:waitfor"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#931",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#936"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#936",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#936",
+      "relation": "about",
+      "to": "topic:waitforfunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#936",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#936",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#936",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#941"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#941",
+      "relation": "about",
+      "to": "topic:output"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#941",
+      "relation": "about",
+      "to": "topic:handles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#943"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#943",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#943",
+      "relation": "about",
+      "to": "topic:ariasnapshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#943",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#948"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#948",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#948",
+      "relation": "about",
+      "to": "topic:ariasnapshotjson"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#948",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#953"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#953",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#953",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#953",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#958"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#958",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#958",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#958",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#958",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#958",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#963"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#963",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#963",
+      "relation": "about",
+      "to": "topic:evaluateall"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#963",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#963",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#968"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#968",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#968",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#968",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#968",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#968",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#973"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#973",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#973",
+      "relation": "about",
+      "to": "topic:elementhandles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#978"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#978",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#978",
+      "relation": "about",
+      "to": "topic:screenshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#978",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#983"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#983",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#983",
+      "relation": "about",
+      "to": "topic:highlight"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#983",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#988"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#988",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#988",
+      "relation": "about",
+      "to": "topic:hidehighlight"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#993"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#993",
+      "relation": "about",
+      "to": "topic:misc"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#993",
+      "relation": "about",
+      "to": "topic:metadata"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#995"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#995",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#995",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1000"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1000",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1000",
+      "relation": "about",
+      "to": "topic:describe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1000",
+      "relation": "about",
+      "to": "topic:description"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1005"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1005",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1005",
+      "relation": "about",
+      "to": "topic:description"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1010"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1010",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1010",
+      "relation": "about",
+      "to": "topic:tostring"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1017"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1017",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1021"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1021",
+      "relation": "about",
+      "to": "topic:properties"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1021",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1023"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1023",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1023",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1028"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1028",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1028",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1033"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1033",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1033",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1038"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1038",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1038",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1043"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1043",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1043",
+      "relation": "about",
+      "to": "topic:isclosed"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1048"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1048",
+      "relation": "about",
+      "to": "topic:pages"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1048",
+      "relation": "about",
+      "to": "topic:workers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1050"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1050",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1050",
+      "relation": "about",
+      "to": "topic:newpage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1055"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1055",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1055",
+      "relation": "about",
+      "to": "topic:pages"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1060"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1060",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1060",
+      "relation": "about",
+      "to": "topic:backgroundpages"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1065"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1065",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1065",
+      "relation": "about",
+      "to": "topic:serviceworkers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1070"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1070",
+      "relation": "about",
+      "to": "topic:configuration"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1070",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1070",
+      "relation": "about",
+      "to": "topic:management"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1072"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1072",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1072",
+      "relation": "about",
+      "to": "topic:cookies"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1072",
+      "relation": "about",
+      "to": "topic:urls"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1077"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1077",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1077",
+      "relation": "about",
+      "to": "topic:addcookies"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1077",
+      "relation": "about",
+      "to": "topic:cookies"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1082"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1082",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1082",
+      "relation": "about",
+      "to": "topic:clearcookies"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1082",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1087"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1087",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1087",
+      "relation": "about",
+      "to": "topic:grantpermissions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1087",
+      "relation": "about",
+      "to": "topic:permissions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1087",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1092"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1092",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1092",
+      "relation": "about",
+      "to": "topic:clearpermissions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1097"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1097",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1097",
+      "relation": "about",
+      "to": "topic:setgeolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1097",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1102"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1102",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1102",
+      "relation": "about",
+      "to": "topic:setextrahttpheaders"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1102",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1107"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1107",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1107",
+      "relation": "about",
+      "to": "topic:setoffline"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1107",
+      "relation": "about",
+      "to": "topic:offline"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1112"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1112",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1112",
+      "relation": "about",
+      "to": "topic:sethttpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1112",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1118"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1118",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1118",
+      "relation": "about",
+      "to": "topic:setdefaultnavigationtimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1118",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1123"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1123",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1123",
+      "relation": "about",
+      "to": "topic:setdefaulttimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1123",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1128"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1128",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1128",
+      "relation": "about",
+      "to": "topic:storagestate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1128",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1133"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1133",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1133",
+      "relation": "about",
+      "to": "topic:setstoragestate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1133",
+      "relation": "about",
+      "to": "topic:storagestate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1138"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1138",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1138",
+      "relation": "about",
+      "to": "topic:routing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1140"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1140",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1140",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1140",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1140",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1140",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1145"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1145",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1145",
+      "relation": "about",
+      "to": "topic:routefromhar"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1145",
+      "relation": "about",
+      "to": "topic:har"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1145",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1150"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1150",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1150",
+      "relation": "about",
+      "to": "topic:routewebsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1150",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1150",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1155"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1155",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1155",
+      "relation": "about",
+      "to": "topic:unroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1155",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1155",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1160"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1160",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1160",
+      "relation": "about",
+      "to": "topic:unrouteall"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1160",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1165"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1165",
+      "relation": "about",
+      "to": "topic:scripts"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1165",
+      "relation": "about",
+      "to": "topic:bindings"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1167"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1167",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1167",
+      "relation": "about",
+      "to": "topic:addinitscript"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1167",
+      "relation": "about",
+      "to": "topic:script"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1167",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1167",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1172"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1172",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1172",
+      "relation": "about",
+      "to": "topic:exposebinding"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1172",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1172",
+      "relation": "about",
+      "to": "topic:callback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1177"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1177",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1177",
+      "relation": "about",
+      "to": "topic:exposefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1177",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1177",
+      "relation": "about",
+      "to": "topic:callback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1182"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1182",
+      "relation": "about",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1182",
+      "relation": "about",
+      "to": "topic:events"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1184"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1184",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1184",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1184",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1189"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1189",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1189",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1189",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1189",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1194"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1194",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1194",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1194",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1199"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1199",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1199",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1199",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1199",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1204"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1204",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1204",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1204",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1204",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1209"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1209",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1209",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1209",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1209",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1214"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1214",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1214",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1214",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1214",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1219"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1219",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1219",
+      "relation": "about",
+      "to": "topic:removealllisteners"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1219",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1219",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1224"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1224",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1224",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1224",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1224",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1229"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1229",
+      "relation": "about",
+      "to": "topic:misc"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1231"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1231",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1231",
+      "relation": "about",
+      "to": "topic:newcdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1231",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1236"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1236",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1236",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1241"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1241",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1241",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1248"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1248",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1252"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1252",
+      "relation": "about",
+      "to": "topic:core"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1252",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1252",
+      "relation": "about",
+      "to": "topic:creation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1254"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1254",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1254",
+      "relation": "about",
+      "to": "topic:newcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1254",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1259"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1259",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1259",
+      "relation": "about",
+      "to": "topic:newpage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1259",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1264"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1264",
+      "relation": "about",
+      "to": "topic:accessors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1264",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1266"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1266",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1266",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1271"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1271",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1271",
+      "relation": "about",
+      "to": "topic:contexts"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1276"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1276",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1276",
+      "relation": "about",
+      "to": "topic:isconnected"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1281"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1281",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1281",
+      "relation": "about",
+      "to": "topic:version"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1286"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1286",
+      "relation": "about",
+      "to": "topic:advanced"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1286",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1288"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1288",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1288",
+      "relation": "about",
+      "to": "topic:starttracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1288",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1288",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1293"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1293",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1293",
+      "relation": "about",
+      "to": "topic:stoptracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1298"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1298",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1298",
+      "relation": "about",
+      "to": "topic:newbrowsercdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1303"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1303",
+      "relation": "about",
+      "to": "topic:remote"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1303",
+      "relation": "about",
+      "to": "topic:connectivity"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1305"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1305",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1305",
+      "relation": "about",
+      "to": "topic:bind"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1305",
+      "relation": "about",
+      "to": "topic:title"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1305",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1310"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1310",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1310",
+      "relation": "about",
+      "to": "topic:unbind"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1315"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1315",
+      "relation": "about",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1315",
+      "relation": "about",
+      "to": "topic:events"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1317"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1317",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1317",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1317",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1322"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1322",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1322",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1322",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1327"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1327",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1327",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1327",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1327",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1332"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1332",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1332",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1332",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1332",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1337"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1337",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1337",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1337",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1337",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1342"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1342",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1342",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1342",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1342",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1347"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1347",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1347",
+      "relation": "about",
+      "to": "topic:removealllisteners"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1347",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1347",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1352"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1352",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1352",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1352",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1352",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1362"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1362",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1366"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1366",
+      "relation": "about",
+      "to": "topic:accessors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1366",
+      "relation": "about",
+      "to": "topic:navigation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1368"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1368",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1368",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1373"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1373",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1373",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1378"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1378",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1378",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1383"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1383",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1383",
+      "relation": "about",
+      "to": "topic:parentframe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1388"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1388",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1388",
+      "relation": "about",
+      "to": "topic:childframes"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1393"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1393",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1393",
+      "relation": "about",
+      "to": "topic:isdetached"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1398"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1398",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1398",
+      "relation": "about",
+      "to": "topic:title"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1403"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1403",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1403",
+      "relation": "about",
+      "to": "topic:goto"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1403",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1403",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1408"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1408",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1408",
+      "relation": "about",
+      "to": "topic:frameelement"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1413"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1413",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1413",
+      "relation": "about",
+      "to": "topic:content"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1418"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1418",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1418",
+      "relation": "about",
+      "to": "topic:setcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1418",
+      "relation": "about",
+      "to": "topic:html"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1418",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1423"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1423",
+      "relation": "about",
+      "to": "topic:locators"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1425"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1425",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1425",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1425",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1425",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1430"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1430",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1430",
+      "relation": "about",
+      "to": "topic:getbytestid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1430",
+      "relation": "about",
+      "to": "topic:testid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1435"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1435",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1435",
+      "relation": "about",
+      "to": "topic:getbyalttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1435",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1435",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1440"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1440",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1440",
+      "relation": "about",
+      "to": "topic:getbylabel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1440",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1440",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1445"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1445",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1445",
+      "relation": "about",
+      "to": "topic:getbyplaceholder"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1445",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1445",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1450"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1450",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1450",
+      "relation": "about",
+      "to": "topic:getbyrole"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1450",
+      "relation": "about",
+      "to": "topic:role"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1450",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1455"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1455",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1455",
+      "relation": "about",
+      "to": "topic:getbytext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1455",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1455",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1460"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1460",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1460",
+      "relation": "about",
+      "to": "topic:getbytitle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1460",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1460",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1465"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1465",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1465",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1465",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1470"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1470",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1470",
+      "relation": "about",
+      "to": "topic:pierceframes"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1470",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1475"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1475",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1475",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1475",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1480"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1480",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1480",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1485"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1485",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1485",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1485",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1485",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1485",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1490"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1490",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1490",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1490",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1490",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1490",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1495"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1495",
+      "relation": "about",
+      "to": "topic:interactions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1495",
+      "relation": "about",
+      "to": "topic:evaluation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1497"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1497",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1497",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1497",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1497",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1502"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1502",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1502",
+      "relation": "about",
+      "to": "topic:dblclick"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1502",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1502",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1507"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1507",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1507",
+      "relation": "about",
+      "to": "topic:draganddrop"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1507",
+      "relation": "about",
+      "to": "topic:source"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1507",
+      "relation": "about",
+      "to": "topic:target"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1507",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1512"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1512",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1512",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1512",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1512",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1517"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1517",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1517",
+      "relation": "about",
+      "to": "topic:fill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1517",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1517",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1517",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1522"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1522",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1522",
+      "relation": "about",
+      "to": "topic:focus"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1522",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1522",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1527"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1527",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1527",
+      "relation": "about",
+      "to": "topic:hover"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1527",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1527",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1532"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1532",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1532",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1532",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1532",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1532",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1537"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1537",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1537",
+      "relation": "about",
+      "to": "topic:selectoption"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1537",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1537",
+      "relation": "about",
+      "to": "topic:values"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1537",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1542"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1542",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1542",
+      "relation": "about",
+      "to": "topic:setinputfiles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1542",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1542",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1542",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1547"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1547",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1547",
+      "relation": "about",
+      "to": "topic:check"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1547",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1547",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1552"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1552",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1552",
+      "relation": "about",
+      "to": "topic:uncheck"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1552",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1552",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1557"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1557",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1557",
+      "relation": "about",
+      "to": "topic:setchecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1557",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1557",
+      "relation": "about",
+      "to": "topic:checked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1557",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1562"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1562",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1562",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1562",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1562",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1562",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1567"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1567",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1567",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1567",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1567",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1567",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1572"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1572",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1572",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1572",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1572",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1572",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1577"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:dispatchevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:eventinit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1577",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1582"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1582",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1582",
+      "relation": "about",
+      "to": "topic:queries"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1584"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1584",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1584",
+      "relation": "about",
+      "to": "topic:textcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1584",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1584",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1589"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1589",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1589",
+      "relation": "about",
+      "to": "topic:innertext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1589",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1589",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1594"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1594",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1594",
+      "relation": "about",
+      "to": "topic:innerhtml"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1594",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1594",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1599"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1599",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1599",
+      "relation": "about",
+      "to": "topic:getattribute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1599",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1599",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1599",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1604"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1604",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1604",
+      "relation": "about",
+      "to": "topic:inputvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1604",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1604",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1609"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1609",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1609",
+      "relation": "about",
+      "to": "topic:ischecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1609",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1609",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1614"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1614",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1614",
+      "relation": "about",
+      "to": "topic:isdisabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1614",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1614",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1619"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1619",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1619",
+      "relation": "about",
+      "to": "topic:iseditable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1619",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1619",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1624"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1624",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1624",
+      "relation": "about",
+      "to": "topic:isenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1624",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1624",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1629"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1629",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1629",
+      "relation": "about",
+      "to": "topic:ishidden"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1629",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1629",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1634"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1634",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1634",
+      "relation": "about",
+      "to": "topic:isvisible"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1634",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1634",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1640"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1640",
+      "relation": "about",
+      "to": "topic:waiting"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1640",
+      "relation": "about",
+      "to": "topic:overrides"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1642"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1642",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1642",
+      "relation": "about",
+      "to": "topic:waitforfunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1642",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1642",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1642",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1647"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1647",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1647",
+      "relation": "about",
+      "to": "topic:waitforloadstate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1647",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1647",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1652"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1652",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1652",
+      "relation": "about",
+      "to": "topic:waitfornavigation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1652",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1657"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1657",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1657",
+      "relation": "about",
+      "to": "topic:waitforselector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1657",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1657",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1662"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1662",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1662",
+      "relation": "about",
+      "to": "topic:waitfortimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1662",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1667"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1667",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1667",
+      "relation": "about",
+      "to": "topic:waitforurl"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1667",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1667",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1672"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1672",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1672",
+      "relation": "about",
+      "to": "topic:addscripttag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1672",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1677"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1677",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1677",
+      "relation": "about",
+      "to": "topic:addstyletag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1677",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1684"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1684",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1688"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1688",
+      "relation": "about",
+      "to": "topic:methods"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1690"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1690",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1690",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1695"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1695",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1695",
+      "relation": "about",
+      "to": "topic:abort"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1695",
+      "relation": "about",
+      "to": "topic:errorcode"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1700"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1700",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1700",
+      "relation": "about",
+      "to": "topic:continue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1700",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1705"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1705",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1705",
+      "relation": "about",
+      "to": "topic:fallback"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1705",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1710"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1710",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1710",
+      "relation": "about",
+      "to": "topic:fetch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1710",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1715"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1715",
+      "relation": "about",
+      "to": "topic:route"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1715",
+      "relation": "about",
+      "to": "topic:fulfill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1715",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1722"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1722",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1726"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1726",
+      "relation": "about",
+      "to": "topic:methods"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1728"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1728",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1728",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1733"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1733",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1733",
+      "relation": "about",
+      "to": "topic:resourcetype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1738"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1738",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1738",
+      "relation": "about",
+      "to": "topic:method"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1743"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1743",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1743",
+      "relation": "about",
+      "to": "topic:postdata"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1748"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1748",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1748",
+      "relation": "about",
+      "to": "topic:postdatabuffer"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1753"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1753",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1753",
+      "relation": "about",
+      "to": "topic:postdatajson"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1758"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1758",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1758",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1763"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1763",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1763",
+      "relation": "about",
+      "to": "topic:allheaders"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1768"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1768",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1768",
+      "relation": "about",
+      "to": "topic:headersarray"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1773"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1773",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1773",
+      "relation": "about",
+      "to": "topic:headervalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1773",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1778"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1778",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1778",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1783"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1783",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1783",
+      "relation": "about",
+      "to": "topic:existingresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1788"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1788",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1788",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1793"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1793",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1793",
+      "relation": "about",
+      "to": "topic:serviceworker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1798"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1798",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1798",
+      "relation": "about",
+      "to": "topic:isnavigationrequest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1803"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1803",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1803",
+      "relation": "about",
+      "to": "topic:redirectedfrom"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1808"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1808",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1808",
+      "relation": "about",
+      "to": "topic:redirectedto"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1813"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1813",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1813",
+      "relation": "about",
+      "to": "topic:failure"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1818"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1818",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1818",
+      "relation": "about",
+      "to": "topic:timing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1823"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1823",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1823",
+      "relation": "about",
+      "to": "topic:sizes"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1830"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1830",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1834"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1834",
+      "relation": "about",
+      "to": "topic:methods"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1836"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1836",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1836",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1841"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1841",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1846"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1846",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1846",
+      "relation": "about",
+      "to": "topic:status"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1851"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1851",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1851",
+      "relation": "about",
+      "to": "topic:statustext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1856"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1856",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1856",
+      "relation": "about",
+      "to": "topic:fromserviceworker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1861"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1861",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1861",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1866"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1866",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1866",
+      "relation": "about",
+      "to": "topic:allheaders"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1871"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1871",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1871",
+      "relation": "about",
+      "to": "topic:headersarray"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1876"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1876",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1876",
+      "relation": "about",
+      "to": "topic:headervalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1876",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1881"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1881",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1881",
+      "relation": "about",
+      "to": "topic:headervalues"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1881",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1886"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1886",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1886",
+      "relation": "about",
+      "to": "topic:finished"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1891"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1891",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1891",
+      "relation": "about",
+      "to": "topic:body"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1896"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1896",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1896",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1901"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1901",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1901",
+      "relation": "about",
+      "to": "topic:json"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1906"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1906",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1906",
+      "relation": "about",
+      "to": "topic:request"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1911"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1911",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1911",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1916"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1916",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1916",
+      "relation": "about",
+      "to": "topic:serveraddr"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1921"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1921",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1921",
+      "relation": "about",
+      "to": "topic:securitydetails"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1926"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1926",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1926",
+      "relation": "about",
+      "to": "topic:httpversion"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1933"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1933",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1937"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1937",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1937",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1937",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1937",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1937",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1942"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1942",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1942",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1942",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1942",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1942",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1947"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1947",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1947",
+      "relation": "about",
+      "to": "topic:jsonvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1952"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1952",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1952",
+      "relation": "about",
+      "to": "topic:aselement"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1957"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1957",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1957",
+      "relation": "about",
+      "to": "topic:dispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1962"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1962",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1962",
+      "relation": "about",
+      "to": "topic:getproperties"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1967"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1967",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1967",
+      "relation": "about",
+      "to": "topic:getproperty"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1967",
+      "relation": "about",
+      "to": "topic:propertyname"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1972"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1972",
+      "relation": "about",
+      "to": "topic:jshandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1972",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1972",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1979"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1979",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1983"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1983",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1983",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1983",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1988"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1988",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1988",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1993"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1993",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1993",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1993",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1993",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1993",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#1998"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1998",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1998",
+      "relation": "about",
+      "to": "topic:eval"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1998",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1998",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#1998",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2003"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2003",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2003",
+      "relation": "about",
+      "to": "topic:boundingbox"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2008"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2008",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2008",
+      "relation": "about",
+      "to": "topic:check"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2008",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2013"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2013",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2013",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2013",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2018"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2018",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2018",
+      "relation": "about",
+      "to": "topic:contentframe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2023"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2023",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2023",
+      "relation": "about",
+      "to": "topic:dblclick"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2023",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2028"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2028",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2028",
+      "relation": "about",
+      "to": "topic:dispatchevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2028",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2028",
+      "relation": "about",
+      "to": "topic:eventinit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2033"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2033",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2033",
+      "relation": "about",
+      "to": "topic:fill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2033",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2033",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2038"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2038",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2038",
+      "relation": "about",
+      "to": "topic:focus"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2043"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2043",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2043",
+      "relation": "about",
+      "to": "topic:getattribute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2043",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2048"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2048",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2048",
+      "relation": "about",
+      "to": "topic:hover"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2048",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2053"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2053",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2053",
+      "relation": "about",
+      "to": "topic:innerhtml"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2058"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2058",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2058",
+      "relation": "about",
+      "to": "topic:innertext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2063"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2063",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2063",
+      "relation": "about",
+      "to": "topic:inputvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2063",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2069"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2069",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2069",
+      "relation": "about",
+      "to": "topic:ischecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2074"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2074",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2074",
+      "relation": "about",
+      "to": "topic:isdisabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2079"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2079",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2079",
+      "relation": "about",
+      "to": "topic:iseditable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2084"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2084",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2084",
+      "relation": "about",
+      "to": "topic:isenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2089"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2089",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2089",
+      "relation": "about",
+      "to": "topic:ishidden"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2094"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2094",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2094",
+      "relation": "about",
+      "to": "topic:isvisible"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2099"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2099",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2099",
+      "relation": "about",
+      "to": "topic:ownerframe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2104"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2104",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2104",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2104",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2104",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2109"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2109",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2109",
+      "relation": "about",
+      "to": "topic:screenshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2109",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2114"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2114",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2114",
+      "relation": "about",
+      "to": "topic:scrollintoviewifneeded"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2114",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2119"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2119",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2119",
+      "relation": "about",
+      "to": "topic:selectoption"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2119",
+      "relation": "about",
+      "to": "topic:values"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2119",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2124"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2124",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2124",
+      "relation": "about",
+      "to": "topic:selecttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2124",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2129"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2129",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2129",
+      "relation": "about",
+      "to": "topic:setchecked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2129",
+      "relation": "about",
+      "to": "topic:checked"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2129",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2134"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2134",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2134",
+      "relation": "about",
+      "to": "topic:setinputfiles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2134",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2134",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2139"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2139",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2139",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2139",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2144"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2144",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2144",
+      "relation": "about",
+      "to": "topic:textcontent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2149"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2149",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2149",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2149",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2149",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2155"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2155",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2155",
+      "relation": "about",
+      "to": "topic:uncheck"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2155",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2160"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2160",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2160",
+      "relation": "about",
+      "to": "topic:waitforelementstate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2160",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2160",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2165"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2165",
+      "relation": "about",
+      "to": "topic:elementhandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2165",
+      "relation": "about",
+      "to": "topic:waitforselector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2165",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2165",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2172"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2172",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2176"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2176",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2176",
+      "relation": "about",
+      "to": "topic:down"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2176",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2181"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2181",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2181",
+      "relation": "about",
+      "to": "topic:inserttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2181",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2186"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2186",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2186",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2186",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2186",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2191"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2191",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2191",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2191",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2191",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2196"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2196",
+      "relation": "about",
+      "to": "topic:keyboard"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2196",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2203"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2203",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2207"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2207",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2207",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2207",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2212"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2212",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2212",
+      "relation": "about",
+      "to": "topic:dblclick"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2212",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2217"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2217",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2217",
+      "relation": "about",
+      "to": "topic:down"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2217",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2222"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2222",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2222",
+      "relation": "about",
+      "to": "topic:move"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2222",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2227"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2227",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2227",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2232"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2232",
+      "relation": "about",
+      "to": "topic:mouse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2232",
+      "relation": "about",
+      "to": "topic:wheel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2232",
+      "relation": "about",
+      "to": "topic:deltax"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2232",
+      "relation": "about",
+      "to": "topic:deltay"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2239"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2239",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2239",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2239",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2252"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2252",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2256"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2256",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2256",
+      "relation": "about",
+      "to": "topic:cancel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2261"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2261",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2261",
+      "relation": "about",
+      "to": "topic:createreadstream"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2266"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2266",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2266",
+      "relation": "about",
+      "to": "topic:delete"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2271"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2271",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2271",
+      "relation": "about",
+      "to": "topic:failure"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2276"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2276",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2276",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2281"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2281",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2281",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2286"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2286",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2286",
+      "relation": "about",
+      "to": "topic:saveas"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2286",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2291"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2291",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2291",
+      "relation": "about",
+      "to": "topic:suggestedfilename"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2296"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2296",
+      "relation": "about",
+      "to": "topic:download"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2296",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2303"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2303",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2307"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2307",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2307",
+      "relation": "about",
+      "to": "topic:accept"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2307",
+      "relation": "about",
+      "to": "topic:prompttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2312"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2312",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2312",
+      "relation": "about",
+      "to": "topic:defaultvalue"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2317"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2317",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2317",
+      "relation": "about",
+      "to": "topic:dismiss"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2322"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2322",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2322",
+      "relation": "about",
+      "to": "topic:message"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2327"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2327",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2327",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2332"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2332",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2332",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2339"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2339",
+      "relation": "about",
+      "to": "topic:filechooser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2343"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2343",
+      "relation": "about",
+      "to": "topic:filechooser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2343",
+      "relation": "about",
+      "to": "topic:element"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2348"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2348",
+      "relation": "about",
+      "to": "topic:filechooser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2348",
+      "relation": "about",
+      "to": "topic:ismultiple"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2353"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2353",
+      "relation": "about",
+      "to": "topic:filechooser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2353",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2358"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2358",
+      "relation": "about",
+      "to": "topic:filechooser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2358",
+      "relation": "about",
+      "to": "topic:setfiles"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2358",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2358",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2366"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2366",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2370"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2370",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2370",
+      "relation": "about",
+      "to": "topic:args"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2375"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2375",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2375",
+      "relation": "about",
+      "to": "topic:location"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2381"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2381",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2381",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2386"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2386",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2386",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2391"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2391",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2391",
+      "relation": "about",
+      "to": "topic:timestamp"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2396"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2396",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2396",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2401"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2401",
+      "relation": "about",
+      "to": "topic:consolemessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2401",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2408"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2408",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2408",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2408",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2421"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2421",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2425"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2425",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2425",
+      "relation": "about",
+      "to": "topic:delete"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2425",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2425",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2430"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2430",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2430",
+      "relation": "about",
+      "to": "topic:dispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2430",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2435"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2435",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2435",
+      "relation": "about",
+      "to": "topic:fetch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2435",
+      "relation": "about",
+      "to": "topic:urlorrequest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2435",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2440"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2440",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2440",
+      "relation": "about",
+      "to": "topic:get"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2440",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2440",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2445"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2445",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2445",
+      "relation": "about",
+      "to": "topic:head"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2445",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2445",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2450"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2450",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2450",
+      "relation": "about",
+      "to": "topic:patch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2450",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2450",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2455"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2455",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2455",
+      "relation": "about",
+      "to": "topic:post"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2455",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2455",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2460"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2460",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2460",
+      "relation": "about",
+      "to": "topic:put"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2460",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2460",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2465"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2465",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2465",
+      "relation": "about",
+      "to": "topic:storagestate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2465",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2470"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2470",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2470",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2475"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2475",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2475",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2475",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2482"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2482",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2486"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2486",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2486",
+      "relation": "about",
+      "to": "topic:body"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2491"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2491",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2491",
+      "relation": "about",
+      "to": "topic:dispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2496"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2496",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2496",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2501"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2501",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2501",
+      "relation": "about",
+      "to": "topic:headersarray"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2506"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2506",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2506",
+      "relation": "about",
+      "to": "topic:json"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2511"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2511",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2516"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2516",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2516",
+      "relation": "about",
+      "to": "topic:securitydetails"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2521"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2521",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2521",
+      "relation": "about",
+      "to": "topic:serveraddr"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2526"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2526",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2526",
+      "relation": "about",
+      "to": "topic:status"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2531"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2531",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2531",
+      "relation": "about",
+      "to": "topic:statustext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2536"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2536",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2536",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2541"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2541",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2541",
+      "relation": "about",
+      "to": "topic:timing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2546"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2546",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2546",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2551"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2551",
+      "relation": "about",
+      "to": "topic:apiresponse"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2551",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2551",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2558"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2558",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2562"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2562",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2562",
+      "relation": "about",
+      "to": "topic:isclosed"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2567"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2567",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2567",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2572"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2572",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2572",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2572",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2572",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2577"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2577",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2577",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2577",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2582"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2582",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2582",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2582",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2582",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2587"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2587",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2587",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2587",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2587",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2592"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2592",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2592",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2592",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2592",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2597"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2597",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2597",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2597",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2597",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2602"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2602",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2602",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2602",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2602",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2609"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2609",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2613"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2613",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2613",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2613",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2613",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2618"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2618",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2618",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2618",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2618",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2623"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2623",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2623",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2623",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2628"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2628",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2628",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2628",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2628",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2633"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2633",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2633",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2633",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2633",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2638"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2638",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2638",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2638",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2638",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2643"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2643",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2643",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2643",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2643",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2648"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2648",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2648",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2648",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2648",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2653"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2653",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2653",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2658"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2658",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2658",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2658",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2658",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2665"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2665",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2665",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2665",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2678"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2678",
+      "relation": "about",
+      "to": "topic:selectors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2682"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2682",
+      "relation": "about",
+      "to": "topic:selectors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2682",
+      "relation": "about",
+      "to": "topic:register"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2682",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2682",
+      "relation": "about",
+      "to": "topic:script"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2682",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2687"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2687",
+      "relation": "about",
+      "to": "topic:selectors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2687",
+      "relation": "about",
+      "to": "topic:settestidattribute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2687",
+      "relation": "about",
+      "to": "topic:attributename"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2694"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2694",
+      "relation": "about",
+      "to": "topic:touchscreen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2698"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2698",
+      "relation": "about",
+      "to": "topic:touchscreen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2698",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2705"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2705",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2709"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2709",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2709",
+      "relation": "about",
+      "to": "topic:group"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2709",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2709",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2714"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2714",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2714",
+      "relation": "about",
+      "to": "topic:groupend"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2719"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2719",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2719",
+      "relation": "about",
+      "to": "topic:start"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2719",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2724"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2724",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2724",
+      "relation": "about",
+      "to": "topic:startchunk"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2724",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2729"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2729",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2729",
+      "relation": "about",
+      "to": "topic:starthar"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2729",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2729",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2734"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2734",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2734",
+      "relation": "about",
+      "to": "topic:stop"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2734",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2739"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2739",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2739",
+      "relation": "about",
+      "to": "topic:stopchunk"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2739",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2744"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2744",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2744",
+      "relation": "about",
+      "to": "topic:stophar"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2751"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2751",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2755"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2755",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2755",
+      "relation": "about",
+      "to": "topic:delete"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2760"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2760",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2760",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2765"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2765",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2765",
+      "relation": "about",
+      "to": "topic:saveas"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2765",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2772"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2772",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2776"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2776",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2776",
+      "relation": "about",
+      "to": "topic:fastforward"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2776",
+      "relation": "about",
+      "to": "topic:ticks"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2781"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2781",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2781",
+      "relation": "about",
+      "to": "topic:install"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2781",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2786"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2786",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2786",
+      "relation": "about",
+      "to": "topic:pauseat"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2786",
+      "relation": "about",
+      "to": "topic:time"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2791"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2791",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2791",
+      "relation": "about",
+      "to": "topic:resume"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2796"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2796",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2796",
+      "relation": "about",
+      "to": "topic:runfor"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2796",
+      "relation": "about",
+      "to": "topic:ticks"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2801"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2801",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2801",
+      "relation": "about",
+      "to": "topic:setfixedtime"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2801",
+      "relation": "about",
+      "to": "topic:time"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2806"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2806",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2806",
+      "relation": "about",
+      "to": "topic:setsystemtime"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2806",
+      "relation": "about",
+      "to": "topic:time"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2813"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2813",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2817"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2817",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2817",
+      "relation": "about",
+      "to": "topic:startcsscoverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2817",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2822"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2822",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2822",
+      "relation": "about",
+      "to": "topic:startjscoverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2822",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2827"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2827",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2827",
+      "relation": "about",
+      "to": "topic:stopcsscoverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2832"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2832",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2832",
+      "relation": "about",
+      "to": "topic:stopjscoverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2839"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2839",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2839",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2839",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2854"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2854",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2858"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2858",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2858",
+      "relation": "about",
+      "to": "topic:connectovercdp"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2858",
+      "relation": "about",
+      "to": "topic:endpointurl"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2858",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2863"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2863",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2863",
+      "relation": "about",
+      "to": "topic:connect"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2863",
+      "relation": "about",
+      "to": "topic:wsendpoint"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2863",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2868"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2868",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2868",
+      "relation": "about",
+      "to": "topic:executablepath"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2873"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2873",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2873",
+      "relation": "about",
+      "to": "topic:launch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2873",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2878"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2878",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2878",
+      "relation": "about",
+      "to": "topic:launchpersistentcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2878",
+      "relation": "about",
+      "to": "topic:userdatadir"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2878",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2883"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2883",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2883",
+      "relation": "about",
+      "to": "topic:launchserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2883",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2888"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2888",
+      "relation": "about",
+      "to": "topic:browsertype"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2888",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2895"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2895",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2899"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2899",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2899",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2899",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2904"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2904",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2904",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2904",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2904",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2909"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2909",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2909",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2909",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2909",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2914"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2914",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2914",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2914",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2914",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2919"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2919",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2919",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2919",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2919",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2924"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2924",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2924",
+      "relation": "about",
+      "to": "topic:send"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2924",
+      "relation": "about",
+      "to": "topic:method"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2924",
+      "relation": "about",
+      "to": "topic:params"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2929"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2929",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2929",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2929",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2929",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2934"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2934",
+      "relation": "about",
+      "to": "topic:cdpsession"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2934",
+      "relation": "about",
+      "to": "topic:detach"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2941"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2941",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2945"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2945",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2945",
+      "relation": "about",
+      "to": "topic:evaluate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2945",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2945",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2950"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2950",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2950",
+      "relation": "about",
+      "to": "topic:evaluatehandle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2950",
+      "relation": "about",
+      "to": "topic:pagefunction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2950",
+      "relation": "about",
+      "to": "topic:arg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2955"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2955",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2955",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2955",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2960"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2960",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2960",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2960",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2960",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2965"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2965",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2965",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2965",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2965",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2970"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2970",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2970",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2970",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2970",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2975"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2975",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2975",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2975",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2975",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2980"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2980",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2980",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2980",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2980",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2985"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2985",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2985",
+      "relation": "about",
+      "to": "topic:browserwindow"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2985",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2990"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2990",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2990",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#2995"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2995",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#2995",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3000"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3000",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3000",
+      "relation": "about",
+      "to": "topic:firstwindow"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3000",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3005"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3005",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3005",
+      "relation": "about",
+      "to": "topic:process"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3010"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3010",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3010",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3010",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3010",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3015"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3015",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3015",
+      "relation": "about",
+      "to": "topic:windows"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3020"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3020",
+      "relation": "about",
+      "to": "topic:electronapplication"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3020",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3020",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3027"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3027",
+      "relation": "about",
+      "to": "topic:electron"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3031"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3031",
+      "relation": "about",
+      "to": "topic:electron"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3031",
+      "relation": "about",
+      "to": "topic:launch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3031",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3038"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3038",
+      "relation": "about",
+      "to": "topic:android"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3042"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3042",
+      "relation": "about",
+      "to": "topic:android"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3042",
+      "relation": "about",
+      "to": "topic:connect"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3042",
+      "relation": "about",
+      "to": "topic:endpoint"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3042",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3047"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3047",
+      "relation": "about",
+      "to": "topic:android"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3047",
+      "relation": "about",
+      "to": "topic:devices"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3047",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3052"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3052",
+      "relation": "about",
+      "to": "topic:android"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3052",
+      "relation": "about",
+      "to": "topic:launchserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3052",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3057"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3057",
+      "relation": "about",
+      "to": "topic:android"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3057",
+      "relation": "about",
+      "to": "topic:setdefaulttimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3057",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3064"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3064",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3068"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3068",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3068",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3068",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3073"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3073",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3073",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3073",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3073",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3078"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3078",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3078",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3078",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3078",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3083"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3083",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3083",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3083",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3083",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3088"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3088",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3088",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3088",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3088",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3093"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3093",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3093",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3093",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3093",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3098"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3098",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3098",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3103"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3103",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3103",
+      "relation": "about",
+      "to": "topic:drag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3103",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3103",
+      "relation": "about",
+      "to": "topic:dest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3103",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3108"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3108",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3108",
+      "relation": "about",
+      "to": "topic:fill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3108",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3108",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3108",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3113"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3113",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3113",
+      "relation": "about",
+      "to": "topic:fling"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3113",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3113",
+      "relation": "about",
+      "to": "topic:direction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3113",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3118"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3118",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3118",
+      "relation": "about",
+      "to": "topic:info"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3118",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3123"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3123",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3123",
+      "relation": "about",
+      "to": "topic:installapk"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3123",
+      "relation": "about",
+      "to": "topic:file"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3123",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3128"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3128",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3128",
+      "relation": "about",
+      "to": "topic:launchbrowser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3128",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3133"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3133",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3133",
+      "relation": "about",
+      "to": "topic:longtap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3133",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3133",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3138"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3138",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3138",
+      "relation": "about",
+      "to": "topic:model"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3143"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3143",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3143",
+      "relation": "about",
+      "to": "topic:open"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3143",
+      "relation": "about",
+      "to": "topic:command"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3148"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3148",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3148",
+      "relation": "about",
+      "to": "topic:pinchclose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3148",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3148",
+      "relation": "about",
+      "to": "topic:percent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3148",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3153"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3153",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3153",
+      "relation": "about",
+      "to": "topic:pinchopen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3153",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3153",
+      "relation": "about",
+      "to": "topic:percent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3153",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3158"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3158",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3158",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3158",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3158",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3158",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3163"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3163",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3163",
+      "relation": "about",
+      "to": "topic:push"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3163",
+      "relation": "about",
+      "to": "topic:file"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3163",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3163",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3168"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3168",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3168",
+      "relation": "about",
+      "to": "topic:screenshot"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3168",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3173"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:scroll"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:direction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:percent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3173",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3178"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3178",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3178",
+      "relation": "about",
+      "to": "topic:serial"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3183"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3183",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3183",
+      "relation": "about",
+      "to": "topic:setdefaulttimeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3183",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3188"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3188",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3188",
+      "relation": "about",
+      "to": "topic:shell"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3188",
+      "relation": "about",
+      "to": "topic:command"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3193"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:swipe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:direction"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:percent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3193",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3198"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3198",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3198",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3198",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3198",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3203"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3203",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3203",
+      "relation": "about",
+      "to": "topic:wait"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3203",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3203",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3208"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3208",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3208",
+      "relation": "about",
+      "to": "topic:waitforevent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3208",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3208",
+      "relation": "about",
+      "to": "topic:optionsorpredicate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3213"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3213",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3213",
+      "relation": "about",
+      "to": "topic:webview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3213",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3213",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3218"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3218",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3218",
+      "relation": "about",
+      "to": "topic:webviews"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3223"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3223",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3223",
+      "relation": "about",
+      "to": "topic:input"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3228"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3228",
+      "relation": "about",
+      "to": "topic:androiddevice"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3228",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3228",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3235"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3235",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3239"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3239",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3239",
+      "relation": "about",
+      "to": "topic:drag"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3239",
+      "relation": "about",
+      "to": "topic:from"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3239",
+      "relation": "about",
+      "to": "topic:steps"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3244"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3244",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3244",
+      "relation": "about",
+      "to": "topic:press"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3244",
+      "relation": "about",
+      "to": "topic:key"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3249"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3249",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3249",
+      "relation": "about",
+      "to": "topic:swipe"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3249",
+      "relation": "about",
+      "to": "topic:from"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3249",
+      "relation": "about",
+      "to": "topic:segments"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3249",
+      "relation": "about",
+      "to": "topic:steps"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3254"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3254",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3254",
+      "relation": "about",
+      "to": "topic:tap"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3254",
+      "relation": "about",
+      "to": "topic:point"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3259"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3259",
+      "relation": "about",
+      "to": "topic:androidinput"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3259",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3259",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3266"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3266",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3270"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3270",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3270",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3270",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3275"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3275",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3275",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3275",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3275",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3280"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3280",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3280",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3280",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3280",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3285"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3285",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3285",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3285",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3285",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3290"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3290",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3290",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3290",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3290",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3295"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3295",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3295",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3295",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3295",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3300"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3300",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3300",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3305"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3305",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3305",
+      "relation": "about",
+      "to": "topic:write"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3305",
+      "relation": "about",
+      "to": "topic:data"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3310"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3310",
+      "relation": "about",
+      "to": "topic:androidsocket"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3310",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3310",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3317"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3317",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3321"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3321",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3321",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3321",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3326"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3326",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3326",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3326",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3326",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3331"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3331",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3331",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3331",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3331",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3336"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3336",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3336",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3336",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3336",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3341"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3341",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3341",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3341",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3341",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3346"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3346",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3346",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3346",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3346",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3351"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3351",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3351",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3356"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3356",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3356",
+      "relation": "about",
+      "to": "topic:pid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3361"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3361",
+      "relation": "about",
+      "to": "topic:androidwebview"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3361",
+      "relation": "about",
+      "to": "topic:pkg"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3368"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3368",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3368",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3368",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3386"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3386",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3390"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3390",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3390",
+      "relation": "about",
+      "to": "topic:first"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3396"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3396",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3396",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3401"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3401",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3401",
+      "relation": "about",
+      "to": "topic:getbyalttext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3401",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3401",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3406"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3406",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3406",
+      "relation": "about",
+      "to": "topic:getbylabel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3406",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3406",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3411"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3411",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3411",
+      "relation": "about",
+      "to": "topic:getbyplaceholder"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3411",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3411",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3416"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3416",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3416",
+      "relation": "about",
+      "to": "topic:getbyrole"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3416",
+      "relation": "about",
+      "to": "topic:role"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3416",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3421"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3421",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3421",
+      "relation": "about",
+      "to": "topic:getbytestid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3421",
+      "relation": "about",
+      "to": "topic:testid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3426"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3426",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3426",
+      "relation": "about",
+      "to": "topic:getbytext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3426",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3426",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3431"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3431",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3431",
+      "relation": "about",
+      "to": "topic:getbytitle"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3431",
+      "relation": "about",
+      "to": "topic:text"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3431",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3436"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3436",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3436",
+      "relation": "about",
+      "to": "topic:last"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3442"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3442",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3442",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3442",
+      "relation": "about",
+      "to": "topic:selectororlocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3442",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3447"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3447",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3447",
+      "relation": "about",
+      "to": "topic:nth"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3447",
+      "relation": "about",
+      "to": "topic:index"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3453"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3453",
+      "relation": "about",
+      "to": "topic:framelocator"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3453",
+      "relation": "about",
+      "to": "topic:owner"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3460"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3460",
+      "relation": "about",
+      "to": "topic:apirequest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3464"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3464",
+      "relation": "about",
+      "to": "topic:apirequest"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3464",
+      "relation": "about",
+      "to": "topic:newcontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3464",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3471"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3471",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3475"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3475",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3475",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3475",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3480"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3480",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3480",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3480",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3480",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3485"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3485",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3485",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3485",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3485",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3490"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3490",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3490",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3490",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3490",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3495"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3495",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3495",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3495",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3495",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3500"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3500",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3500",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3500",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3500",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3505"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3505",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3505",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3510"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3510",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3510",
+      "relation": "about",
+      "to": "topic:kill"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3515"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3515",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3515",
+      "relation": "about",
+      "to": "topic:process"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3520"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3520",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3520",
+      "relation": "about",
+      "to": "topic:wsendpoint"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3525"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3525",
+      "relation": "about",
+      "to": "topic:browserserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3525",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3525",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3532"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3532",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3536"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3536",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3536",
+      "relation": "about",
+      "to": "topic:onmessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3536",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3541"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3541",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3541",
+      "relation": "about",
+      "to": "topic:onclose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3541",
+      "relation": "about",
+      "to": "topic:handler"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3546"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3546",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3546",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3546",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3551"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3551",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3551",
+      "relation": "about",
+      "to": "topic:connecttoserver"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3556"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3556",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3556",
+      "relation": "about",
+      "to": "topic:protocols"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3561"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3561",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3561",
+      "relation": "about",
+      "to": "topic:send"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3561",
+      "relation": "about",
+      "to": "topic:message"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3566"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3566",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3566",
+      "relation": "about",
+      "to": "topic:url"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3571"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3571",
+      "relation": "about",
+      "to": "topic:websocketroute"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3571",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3571",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3578"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3578",
+      "relation": "about",
+      "to": "topic:weberror"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3582"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3582",
+      "relation": "about",
+      "to": "topic:weberror"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3582",
+      "relation": "about",
+      "to": "topic:error"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3587"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3587",
+      "relation": "about",
+      "to": "topic:weberror"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3587",
+      "relation": "about",
+      "to": "topic:location"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3592"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3592",
+      "relation": "about",
+      "to": "topic:weberror"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3592",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3599"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3599",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3603"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3603",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3603",
+      "relation": "about",
+      "to": "topic:start"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3603",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3608"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3608",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3608",
+      "relation": "about",
+      "to": "topic:hideactions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3613"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3613",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3613",
+      "relation": "about",
+      "to": "topic:hideoverlays"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3618"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3618",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3618",
+      "relation": "about",
+      "to": "topic:showactions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3618",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3623"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3623",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3623",
+      "relation": "about",
+      "to": "topic:showchapter"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3623",
+      "relation": "about",
+      "to": "topic:title"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3623",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3628"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3628",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3628",
+      "relation": "about",
+      "to": "topic:showoverlay"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3628",
+      "relation": "about",
+      "to": "topic:html"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3628",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3633"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3633",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3633",
+      "relation": "about",
+      "to": "topic:showoverlays"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3638"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3638",
+      "relation": "about",
+      "to": "topic:screencast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3638",
+      "relation": "about",
+      "to": "topic:stop"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3645"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3645",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3649"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3649",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3649",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3649",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3654"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3654",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3654",
+      "relation": "about",
+      "to": "topic:once"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3654",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3654",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3659"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3659",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3659",
+      "relation": "about",
+      "to": "topic:addlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3659",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3659",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3664"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3664",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3664",
+      "relation": "about",
+      "to": "topic:removelistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3664",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3664",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3669"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3669",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3669",
+      "relation": "about",
+      "to": "topic:off"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3669",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3669",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3674"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3674",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3674",
+      "relation": "about",
+      "to": "topic:prependlistener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3674",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3674",
+      "relation": "about",
+      "to": "topic:listener"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3679"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3679",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3679",
+      "relation": "about",
+      "to": "topic:next"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3684"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3684",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3684",
+      "relation": "about",
+      "to": "topic:pauseddetails"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3689"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3689",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3689",
+      "relation": "about",
+      "to": "topic:requestpause"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3694"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3694",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3694",
+      "relation": "about",
+      "to": "topic:resume"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3699"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3699",
+      "relation": "about",
+      "to": "topic:debugger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3699",
+      "relation": "about",
+      "to": "topic:runto"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3699",
+      "relation": "about",
+      "to": "topic:location"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3706"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3706",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3706",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3706",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3722"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3722",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3726"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3726",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3726",
+      "relation": "about",
+      "to": "topic:open"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3731"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3731",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3731",
+      "relation": "about",
+      "to": "topic:send"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3731",
+      "relation": "about",
+      "to": "topic:message"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3736"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3736",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3736",
+      "relation": "about",
+      "to": "topic:close"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3741"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3741",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3741",
+      "relation": "about",
+      "to": "topic:onmessage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3746"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3746",
+      "relation": "about",
+      "to": "topic:connectovercdptransport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3746",
+      "relation": "about",
+      "to": "topic:onclose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3753"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3753",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3757"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3757",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3757",
+      "relation": "about",
+      "to": "topic:create"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3757",
+      "relation": "about",
+      "to": "topic:rpid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3757",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3762"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3762",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3762",
+      "relation": "about",
+      "to": "topic:delete"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3767"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3767",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3767",
+      "relation": "about",
+      "to": "topic:get"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3767",
+      "relation": "about",
+      "to": "topic:options"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3772"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3772",
+      "relation": "about",
+      "to": "topic:credentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3772",
+      "relation": "about",
+      "to": "topic:install"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3779"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3779",
+      "relation": "about",
+      "to": "topic:disposable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3783"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3783",
+      "relation": "about",
+      "to": "topic:disposable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3783",
+      "relation": "about",
+      "to": "topic:dispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3788"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3788",
+      "relation": "about",
+      "to": "topic:disposable"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3788",
+      "relation": "about",
+      "to": "topic:symbol"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3788",
+      "relation": "about",
+      "to": "topic:asyncdispose"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3795"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3795",
+      "relation": "about",
+      "to": "topic:logger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3799"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3799",
+      "relation": "about",
+      "to": "topic:logger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3799",
+      "relation": "about",
+      "to": "topic:isenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3799",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3799",
+      "relation": "about",
+      "to": "topic:severity"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3804"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:logger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:log"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:severity"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:message"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:args"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3804",
+      "relation": "about",
+      "to": "topic:hints"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3811"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3811",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3815"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3815",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3815",
+      "relation": "about",
+      "to": "topic:clear"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3820"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3820",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3820",
+      "relation": "about",
+      "to": "topic:getitem"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3820",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3825"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3825",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3825",
+      "relation": "about",
+      "to": "topic:items"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3830"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3830",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3830",
+      "relation": "about",
+      "to": "topic:removeitem"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3830",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3835"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3835",
+      "relation": "about",
+      "to": "topic:webstorage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3835",
+      "relation": "about",
+      "to": "topic:setitem"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3835",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3835",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3842"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3842",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3846"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3846",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3846",
+      "relation": "about",
+      "to": "topic:args"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3851"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3851",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3851",
+      "relation": "about",
+      "to": "topic:artifactsdir"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3856"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3856",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3856",
+      "relation": "about",
+      "to": "topic:channel"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3861"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3861",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3861",
+      "relation": "about",
+      "to": "topic:chromiumsandbox"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3866"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3866",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3866",
+      "relation": "about",
+      "to": "topic:downloadspath"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3871"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3871",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3871",
+      "relation": "about",
+      "to": "topic:env"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3876"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3876",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3876",
+      "relation": "about",
+      "to": "topic:executablepath"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3881"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3881",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3881",
+      "relation": "about",
+      "to": "topic:firefoxuserprefs"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3886"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3886",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3886",
+      "relation": "about",
+      "to": "topic:handlesighup"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3891"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3891",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3891",
+      "relation": "about",
+      "to": "topic:handlesigint"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3896"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3896",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3896",
+      "relation": "about",
+      "to": "topic:handlesigterm"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3901"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3901",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3901",
+      "relation": "about",
+      "to": "topic:headless"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3906"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3906",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3906",
+      "relation": "about",
+      "to": "topic:ignoredefaultargs"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3911"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3911",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3911",
+      "relation": "about",
+      "to": "topic:logger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3917"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3917",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3917",
+      "relation": "about",
+      "to": "topic:proxy"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3922"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3922",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3922",
+      "relation": "about",
+      "to": "topic:slowmo"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3927"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3927",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3927",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3932"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3932",
+      "relation": "about",
+      "to": "topic:launchoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3932",
+      "relation": "about",
+      "to": "topic:tracesdir"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3939"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3939",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3943"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3943",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3943",
+      "relation": "about",
+      "to": "topic:artifactsdir"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3948"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3948",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3948",
+      "relation": "about",
+      "to": "topic:endpointurl"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3954"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3954",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3954",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3959"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3959",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3959",
+      "relation": "about",
+      "to": "topic:islocal"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3964"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3964",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3964",
+      "relation": "about",
+      "to": "topic:nodefaults"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3969"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3969",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3969",
+      "relation": "about",
+      "to": "topic:slowmo"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3974"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3974",
+      "relation": "about",
+      "to": "topic:connectovercdpoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3974",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3981"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3981",
+      "relation": "about",
+      "to": "topic:connectoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3985"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3985",
+      "relation": "about",
+      "to": "topic:connectoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3985",
+      "relation": "about",
+      "to": "topic:exposenetwork"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3990"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3990",
+      "relation": "about",
+      "to": "topic:connectoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3990",
+      "relation": "about",
+      "to": "topic:headers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#3995"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3995",
+      "relation": "about",
+      "to": "topic:connectoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#3995",
+      "relation": "about",
+      "to": "topic:slowmo"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4000"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4000",
+      "relation": "about",
+      "to": "topic:connectoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4000",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4007"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4007",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4011"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4011",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4011",
+      "relation": "about",
+      "to": "topic:animations"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4016"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4016",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4016",
+      "relation": "about",
+      "to": "topic:caret"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4021"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4021",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4021",
+      "relation": "about",
+      "to": "topic:mask"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4026"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4026",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4026",
+      "relation": "about",
+      "to": "topic:maskcolor"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4031"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4031",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4031",
+      "relation": "about",
+      "to": "topic:omitbackground"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4036"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4036",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4036",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4041"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4041",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4041",
+      "relation": "about",
+      "to": "topic:quality"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4046"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4046",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4046",
+      "relation": "about",
+      "to": "topic:scale"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4051"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4051",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4051",
+      "relation": "about",
+      "to": "topic:signal"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4056"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4056",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4056",
+      "relation": "about",
+      "to": "topic:style"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4061"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4061",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4061",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4066"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4066",
+      "relation": "about",
+      "to": "topic:locatorscreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4066",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4073"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4073",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4077"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4077",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4077",
+      "relation": "about",
+      "to": "topic:acceptdownloads"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4082"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4082",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4082",
+      "relation": "about",
+      "to": "topic:baseurl"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4087"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4087",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4087",
+      "relation": "about",
+      "to": "topic:bypasscsp"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4092"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4092",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4092",
+      "relation": "about",
+      "to": "topic:clientcertificates"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4097"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4097",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4097",
+      "relation": "about",
+      "to": "topic:colorscheme"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4102"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4102",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4102",
+      "relation": "about",
+      "to": "topic:contrast"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4107"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4107",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4107",
+      "relation": "about",
+      "to": "topic:devicescalefactor"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4112"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4112",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4112",
+      "relation": "about",
+      "to": "topic:extrahttpheaders"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4117"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4117",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4117",
+      "relation": "about",
+      "to": "topic:forcedcolors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4122"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4122",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4122",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4127"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4127",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4127",
+      "relation": "about",
+      "to": "topic:hastouch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4132"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4132",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4132",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4137"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4137",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4137",
+      "relation": "about",
+      "to": "topic:ignorehttpserrors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4142"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4142",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4142",
+      "relation": "about",
+      "to": "topic:ismobile"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4147"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4147",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4147",
+      "relation": "about",
+      "to": "topic:javascriptenabled"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4152"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4152",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4152",
+      "relation": "about",
+      "to": "topic:locale"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4157"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4157",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4157",
+      "relation": "about",
+      "to": "topic:logger"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4162"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4162",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4162",
+      "relation": "about",
+      "to": "topic:offline"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4167"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4167",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4167",
+      "relation": "about",
+      "to": "topic:permissions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4172"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4172",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4172",
+      "relation": "about",
+      "to": "topic:pierceframes"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4177"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4177",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4177",
+      "relation": "about",
+      "to": "topic:proxy"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4182"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4182",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4182",
+      "relation": "about",
+      "to": "topic:recordhar"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4187"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4187",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4187",
+      "relation": "about",
+      "to": "topic:recordvideo"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4192"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4192",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4192",
+      "relation": "about",
+      "to": "topic:reducedmotion"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4197"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4197",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4197",
+      "relation": "about",
+      "to": "topic:screen"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4202"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4202",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4202",
+      "relation": "about",
+      "to": "topic:serviceworkers"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4207"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4207",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4207",
+      "relation": "about",
+      "to": "topic:storagestate"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4212"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4212",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4212",
+      "relation": "about",
+      "to": "topic:strictselectors"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4217"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4217",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4217",
+      "relation": "about",
+      "to": "topic:timezoneid"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4222"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4222",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4222",
+      "relation": "about",
+      "to": "topic:useragent"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4227"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4227",
+      "relation": "about",
+      "to": "topic:browsercontextoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4227",
+      "relation": "about",
+      "to": "topic:viewport"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4234"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4234",
+      "relation": "about",
+      "to": "topic:viewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4238"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4238",
+      "relation": "about",
+      "to": "topic:viewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4238",
+      "relation": "about",
+      "to": "topic:width"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4243"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4243",
+      "relation": "about",
+      "to": "topic:viewportsize"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4243",
+      "relation": "about",
+      "to": "topic:height"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4250"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4250",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4254"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4254",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4254",
+      "relation": "about",
+      "to": "topic:username"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4259"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4259",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4259",
+      "relation": "about",
+      "to": "topic:password"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4264"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4264",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4264",
+      "relation": "about",
+      "to": "topic:origin"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4269"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4269",
+      "relation": "about",
+      "to": "topic:httpcredentials"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4269",
+      "relation": "about",
+      "to": "topic:send"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4276"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4276",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4280"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4280",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4280",
+      "relation": "about",
+      "to": "topic:latitude"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4285"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4285",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4285",
+      "relation": "about",
+      "to": "topic:longitude"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4290"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4290",
+      "relation": "about",
+      "to": "topic:geolocation"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4290",
+      "relation": "about",
+      "to": "topic:accuracy"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4297"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4297",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4301"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4301",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4301",
+      "relation": "about",
+      "to": "topic:name"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4306"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4306",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4306",
+      "relation": "about",
+      "to": "topic:value"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4311"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4311",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4311",
+      "relation": "about",
+      "to": "topic:domain"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4316"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4316",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4316",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4321"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4321",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4321",
+      "relation": "about",
+      "to": "topic:expires"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4326"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4326",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4326",
+      "relation": "about",
+      "to": "topic:httponly"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4331"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4331",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4331",
+      "relation": "about",
+      "to": "topic:secure"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4336"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4336",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4336",
+      "relation": "about",
+      "to": "topic:samesite"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4341"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4341",
+      "relation": "about",
+      "to": "topic:cookie"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4341",
+      "relation": "about",
+      "to": "topic:partitionkey"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4348"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4348",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4352"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4352",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4352",
+      "relation": "about",
+      "to": "topic:animations"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4357"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4357",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4357",
+      "relation": "about",
+      "to": "topic:caret"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4362"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4362",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4362",
+      "relation": "about",
+      "to": "topic:clip"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4367"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4367",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4367",
+      "relation": "about",
+      "to": "topic:fullpage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4372"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4372",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4372",
+      "relation": "about",
+      "to": "topic:mask"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4377"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4377",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4377",
+      "relation": "about",
+      "to": "topic:maskcolor"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4382"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4382",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4382",
+      "relation": "about",
+      "to": "topic:omitbackground"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4387"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4387",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4387",
+      "relation": "about",
+      "to": "topic:path"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4392"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4392",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4392",
+      "relation": "about",
+      "to": "topic:quality"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4397"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4397",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4397",
+      "relation": "about",
+      "to": "topic:scale"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4402"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4402",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4402",
+      "relation": "about",
+      "to": "topic:signal"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4407"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4407",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4407",
+      "relation": "about",
+      "to": "topic:style"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4412"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4412",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4412",
+      "relation": "about",
+      "to": "topic:timeout"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4417"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4417",
+      "relation": "about",
+      "to": "topic:pagescreenshotoptions"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4417",
+      "relation": "about",
+      "to": "topic:type"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4424"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4424",
+      "relation": "about",
+      "to": "topic:chromiumbrowsercontext"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4431"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4431",
+      "relation": "about",
+      "to": "topic:chromiumbrowser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4438"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4438",
+      "relation": "about",
+      "to": "topic:firefoxbrowser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4445"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4445",
+      "relation": "about",
+      "to": "topic:webkitbrowser"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4452"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4452",
+      "relation": "about",
+      "to": "topic:chromiumcoverage"
+    },
+    {
+      "from": "doc:API_REFERENCE.md",
+      "relation": "contains",
+      "to": "doc:API_REFERENCE.md#4459"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4459",
+      "relation": "about",
+      "to": "topic:batch"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4459",
+      "relation": "about",
+      "to": "topic:audit"
+    },
+    {
+      "from": "doc:API_REFERENCE.md#4459",
+      "relation": "about",
+      "to": "topic:summary"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#1"
+    },
+    {
+      "from": "doc:NOTES.md#1",
+      "relation": "about",
+      "to": "topic:playwright"
+    },
+    {
+      "from": "doc:NOTES.md#1",
+      "relation": "about",
+      "to": "topic:playwright-core"
+    },
+    {
+      "from": "doc:NOTES.md#1",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#1",
+      "relation": "about",
+      "to": "topic:notes"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#12"
+    },
+    {
+      "from": "doc:NOTES.md#12",
+      "relation": "about",
+      "to": "topic:browser"
+    },
+    {
+      "from": "doc:NOTES.md#12",
+      "relation": "about",
+      "to": "topic:launch"
+    },
+    {
+      "from": "doc:NOTES.md#12",
+      "relation": "about",
+      "to": "topic:mechanism"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#14"
+    },
+    {
+      "from": "doc:NOTES.md#14",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#14",
+      "relation": "about",
+      "to": "topic:flow"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#30"
+    },
+    {
+      "from": "doc:NOTES.md#30",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:NOTES.md#30",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#30",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:NOTES.md#30",
+      "relation": "about",
+      "to": "topic:ownership"
+    },
+    {
+      "from": "doc:NOTES.md#30",
+      "relation": "about",
+      "to": "topic:relationships"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#32"
+    },
+    {
+      "from": "doc:NOTES.md#32",
+      "relation": "about",
+      "to": "topic:browsercontext"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#42"
+    },
+    {
+      "from": "doc:NOTES.md#42",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#54"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:resolution"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#54",
+      "relation": "about",
+      "to": "topic:auto-waiting"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#56"
+    },
+    {
+      "from": "doc:NOTES.md#56",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:NOTES.md#56",
+      "relation": "about",
+      "to": "topic:definition"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#61"
+    },
+    {
+      "from": "doc:NOTES.md#61",
+      "relation": "about",
+      "to": "topic:auto-waiting"
+    },
+    {
+      "from": "doc:NOTES.md#61",
+      "relation": "about",
+      "to": "topic:mechanism"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#72"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:end-to-end"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:action"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:call"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:trace"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:NOTES.md#72",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#109"
+    },
+    {
+      "from": "doc:NOTES.md#109",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:NOTES.md#109",
+      "relation": "about",
+      "to": "topic:interception"
+    },
+    {
+      "from": "doc:NOTES.md#109",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#111"
+    },
+    {
+      "from": "doc:NOTES.md#111",
+      "relation": "about",
+      "to": "topic:client"
+    },
+    {
+      "from": "doc:NOTES.md#111",
+      "relation": "about",
+      "to": "topic:routing"
+    },
+    {
+      "from": "doc:NOTES.md#111",
+      "relation": "about",
+      "to": "topic:api"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#119"
+    },
+    {
+      "from": "doc:NOTES.md#119",
+      "relation": "about",
+      "to": "topic:server"
+    },
+    {
+      "from": "doc:NOTES.md#119",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:NOTES.md#119",
+      "relation": "about",
+      "to": "topic:engine"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#125"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:recorder"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:expanded"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:deep"
+    },
+    {
+      "from": "doc:NOTES.md#125",
+      "relation": "about",
+      "to": "topic:dive"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#154"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:recorder"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:overlay"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:toolbar"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:client-server"
+    },
+    {
+      "from": "doc:NOTES.md#154",
+      "relation": "about",
+      "to": "topic:bridge"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#172"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:storage"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:state"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:capture"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:save-storage"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#172",
+      "relation": "about",
+      "to": "topic:load-storage"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#188"
+    },
+    {
+      "from": "doc:NOTES.md#188",
+      "relation": "about",
+      "to": "topic:multi-language"
+    },
+    {
+      "from": "doc:NOTES.md#188",
+      "relation": "about",
+      "to": "topic:code"
+    },
+    {
+      "from": "doc:NOTES.md#188",
+      "relation": "about",
+      "to": "topic:generation"
+    },
+    {
+      "from": "doc:NOTES.md#188",
+      "relation": "about",
+      "to": "topic:target"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#203"
+    },
+    {
+      "from": "doc:NOTES.md#203",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:NOTES.md#203",
+      "relation": "about",
+      "to": "topic:generator"
+    },
+    {
+      "from": "doc:NOTES.md#203",
+      "relation": "about",
+      "to": "topic:ranking"
+    },
+    {
+      "from": "doc:NOTES.md#203",
+      "relation": "about",
+      "to": "topic:algorithm"
+    },
+    {
+      "from": "doc:NOTES.md#203",
+      "relation": "about",
+      "to": "topic:generateselector"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#225"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:action"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:recording"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:fresh"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:session"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:attaching"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:existing"
+    },
+    {
+      "from": "doc:NOTES.md#225",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#237"
+    },
+    {
+      "from": "doc:NOTES.md#237",
+      "relation": "about",
+      "to": "topic:verification"
+    },
+    {
+      "from": "doc:NOTES.md#237",
+      "relation": "about",
+      "to": "topic:sources"
+    },
+    {
+      "from": "doc:NOTES.md#237",
+      "relation": "about",
+      "to": "topic:documentation"
+    },
+    {
+      "from": "doc:NOTES.md#237",
+      "relation": "about",
+      "to": "topic:alignment"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#248"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:programmatic"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:initiation"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:termination"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:signals"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:NOTES.md#248",
+      "relation": "about",
+      "to": "topic:pause"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#267"
+    },
+    {
+      "from": "doc:NOTES.md#267",
+      "relation": "about",
+      "to": "topic:playwright"
+    },
+    {
+      "from": "doc:NOTES.md#267",
+      "relation": "about",
+      "to": "topic:test"
+    },
+    {
+      "from": "doc:NOTES.md#267",
+      "relation": "about",
+      "to": "topic:runner"
+    },
+    {
+      "from": "doc:NOTES.md#267",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#293"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:test"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:runner"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:core"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:loop"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:discovery"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:suite"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:building"
+    },
+    {
+      "from": "doc:NOTES.md#293",
+      "relation": "about",
+      "to": "topic:dispatch"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#313"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:fixtures"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:system"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:test"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:extend"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:scoping"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:dependency"
+    },
+    {
+      "from": "doc:NOTES.md#313",
+      "relation": "about",
+      "to": "topic:dag"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#328"
+    },
+    {
+      "from": "doc:NOTES.md#328",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:NOTES.md#328",
+      "relation": "about",
+      "to": "topic:process"
+    },
+    {
+      "from": "doc:NOTES.md#328",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#328",
+      "relation": "about",
+      "to": "topic:test"
+    },
+    {
+      "from": "doc:NOTES.md#328",
+      "relation": "about",
+      "to": "topic:isolation"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#343"
+    },
+    {
+      "from": "doc:NOTES.md#343",
+      "relation": "about",
+      "to": "topic:auto-retrying"
+    },
+    {
+      "from": "doc:NOTES.md#343",
+      "relation": "about",
+      "to": "topic:assertions"
+    },
+    {
+      "from": "doc:NOTES.md#343",
+      "relation": "about",
+      "to": "topic:expect"
+    },
+    {
+      "from": "doc:NOTES.md#343",
+      "relation": "about",
+      "to": "topic:locator"
+    },
+    {
+      "from": "doc:NOTES.md#343",
+      "relation": "about",
+      "to": "topic:tobevisible"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#357"
+    },
+    {
+      "from": "doc:NOTES.md#357",
+      "relation": "about",
+      "to": "topic:reporters"
+    },
+    {
+      "from": "doc:NOTES.md#357",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:NOTES.md#357",
+      "relation": "about",
+      "to": "topic:multiplexing"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#380"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:trace"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:viewer"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:cross-origin"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:NOTES.md#380",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#382"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:recording"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:start"
+    },
+    {
+      "from": "doc:NOTES.md#382",
+      "relation": "about",
+      "to": "topic:stop"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#394"
+    },
+    {
+      "from": "doc:NOTES.md#394",
+      "relation": "about",
+      "to": "topic:trace"
+    },
+    {
+      "from": "doc:NOTES.md#394",
+      "relation": "about",
+      "to": "topic:archive"
+    },
+    {
+      "from": "doc:NOTES.md#394",
+      "relation": "about",
+      "to": "topic:zip"
+    },
+    {
+      "from": "doc:NOTES.md#394",
+      "relation": "about",
+      "to": "topic:structure"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#410"
+    },
+    {
+      "from": "doc:NOTES.md#410",
+      "relation": "about",
+      "to": "topic:trace"
+    },
+    {
+      "from": "doc:NOTES.md#410",
+      "relation": "about",
+      "to": "topic:viewer"
+    },
+    {
+      "from": "doc:NOTES.md#410",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#422"
+    },
+    {
+      "from": "doc:NOTES.md#422",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:NOTES.md#422",
+      "relation": "about",
+      "to": "topic:hierarchy"
+    },
+    {
+      "from": "doc:NOTES.md#422",
+      "relation": "about",
+      "to": "topic:ownership"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#432"
+    },
+    {
+      "from": "doc:NOTES.md#432",
+      "relation": "about",
+      "to": "topic:cross-origin"
+    },
+    {
+      "from": "doc:NOTES.md#432",
+      "relation": "about",
+      "to": "topic:iframes"
+    },
+    {
+      "from": "doc:NOTES.md#432",
+      "relation": "about",
+      "to": "topic:oopif"
+    },
+    {
+      "from": "doc:NOTES.md#432",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#444"
+    },
+    {
+      "from": "doc:NOTES.md#444",
+      "relation": "about",
+      "to": "topic:frame"
+    },
+    {
+      "from": "doc:NOTES.md#444",
+      "relation": "about",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "doc:NOTES.md#444",
+      "relation": "about",
+      "to": "topic:navigation"
+    },
+    {
+      "from": "doc:NOTES.md#444",
+      "relation": "about",
+      "to": "topic:event"
+    },
+    {
+      "from": "doc:NOTES.md#444",
+      "relation": "about",
+      "to": "topic:propagation"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#464"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:downloads"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:api"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:testing"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:time"
+    },
+    {
+      "from": "doc:NOTES.md#464",
+      "relation": "about",
+      "to": "topic:mocking"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#466"
+    },
+    {
+      "from": "doc:NOTES.md#466",
+      "relation": "about",
+      "to": "topic:downloads"
+    },
+    {
+      "from": "doc:NOTES.md#466",
+      "relation": "about",
+      "to": "topic:uploads"
+    },
+    {
+      "from": "doc:NOTES.md#466",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#466",
+      "relation": "about",
+      "to": "topic:dialog"
+    },
+    {
+      "from": "doc:NOTES.md#466",
+      "relation": "about",
+      "to": "topic:handling"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#477"
+    },
+    {
+      "from": "doc:NOTES.md#477",
+      "relation": "about",
+      "to": "topic:api"
+    },
+    {
+      "from": "doc:NOTES.md#477",
+      "relation": "about",
+      "to": "topic:testing"
+    },
+    {
+      "from": "doc:NOTES.md#477",
+      "relation": "about",
+      "to": "topic:apirequestcontext"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#482"
+    },
+    {
+      "from": "doc:NOTES.md#482",
+      "relation": "about",
+      "to": "topic:clock"
+    },
+    {
+      "from": "doc:NOTES.md#482",
+      "relation": "about",
+      "to": "topic:time"
+    },
+    {
+      "from": "doc:NOTES.md#482",
+      "relation": "about",
+      "to": "topic:mocking"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#489"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:load"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:detection"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:multi-tab"
+    },
+    {
+      "from": "doc:NOTES.md#489",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#491"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:page"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:load"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:detection"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:visual"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:readiness"
+    },
+    {
+      "from": "doc:NOTES.md#491",
+      "relation": "about",
+      "to": "topic:data"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#502"
+    },
+    {
+      "from": "doc:NOTES.md#502",
+      "relation": "about",
+      "to": "topic:multi-tab"
+    },
+    {
+      "from": "doc:NOTES.md#502",
+      "relation": "about",
+      "to": "topic:multi-page"
+    },
+    {
+      "from": "doc:NOTES.md#502",
+      "relation": "about",
+      "to": "topic:switching"
+    },
+    {
+      "from": "doc:NOTES.md#502",
+      "relation": "about",
+      "to": "topic:logic"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#514"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:deterministic"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:readiness"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:patterns"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:for"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:dynamic"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:elements"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:dropdowns"
+    },
+    {
+      "from": "doc:NOTES.md#514",
+      "relation": "about",
+      "to": "topic:beyond"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#518"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:targeted"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:interception"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:wait"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:for"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:the"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:one"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:response"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:that"
+    },
+    {
+      "from": "doc:NOTES.md#518",
+      "relation": "about",
+      "to": "topic:matters"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#523"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:browser-side"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:predicate"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:polling"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:wait"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:for"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:the"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:dom"
+    },
+    {
+      "from": "doc:NOTES.md#523",
+      "relation": "about",
+      "to": "topic:say"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#528"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:network"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:stubbing"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:mocking"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:skip"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:the"
+    },
+    {
+      "from": "doc:NOTES.md#528",
+      "relation": "about",
+      "to": "topic:entirely"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#533"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:click"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:retry"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:loop"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:brute-force"
+    },
+    {
+      "from": "doc:NOTES.md#533",
+      "relation": "about",
+      "to": "topic:fallback"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#538"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:recording"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:architecture"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:recordvideo"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:its"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:hard"
+    },
+    {
+      "from": "doc:NOTES.md#538",
+      "relation": "about",
+      "to": "topic:constraints"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#540"
+    },
+    {
+      "from": "doc:NOTES.md#540",
+      "relation": "about",
+      "to": "topic:ffmpeg"
+    },
+    {
+      "from": "doc:NOTES.md#540",
+      "relation": "about",
+      "to": "topic:encoding"
+    },
+    {
+      "from": "doc:NOTES.md#540",
+      "relation": "about",
+      "to": "topic:pipeline"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#552"
+    },
+    {
+      "from": "doc:NOTES.md#552",
+      "relation": "about",
+      "to": "topic:default"
+    },
+    {
+      "from": "doc:NOTES.md#552",
+      "relation": "about",
+      "to": "topic:environmental"
+    },
+    {
+      "from": "doc:NOTES.md#552",
+      "relation": "about",
+      "to": "topic:settings"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#557"
+    },
+    {
+      "from": "doc:NOTES.md#557",
+      "relation": "about",
+      "to": "topic:auto-waiting"
+    },
+    {
+      "from": "doc:NOTES.md#557",
+      "relation": "about",
+      "to": "topic:stable"
+    },
+    {
+      "from": "doc:NOTES.md#557",
+      "relation": "about",
+      "to": "topic:check"
+    },
+    {
+      "from": "doc:NOTES.md#557",
+      "relation": "about",
+      "to": "topic:scope"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#561"
+    },
+    {
+      "from": "doc:NOTES.md#561",
+      "relation": "about",
+      "to": "topic:cursor"
+    },
+    {
+      "from": "doc:NOTES.md#561",
+      "relation": "about",
+      "to": "topic:visibility"
+    },
+    {
+      "from": "doc:NOTES.md#561",
+      "relation": "about",
+      "to": "topic:recorded"
+    },
+    {
+      "from": "doc:NOTES.md#561",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#566"
+    },
+    {
+      "from": "doc:NOTES.md#566",
+      "relation": "about",
+      "to": "topic:navigator"
+    },
+    {
+      "from": "doc:NOTES.md#566",
+      "relation": "about",
+      "to": "topic:webdriver"
+    },
+    {
+      "from": "doc:NOTES.md#566",
+      "relation": "about",
+      "to": "topic:automation"
+    },
+    {
+      "from": "doc:NOTES.md#566",
+      "relation": "about",
+      "to": "topic:detection"
+    },
+    {
+      "from": "doc:NOTES.md#566",
+      "relation": "about",
+      "to": "topic:surface"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#572"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:custom"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:engines"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:emulation"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:observability"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:and"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:automation"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:detection"
+    },
+    {
+      "from": "doc:NOTES.md#572",
+      "relation": "about",
+      "to": "topic:surface"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#574"
+    },
+    {
+      "from": "doc:NOTES.md#574",
+      "relation": "about",
+      "to": "topic:custom"
+    },
+    {
+      "from": "doc:NOTES.md#574",
+      "relation": "about",
+      "to": "topic:selector"
+    },
+    {
+      "from": "doc:NOTES.md#574",
+      "relation": "about",
+      "to": "topic:engines"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#578"
+    },
+    {
+      "from": "doc:NOTES.md#578",
+      "relation": "about",
+      "to": "topic:slowmo"
+    },
+    {
+      "from": "doc:NOTES.md#578",
+      "relation": "about",
+      "to": "topic:launch"
+    },
+    {
+      "from": "doc:NOTES.md#578",
+      "relation": "about",
+      "to": "topic:option"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#582"
+    },
+    {
+      "from": "doc:NOTES.md#582",
+      "relation": "about",
+      "to": "topic:device"
+    },
+    {
+      "from": "doc:NOTES.md#582",
+      "relation": "about",
+      "to": "topic:emulation"
+    },
+    {
+      "from": "doc:NOTES.md#582",
+      "relation": "about",
+      "to": "topic:scope"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#586"
+    },
+    {
+      "from": "doc:NOTES.md#586",
+      "relation": "about",
+      "to": "topic:visual"
+    },
+    {
+      "from": "doc:NOTES.md#586",
+      "relation": "about",
+      "to": "topic:regression"
+    },
+    {
+      "from": "doc:NOTES.md#586",
+      "relation": "about",
+      "to": "topic:masking"
+    },
+    {
+      "from": "doc:NOTES.md#586",
+      "relation": "about",
+      "to": "topic:animation"
+    },
+    {
+      "from": "doc:NOTES.md#586",
+      "relation": "about",
+      "to": "topic:freezing"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#590"
+    },
+    {
+      "from": "doc:NOTES.md#590",
+      "relation": "about",
+      "to": "topic:accessibility"
+    },
+    {
+      "from": "doc:NOTES.md#590",
+      "relation": "about",
+      "to": "topic:tree"
+    },
+    {
+      "from": "doc:NOTES.md#590",
+      "relation": "about",
+      "to": "topic:access"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#593"
+    },
+    {
+      "from": "doc:NOTES.md#593",
+      "relation": "about",
+      "to": "topic:worker"
+    },
+    {
+      "from": "doc:NOTES.md#593",
+      "relation": "about",
+      "to": "topic:service"
+    },
+    {
+      "from": "doc:NOTES.md#593",
+      "relation": "about",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "doc:NOTES.md#593",
+      "relation": "about",
+      "to": "topic:hooks"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#598"
+    },
+    {
+      "from": "doc:NOTES.md#598",
+      "relation": "about",
+      "to": "topic:low-level"
+    },
+    {
+      "from": "doc:NOTES.md#598",
+      "relation": "about",
+      "to": "topic:cdp"
+    },
+    {
+      "from": "doc:NOTES.md#598",
+      "relation": "about",
+      "to": "topic:session"
+    },
+    {
+      "from": "doc:NOTES.md#598",
+      "relation": "about",
+      "to": "topic:access"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#602"
+    },
+    {
+      "from": "doc:NOTES.md#602",
+      "relation": "about",
+      "to": "topic:code"
+    },
+    {
+      "from": "doc:NOTES.md#602",
+      "relation": "about",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#606"
+    },
+    {
+      "from": "doc:NOTES.md#606",
+      "relation": "about",
+      "to": "topic:automation"
+    },
+    {
+      "from": "doc:NOTES.md#606",
+      "relation": "about",
+      "to": "topic:detection"
+    },
+    {
+      "from": "doc:NOTES.md#606",
+      "relation": "about",
+      "to": "topic:surface"
+    },
+    {
+      "from": "doc:NOTES.md#606",
+      "relation": "about",
+      "to": "topic:correction"
+    },
+    {
+      "from": "doc:NOTES.md#606",
+      "relation": "about",
+      "to": "topic:pass"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#613"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:multi-tab"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:recording"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:video"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:fragmentation"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:NOTES.md#613",
+      "relation": "about",
+      "to": "topic:correlation"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#615"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:recordvideo"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:produces"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:independent"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:uncorrelated"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:files"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:per"
+    },
+    {
+      "from": "doc:NOTES.md#615",
+      "relation": "about",
+      "to": "topic:tab"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#621"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:context"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:the"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:actual"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:cross-tab"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:correlation"
+    },
+    {
+      "from": "doc:NOTES.md#621",
+      "relation": "about",
+      "to": "topic:mechanism"
+    },
+    {
+      "from": "doc:NOTES.md",
+      "relation": "contains",
+      "to": "doc:NOTES.md#631"
+    },
+    {
+      "from": "doc:NOTES.md#631",
+      "relation": "about",
+      "to": "topic:unverified"
+    },
+    {
+      "from": "doc:NOTES.md#631",
+      "relation": "about",
+      "to": "topic:claims"
+    },
+    {
+      "from": "doc:NOTES.md#631",
+      "relation": "about",
+      "to": "topic:caveats"
+    },
+    {
+      "from": "example:examples/01-launch-browser.js",
+      "relation": "illustrates",
+      "to": "topic:launch"
+    },
+    {
+      "from": "example:examples/01-launch-browser.js",
+      "relation": "illustrates",
+      "to": "topic:browser"
+    },
+    {
+      "from": "example:examples/02-context-and-page.js",
+      "relation": "illustrates",
+      "to": "topic:context"
+    },
+    {
+      "from": "example:examples/02-context-and-page.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/02-context-and-page.js",
+      "relation": "illustrates",
+      "to": "topic:page"
+    },
+    {
+      "from": "example:examples/03-locator-basics.js",
+      "relation": "illustrates",
+      "to": "topic:locator"
+    },
+    {
+      "from": "example:examples/03-locator-basics.js",
+      "relation": "illustrates",
+      "to": "topic:basics"
+    },
+    {
+      "from": "example:examples/04-network-interception.js",
+      "relation": "illustrates",
+      "to": "topic:network"
+    },
+    {
+      "from": "example:examples/04-network-interception.js",
+      "relation": "illustrates",
+      "to": "topic:interception"
+    },
+    {
+      "from": "example:examples/05-codegen-invocation.js",
+      "relation": "illustrates",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "example:examples/05-codegen-invocation.js",
+      "relation": "illustrates",
+      "to": "topic:invocation"
+    },
+    {
+      "from": "example:examples/06-codegen-language-targets.js",
+      "relation": "illustrates",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "example:examples/06-codegen-language-targets.js",
+      "relation": "illustrates",
+      "to": "topic:language"
+    },
+    {
+      "from": "example:examples/06-codegen-language-targets.js",
+      "relation": "illustrates",
+      "to": "topic:targets"
+    },
+    {
+      "from": "example:examples/07-codegen-selector-scoring.js",
+      "relation": "illustrates",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "example:examples/07-codegen-selector-scoring.js",
+      "relation": "illustrates",
+      "to": "topic:selector"
+    },
+    {
+      "from": "example:examples/07-codegen-selector-scoring.js",
+      "relation": "illustrates",
+      "to": "topic:scoring"
+    },
+    {
+      "from": "example:examples/08-codegen-storage-and-session.js",
+      "relation": "illustrates",
+      "to": "topic:codegen"
+    },
+    {
+      "from": "example:examples/08-codegen-storage-and-session.js",
+      "relation": "illustrates",
+      "to": "topic:storage"
+    },
+    {
+      "from": "example:examples/08-codegen-storage-and-session.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/08-codegen-storage-and-session.js",
+      "relation": "illustrates",
+      "to": "topic:session"
+    },
+    {
+      "from": "example:examples/09-test-runner-and-config.js",
+      "relation": "illustrates",
+      "to": "topic:test"
+    },
+    {
+      "from": "example:examples/09-test-runner-and-config.js",
+      "relation": "illustrates",
+      "to": "topic:runner"
+    },
+    {
+      "from": "example:examples/09-test-runner-and-config.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/09-test-runner-and-config.js",
+      "relation": "illustrates",
+      "to": "topic:config"
+    },
+    {
+      "from": "example:examples/10-fixtures-and-dependency-graph.js",
+      "relation": "illustrates",
+      "to": "topic:fixtures"
+    },
+    {
+      "from": "example:examples/10-fixtures-and-dependency-graph.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/10-fixtures-and-dependency-graph.js",
+      "relation": "illustrates",
+      "to": "topic:dependency"
+    },
+    {
+      "from": "example:examples/10-fixtures-and-dependency-graph.js",
+      "relation": "illustrates",
+      "to": "topic:graph"
+    },
+    {
+      "from": "example:examples/11-reporters-and-events.js",
+      "relation": "illustrates",
+      "to": "topic:reporters"
+    },
+    {
+      "from": "example:examples/11-reporters-and-events.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/11-reporters-and-events.js",
+      "relation": "illustrates",
+      "to": "topic:events"
+    },
+    {
+      "from": "example:examples/12-tracing.js",
+      "relation": "illustrates",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "example:examples/13-frames-and-oopif.js",
+      "relation": "illustrates",
+      "to": "topic:frames"
+    },
+    {
+      "from": "example:examples/13-frames-and-oopif.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/13-frames-and-oopif.js",
+      "relation": "illustrates",
+      "to": "topic:oopif"
+    },
+    {
+      "from": "example:examples/14-downloads-and-dialogs.js",
+      "relation": "illustrates",
+      "to": "topic:downloads"
+    },
+    {
+      "from": "example:examples/14-downloads-and-dialogs.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/14-downloads-and-dialogs.js",
+      "relation": "illustrates",
+      "to": "topic:dialogs"
+    },
+    {
+      "from": "example:examples/15-api-testing.js",
+      "relation": "illustrates",
+      "to": "topic:api"
+    },
+    {
+      "from": "example:examples/15-api-testing.js",
+      "relation": "illustrates",
+      "to": "topic:testing"
+    },
+    {
+      "from": "example:examples/16-page-load-and-lifecycle.js",
+      "relation": "illustrates",
+      "to": "topic:page"
+    },
+    {
+      "from": "example:examples/16-page-load-and-lifecycle.js",
+      "relation": "illustrates",
+      "to": "topic:load"
+    },
+    {
+      "from": "example:examples/16-page-load-and-lifecycle.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/16-page-load-and-lifecycle.js",
+      "relation": "illustrates",
+      "to": "topic:lifecycle"
+    },
+    {
+      "from": "example:examples/17-multi-tab-and-pages.js",
+      "relation": "illustrates",
+      "to": "topic:multi"
+    },
+    {
+      "from": "example:examples/17-multi-tab-and-pages.js",
+      "relation": "illustrates",
+      "to": "topic:tab"
+    },
+    {
+      "from": "example:examples/17-multi-tab-and-pages.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/17-multi-tab-and-pages.js",
+      "relation": "illustrates",
+      "to": "topic:pages"
+    },
+    {
+      "from": "example:examples/18-targeted-network-interception.js",
+      "relation": "illustrates",
+      "to": "topic:targeted"
+    },
+    {
+      "from": "example:examples/18-targeted-network-interception.js",
+      "relation": "illustrates",
+      "to": "topic:network"
+    },
+    {
+      "from": "example:examples/18-targeted-network-interception.js",
+      "relation": "illustrates",
+      "to": "topic:interception"
+    },
+    {
+      "from": "example:examples/19-browser-side-polling.js",
+      "relation": "illustrates",
+      "to": "topic:browser"
+    },
+    {
+      "from": "example:examples/19-browser-side-polling.js",
+      "relation": "illustrates",
+      "to": "topic:side"
+    },
+    {
+      "from": "example:examples/19-browser-side-polling.js",
+      "relation": "illustrates",
+      "to": "topic:polling"
+    },
+    {
+      "from": "example:examples/20-network-stubbing.js",
+      "relation": "illustrates",
+      "to": "topic:network"
+    },
+    {
+      "from": "example:examples/20-network-stubbing.js",
+      "relation": "illustrates",
+      "to": "topic:stubbing"
+    },
+    {
+      "from": "example:examples/21-click-and-retry-loop.js",
+      "relation": "illustrates",
+      "to": "topic:click"
+    },
+    {
+      "from": "example:examples/21-click-and-retry-loop.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/21-click-and-retry-loop.js",
+      "relation": "illustrates",
+      "to": "topic:retry"
+    },
+    {
+      "from": "example:examples/21-click-and-retry-loop.js",
+      "relation": "illustrates",
+      "to": "topic:loop"
+    },
+    {
+      "from": "example:examples/22-video-recording-pipeline.js",
+      "relation": "illustrates",
+      "to": "topic:video"
+    },
+    {
+      "from": "example:examples/22-video-recording-pipeline.js",
+      "relation": "illustrates",
+      "to": "topic:recording"
+    },
+    {
+      "from": "example:examples/22-video-recording-pipeline.js",
+      "relation": "illustrates",
+      "to": "topic:pipeline"
+    },
+    {
+      "from": "example:examples/23-environmental-settings.js",
+      "relation": "illustrates",
+      "to": "topic:environmental"
+    },
+    {
+      "from": "example:examples/23-environmental-settings.js",
+      "relation": "illustrates",
+      "to": "topic:settings"
+    },
+    {
+      "from": "example:examples/24-stability-and-opacity.js",
+      "relation": "illustrates",
+      "to": "topic:stability"
+    },
+    {
+      "from": "example:examples/24-stability-and-opacity.js",
+      "relation": "illustrates",
+      "to": "topic:and"
+    },
+    {
+      "from": "example:examples/24-stability-and-opacity.js",
+      "relation": "illustrates",
+      "to": "topic:opacity"
+    },
+    {
+      "from": "example:examples/25-video-cursor-overlay.js",
+      "relation": "illustrates",
+      "to": "topic:video"
+    },
+    {
+      "from": "example:examples/25-video-cursor-overlay.js",
+      "relation": "illustrates",
+      "to": "topic:cursor"
+    },
+    {
+      "from": "example:examples/25-video-cursor-overlay.js",
+      "relation": "illustrates",
+      "to": "topic:overlay"
+    },
+    {
+      "from": "example:examples/26-automation-detection.js",
+      "relation": "illustrates",
+      "to": "topic:automation"
+    },
+    {
+      "from": "example:examples/26-automation-detection.js",
+      "relation": "illustrates",
+      "to": "topic:detection"
+    },
+    {
+      "from": "example:examples/27-custom-selector-engines.js",
+      "relation": "illustrates",
+      "to": "topic:custom"
+    },
+    {
+      "from": "example:examples/27-custom-selector-engines.js",
+      "relation": "illustrates",
+      "to": "topic:selector"
+    },
+    {
+      "from": "example:examples/27-custom-selector-engines.js",
+      "relation": "illustrates",
+      "to": "topic:engines"
+    },
+    {
+      "from": "example:examples/28-slowmo-dispatcher-delay.js",
+      "relation": "illustrates",
+      "to": "topic:slowmo"
+    },
+    {
+      "from": "example:examples/28-slowmo-dispatcher-delay.js",
+      "relation": "illustrates",
+      "to": "topic:dispatcher"
+    },
+    {
+      "from": "example:examples/28-slowmo-dispatcher-delay.js",
+      "relation": "illustrates",
+      "to": "topic:delay"
+    },
+    {
+      "from": "example:examples/29-emulation-scope.js",
+      "relation": "illustrates",
+      "to": "topic:emulation"
+    },
+    {
+      "from": "example:examples/29-emulation-scope.js",
+      "relation": "illustrates",
+      "to": "topic:scope"
+    },
+    {
+      "from": "example:examples/30-screenshot-masking.js",
+      "relation": "illustrates",
+      "to": "topic:screenshot"
+    },
+    {
+      "from": "example:examples/30-screenshot-masking.js",
+      "relation": "illustrates",
+      "to": "topic:masking"
+    },
+    {
+      "from": "example:examples/31-accessibility-tree.js",
+      "relation": "illustrates",
+      "to": "topic:accessibility"
+    },
+    {
+      "from": "example:examples/31-accessibility-tree.js",
+      "relation": "illustrates",
+      "to": "topic:tree"
+    },
+    {
+      "from": "example:examples/32-worker-websocket-hooks.js",
+      "relation": "illustrates",
+      "to": "topic:worker"
+    },
+    {
+      "from": "example:examples/32-worker-websocket-hooks.js",
+      "relation": "illustrates",
+      "to": "topic:websocket"
+    },
+    {
+      "from": "example:examples/32-worker-websocket-hooks.js",
+      "relation": "illustrates",
+      "to": "topic:hooks"
+    },
+    {
+      "from": "example:examples/33-cdp-session-access.js",
+      "relation": "illustrates",
+      "to": "topic:cdp"
+    },
+    {
+      "from": "example:examples/33-cdp-session-access.js",
+      "relation": "illustrates",
+      "to": "topic:session"
+    },
+    {
+      "from": "example:examples/33-cdp-session-access.js",
+      "relation": "illustrates",
+      "to": "topic:access"
+    },
+    {
+      "from": "example:examples/34-code-coverage.js",
+      "relation": "illustrates",
+      "to": "topic:code"
+    },
+    {
+      "from": "example:examples/34-code-coverage.js",
+      "relation": "illustrates",
+      "to": "topic:coverage"
+    },
+    {
+      "from": "example:examples/35-automation-evasion-initscript.js",
+      "relation": "illustrates",
+      "to": "topic:automation"
+    },
+    {
+      "from": "example:examples/35-automation-evasion-initscript.js",
+      "relation": "illustrates",
+      "to": "topic:evasion"
+    },
+    {
+      "from": "example:examples/35-automation-evasion-initscript.js",
+      "relation": "illustrates",
+      "to": "topic:initscript"
+    },
+    {
+      "from": "example:examples/36-video-fragmentation.js",
+      "relation": "illustrates",
+      "to": "topic:video"
+    },
+    {
+      "from": "example:examples/36-video-fragmentation.js",
+      "relation": "illustrates",
+      "to": "topic:fragmentation"
+    },
+    {
+      "from": "example:examples/37-tracing-tab-correlation.js",
+      "relation": "illustrates",
+      "to": "topic:tracing"
+    },
+    {
+      "from": "example:examples/37-tracing-tab-correlation.js",
+      "relation": "illustrates",
+      "to": "topic:tab"
+    },
+    {
+      "from": "example:examples/37-tracing-tab-correlation.js",
+      "relation": "illustrates",
+      "to": "topic:correlation"
+    },
+    {
+      "from": "example:examples/38-programmatic-pause.js",
+      "relation": "illustrates",
+      "to": "topic:programmatic"
+    },
+    {
+      "from": "example:examples/38-programmatic-pause.js",
+      "relation": "illustrates",
+      "to": "topic:pause"
+    }
+  ]
+}

--- a/agi-training-notes/GRAPH_README.md
+++ b/agi-training-notes/GRAPH_README.md
@@ -1,0 +1,50 @@
+# Documentation graph
+
+`DOC_GRAPH.json` is a compact routing index for this directory. It does not replace `NOTES.md`, `API_REFERENCE.md`, or the examples; those remain the source of truth.
+
+The graph records:
+
+- a schema version
+- a `generated_at` timestamp
+- the pinned upstream revision when the notes expose one
+- per-document provenance in `source_documents`
+
+The graph contains three node types:
+
+- `document` and `section` nodes point to exact source files and line numbers.
+- `topic` nodes provide keyword routing.
+- `example` nodes connect runnable examples to their topic words.
+
+Use the graph to select a small context window, then read the referenced source sections. A model prompt should receive the selected excerpts, not the entire graph or documentation set. Keep the answer grounded in the cited file and line references.
+
+## Rebuild
+
+The original prototype indexer is retained at `tools/graphify-docs.mjs`:
+
+```sh
+node tools/graphify-docs.mjs
+```
+
+The reusable, model-independent implementation now lives in `../doc-graph/`. This directory opts in via `doc-graph.config.json`, so the same graph can be rebuilt with the shared tool:
+
+```sh
+node ../doc-graph/bin/doc-graph.mjs build --root .
+```
+
+## Query
+
+```sh
+# Prototype routing query.
+node tools/query-doc-graph.mjs agi-training-notes multi-tab
+
+# Reusable ranked search (bounded references with file/line/provenance).
+node ../doc-graph/bin/doc-graph.mjs search "shadow dom" --root .
+
+# Reusable context retrieval (references plus source excerpts).
+node ../doc-graph/bin/doc-graph.mjs context "shadow dom" --root .
+
+# HTTP API.
+node ../doc-graph/bin/doc-graph.mjs serve --root . --port 8080
+```
+
+The HTTP API exposes `GET /search?q=...` and `GET /context?q=...`. See `../doc-graph/README.md` for the full library, CLI, and API reference.

--- a/agi-training-notes/MILESTONE.md
+++ b/agi-training-notes/MILESTONE.md
@@ -1,0 +1,38 @@
+# Milestone: Reusable Documentation Graph Service
+
+Status: complete
+Assignee: opencode
+
+Completion: Implemented in `../doc-graph/`; 30 focused tests pass.
+
+Follow-up: MCP stdio support added with `doc_graph_search` and `doc_graph_context` tools.
+
+## Objective
+
+Turn the documentation graph prototype into a reusable, model-independent tool that other projects can index and query.
+
+## Scope
+
+- Extract graph indexing and retrieval into a reusable package or library.
+- Support configurable document globs, examples, project names, and output paths.
+- Preserve provenance, source line references, and graph schema versioning.
+- Provide CLI commands for build and search/context retrieval.
+- Provide a small HTTP API with `/search` and `/context` endpoints.
+- Keep model invocation separate from graph/indexing code.
+- Add tests and a minimal example project showing reuse outside Playwright.
+- Update documentation and rebuild instructions.
+
+## Acceptance criteria
+
+- A second project with a different documentation layout can be indexed without modifying source code.
+- Search returns ranked, bounded references with file paths, line numbers, examples, and provenance.
+- Context retrieval returns source excerpts suitable for prompting an external model.
+- CLI and HTTP API work from a clean install.
+- Automated tests cover indexing, querying, stale/missing files, and provenance.
+- Existing Playwright notes still build and answer representative queries.
+
+## Constraints
+
+- Do not execute browser examples or download browser binaries.
+- Do not hardcode Gemini, OpenAI, or another model provider into the core library.
+- Keep generated graph artifacts rebuildable and clearly separated from source documentation.

--- a/agi-training-notes/NOTES.md
+++ b/agi-training-notes/NOTES.md
@@ -1,0 +1,634 @@
+# Playwright & Playwright-Core Architecture Notes
+
+This document summarizes the internal architecture and operational mechanisms of `playwright-core`, Playwright's `codegen`, the `@playwright/test` test runner, and Playwright's tracing & frame subsystem based on source reading of upstream Playwright.
+
+> **Provenance**
+> - Source Commit: `b4a646a624c0b1e8e352d320cbc6684581625ff6`
+> - Commit Date: `2026-08-06`
+> - Methodology: Static-source analysis of upstream Playwright TypeScript files. Runtime/browser behavior was not exercised.
+
+---
+
+## 1. Browser Launch Mechanism
+
+### Architecture & Flow
+1. **Public API Entry Point**: Calling `chromium.launch(options)`, `firefox.launch(options)`, or `webkit.launch(options)` executes `BrowserType.launch(options)` in `packages/playwright-core/src/client/browserType.ts`.
+2. **RPC Dispatch**: `BrowserType.launch()` wraps launch parameters (environment variables, default args overrides, timeouts) and issues a `this._channel.launch(...)` RPC request over the Playwright connection channel to the backend server process.
+3. **Server Launch Processing**: `BrowserType.launch(progress, options, protocolLogger)` in `packages/playwright-core/src/server/browserType.ts`:
+   - Validates launch options via `_validateLaunchOptions()`.
+   - Prepares profile directories and temporary artifact folders via `_prepareToLaunch()`.
+   - Resolves the binary executable using `registry.findExecutable(name)` in `packages/playwright-core/src/server/registry/index.ts`.
+   - Spawns the child process via `launchProcess()` from `@utils/processLauncher`.
+   - Establishes a transport connection using `this.connectToTransport(transport, browserOptions)`.
+4. **Engine-Specific Launchers**:
+   - **Chromium** (`packages/playwright-core/src/server/chromium/chromium.ts` -> `Chromium.launch`): Connects via Chrome DevTools Protocol (CDP) through `CRBrowser.connect()` in `packages/playwright-core/src/server/chromium/crBrowser.ts`.
+   - **Firefox** (`packages/playwright-core/src/server/firefox/firefox.ts` -> `Firefox.launch`): Connects via Firefox protocol / JSDebugger through `FFBrowser.connect()` in `packages/playwright-core/src/server/firefox/ffBrowser.ts`.
+   - **WebKit** (`packages/playwright-core/src/server/webkit/webkit.ts` -> `WebKit.connectToTransport`): Connects via WebKit Inspector protocol through `WKBrowser.connect()` in `packages/playwright-core/src/server/webkit/wkBrowser.ts`.
+
+---
+
+## 2. BrowserContext and Page Ownership & Relationships
+
+### BrowserContext
+- **Client Class**: `BrowserContext` in `packages/playwright-core/src/client/browserContext.ts`.
+- **Server Class**: `BrowserContext` in `packages/playwright-core/src/server/browserContext.ts`.
+- **Responsibilities**:
+  - Acts as an isolated session boundary (equivalent to an incognito profile with isolated cookies, localStorage, IndexedDB, HTTP credentials, proxy settings, permissions, and storage state).
+  - Owns a set of active page instances (`_pages: Set<Page>`).
+  - Owns context-level network interception handlers (`_routes: RouteHandler[]`).
+  - Owns context-wide auxiliary services: `request: APIRequestContext`, `tracing: Tracing`, `clock: Clock`, `credentials: Credentials`, `debugger: Debugger`.
+  - Spawns new pages via `newPage()`, which sends `_channel.newPage()` to the server.
+
+### Page
+- **Client Class**: `Page` in `packages/playwright-core/src/client/page.ts`.
+- **Server Class**: `Page` in `packages/playwright-core/src/server/page.ts`.
+- **Responsibilities**:
+  - Belongs to a single parent `BrowserContext` (`_browserContext: BrowserContext`).
+  - Owns the document frame hierarchy starting from top-level `_mainFrame: Frame` and child frames in `_frames: Set<Frame>`.
+  - Owns input device controllers: `keyboard: Keyboard`, `mouse: Mouse`, `touchscreen: Touchscreen` (defined in `packages/playwright-core/src/client/input.ts`).
+  - Owns page-level network routes (`_routes: RouteHandler[]`).
+  - Manages page lifecycle events (`load`, `domcontentloaded`, `console`, `dialog`, `download`, `filechooser`, `popup`, `close`, `crash`).
+
+---
+
+## 3. Locator Architecture, Selector Resolution, and Auto-Waiting
+
+### Locator Definition
+- **Client Class**: `Locator` in `packages/playwright-core/src/client/locator.ts`.
+- Locators are **lazy descriptors**. Creating a locator (`page.locator('button')`, `page.getByRole('button')`, `page.getByTestId('submit')`) does NOT trigger any network or DOM calls.
+- The `Locator` constructor formats combined selector queries (e.g. appending `>> internal:has-text=...` or `>> internal:role=button`).
+
+### Auto-Waiting Mechanism
+When an action method (e.g. `locator.click()`) is called, Playwright performs rigorous auto-waiting checks on the server side in `packages/playwright-core/src/server/dom.ts` inside `ElementHandle._retryPointerAction()` and `ElementHandle._performPointerAction()`:
+1. **Attached & Visible Check**: Verifies element exists in DOM and is visible (`injected.checkElementStates` and `packages/injected/src/domUtils.ts` checking CSS display/visibility and non-zero bounding box; explicitly does *not* examine opacity, as detailed in Section 12.3).
+2. **Enabled & Stable Check**: Verifies element is not disabled (`:disabled`) and is visually stable (bounding box does not shift across consecutive animation frames).
+3. **Scroll into View**: Executes `doScrollIntoView()` / `scrollIntoViewIfNeeded` to bring element into the browser viewport.
+4. **Hit Target Check**: Evaluates `injected.checkElementHitTarget()` at the action point `(x, y)` to ensure pointer events reach the target element and are not intercepted by overlay elements (e.g., sticky headers, modal backdrops).
+5. **Action Execution**: Dispatches mouse/keyboard events (`Page.mouse.click`).
+6. **Wait-After Action**: Optionally waits for pending network requests or navigation events initiated by the action (unless `noWaitAfter: true`).
+
+---
+
+## 4. End-to-End Action Call Trace (`Locator.click`)
+
+Tracing `locator.click(options)` from public client API down to browser protocol layer:
+
+```
+[Public Client API] Locator.click(options)
+  │ (packages/playwright-core/src/client/locator.ts)
+  ▼
+[Client Frame] Frame.click(this._selector, options)
+  │ (packages/playwright-core/src/client/frame.ts)
+  ▼
+[Playwright Channel RPC] sends `click` payload over connection channel
+  │
+  ▼
+[Server Dispatcher] FrameDispatcher.click(params, progress)
+  │ (packages/playwright-core/src/server/dispatchers/frameDispatcher.ts)
+  ▼
+[Server Frame] Frame.click(progress, selector, options)
+  │ (packages/playwright-core/src/server/frames.ts) -> invokes `_retryWithProgressIfNotConnected`
+  ▼
+[Server Selector & DOM] ElementHandle.click(progress, options) -> ElementHandle._click
+  │ (packages/playwright-core/src/server/dom.ts)
+  ▼
+[Auto-Waiting & Retry] ElementHandle._retryPointerAction -> ElementHandle._performPointerAction
+  │ checks attached, visible, enabled, stable, scrolls into view, hit target test
+  ▼
+[Server Input Device] Page.mouse.click(progress, point.x, point.y, options)
+  │ (packages/playwright-core/src/server/input.ts) -> issues move, down, up calls
+  ▼
+[Browser Engine Protocol] CRSession / FFSession / WKSession
+  │ (e.g., packages/playwright-core/src/server/chromium/crConnection.ts)
+  ▼
+[Browser Process] Dispatches CDP `Input.dispatchMouseEvent` / native OS event
+```
+
+---
+
+## 5. Network Interception Architecture
+
+### Client Routing API
+- `page.route(url, handler)` / `context.route(url, handler)` in `packages/playwright-core/src/client/page.ts` & `browserContext.ts` registers `RouteHandler` entries.
+- When network requests occur, matching route handlers receive a `Route` instance (`packages/playwright-core/src/client/network.ts`):
+  - **`route.fulfill(options)`**: Intercepts request and responds with custom status, headers, and body (base64-encoded if binary). Calls `_channel.fulfill(...)`.
+  - **`route.continue(options)`**: Modifies request URL, HTTP method, headers, or post data and resumes network fetch. Calls `_channel.continue(...)`.
+  - **`route.abort(errorCode)`**: Cancels network request with error code (e.g. `'failed'`, `'aborted'`). Calls `_channel.abort(...)`.
+  - **`route.fallback(options)`**: Passes control to the next matching route handler in chain.
+
+### Server Network Engine
+- `RouteDispatcher` in `packages/playwright-core/src/server/dispatchers/networkDispatchers.ts` processes channel commands.
+- `Route` & `Request` in `packages/playwright-core/src/server/network.ts` manage browser protocol network interception hooks (`Fetch.enable` / `Network.setRequestInterception` in CDP).
+
+---
+
+## 6. Codegen / Recorder Architecture (Expanded Deep Dive)
+
+Playwright's `codegen` (test generator) operates as a multi-tier pipeline connecting injected DOM event listeners, a server-side action recorder and debouncer, a standalone Vite-powered GUI window, score-based selector generators, and language code formatters.
+
+```
+[Web Page DOM (Injected Script)]
+  │ Injected Recorder (packages/injected/src/recorder/recorder.ts) listens to click, input, keydown
+  │ Computes optimal selector via SelectorGenerator (packages/injected/src/selectorGenerator.ts)
+  ▼
+[Exposed Binding IPC Bridge] window.__pw_recorderRecordAction(action)
+  │ (packages/playwright-core/src/client/browserContext.ts & server/recorder.ts)
+  ▼
+[Server Recorder Controller] Recorder (packages/playwright-core/src/server/recorder.ts)
+  │ Passes action to RecorderSignalProcessor (server/recorder/recorderSignalProcessor.ts)
+  │ Emits RecorderEvent.ActionAdded to listeners
+  ▼
+[GUI Window & File Stream]
+  ├── RecorderApp (packages/playwright-core/src/server/recorder/recorderApp.ts) -> Vite React UI (packages/recorder/src/recorder.tsx)
+  └── ThrottledFile (packages/playwright-core/src/server/recorder/throttledFile.ts) -> streams generated code to disk (-o/--output)
+  ▼
+[Language Code Generators] (packages/isomorphic/codegen/)
+  ├── JavaScriptLanguageGenerator (javascript.ts) -> Node.js / Playwright Test
+  ├── PythonLanguageGenerator (python.ts) -> Pytest / Sync Library / Async Library
+  ├── CSharpLanguageGenerator (csharp.ts) -> NUnit / MSTest / xUnit
+  └── JavaLanguageGenerator (java.ts) -> JUnit / Library
+```
+
+---
+
+### 6.1 Recorder Overlay, Toolbar UI, and Client-Server Bridge
+- **GUI Window Launch (`RecorderApp`)**:
+  - Located in `packages/playwright-core/src/server/recorder/recorderApp.ts` -> `RecorderApp.show(context, params)`.
+  - Spawns a dedicated auxiliary browser window running a Vite React frontend app (`packages/recorder/src/recorder.tsx`).
+  - Registers custom request interceptors for `https://playwright/` URLs to serve static Vite bundles (`libPath('vite', 'recorder')`).
+- **Injected Overlay & Element Highlight**:
+  - Injected script `Recorder` in `packages/injected/src/recorder/recorder.ts`:
+    - Renders a highlight canvas box around elements when hovering in `inspecting` / `recording` mode (`HighlightModel` & `HighlightColors`).
+    - Communicates overlay positioning adjustments to the server via exposed binding `window.__pw_recorderSetOverlayState()`.
+- **IPC Binding Bridge**:
+  - `Recorder` in `packages/playwright-core/src/server/recorder.ts` registers bindings into the browser execution context via `_context.exposeBinding()`:
+    - `__pw_recorderState`: returns UI mode (`recording`, `inspecting`, `none`), active action point `(x, y)`, highlighted selector, and target test language.
+    - `__pw_recorderRecordAction`: receives recorded `Action` payloads from injected DOM event listeners.
+    - `__pw_recorderPerformAction`: allows the Recorder GUI to trigger actions in the page.
+    - `__pw_recorderElementPicked`: fires when the user clicks an element in locator picker mode.
+
+---
+
+### 6.2 Storage State Capture (`--save-storage` and `--load-storage`)
+- **CLI Flag Processing**:
+  - `codegen(options, url)` in `packages/playwright-core/src/cli/browserActions.ts` parses `--save-storage=<path>` and `--load-storage=<path>`.
+- **Session State Saving**:
+  - Upon codegen exit or context closure, `launchContext()` in `cli/browserActions.ts` calls:
+    ```js
+    if (options.saveStorage)
+      await context.storageState({ path: options.saveStorage });
+    ```
+  - `BrowserContext.storageState(options)` in `packages/playwright-core/src/client/browserContext.ts` issues a `_channel.storageState()` RPC call.
+  - Server implementation `BrowserContext.storageState(progress, options)` in `packages/playwright-core/src/server/browserContext.ts` collects all cookies, origin security details, and `localStorage` key-value maps, serializing them to a JSON file.
+- **Session State Loading**:
+  - When `--load-storage=state.json` is passed, `launchContext()` initializes the context with `{ storageState: options.loadStorage }`, pre-populating cookies and `localStorage` so codegen starts in an authenticated state.
+
+---
+
+### 6.3 Multi-Language Code Generation (`--target`)
+- **CLI Target Resolution**:
+  - `codegenId()` in `packages/playwright-core/src/cli/program.ts` maps `--target` command line values (`playwright-test`, `javascript`, `python`, `python-pytest`, `python-async`, `csharp`, `csharp-nunit`, `java`, `java-junit`) to internal generator identifiers.
+- **Generator Registry**:
+  - `languageSet()` in `packages/isomorphic/codegen/languages.ts` instantiates and exports the set of available `LanguageGenerator` implementations:
+    - `JavaScriptLanguageGenerator` (`packages/isomorphic/codegen/javascript.ts`): outputs Node.js `@playwright/test` or `playwright` library code.
+    - `PythonLanguageGenerator` (`packages/isomorphic/codegen/python.ts`): outputs `pytest-playwright`, sync Python, or async Python (`asyncio`).
+    - `CSharpLanguageGenerator` (`packages/isomorphic/codegen/csharp.ts`): outputs .NET code formatted for NUnit, MSTest, xUnit, or Library.
+    - `JavaLanguageGenerator` (`packages/isomorphic/codegen/java.ts`): outputs Java code formatted for JUnit or Library.
+    - `JsonlLanguageGenerator` (`packages/isomorphic/codegen/jsonl.ts`): outputs raw JSON lines for programmatic consumption.
+- **Dynamic Language Switching**:
+  - When the user selects a different target language in the Recorder GUI dropdown, `RecorderApp` calls `this._recorder.setLanguage(language.highlighter)` in `packages/playwright-core/src/server/recorder.ts`, which re-runs `generateCode()` over accumulated actions to dynamically re-render the preview.
+
+---
+
+### 6.4 Selector Generator Ranking Algorithm (`generateSelector`)
+- **Core Function**: `generateSelector(targetElement, options)` in `packages/injected/src/selectorGenerator.ts`.
+- **Heuristic Scoring System**:
+  Playwright calculates candidate selector tokens and assigns numeric penalty scores (lower score = higher preference). The engine selects the token with the lowest score that uniquely resolves `targetElement`:
+
+| Selector Type | Penalty Score | Example Generated Code |
+| :--- | :--- | :--- |
+| Custom Test ID | `kTestIdScore = 1` | `page.getByTestId('submit-btn')` |
+| Secondary Test ID | `kOtherTestIdScore = 2` | `page.locator('[data-test="submit"]')` |
+| ARIA Role + Accessible Name | `kRoleWithNameScore = 100` | `page.getByRole('button', { name: 'Submit' })` |
+| Input Placeholder | `kPlaceholderScore = 120` | `page.getByPlaceholder('Enter email')` |
+| Associated Label | `kLabelScore = 140` | `page.getByLabel('Password')` |
+| Image Alt Text | `kAltTextScore = 160` | `page.getByAltText('Company Logo')` |
+| Text Content | `kTextScore = 180` | `page.getByText('Learn more')` |
+| Title Attribute | `kTitleScore = 200` | `page.getByTitle('Close modal')` |
+| CSS / Tag / Class Fallback | `kEndPenalizedScore = 300` | `page.locator('div.container > button')` |
+
+- **Custom Test ID Attribute Configuration**:
+  Passing `--test-id-attribute=data-qa` updates `testIdAttributeName` in `SelectorGeneratorOptions`, allowing custom test attributes (e.g. `data-qa="login-btn"`) to be evaluated at `kTestIdScore = 1`.
+
+---
+
+### 6.5 Action Recording Lifecycle: Fresh Session vs. Attaching to Existing Context
+- **Fresh Recording Session (`playwright codegen [url]`)**:
+  - Function: `launchContext()` in `packages/playwright-core/src/cli/browserActions.ts`.
+  - Spawns a brand-new browser process (`chromium.launch()`), creates a new `BrowserContext`, immediately invokes `context._enableRecorder()`, and opens `url` via `openPage(context, url)`.
+- **Attaching to an Existing Context (e.g. `page.pause()` or programmatic `context._enableRecorder()`)**:
+  - Function: `Recorder.forContext(context, params)` in `packages/playwright-core/src/server/recorder.ts`.
+  - Detects existing active pages in `context.pages()` via `Recorder._onPage(page)` and subscribes to future pages (`context.on('page')`).
+  - Extends injected script across all current and future document frames (`_context.extendInjectedScript(rawRecorderSource.source)`).
+  - **Single-Page Isolation (`_pickLocatorPage`)**: When inspect mode is triggered on a specific page, `_pickLocatorPage` limits highlight overlay and locator picking to that page while leaving other open context pages operating normally.
+
+---
+
+### 6.6 Verification Sources & Documentation Alignment
+
+| Feature / Behavior | Source Code File & Function | Confirmed via Playwright Official Docs |
+| :--- | :--- | :--- |
+| CLI `--target` flag options | `cli/program.ts` -> `codegenId()` | Confirmed (`https://playwright.dev/docs/codegen`) |
+| `--save-storage` & `--load-storage` | `cli/browserActions.ts` -> `codegen()` | Confirmed (`https://playwright.dev/docs/codegen#preserve-authenticated-state`) |
+| Custom `--test-id-attribute` | `injected/src/selectorGenerator.ts` | Confirmed (`https://playwright.dev/docs/locators#customize-test-id-attribute`) |
+| Injected DOM Event Listening | `injected/src/recorder/recorder.ts` -> `Recorder` | Purely from Source |
+| Action Debouncing (`RecorderSignalProcessor`) | `server/recorder/recorderSignalProcessor.ts` | Purely from Source |
+| Multi-language Generator implementations | `isomorphic/codegen/javascript.ts`, `python.ts`, `csharp.ts`, `java.ts` | Purely from Source |
+
+### 6.7 Programmatic Initiation and Termination Signals (`page.pause()`)
+
+While the CLI launches a fresh session, programmatic control flows through `page.pause()` and resolves through a sophisticated dispatcher-interception layer.
+
+1. **`page.pause()` -- The Real Programmatic Entry Point:**
+   - **Client-Side Blocking:** In `packages/playwright-core/src/client/page.ts`, `page.pause()` temporarily zeroes out timeouts (`setDefaultNavigationTimeout(0)`) and directly awaits the channel message `this.context()._channel.pause({}, kNoTimeout)` within a `safeRace`. It does **not** natively launch the UI itself—it simply blocks until the server resolves the pause state.
+   - **Server-Side Interception:** In `packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts`, the explicit `pause()` channel handler is empty (`// Debugger will take care of this.`). Instead, the global `Debugger` class (`packages/playwright-core/src/server/debugger.ts`) intercepts *all* calls via `onBeforeCall()`. When it detects a `BrowserContext.pause` method, it triggers `_pause()`, creating an unresolved promise (`_pausedCall`) that blocks the dispatcher from returning control to the client.
+   - **Launching the App:** The act of pausing emits `Debugger.Events.PausedStateChanged`. The `BrowserContext` class (`packages/playwright-core/src/server/browserContext.ts`) listens to this event. If it detects a paused state, it triggers `RecorderApp.showInspectorNoReply(this)`. This executes `launchApp()` (`packages/playwright-core/src/server/recorder/recorderApp.ts`), which spawns an entirely *separate* and isolated Chromium browser context (`appContext`) specifically for the Inspector GUI, ensuring the inspected context is unpolluted.
+
+2. **The "Resume" / "Close" Signal -- Unblocking the Script:**
+   The `page.pause()` channel call remains permanently blocked until `Debugger.resume()` is invoked, which resolves the pending `_pausedCall` promise. The source handles this identically across two UI paths:
+   - **"Resume" (Toolbar Button):** Resolves through an explicitly exposed binding named `__pw_resume` registered onto the inspected context in `packages/playwright-core/src/server/recorder.ts` (this is used by in-page overlays) OR via `doResume()` invoked through `sendCommand` from the Inspector UI (handled by `DebuggerDispatcher`). Both paths simply execute `this._debugger.resume()`.
+   - **"Close" (Native Window Button):** Caught in `packages/playwright-core/src/server/recorder/recorderApp.ts` via `this._page.once('close', ...)`. The handler explicitly calls `this._recorder.close()` (which under the hood merely delegates to `this._debugger.resume()`).
+
+3. **What happens to the browser/context after the signal fires?**
+   - **Neither action closes the inspected script's browser or context.** The `page.pause()` promise resolves, and execution control returns immediately to the calling Node.js script. Subsequent lines of the test script continue perfectly normally against the same alive page.
+   - **The only difference is the UI lifecycle:** Clicking "Resume" leaves the Recorder UI's isolated context alive in the background (ready to be paused again). Clicking the native window "Close" button explicitly tears down the Recorder's *own* isolated browser context (`this._page.browserContext.close()`), destroying the GUI.
+---
+
+## 7. @playwright/test Test Runner Architecture
+
+The `@playwright/test` package provides the test runner framework built on top of `playwright-core`. It manages test file discovery, configuration parsing, fixture dependency injection, parallel worker process execution, auto-retrying assertions, and event reporting.
+
+```
+[CLI / Main Process]
+  │ TaskRunner (packages/playwright/src/runner/tasks.ts)
+  │  ├── collectProjectsAndTestFiles() (packages/playwright/src/runner/loadUtils.ts)
+  │  ├── loadFileSuites() (packages/playwright/src/runner/loadUtils.ts) via LoaderHost
+  │  └── createTestGroups() (packages/playwright/src/runner/testGroups.ts)
+  ▼
+[Dispatcher] (packages/playwright/src/runner/dispatcher.ts)
+  │ Dispatches TestGroup payloads over IPC to worker processes
+  ▼
+[Worker Processes]
+  │ WorkerHost (packages/playwright/src/runner/workerHost.ts) ──IPC── WorkerMain (packages/playwright/src/worker/workerMain.ts)
+  │  ├── FixturePool (packages/playwright/src/common/fixtures.ts) -> Builds Fixture DAG
+  │  ├── FixtureRunner (packages/playwright/src/worker/fixtureRunner.ts) -> Runs setup/use/teardown
+  │  └── Expect & Auto-Retries (packages/playwright/src/matchers/expect.ts) -> pollAgainstDeadline()
+  ▼
+[Reporters]
+  └── Multiplexer (packages/playwright/src/reporters/multiplexer.ts) -> broadcasts to List, Line, HTML, JSON reporters
+```
+
+---
+
+### 7.1 Test Runner Core Loop: Discovery, Suite Building & Dispatch
+- **Task Runner Pipeline**:
+  - Entry point: `runTasks()` in `packages/playwright/src/runner/tasks.ts`.
+  - Executes sequential setup, test run, and cleanup tasks using `TaskRunner<TestRun>` (`packages/playwright/src/runner/taskRunner.ts`).
+- **Spec File Discovery**:
+  - `collectProjectsAndTestFiles()` in `packages/playwright/src/runner/loadUtils.ts`:
+    - Iterates over filtered projects in `TestRun.filteredProjects`.
+    - Invokes `collectFilesForProject()` in `packages/playwright/src/runner/projectUtils.ts` using glob matching (`testMatch`, `testIgnore`).
+- **Spec File Loading & Transformation**:
+  - `loadFileSuites()` in `packages/playwright/src/runner/loadUtils.ts`:
+    - Uses `InProcessLoaderHost` or `OutOfProcessLoaderHost` (`packages/playwright/src/runner/loaderHost.ts`).
+    - Uses Playwright's custom transpiler (`packages/playwright/src/transform/transform.ts`) to compile ESM/TypeScript files on the fly.
+- **Suite Tree & Test Grouping**:
+  - `createRootSuite()` in `loadUtils.ts` constructs the root `Suite` containing project suites and test file suites.
+  - `createTestGroups()` in `packages/playwright/src/runner/testGroups.ts` partitions tests into `TestGroup` bundles based on `workerHash`, shard settings, and `repeatEachIndex`.
+- **Dispatcher**:
+  - `Dispatcher` in `packages/playwright/src/runner/dispatcher.ts` maintains worker pool slots and dispatches `TestGroup` payloads over IPC to child worker processes.
+
+---
+
+### 7.2 Fixtures System (`test.extend()`, Scoping, and Dependency DAG)
+- **Fixture Registration**:
+  - `test.extend()` registers fixture definitions in `FixturePool` (`packages/playwright/src/common/fixtures.ts`).
+  - Each fixture is represented as a `FixtureRegistration` containing fixture `name`, `scope` (`'test'` or `'worker'`), `fn` (the generator function), and `deps` (array of dependency names parsed from the function parameters `({ page, db }, use) => ...`).
+- **Fixture Scoping**:
+  - **`scope: 'worker'`**: Created once per worker process. Reused across all tests executed within that worker process (e.g. database connections, browser server instances).
+  - **`scope: 'test'`** (default): Created fresh before each test and torn down immediately after (e.g. `page`, `context`, custom test state).
+- **Dependency DAG & Execution**:
+  - `FixtureRunner` in `packages/playwright/src/worker/fixtureRunner.ts` resolves dependencies in topological order:
+    1. **Setup**: Evaluates leaf fixtures first, calling fixture functions up to `await use(value)`. The yielded value is passed to downstream dependent fixtures and finally to the test body.
+    2. **Execution**: The test body runs with the resolved fixture values.
+    3. **Teardown**: Runs in reverse topological order (root to leaves) after the test completes, resuming execution after `use(value)` to run cleanup logic.
+
+---
+
+### 7.3 Worker Process Architecture & Test Isolation
+- **Process Spawning**:
+  - `WorkerHost` in `packages/playwright/src/runner/workerHost.ts` extends `ProcessHost` (`packages/playwright/src/runner/processHost.ts`).
+  - Spawns isolated Node.js child processes via `child_process.fork()` executing the generated `packages/playwright/src/worker/workerProcessEntry.js` (compiled from the checked-in TypeScript source `packages/playwright/src/worker/workerProcessEntry.ts`).
+- **Process Communication**:
+  - Main process and worker process communicate using structured IPC messages (`packages/playwright/src/common/ipc.ts`).
+  - `WorkerMain` in `packages/playwright/src/worker/workerMain.ts` receives `runTestGroup` IPC commands from `WorkerHost`.
+- **Test Isolation Boundary**:
+  - Each worker process runs in an isolated OS process with distinct global memory, `process.env` overrides (`TEST_WORKER_INDEX`, `TEST_PARALLEL_INDEX`), and output artifact folders.
+  - Test-scoped browser contexts and pages are destroyed between tests, preventing state pollution.
+- **Reporting Results & Errors**:
+  - Worker streams live stdio chunks (`stdOut`, `stdErr`) and test execution hooks (`testBegin`, `testEnd`, `stepBegin`, `stepEnd`) back to `WorkerHost`, which delegates them to the main runner's `InternalReporter`.
+
+---
+
+### 7.4 Auto-Retrying Assertions (`expect(locator).toBeVisible()`)
+- **Expect Core & Async Matchers**:
+  - Implemented in `packages/playwright/src/matchers/expect.ts` & `packages/playwright/src/matchers/matchers.ts`.
+  - Custom web matchers (`toBeVisible`, `toBeAttached`, `toBeChecked`, `toBeEnabled`, `toHaveText`, `toHaveURL`, etc.) are registered in `customAsyncMatchers`.
+- **Polling & Retry Loop**:
+  - Unlike synchronous one-shot assertions (e.g. `expect(value).toBe(5)` which fail immediately on mismatch), web assertions call `pollAgainstDeadline()` from `@isomorphic/timeoutRunner`.
+  - The matcher repeatedly queries the server element state (e.g. checking visibility or text content) until either:
+    1. The expected condition evaluates to `true` (assertion passes).
+    2. The assertion timeout deadline is reached, throwing an `ExpectError` with a formatted diff and stack trace.
+- **Soft Assertions**:
+  - `expect.soft()` sets `info.isSoft = true` in `callMatcherAsStep()`. On failure, the step catches the `ExpectError` and appends it to `TestInfoImpl._errors` without aborting remaining test execution.
+
+---
+
+### 7.5 Reporters & Event Multiplexing
+- **Reporter V2 Interface**:
+  - Defined in `packages/playwright/src/reporters/reporterV2.ts` (`ReporterV2`).
+  - Specifies lifecycle event callbacks:
+    - `onConfigure(config)`: config initialization.
+    - `onBegin(suite)`: test run start with full suite tree.
+    - `onTestBegin(test, result)`: individual test start.
+    - `onStepBegin(test, result, step)` / `onStepEnd(test, result, step)`: test step progress.
+    - `onTestEnd(test, result)`: individual test completion (passed, failed, timedOut, skipped).
+    - `onEnd(result)`: test run completion with final status summary.
+    - `onStdOut(chunk, test, result)` / `onStdErr(chunk, test, result)`: console output.
+- **Event Multiplexer**:
+  - Implemented in `packages/playwright/src/reporters/multiplexer.ts` (`Multiplexer`).
+  - Acts as a fan-out router, broadcasting every runner event to all configured reporters simultaneously.
+- **Built-in Reporters**:
+  - `ListReporter` (`packages/playwright/src/reporters/list.ts`): renders real-time terminal output with progress indicators.
+  - `LineReporter` (`packages/playwright/src/reporters/line.ts`): single-line terminal progress updates.
+  - `DotReporter` (`packages/playwright/src/reporters/dot.ts`): concise dot output.
+  - `HTMLReporter` (`packages/playwright/src/reporters/html.ts`): builds interactive HTML report bundle.
+  - `JSONReporter` (`packages/playwright/src/reporters/json.ts`): writes structured JSON test result tree.
+
+---
+
+## 8. Tracing, Trace Viewer, and Cross-Origin Frame Architecture
+
+### 8.1 Tracing Recording Architecture (`context.tracing.start()` / `stop()`)
+- **Client Entry Point**:
+  - `Tracing` class in `packages/playwright-core/src/client/tracing.ts`.
+  - Methods: `start()`, `startChunk()`, `stopChunk()`, `stop({ path })`.
+  - Sends `tracingStart`, `tracingStartChunk`, `tracingStop` RPC requests over `TracingChannel` to server `TracingDispatcher` (`packages/playwright-core/src/server/dispatchers/tracingDispatcher.ts`).
+- **Server Trace Recorder**:
+  - `Tracing` class in `packages/playwright-core/src/server/trace/recorder/tracing.ts`.
+  - Implements `InstrumentationListener`, `SnapshotterDelegate`, and `HarTracerDelegate`.
+  - Attaches `Snapshotter` (`packages/playwright-core/src/server/trace/recorder/snapshotter.ts`) for DOM snapshotting (`snapshotterInjected.ts`), `HarTracer` for HTTP request/response capturing, and screencast frame recorders per page.
+
+---
+
+### 8.2 Trace Archive Zip Structure
+When `context.tracing.stop({ path: 'trace.zip' })` is executed, `Tracing.stopChunk()` packages captured data into a compressed `.zip` archive containing:
+
+```
+trace.zip
+├── trace.trace         # JSON lines: API call events, durations, stack traces, console messages, page events
+├── trace.network       # JSON lines: HAR network request/response headers, timings, status codes, payload hashes
+└── resources/          # Content-addressed storage (SHA1 filename keys)
+    ├── <sha1>.html     # Page DOM HTML snapshots
+    ├── <sha1>.jpeg     # Screencast viewport frame images
+    ├── <sha1>.png      # Action point screenshot overlays
+    └── <sha1>.bin      # Network response binary bodies (CSS, JS, fonts, images)
+```
+
+---
+
+### 8.3 Trace Viewer Architecture
+- **Web App & Standalone Viewer**:
+  - `startTraceViewerServer()` in `packages/playwright-core/src/server/trace/viewer/traceViewer.ts`:
+    - Spawns an internal `HttpServer` serving the Vite React web application from `packages/trace-viewer/` (`libPath('vite', 'traceViewer')`).
+    - Exposes endpoints `/file?path=...` to serve trace files (`trace.trace`, `trace.network`) and SHA1 resources to the browser UI.
+- **Trace Viewer UI Parsing**:
+  - Front-end React UI (`packages/trace-viewer/src/ui/workbench.tsx`) and isomorphic model (`packages/isomorphic/trace/traceModel.ts`, exposed to the UI via `packages/trace-viewer/src/ui/traceModelContext.tsx` hook):
+    - Parses `trace.trace` and `trace.network` to construct a unified interactive timeline.
+    - `SnapshotServer` & `SnapshotViewer` iframe reconstruct full DOM snapshots at exact pre-action and post-action timestamps without running a live browser.
+
+---
+
+### 8.4 Frame Hierarchy & Ownership
+- **Client Frame**: `Frame` class in `packages/playwright-core/src/client/frame.ts`.
+  - Linked to parent `Page` (`_page: Page`).
+  - Navigating or querying elements in child frames uses `frame.childFrames()`, `frame.parentFrame()`, or `page.frameLocator(selector)`.
+- **Server Frame Tree**: `Frame` & `FrameManager` classes in `packages/playwright-core/src/server/frames.ts`.
+  - `Page` owns a `FrameManager` instance which maintains the frame tree (`_mainFrame` and `_childFrames: Set<Frame>`).
+  - Dispatches frame lifecycle events (`Page.Events.FrameAttached`, `FrameNavigated`, `FrameDetached`).
+
+---
+
+### 8.5 Cross-Origin IFrames & OOPIF Architecture
+- **Chromium Out-Of-Process IFrames (OOPIF)**:
+  - Chromium isolates cross-origin iframes into separate renderer processes (OOPIF).
+  - Implemented in `packages/playwright-core/src/server/chromium/crPage.ts` inside `_onAttachedToTarget()`.
+- **Target Auto-Attach & Child CDP Sessions**:
+  - Playwright configures Chromium target manager with `Target.setAutoAttach({ autoAttach: true, flatten: true })`.
+  - When a cross-origin iframe is created or navigated, Chrome fires `Target.attachedToTarget` with `targetInfo.type === 'iframe'`.
+  - `crPage.ts` creates a child CDP session (`session = this._client.createChildSession(event.sessionId)`) and wraps it in a `FrameSession`.
+  - Protocol commands directed at elements inside the OOPIF are automatically routed through the child CDP session to the correct renderer process, while `FrameManager` presents a single, unified `Frame` tree to the user.
+
+---
+
+### 8.6 Frame Lifecycle & Navigation Event Propagation
+
+```
+[Browser Renderer / Target Session]
+  │ Fires CDP Page.frameAttached, Page.frameNavigated, Page.frameDetached (or Target.attachedToTarget for OOPIF)
+  ▼
+[Server CRPage / FrameManager] (packages/playwright-core/src/server/frames.ts & server/chromium/crPage.ts)
+  │ Updates internal frame tree (_mainFrame, _childFrames)
+  │ Dispatches Page.Events.FrameAttached, FrameNavigated, FrameDetached
+  ▼
+[Server FrameDispatcher] (packages/playwright-core/src/server/dispatchers/frameDispatcher.ts)
+  │ Emits RPC channel events: `navigated`, `loadstate` over FrameChannel
+  ▼
+[Client Page & Frame] (packages/playwright-core/src/client/page.ts & client/frame.ts)
+  │ Updates client Frame properties (url, name)
+  │ Fires public Page events: `page.on('frameattached')`, `page.on('framenavigated')`, `page.on('framedetached')`
+```
+
+---
+
+## 9. Downloads, API Testing, and Time Mocking
+
+### 9.1 Downloads, Uploads, and Dialog Handling
+- **Downloads**:
+  - Emits `Page.Events.Download` natively via `packages/playwright-core/src/server/download.ts` (`Download` class) and `packages/playwright-core/src/server/artifact.ts` (`Artifact` class).
+  - Chromium listens for `Browser.downloadWillBegin` and `Browser.downloadProgress` in `packages/playwright-core/src/server/chromium/crBrowser.ts`.
+- **Uploads (`setInputFiles`)**:
+  - Calling `page.setInputFiles()` flows through `packages/playwright-core/src/server/dom.ts` (`_setInputFiles`), calling `_page.delegate.setInputFilePaths`.
+  - Chromium implementation (`packages/playwright-core/src/server/chromium/crPage.ts`) pushes files directly via `DOM.setFileInputFiles` CDP command.
+- **Dialogs & File Choosers (`page.on('dialog')` / `page.on('filechooser')`)**:
+  - File chooser interception is enabled via `Page.setInterceptFileChooserDialog` CDP command; Chromium (`crPage.ts`) captures `Page.fileChooserOpened` and wraps it in a `FileChooser` (`packages/playwright-core/src/server/fileChooser.ts`).
+  - Native dialogs (alert/confirm/prompt) trigger `Page.javascriptDialogOpening` in `crPage.ts`, creating a `Dialog` object (`packages/playwright-core/src/server/dialog.ts`). Actions on the dialog send `Page.handleJavaScriptDialog`.
+
+### 9.2 API Testing (`APIRequestContext`)
+- **Location**: Defined in `packages/playwright-core/src/server/fetch.ts` (`APIRequestContext`) and `packages/playwright-core/src/client/fetch.ts`.
+- **Network Stack Independence**: Instead of routing through the browser's CDP network stack, `APIRequestContext` utilizes Node.js native `http`/`https` modules (`http.request` / `https.request` in `fetch.ts`) directly.
+- **Cookie & Storage Sharing**: Subclasses like `BrowserContextAPIRequestContext` (`server/fetch.ts`) override `addCookies`, `cookies`, and `storageState` to directly call methods on the underlying `BrowserContext`, seamlessly sharing the authentication state between Node.js API requests and browser-driven CDP requests.
+
+### 9.3 Clock & Time Mocking
+- **Location**: `packages/playwright-core/src/server/clock.ts`.
+- **Mechanism**: The `Clock` class manages time by reading a raw mock implementation (`rawClockSource.source`, likely based on SinonJS) and injecting it into the page via `_browserContext.addInitScript()`.
+- **Execution**: Methods like `clock.install()`, `clock.pauseAt()`, and `clock.fastForward()` trigger `_evaluateInFrames('globalThis.__pwClock.controller...')` in the page, completely faking `Date` and `setTimeout` entirely within the JavaScript environment.
+
+---
+
+## 10. Page Load Detection and Multi-Tab Architecture
+
+### 10.1 Page Load Detection -- Visual Readiness vs. Data Readiness
+- **Lifecycle Events**: Tracked via `this._firedLifecycleEvents` in `packages/playwright-core/src/server/frames.ts`. `page.waitForLoadState(state)` awaits the `Frame.Events.AddLifecycle` event if the state isn't already reached.
+- **The `networkidle` Algorithm**:
+  - Tracked via `_inflightRequests` in `packages/playwright-core/src/server/frames.ts`.
+  - When the last in-flight request finishes (`_inflightRequests.size === 0`), `_startNetworkIdleTimer()` schedules a `setTimeout` for exactly `500` ms.
+  - If a new request begins (`_inflightRequestStarted`), `_stopNetworkIdleTimer()` clears the timer. Thus, `networkidle` strictly requires zero active network connections for 500 milliseconds.
+- **Visual Stability**:
+  - Playwright's `page.screenshot()` handles visual stability natively. In `packages/playwright-core/src/server/screenshotter.ts`, `_preparePageForScreenshot` disables animations (if requested) via injected CSS, and actively waits for fonts to settle using `frame.nonStallingEvaluateInExistingContext('document.fonts.ready', 'utility')` unless explicitly skipped by an environment variable.
+- **Data Readiness**:
+  - While lifecycle events apply to the whole frame, `page.waitForResponse()` and `page.waitForRequestFinished()` (in `packages/playwright-core/src/client/page.ts`) delegate directly to the underlying `EventEmitter` tracking individual CDP network payloads (e.g. `Events.Page.Response`). These are completely decoupled from `networkidle` or `load` events.
+
+### 10.2 Multi-Tab / Multi-Page Switching Logic
+- **New Tab Creation**:
+  - Popups and new tabs trigger Chromium's `Target.attachedToTarget` event, caught in `packages/playwright-core/src/server/chromium/crBrowser.ts` (`_onAttachedToTarget`).
+  - If `targetInfo.type === 'page'`, it initializes a new `CRPage`, sets the `opener` using `targetInfo.openerId`, and fires `this._page.reportAsNew(this._opener?._page)`, which propagates the `context.on('page')` event.
+- **`page.bringToFront()`**:
+  - Implemented in `packages/playwright-core/src/server/chromium/crPage.ts` (`bringToFront`). It sends the `Page.bringToFront` CDP command directly to the tab's session (not `Target.activateTarget`).
+- **Context & Page Inventory**:
+  - `browser.contexts()` simply returns the internal `_contexts` array.
+  - `context.pages()` (in `packages/playwright-core/src/server/browserContext.ts`) filters the `_crPages` Map kept by `CRBrowser`. There is no global registry; targets are just tracked locally in memory as they attach/detach.
+- **"Active" Tab Concept**:
+  - Playwright does *not* utilize a single "active tab" concept for automation. Because every `CRPage` holds its own direct CDP child session (`CRSession`), scripts can interact with any `Page` concurrently. `bringToFront()` is purely for human visual inspection or triggering visibility-based DOM events (like `requestAnimationFrame`), but is not required to issue CDP commands.
+
+## 11. Deterministic Readiness Patterns for Dynamic UI Elements (Dropdowns & Beyond)
+
+*Note: The following are ENGINEERED PATTERNS composed from real Playwright APIs to address real-world unreliability with global heuristic checks like `networkidle`. They are not built-in Playwright methods.*
+
+### 11.1 Targeted Network Interception ("wait for the one response that matters")
+- **Mechanism**: Instead of waiting for all network traffic to cease (`networkidle`), you wait for a specific HTTP response indicating that the specific data you need has arrived.
+- **API**: `page.waitForResponse(urlOrPredicate, options)` in `packages/playwright-core/src/client/page.ts`.
+- **Default Timeout**: By default, it uses the global timeout setting, which falls back to `DEFAULT_PLAYWRIGHT_TIMEOUT` defined as `30_000` (30 seconds) in `packages/isomorphic/time.ts`.
+
+### 11.2 Browser-Side Predicate Polling ("wait for the DOM to say so")
+- **Mechanism**: Executing a JavaScript function inside the browser repeatedly until it returns a truthy value, confirming that the DOM has reached the desired state (e.g., a dropdown is populated).
+- **API**: `page.waitForFunction(pageFunction, arg, options)` in `packages/playwright-core/src/client/page.ts`.
+- **Default Polling Strategy**: Tracing `_mainFrame.waitForFunction` down to `packages/playwright-core/src/server/frames.ts` (inside `waitForFunctionExpression`), the default polling strategy when `polling` is not specified (or explicitly set to `'raf'`) utilizes `requestAnimationFrame(next)` inside the browser. If a numeric value is passed, it uses `setTimeout(next, polling)`.
+
+### 11.3 Network Stubbing / Mocking ("skip the network entirely")
+- **Mechanism**: Preempting the network request entirely by stubbing the response, providing immediate mocked data for UI components.
+- **API**: `page.route(url, handler)` and `route.fulfill(response)` (implemented in `packages/playwright-core/src/server/chromium/crNetworkManager.ts`).
+- **Internal Behavior**: Calling `route.fulfill()` sends the CDP command `Fetch.fulfillRequest` directly to the Chromium session. This explicitly short-circuits the request at the browser level—the request *never reaches the physical network layer* and instead Playwright directly injects the mocked HTTP response into the browser over the CDP websocket.
+
+### 11.4 "Click and Retry" Loop (brute-force fallback)
+- **Mechanism**: Wrapping an interaction in a manual `try/catch` block that retries after a short delay (e.g., a chosen 100ms) if it throws an error.
+- **Comparison to Built-in Retries**: Playwright's `locator.click()` automatically utilizes `_retryPointerAction()` (in `packages/playwright-core/src/server/dom.ts`) to poll for standard actionability checks (visible, stable, enabled, receives events).
+- **What this adds**: A manual retry loop catches *application-level* rejections or custom `evaluate()` failures that bypass or fool Playwright's structural actionability checks. For example, if an element is technically "actionable" but clicking it causes the app to throw an error because internal app state isn't ready, or if you use `.click({ force: true })` on a non-standard element, a manual loop allows you to recover from those arbitrary JavaScript/DOM exceptions.
+
+## 12. Video Recording Architecture (`recordVideo`) and Its Hard Constraints
+
+### 12.1 FFmpeg Encoding Pipeline
+- **Binary Sourcing**: Tracing `packages/playwright-core/src/server/videoRecorder.ts` confirms it spawns a physical `ffmpeg` child process via `registry.findExecutable('ffmpeg')!.executablePathOrDie(...)`.
+- **FFmpeg Arguments**: The `FfmpegVideoRecorder` class hardcodes the encoding parameters:
+  - **Codec**: `vp8` (`-c:v vp8`)
+  - **Quality**: `-qmin 0 -qmax 50 -crf 8` (constant quality mode)
+  - **Speed**: `-deadline realtime -speed 8`
+  - **Bitrate**: `-b:v 1M`
+  - **Audio**: Excluded entirely via `-an`. Playwright videos are purely visual.
+  - **Framerate**: `-r 25`, driven by a hardcoded `const fps = 25;` at the top of the file. It is not exposed for configuration.
+  - **Threads**: `-threads 1` to reduce CPU stalling.
+- **Default Dimensions**: If `recordVideo.size` is unspecified, `Screencast.addClient` in `packages/playwright-core/src/server/screencast.ts` falls back to the context's viewport size. If no viewport is defined, it defaults to `{ width: 800, height: 600 }`, scales it to fit within an 800px bounding box, and forcefully rounds down to even numbers (`& ~1`) to satisfy `vp8` requirements.
+
+### 12.2 Default Environmental Settings
+- **Viewport**: Confirmed in `packages/playwright-core/src/server/browserContext.ts` (`validateBrowserContextOptions`): `options.viewport` defaults to `{ width: 1280, height: 720 }`.
+- **Device Scale Factor**: Confirmed in `packages/playwright-core/src/server/chromium/crPage.ts` (`deviceScaleFactor: options.deviceScaleFactor || 1`).
+- **Timezone & Locale**: In `packages/playwright-core/src/server/browserContext.ts`, `locale` explicitly defaults to `'en-US'`. However, `timezoneId` has no default fallback in Playwright's configuration object; if omitted, Playwright simply does not send the `Emulation.setTimezoneOverride` CDP command, leaving the browser to inherit the host operating system's timezone natively.
+
+### 12.3 Auto-Waiting "Stable" Check Scope
+- **Scope limitation**: Verified `_checkElementIsStable()` in `packages/injected/src/injectedScript.ts`. The check strictly compares `getBoundingClientRect()` values across multiple `requestAnimationFrame` ticks.
+- **Implication**: It does *not* read `opacity`, `visibility`, or computed style transitions. A CSS fade-in animation that doesn't shift layout coordinates is immediately deemed "stable", meaning Playwright might execute a click while the element is completely transparent.
+
+### 12.4 Cursor Visibility in Recorded Video
+- **Mechanism**: The `FfmpegVideoRecorder` simply ingests MJPEG frames emitted by the page.
+- **Cursor Absence**: Playwright actions (`page.click`) dispatch synthetic CDP `Input.dispatchMouseEvent` events rather than moving the OS-level pointer. Because the OS pointer isn't moving over the viewport, no cursor is naturally rendered.
+- **Screencast Overlay**: While `packages/playwright-core/src/server/screencast.ts` does contain cursor rendering logic (injecting a fake DOM overlay via `injected.setScreencastAnnotation`), this is used explicitly when `recordVideo.showActions` is true (e.g. for Inspector/Codegen/Traces). Normal video recordings lack this overlay.
+
+### 12.5 `navigator.webdriver` / Automation Detection Surface
+- **Missing Flag**: A complete read of `_innerDefaultArgs()` (in `packages/playwright-core/src/server/chromium/chromium.ts`) and `chromiumSwitches()` (in `packages/playwright-core/src/server/chromium/chromiumSwitches.ts`) definitively proves that `--enable-automation` is NEVER added by Playwright's TypeScript source.
+- **Implication**: Because Playwright never actually pushes `--enable-automation` into the Chromium arguments array to begin with, passing `ignoreDefaultArgs: ['--enable-automation']` is a syntactically valid but functionally inert no-op. It attempts to filter a flag that was never in the defaults list, meaning it is not a real evasion technique.
+
+---
+
+## 13. Custom Engines, Emulation, Observability, and Automation Detection Surface
+
+### 13.1 Custom Selector Engines
+- **Mechanism**: `selectors.register(name, script)` (verified in `packages/playwright-core/src/client/selectors.ts`) injects a JavaScript module into the page.
+- **Implementation**: The injected script object must expose at least a `query(root, selector)` function (returning an `Element` or `undefined`) and a `queryAll(root, selector)` function (returning an `Element[]`). Once registered, it can be invoked via `page.locator('name=value')`.
+
+### 13.2 `slowMo` Launch Option
+- **Scope and Unit**: Verified as a top-level `BrowserType.launch()` option (`options.slowMo`) defined in milliseconds.
+- **Pipeline Insertion**: Traced to `packages/playwright-core/src/server/dispatchers/dispatcher.ts` (inside `_doSlowMo`). After an action completes (in the `finally` block of the dispatcher), it literally calls `await new Promise(f => setTimeout(f, slowMo))`, globally throttling every individual CDP command response dispatched back to the client.
+
+### 13.3 Device Emulation Scope
+- **Level of Enforcement**: Emulation options like `viewport`, `geolocation`, `offline`, and `userAgent` are bound strictly to the `BrowserContext` level.
+- **Verification**: Confirmed via the `BrowserContextOptions` interface within `packages/playwright-core/types/types.d.ts`, which defines these properties globally for the context, meaning they apply uniformly to all Pages within that context rather than being set per-page or per-browser-instance.
+
+### 13.4 Visual Regression -- Masking & Animation Freezing
+- **Masking Scope**: Verified in `packages/playwright/src/matchers/toMatchSnapshot.ts` that the `mask` option legitimately accepts an `Array<Locator>`, allowing targeted blocking of dynamic regions.
+- **Animation Freezing**: Verified that `toHaveScreenshot` defaults to `animations: 'disabled'`, which propagates directly to `page._expectScreenshot`. It reuses the exact same CSS-freezing mechanism (`*, *::before, *::after { transition: none... }`) built into the standard `locator.screenshot()` CDP pipeline; it does not implement a separate freezing logic.
+
+### 13.5 Accessibility Tree Access
+- **No Direct API**: A comprehensive search of the Playwright source and type definitions confirms that unlike Puppeteer, Playwright does *not* provide a native `page.accessibility.snapshot()` API. Accessibility is handled exclusively via DOM traversal (`.getByRole()`) or externally via `@axe-core/playwright`.
+
+### 13.6 Worker / Service Worker / WebSocket Hooks
+- **Worker**: `page.on('worker')` (verified in `packages/playwright-core/src/client/page.ts`) exposes a `Worker` instance (from `client/worker.ts`) representing a Web Worker.
+- **Service Worker**: `context.serviceWorkers()` (verified in `packages/playwright-core/src/client/browserContext.ts`) returns an array of `Worker` instances (`Worker[]`).
+- **WebSocket**: `page.on('websocket')` exposes a `WebSocket` instance (imported from `client/network.ts`), triggered by the underlying `webSocketRoute` internal CDP bindings.
+
+### 13.7 Low-Level CDP Session Access
+- **Capabilities**: `context.newCDPSession(page)` returns a `CDPSession` that bypasses Playwright's high-level abstractions.
+- **Verification**: Verified in `packages/playwright-core/src/server/chromium/protocol.d.ts` that raw domains like `Emulation.setCPUThrottlingRate` and `Network.emulateNetworkConditions` (though the latter notes deprecation in favor of `Network.emulateNetworkConditionsByRule`) are formally supported by the protocol bindings, allowing advanced manipulations like CPU throttling.
+
+### 13.8 Code Coverage
+- **Mechanism**: Verified in `packages/playwright-core/src/server/chromium/crCoverage.ts` (and exposed via `packages/playwright-core/src/client/coverage.ts`).
+- **API Surface**: It exposes `page.coverage.startJSCoverage()`, `stopJSCoverage()`, `startCSSCoverage()`, and `stopCSSCoverage()`. It is a Chromium-only feature backed directly by V8's native profiling capabilities.
+
+### 13.9 Automation Detection Surface -- Correction Pass
+- **Mechanics of Early Execution**: `page.addInitScript()` evaluates before the page's own scripts run because it leverages the native CDP command `Page.addScriptToEvaluateOnNewDocument` (verified in `packages/playwright-core/src/server/chromium/crPage.ts` via `_evaluateOnNewDocument`).
+- **Impact**: Because V8 invokes this command upon a new document instantiation before the DOM is populated, it provides a mechanism for overriding `navigator.webdriver` or deleting fingerprint-able properties before client-side scripts run.
+- **Definitive Finding on `--enable-automation`**: Passing `ignoreDefaultArgs: ['--enable-automation']` does absolutely nothing. An exhaustive verification of `chromium.ts` (`_innerDefaultArgs`) and `chromiumSwitches.ts` (`chromiumSwitches`) confirms the string `--enable-automation` is never added to the default arguments array in this version of Playwright. Filtering it is a strict no-op.
+
+---
+
+## 14. Multi-Tab Recording: Video Fragmentation vs. Tracing Correlation
+
+### 14.1 `recordVideo` Produces Independent, Uncorrelated Files Per Tab
+- **Mechanism**: Re-verifying `startAutomaticVideoRecording(page)` in `packages/playwright-core/src/server/videoRecorder.ts` (lines 87-97) confirms that video recording is instantiated strictly on a per-page basis. It reads the context-level `recordVideo` configuration but actively spawns an independent `VideoRecorder` for the current page.
+- **File Output**: The output filename is hardcoded as `path.join(dir, page.guid + '.webm')`. Consequently, every page/tab inside a configured context automatically yields its own strictly separate `.webm` file named after the tab's `guid`.
+- **Complete Fragmentation**: There is no code within `videoRecorder.ts` that writes cross-referencing metadata (such as an opener page ID, a shared timeline, or any synchronized metadata artifact) into the video or its filename.
+- **Practical Implication**: If a user flow involves opening a link in a new tab, manipulating state, closing it, and returning to the original tab, Playwright generates *two separate video files*. Because the videos lack synchronized timelines, it is impossible to deterministically reconstruct from the `.webm` files alone precisely when the tab switch occurred or which tab initiated the other.
+
+### 14.2 `context.tracing` Is the Actual Cross-Tab Correlation Mechanism
+- **Context-Level Scope**: In contrast to video recordings, `packages/playwright-core/src/server/browserContext.ts` instantiates a single `Tracing` instance (`this.tracing = new Tracing(...)`) bound to the entire BrowserContext. A single trace archive encapsulates every tab.
+- **Event Relationships**: `packages/playwright-core/src/server/trace/recorder/tracing.ts` handles lifecycle events across all pages in the context.
+  - `onPageOpen` emits an event containing `{ pageId: page.guid, openerPageId: page.opener()?.guid }`.
+  - `onPageClose` emits an event with `method: 'pageClosed'` and `{ pageId: page.guid }`.
+- **Monotonic Clock**: These events are stamped with `monotonicTime()`. Tracing `packages/isomorphic/time.ts` (lines 35-37) confirms this relies on `performance.now()` (plus a localized shift). This is a process-relative clock, not an epoch wall-clock. Because the entire Node.js context shares this single time origin, it provides consistent process-level sequencing.
+- **Practical Implication**: `openerPageId` is the definitive field that answers "which tab opened this tab". When combined with the shared `monotonicTime()` clock tying together actions and lifecycle events, `context.tracing` allows precise correlation of multi-tab flows, a capability fundamentally absent from raw video recordings.
+
+---
+
+## 15. Unverified Claims & Caveats
+
+- **Unverified (No Runtime Execution)**: As mandated by task constraints, no `npm install`, browser binary downloads, or script execution were performed. All findings are derived strictly from inspecting TypeScript source files in `upstream/playwright` and cross-referencing official documentation.
+- **Unverified (Browser Binary Protocol Messages)**: Low-level C++ browser binary internal handling of CDP/RDP packets beyond Playwright's TypeScript transport layer (`CRConnection`, `FFConnection`, `WKConnection`) is unverified as engine source code is outside this repository.

--- a/agi-training-notes/doc-graph.config.json
+++ b/agi-training-notes/doc-graph.config.json
@@ -1,0 +1,6 @@
+{
+  "project": "playwright",
+  "documents": ["NOTES.md", "API_REFERENCE.md"],
+  "examples": ["examples/*.js"],
+  "output": "DOC_GRAPH.json"
+}

--- a/agi-training-notes/examples/01-launch-browser.js
+++ b/agi-training-notes/examples/01-launch-browser.js
@@ -1,0 +1,43 @@
+/**
+ * 01-launch-browser.js
+ *
+ * Demonstrates direct usage of playwright-core to launch and close a browser instance.
+ *
+ * Real source code references studied:
+ * - Public API / Client side:
+ *   - `packages/playwright-core/src/client/browserType.ts` -> `BrowserType.launch(options)`
+ *     Wraps client-side launch options, creates channel request `this._channel.launch(...)`
+ *     over Playwright RPC connection, and returns a `Browser` client instance.
+ * - Server side dispatch & execution:
+ *   - `packages/playwright-core/src/server/browserType.ts` -> `BrowserType.launch(progress, options, protocolLogger)`
+ *     Validates options via `_validateLaunchOptions()`, prepares temporary user profile directory via
+ *     `_prepareToLaunch()`, resolves browser binary using `registry.findExecutable(name)`,
+ *     spawns child process via `launchProcess()`, and attaches protocol connection.
+ * - Engine specific launcher:
+ *   - `packages/playwright-core/src/server/chromium/chromium.ts` -> `Chromium.launch(...)`
+ *     Connects to Chrome via CDP (Chrome DevTools Protocol) using `CRBrowser.connect()`.
+ */
+
+const { chromium, firefox, webkit } = require('playwright-core');
+
+async function main() {
+  // Launch Chromium browser in headless mode.
+  // Under the hood, BrowserType.launch() sends an RPC channel request to the server,
+  // which invokes registry.findExecutable('chromium') and spawns the browser process.
+  const browser = await chromium.launch({
+    headless: true, // default is true
+    args: ['--no-sandbox'] // custom CLI flags passed to browser arguments array
+  });
+
+  console.log('Browser launched successfully. Is connected:', browser.isConnected());
+
+  // Close the browser.
+  // Calls Browser.close() in client/browser.ts -> sends RPC close message to BrowserDispatcher ->
+  // closes transport and gracefully terminates the browser child process via BrowserProcess.close().
+  await browser.close();
+  console.log('Browser closed successfully.');
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/02-context-and-page.js
+++ b/agi-training-notes/examples/02-context-and-page.js
@@ -1,0 +1,53 @@
+/**
+ * 02-context-and-page.js
+ *
+ * Demonstrates creating an isolated BrowserContext and spawning Page instances.
+ *
+ * Real source code references studied:
+ * - Client side BrowserContext & Page ownership:
+ *   - `packages/playwright-core/src/client/browserContext.ts` -> `BrowserContext`
+ *     Manages an isolated session state (cookies, localStorage, cache, proxy, context-level routes in `_routes`).
+ *     `BrowserContext.newPage()` sends `_channel.newPage()` RPC request to server side `BrowserContextDispatcher`.
+ *   - `packages/playwright-core/src/client/page.ts` -> `Page`
+ *     Belongs to a single `BrowserContext` (`_browserContext`), owns main frame (`_mainFrame`), frame hierarchy (`_frames`),
+ *     page-level routes (`_routes`), and input devices (`keyboard`, `mouse`, `touchscreen`).
+ *   - `packages/playwright-core/src/client/frame.ts` -> `Frame.goto(url, options)`
+ *     Delegates navigation request to `_channel.goto(...)` RPC channel call, which executes `FrameDispatcher.goto` on server.
+ * - Server side context & page implementations:
+ *   - `packages/playwright-core/src/server/browserContext.ts` -> `BrowserContext`
+ *     Manages isolation boundaries and browser contexts at engine level.
+ *   - `packages/playwright-core/src/server/page.ts` -> `Page`
+ *     Coordinates page lifecycle events, frames, and delegating protocol commands to browser engine page delegates.
+ */
+
+const { chromium } = require('playwright-core');
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+
+  // Create an isolated BrowserContext (incognito-like session with independent storage/cookies).
+  // BrowserContext in client/browserContext.ts owns context options (viewport, locale, permissions).
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+    userAgent: 'Playwright-Core-Research-Bot/1.0',
+    locale: 'en-US'
+  });
+
+  // Create a new Page inside this context.
+  // Page in client/page.ts references its parent context via _browserContext and creates _mainFrame.
+  const page = await context.newPage();
+
+  // Navigate to a URL.
+  // Page.goto() delegates to mainFrame.goto() in client/frame.ts -> sends RPC goto request to server.
+  const response = await page.goto('https://example.com', { waitUntil: 'domcontentloaded' });
+  console.log('Navigation response status:', response.status());
+  console.log('Page title:', await page.title());
+
+  // Clean up: closing context closes all pages owned by it (_pages Set in BrowserContext).
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/03-locator-basics.js
+++ b/agi-training-notes/examples/03-locator-basics.js
@@ -1,0 +1,60 @@
+/**
+ * 03-locator-basics.js
+ *
+ * Demonstrates Locator creation, selector resolution, and auto-waiting action execution (click, fill).
+ *
+ * Real source code references studied:
+ * - Public API / Client side:
+ *   - `packages/playwright-core/src/client/locator.ts` -> `Locator`
+ *     Represents a lazy selector descriptor (`this._frame`, `this._selector`).
+ *     Methods like `getByRole`, `getByTestId`, `filter` chain selector engines (e.g. `internal:role=button`).
+ *     `Locator.click()` delegates to `this._frame.click(this._selector, { strict: true, ...options })`.
+ *   - `packages/playwright-core/src/client/frame.ts` -> `Frame.click(selector, options)`
+ *     Dispatches `_channel.click(...)` RPC message to server side `FrameDispatcher`.
+ * - Server side dispatcher & execution:
+ *   - `packages/playwright-core/src/server/dispatchers/frameDispatcher.ts` -> `FrameDispatcher.click(...)`
+ *     Calls `this._frame.click(progress, params.selector, params)`.
+ *   - `packages/playwright-core/src/server/frames.ts` -> `Frame.click(progress, selector, options)`
+ *     Executes `_retryWithProgressIfNotConnected()` which resolves the selector and invokes `ElementHandle._click()`.
+ *   - `packages/playwright-core/src/server/dom.ts` -> `ElementHandle._retryPointerAction` & `ElementHandle._performPointerAction`
+ *     Performs Playwright's strict auto-waiting checks:
+ *     1. attached & visible check (`injected.checkElementStates`)
+ *     2. enabled & stable check (ensures element bounding box is not moving)
+ *     3. scrollIntoViewIfNeeded (reveals element in viewport)
+ *     4. hit target test (`injected.checkElementHitTarget` ensures no overlay elements block pointer events)
+ *     5. dispatches raw input event (`Page.mouse.click` / `Page.keyboard.type`)
+ */
+
+const { chromium } = require('playwright-core');
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://example.com');
+
+  // Creating Locators is lazy and synchronous — no RPC call is made until an action is called.
+  // Locator constructor in client/locator.ts builds internal selector strings.
+  const searchInput = page.getByPlaceholder('Search documentation...');
+  const submitButton = page.getByRole('button', { name: 'Submit' });
+  const linkLocator = page.locator('a').filter({ hasText: 'More information' });
+
+  // Locator.fill() -> client/locator.ts calls Frame.fill() -> server/frames.ts -> server/dom.ts ElementHandle._fill()
+  // Auto-waits for searchInput to be attached, visible, enabled, and editable.
+  await searchInput.fill('Playwright architecture');
+
+  // Locator.click() -> client/locator.ts calls Frame.click() -> server/frames.ts -> server/dom.ts ElementHandle._click()
+  // Auto-waits for submitButton to be attached, visible, enabled, stable, scrolled into view, and un-obscured.
+  await submitButton.click();
+
+  // Perform action on filtered link locator
+  await linkLocator.click();
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/04-network-interception.js
+++ b/agi-training-notes/examples/04-network-interception.js
@@ -1,0 +1,76 @@
+/**
+ * 04-network-interception.js
+ *
+ * Demonstrates request interception and mocking using page.route() and the Route API.
+ *
+ * Real source code references studied:
+ * - Public API / Client side:
+ *   - `packages/playwright-core/src/client/page.ts` -> `Page.route(url, handler)`
+ *     Registers a `RouteHandler` in `_routes` array on the Page (or BrowserContext).
+ *   - `packages/playwright-core/src/client/network.ts` -> `Route`
+ *     Provides methods:
+ *     - `route.fulfill(options)`: Fulfills request with mock status, headers, and body (base64 encoded if binary/file).
+ *     - `route.continue(options)`: Continues network request with optional modified headers/url/method.
+ *     - `route.abort(errorCode)`: Aborts network request (e.g. 'failed', 'timedout').
+ *     - `route.fallback(options)`: Yields control to next matching route handler.
+ *     - `route.request()`: Returns `Request` instance representing intercepted network request.
+ * - Server side dispatcher & execution:
+ *   - `packages/playwright-core/src/server/dispatchers/networkDispatchers.ts` -> `RouteDispatcher`
+ *     Dispatches RPC messages (`fulfill`, `continue`, `abort`) to server side network manager.
+ *   - `packages/playwright-core/src/server/network.ts` -> `Route` & `Request`
+ *     Manages network interceptors attached to CDP/Firefox/WebKit network domains.
+ */
+
+const { chromium } = require('playwright-core');
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Intercept all API JSON requests to /api/user/*
+  // Page.route in client/page.ts adds a RouteHandler to page._routes
+  await page.route('**/api/user/*', async (route, request) => {
+    console.log('Intercepted request method:', request.method());
+    console.log('Intercepted request URL:', request.url());
+
+    // Fulfill request with mock data without sending network traffic to remote server.
+    // Route.fulfill in client/network.ts constructs parameters (status, headers, body)
+    // and sends RPC message to RouteDispatcher on server side.
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 42,
+        username: 'mocked_user',
+        role: 'admin'
+      })
+    });
+  });
+
+  // Intercept image requests and abort them to save bandwidth
+  await page.route(/\.(png|jpg|jpeg|svg)$/, async route => {
+    // Route.abort in client/network.ts sends RPC abort message to server
+    await route.abort('failed');
+  });
+
+  // Intercept analytics requests and modify headers before sending to server
+  await page.route('**/analytics', async route => {
+    // Route.continue in client/network.ts passes modified headers upstream
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        'X-Mock-Analytics': 'true'
+      }
+    });
+  });
+
+  await page.goto('https://example.com');
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/05-codegen-invocation.js
+++ b/agi-training-notes/examples/05-codegen-invocation.js
@@ -1,0 +1,84 @@
+/**
+ * 05-codegen-invocation.js
+ *
+ * Demonstrates how Playwright's Codegen/Recorder can be invoked programmatically
+ * or via CLI, explaining the internal event listener, selector generator, and code generator pipeline.
+ *
+ * Real source code references studied:
+ * - CLI Entry point & Programmatic invocation:
+ *   - `packages/playwright-core/src/cli/browserActions.ts` -> `codegen(options, url)`
+ *     Parses options (`target`, `output`, `device`, `saveStorage`, etc.), launches context,
+ *     and calls `context._enableRecorder(params)`.
+ *   - `packages/playwright-core/src/client/browserContext.ts` -> `BrowserContext._enableRecorder(params)`
+ *     Sends `enableRecorder` RPC request over `_channel` to `BrowserContextDispatcher.enableRecorder`.
+ * - Server side Recorder controller:
+ *   - `packages/playwright-core/src/server/recorder.ts` -> `Recorder` class
+ *     Instantiates server recorder, exposes bindings (`__pw_recorderRecordAction`, `__pw_recorderState`, `__pw_recorderPerformAction`),
+ *     and injects page recorder script via `_context.extendInjectedScript(rawRecorderSource.source)`.
+ * - Page Injected DOM event listener & selector generator:
+ *   - `packages/injected/src/recorder/recorder.ts` -> Injected `Recorder` class
+ *     Installs DOM event listeners (`onClick`, `onInput`, `onKeyDown`).
+ *   - `packages/injected/src/selectorGenerator.ts` -> `generateSelector(targetElement, options)`
+ *     Uses a strict score-based ranking algorithm to pick the most resilient selector:
+ *     1. Test ID (`kTestIdScore = 1`)
+ *     2. Accessible Role + Name (`kRoleWithNameScore = 100`)
+ *     3. Placeholder (`kPlaceholderScore = 120`)
+ *     4. Label (`kLabelScore = 140`)
+ *     5. Alt text (`kAltTextScore = 160`)
+ *     6. Text content (`kTextScore = 180`)
+ *     7. CSS / XPath (fallback)
+ * - Action debouncing & signal processing:
+ *   - `packages/playwright-core/src/server/recorder/recorderSignalProcessor.ts` -> `RecorderSignalProcessor`
+ *     Debounces rapid input (e.g. keypresses into a single fill, click + click into dblclick).
+ * - Code emission / Formatting:
+ *   - `packages/isomorphic/codegen/javascript.ts` -> `JavaScriptLanguageGenerator`
+ *   - `packages/isomorphic/codegen/python.ts`, `csharp.ts`, `java.ts`
+ *     Formats recorded `ActionInContext` objects into clean target language code.
+ */
+
+const { chromium } = require('playwright-core');
+
+/**
+ * CLI Usage Example:
+ * npx playwright codegen https://example.com --target=javascript --output=./tests/generated.spec.js -b chromium
+ *
+ * Command Line Flags Explained:
+ *   --target <language>        Language to generate (playwright-test, javascript, python, python-pytest, csharp, java)
+ *   -b, --browser <browser>    Browser engine to use (chromium, firefox, webkit)
+ *   -o, --output <file>        File path to write generated code output
+ *   --load-storage <file>      Path to JSON file containing saved storage state (cookies, localStorage)
+ *   --save-storage <file>      Path to save storage state upon exiting codegen
+ *   --viewport-size <size>     Custom viewport size (e.g. "1280,720")
+ *   --device <device>          Emulate a specific device descriptor (e.g. "iPhone 13")
+ *   --test-id-attribute <name> Custom attribute for test IDs (default is "data-testid")
+ */
+
+async function programmaticCodegenDemo() {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+
+  // Programmatically enable recorder on the browser context.
+  // Under the hood, BrowserContext._enableRecorder in client/browserContext.ts calls
+  // BrowserContextDispatcher.enableRecorder, which instantiates server/recorder.ts.
+  await context._enableRecorder({
+    language: 'javascript', // 'javascript' | 'playwright-test' | 'python' | 'csharp' | 'java'
+    mode: 'recording',      // 'recording' | 'inspecting' | 'none'
+    testIdAttributeName: 'data-testid'
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+
+  console.log('Codegen recorder enabled programmatically.');
+  console.log('User actions in the browser are captured by injected/src/recorder/recorder.ts,');
+  console.log('selectors resolved via injected/src/selectorGenerator.ts,');
+  console.log('and code generated via isomorphic/codegen/javascript.ts.');
+
+  // Close context and browser when done recording
+  // await context.close();
+  // await browser.close();
+}
+
+if (require.main === module) {
+  programmaticCodegenDemo().catch(console.error);
+}

--- a/agi-training-notes/examples/06-codegen-language-targets.js
+++ b/agi-training-notes/examples/06-codegen-language-targets.js
@@ -1,0 +1,72 @@
+/**
+ * 06-codegen-language-targets.js
+ *
+ * Demonstrates codegen multi-language code generation (--target flag) and how Playwright's
+ * language generators emit code across different programming languages and test runners.
+ *
+ * Real source code references studied:
+ * - CLI Flag Parsing:
+ *   - `packages/playwright-core/src/cli/program.ts` -> `codegenId()`
+ *     Maps target strings (`playwright-test`, `javascript`, `python`, `python-pytest`, `python-async`, `csharp`, `csharp-mstest`, `csharp-nunit`, `csharp-xunit`, `java`, `java-junit`) to internal generator IDs.
+ *   - `packages/playwright-core/src/cli/browserActions.ts` -> `codegen(options, url)`
+ *     Accepts options.target and passes it to `context._enableRecorder({ language: options.target })`.
+ * - Language Generators Registry:
+ *   - `packages/isomorphic/codegen/languages.ts` -> `languageSet()`
+ *     Returns a set of language generators:
+ *     1. `JavaScriptLanguageGenerator(true/false)` (`packages/isomorphic/codegen/javascript.ts`) - Node.js Playwright Test / Library
+ *     2. `PythonLanguageGenerator(isAsync, isPyTest)` (`packages/isomorphic/codegen/python.ts`) - Pytest / Sync Library / Async Library
+ *     3. `CSharpLanguageGenerator(framework)` (`packages/isomorphic/codegen/csharp.ts`) - MSTest / NUnit / xUnit / Library
+ *     4. `JavaLanguageGenerator(framework)` (`packages/isomorphic/codegen/java.ts`) - JUnit / Library
+ *     5. `JsonlLanguageGenerator()` (`packages/isomorphic/codegen/jsonl.ts`) - Raw JSON lines format
+ * - Server Code Generation Engine:
+ *   - `packages/playwright-core/src/server/recorder.ts` -> `Recorder.setLanguage(language)`
+ *   - `packages/playwright-core/src/server/recorder/recorderApp.ts` -> `RecorderApp`
+ *     Streams generated code to `outputFile` using `ThrottledFile` (`server/recorder/throttledFile.ts`).
+ */
+
+const { chromium } = require('playwright-core');
+
+/**
+ * CLI Equivalent Examples for different language targets:
+ *
+ * 1. Playwright Test (TypeScript/JavaScript default):
+ *    npx playwright codegen --target=playwright-test -o ./tests/login.spec.ts https://example.com
+ *
+ * 2. Python Pytest:
+ *    npx playwright codegen --target=python-pytest -o ./tests/test_login.py https://example.com
+ *
+ * 3. C# NUnit:
+ *    npx playwright codegen --target=csharp-nunit -o ./Tests/LoginTest.cs https://example.com
+ *
+ * 4. Java JUnit:
+ *    npx playwright codegen --target=java-junit -o ./src/test/java/TestLogin.java https://example.com
+ */
+
+async function main() {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+
+  // Target 1: JavaScript / Playwright Test Runner
+  // Uses JavaScriptLanguageGenerator(true) in packages/isomorphic/codegen/javascript.ts
+  await context._enableRecorder({
+    language: 'playwright-test',
+    mode: 'recording',
+    outputFile: './examples/scratch/generated_test.spec.js'
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+
+  console.log('Codegen initialized with target: playwright-test');
+  console.log('Language generator formats actions into Playwright Test runner code.');
+
+  // Note: To switch target language programmatically on the server, Recorder.setLanguage() is called,
+  // which updates the active LanguageGenerator in isomorphic/codegen/language.ts.
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/07-codegen-selector-scoring.js
+++ b/agi-training-notes/examples/07-codegen-selector-scoring.js
@@ -1,0 +1,86 @@
+/**
+ * 07-codegen-selector-scoring.js
+ *
+ * Demonstrates how Playwright's injected SelectorGenerator evaluates candidate selectors
+ * using a strict score-based heuristic (lower score wins) to generate resilient locators.
+ *
+ * Real source code references studied:
+ * - Selector Generator Algorithm:
+ *   - `packages/injected/src/selectorGenerator.ts` -> `generateSelector(targetElement, options)`
+ *     Evaluates DOM element attributes and context to build candidate selector tokens.
+ * - Score Table (`packages/injected/src/selectorGenerator.ts`):
+ *   - `kTestIdScore = 1`        -> data-testid attribute (or custom test ID attribute)
+ *   - `kOtherTestIdScore = 2`   -> data-test, data-qa, data-cy attributes
+ *   - `kRoleWithNameScore = 100` -> getByRole(role, { name })
+ *   - `kPlaceholderScore = 120` -> getByPlaceholder(placeholder)
+ *   - `kLabelScore = 140`       -> getByLabel(labelText)
+ *   - `kAltTextScore = 160`     -> getByAltText(altText)
+ *   - `kTextScore = 180`        -> getByText(textContent)
+ *   - `kTitleScore = 200`       -> getByTitle(titleText)
+ *   - `kEndPenalizedScore = 300` -> generic CSS class / id / tag / XPath fallback
+ * - Custom Test ID Attribute Config:
+ *   - CLI flag: `--test-id-attribute=data-qa`
+ *   - `packages/playwright-core/src/client/locator.ts` -> `testIdAttributeName()`
+ *   - Configured in `generateSelector` options as `testIdAttributeName`.
+ */
+
+const { chromium } = require('playwright-core');
+
+/**
+ * Example DOM Element to Generated Locator Resolution Mapping:
+ *
+ * 1. Element: <button data-testid="submit-btn" class="btn btn-primary">Submit Form</button>
+ *    Candidates:
+ *    - data-testid="submit-btn" -> Score: 1 (BEST -> Selected: getByTestId('submit-btn'))
+ *    - role="button" name="Submit Form" -> Score: 100
+ *    - text="Submit Form" -> Score: 180
+ *    - css=".btn.btn-primary" -> Score: 300
+ *
+ * 2. Element: <input type="email" placeholder="Enter your email" />
+ *    Candidates:
+ *    - placeholder="Enter your email" -> Score: 120 (Selected: getByPlaceholder('Enter your email'))
+ *    - css="input[type='email']" -> Score: 300
+ *
+ * 3. Element: <img src="logo.png" alt="Acme Corporation Logo" />
+ *    Candidates:
+ *    - alt="Acme Corporation Logo" -> Score: 160 (Selected: getByAltText('Acme Corporation Logo'))
+ *    - css="img" -> Score: 300
+ */
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+
+  // Programmatically enable recorder with custom testIdAttributeName
+  // Inside injected/src/selectorGenerator.ts, this overrides kTestIdScore attribute matching
+  await context._enableRecorder({
+    language: 'javascript',
+    mode: 'recording',
+    testIdAttributeName: 'data-qa' // custom attribute: data-qa="login-button" gets score 1
+  });
+
+  const page = await context.newPage();
+
+  // Simulate navigating to page with structured HTML
+  await page.goto('data:text/html,' + encodeURIComponent(`
+    <!text/html>
+    <html>
+      <body>
+        <label for="user">Username</label>
+        <input id="user" placeholder="Enter username" />
+
+        <button data-qa="login-submit" class="btn-login">Log In</button>
+      </body>
+    </html>
+  `));
+
+  console.log('Page loaded with custom data-qa attribute.');
+  console.log('SelectorGenerator will pick getByTestId("login-submit") (Score 1) over class selector .btn-login (Score 300).');
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/08-codegen-storage-and-session.js
+++ b/agi-training-notes/examples/08-codegen-storage-and-session.js
@@ -1,0 +1,79 @@
+/**
+ * 08-codegen-storage-and-session.js
+ *
+ * Demonstrates codegen session state persistence (--save-storage and --load-storage)
+ * and the structural differences between spawning a fresh recording session versus
+ * attaching the Recorder to an already existing BrowserContext/Page.
+ *
+ * Real source code references studied:
+ * - Session State Persistence:
+ *   - `packages/playwright-core/src/cli/browserActions.ts` -> `codegen(options, url)`
+ *     On codegen termination, `launchContext()` executes `context.storageState({ path: options.saveStorage })`
+ *     to dump cookies, origins, and localStorage to disk as JSON.
+ *   - `packages/playwright-core/src/client/browserContext.ts` -> `BrowserContext.storageState(options)`
+ *     Fetches storage state from server via `_channel.storageState()`.
+ *   - `packages/playwright-core/src/server/browserContext.ts` -> `BrowserContext.storageState(progress, options)`
+ *     Serializes browser cookies and localStorage key-value maps per origin.
+ * - Fresh Recording Session vs Attaching to Existing Context:
+ *   - **Fresh Codegen Session**:
+ *     - CLI command `playwright codegen [url]` calls `launchContext()` in `cli/browserActions.ts`.
+ *     - Spawns a dedicated browser process, creates a fresh `BrowserContext`, calls `context._enableRecorder()`,
+ *       and opens the target URL (`openPage(context, url)`).
+ *   - **Attaching to Existing Context (e.g. `page.pause()` or programmatic `_enableRecorder` mid-session)**:
+ *     - `Recorder.forContext(context, params)` in `packages/playwright-core/src/server/recorder.ts` retrieves or creates the `Recorder` singleton attached to `context[recorderSymbol]`.
+ *     - `Recorder._onPage(page)` binds to both existing pages in `context.pages()` and listens for new pages (`context.on('page')`).
+ *     - `_context.extendInjectedScript()` injects the recorder script into all current and future documents in the context.
+ *     - `_pickLocatorPage`: when inspect mode is activated, locator picking is isolated to `_pickLocatorPage` while other pages continue normal execution.
+ */
+
+const { chromium } = require('playwright-core');
+
+/**
+ * CLI Usage Example for Storage State Persistence:
+ *
+ * Step 1: Save authentication cookies & localStorage during manual login:
+ * npx playwright codegen https://example.com/login --save-storage=auth.json
+ *
+ * Step 2: Reuse saved session state to record actions as an authenticated user:
+ * npx playwright codegen https://example.com/dashboard --load-storage=auth.json
+ */
+
+async function attachRecorderToExistingContextDemo() {
+  const browser = await chromium.launch({ headless: false });
+
+  // Load existing session state if available (simulates --load-storage flag)
+  const contextOptions = {
+    // storageState: './auth.json' // restores cookies and localStorage
+  };
+  const context = await browser.newContext(contextOptions);
+
+  // Open pages and perform standard automation work
+  const page1 = await context.newPage();
+  await page1.goto('https://example.com');
+
+  console.log('Attaching Recorder to an existing, live BrowserContext...');
+
+  // Programmatically attach Recorder to the active context (simulates page.pause())
+  // Recorder.forContext() in server/recorder.ts detects existing pages in context.pages()
+  // and injects rawRecorderSource into all current and future frame execution contexts.
+  await context._enableRecorder({
+    language: 'javascript',
+    mode: 'recording'
+  });
+
+  console.log('Recorder successfully attached to existing session.');
+
+  // Open a second page — Recorder._onPage() automatically hooks into new pages via context.on('page')
+  const page2 = await context.newPage();
+  await page2.goto('https://example.com');
+
+  // Save session state explicitly before closing (simulates --save-storage flag)
+  // const state = await context.storageState({ path: './examples/scratch/auth.json' });
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  attachRecorderToExistingContextDemo().catch(console.error);
+}

--- a/agi-training-notes/examples/09-test-runner-and-config.js
+++ b/agi-training-notes/examples/09-test-runner-and-config.js
@@ -1,0 +1,54 @@
+/**
+ * 09-test-runner-and-config.js
+ *
+ * Demonstrates the structure of @playwright/test runner configuration, spec file discovery,
+ * project hierarchy, and test list collection.
+ *
+ * Real source code references studied:
+ * - Runner Core Tasks & Lifecycle:
+ *   - `packages/playwright/src/runner/tasks.ts` -> `TaskRunner`, `runTasks()`, `TestRun`
+ *     Manages task pipeline execution (`createGlobalSetupTasks`, `createRunTestsTasks`).
+ * - Spec Discovery & Project Construction:
+ *   - `packages/playwright/src/runner/loadUtils.ts` -> `collectProjectsAndTestFiles()`, `loadFileSuites()`
+ *     Uses glob patterns (`testMatch`, `testIgnore`) on `FullProjectInternal` to discover test files.
+ *     Loads test files using `InProcessLoaderHost` / `OutOfProcessLoaderHost` (`runner/loaderHost.ts`).
+ * - Suite Tree & Test Grouping:
+ *   - `packages/playwright/src/runner/testGroups.ts` -> `createTestGroups()`
+ *     Groups tests by project and worker hash (`TestGroup`), assigning shards and workers.
+ * - Dispatcher & Execution:
+ *   - `packages/playwright/src/runner/dispatcher.ts` -> `Dispatcher`
+ *     Dispatches `TestGroup` payloads over IPC to worker processes (`WorkerHost` in `runner/workerHost.ts`).
+ */
+
+// Example configuration showing Playwright Test runner configuration options
+const config = {
+  testDir: './tests',
+  timeout: 30000, // 30 second timeout per test
+  retries: 2,     // retry failing tests twice
+  workers: 4,     // max 4 parallel worker processes
+  reporter: [
+    ['list'],
+    ['json', { outputFile: 'results.json' }],
+    ['html', { open: 'never' }]
+  ],
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    trace: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'Chromium Desktop',
+      use: { browserName: 'chromium' }
+    },
+    {
+      name: 'Firefox Desktop',
+      use: { browserName: 'firefox' }
+    }
+  ]
+};
+
+console.log('Playwright Test runner configuration loaded successfully.');
+console.log('Spec discovery uses collectFilesForProject() in loadUtils.ts,');
+console.log('spec loading runs via loadFileSuites(),');
+console.log('and test groups are dispatched to workers by Dispatcher in dispatcher.ts.');

--- a/agi-training-notes/examples/10-fixtures-and-dependency-graph.js
+++ b/agi-training-notes/examples/10-fixtures-and-dependency-graph.js
@@ -1,0 +1,44 @@
+/**
+ * 10-fixtures-and-dependency-graph.js
+ *
+ * Demonstrates Playwright Test's dependency-injection fixture system (test.extend),
+ * fixture scoping (test vs worker), and DAG resolution order.
+ *
+ * Real source code references studied:
+ * - Fixture Registration & Pool:
+ *   - `packages/playwright/src/common/fixtures.ts` -> `FixturePool` class, `FixtureRegistration` type
+ *     Parses fixture function parameters (e.g. `({ db, page }, use) => ...` -> `deps: ['db', 'page']`).
+ *     Manages fixture overrides (`test.use()`) and validates scoping rules.
+ * - Fixture Execution & Lifecycle:
+ *   - `packages/playwright/src/worker/fixtureRunner.ts` -> `FixtureRunner` & `Fixture` classes
+ *     Resolves dependency DAG in topological order:
+ *     1. Setup: leaf dependencies first -> downstream dependencies -> test body.
+ *     2. Fixture pauses at `await use(value)`.
+ *     3. Teardown: test body completes -> root fixtures teardown -> leaf fixtures teardown.
+ * - Fixture Scoping:
+ *   - `scope: 'worker'`: Instantiated once per worker process, shared across tests in that worker.
+ *   - `scope: 'test'` (default): Instantiated fresh before each test and torn down immediately after.
+ */
+
+// Simulated fixture definitions demonstrating dependency resolution
+const customFixtures = {
+  // Worker-scoped fixture (created once per worker process)
+  dbConnection: [async ({}, use) => {
+    console.log('[Worker Setup] Initializing database connection...');
+    const db = { query: (sql) => `Results for ${sql}` };
+    await use(db);
+    console.log('[Worker Teardown] Closing database connection.');
+  }, { scope: 'worker' }],
+
+  // Test-scoped fixture depending on dbConnection worker fixture
+  authenticatedUser: async ({ dbConnection }, use) => {
+    console.log('[Test Setup] Creating temporary test user in DB...');
+    const user = { id: 101, username: 'test_user', db: dbConnection };
+    await use(user);
+    console.log('[Test Teardown] Cleaning up temporary test user.');
+  }
+};
+
+console.log('Fixture definitions structure prepared.');
+console.log('In Playwright Test, FixturePool (common/fixtures.ts) constructs the dependency graph,');
+console.log('and FixtureRunner (worker/fixtureRunner.ts) executes setup/teardown in topological order.');

--- a/agi-training-notes/examples/11-reporters-and-events.js
+++ b/agi-training-notes/examples/11-reporters-and-events.js
@@ -1,0 +1,51 @@
+/**
+ * 11-reporters-and-events.js
+ *
+ * Demonstrates Playwright Test's custom reporter interface (ReporterV2) and event multiplexing.
+ *
+ * Real source code references studied:
+ * - Reporter Interface:
+ *   - `packages/playwright/src/reporters/reporterV2.ts` -> `ReporterV2` interface
+ *     Defines lifecycle hooks:
+ *     - `onConfigure(config)`: called when test config is loaded.
+ *     - `onBegin(suite)`: called before test run starts, receives root suite tree.
+ *     - `onTestBegin(test, result)`: called when a test starts running.
+ *     - `onStepBegin(test, result, step)`: called when a test step starts.
+ *     - `onStepEnd(test, result, step)`: called when a test step completes.
+ *     - `onTestEnd(test, result)`: called when a test finishes (with status 'passed', 'failed', 'timedOut', 'skipped').
+ *     - `onEnd(result)`: called when test run completes.
+ * - Event Multiplexer:
+ *   - `packages/playwright/src/reporters/multiplexer.ts` -> `Multiplexer` class
+ *     Broadcasts runner lifecycle events to all registered built-in (List, Line, Dot, HTML, JSON)
+ *     and custom reporters.
+ */
+
+// Custom Reporter class implementing ReporterV2 interface
+class CustomConsoleReporter {
+  version() {
+    return 'v2';
+  }
+
+  onConfigure(config) {
+    console.log(`[Reporter] Test configuration loaded. Timeout: ${config.timeout}ms`);
+  }
+
+  onBegin(suite) {
+    console.log(`[Reporter] Test run starting. Total tests discovered: ${suite.allTests().length}`);
+  }
+
+  onTestBegin(test, result) {
+    console.log(`[Reporter] Test started: ${test.title} (Retry #${result.retry})`);
+  }
+
+  onTestEnd(test, result) {
+    console.log(`[Reporter] Test completed: ${test.title} | Status: ${result.status} | Duration: ${result.duration}ms`);
+  }
+
+  async onEnd(result) {
+    console.log(`[Reporter] Test run finished. Overall status: ${result.status}`);
+  }
+}
+
+console.log('Custom Reporter class implementing ReporterV2 interface defined.');
+console.log('Multiplexer in reporters/multiplexer.ts broadcasts all events to configured reporters.');

--- a/agi-training-notes/examples/12-tracing.js
+++ b/agi-training-notes/examples/12-tracing.js
@@ -1,0 +1,67 @@
+/**
+ * 12-tracing.js
+ *
+ * Demonstrates Playwright Tracing API (context.tracing.start/stop), trace archive generation,
+ * and how the Trace Viewer reconstructs test execution timelines.
+ *
+ * Real source code references studied:
+ * - Client API Entry Point:
+ *   - `packages/playwright-core/src/client/tracing.ts` -> `Tracing` class
+ *     Methods: `start()`, `startChunk()`, `stopChunk()`, `stop({ path })`.
+ *     Sends RPC channel commands `tracingStart`, `tracingStartChunk`, `tracingStop` over `_channel`.
+ * - Server Trace Recorder Engine:
+ *   - `packages/playwright-core/src/server/trace/recorder/tracing.ts` -> `Tracing` class
+ *     Coordinates `Snapshotter` (`server/trace/recorder/snapshotter.ts`) for DOM snapshots,
+ *     `HarTracer` for network events, and screencast frame recorders.
+ * - Trace Archive Structure (.zip):
+ *   - `trace.trace`: JSON lines format containing API calls, parameters, durations, console logs, stack frames.
+ *   - `trace.network`: JSON lines format containing HAR network request/response headers, timings, and status codes.
+ *   - `resources/`: Content-addressed directory (keyed by SHA1) storing response bodies, DOM snapshots, images, fonts.
+ *   - `trace.stacks`: Source code stack traces and location mappings.
+ * - Trace Viewer Architecture:
+ *   - `packages/playwright-core/src/server/trace/viewer/traceViewer.ts` -> `startTraceViewerServer()`
+ *     Spawns an `HttpServer` serving the Vite web application from `packages/trace-viewer/`.
+ *     Serves trace files and resources via `/file?path=...` endpoints to the React frontend (`packages/trace-viewer/src/ui/workbench.tsx`).
+ */
+
+const { chromium } = require('playwright-core');
+const path = require('path');
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+
+  // Start tracing on the browser context.
+  // Tracing in client/tracing.ts sends tracingStart RPC to server/trace/recorder/tracing.ts.
+  await context.tracing.start({
+    name: 'user_flow_trace',
+    title: 'User Login & Checkout Flow',
+    screenshots: true, // captures screencast images for visual timeline
+    snapshots: true,   // captures DOM snapshots before & after each action for time-travel inspection
+    sources: true      // captures source code stack frames
+  });
+
+  const page = await context.newPage();
+
+  // Actions executed here are logged to trace.trace by Tracing.onBeforeCall / onAfterCall
+  await page.goto('https://example.com');
+  const link = page.locator('a');
+  await link.click();
+
+  // Stop tracing and save archive to disk.
+  // Tracing.stop() in client/tracing.ts stops recording and streams the zip archive containing
+  // trace.trace, trace.network, and resources/ to the specified path.
+  const tracePath = path.join(__dirname, 'scratch', 'trace.zip');
+  await context.tracing.stop({ path: tracePath });
+
+  console.log(`Trace archive successfully recorded and saved to: ${tracePath}`);
+  console.log('To view the recorded trace, run:');
+  console.log(`npx playwright show-trace ${tracePath}`);
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/13-frames-and-oopif.js
+++ b/agi-training-notes/examples/13-frames-and-oopif.js
@@ -1,0 +1,70 @@
+/**
+ * 13-frames-and-oopif.js
+ *
+ * Demonstrates Playwright's Frame tree hierarchy (mainFrame, childFrames), frame lifecycle events,
+ * and how Playwright seamlessly interacts with cross-origin Out-Of-Process IFrames (OOPIF).
+ *
+ * Real source code references studied:
+ * - Frame Hierarchy & Client API:
+ *   - `packages/playwright-core/src/client/frame.ts` -> `Frame` class
+ *     Methods: `childFrames()`, `parentFrame()`, `name()`, `url()`, `locator()`.
+ *   - `packages/playwright-core/src/client/page.ts` -> `Page` class
+ *     Properties: `page.mainFrame()`, `page.frames()`.
+ *     Events: `frameattached`, `framenavigated`, `framedetached`.
+ * - Server Frame Manager & Lifecycle:
+ *   - `packages/playwright-core/src/server/frames.ts` -> `Frame` & `FrameManager` classes
+ *     Tracks the frame tree structure (`_mainFrame`, `_childFrames`, `_parentFrame`).
+ *     Emits lifecycle events (`Page.Events.FrameAttached`, `FrameNavigated`, `FrameDetached`).
+ * - Cross-Origin IFrame (OOPIF) Handling:
+ *   - `packages/playwright-core/src/server/chromium/crPage.ts` -> `_onAttachedToTarget()`
+ *     Chromium isolates cross-origin iframes into separate renderer processes (OOPIF).
+ *     Playwright enables auto-attach (`Target.setAutoAttach` with `flatten: true`).
+ *     When a cross-origin iframe navigates, Chrome fires `Target.attachedToTarget` with type `'iframe'`.
+ *     Playwright creates a child CDP session (`session.createChildSession()`) wrapped in a `FrameSession`,
+ *     transparently unifying execution contexts while routing protocol commands to the target process.
+ */
+
+const { chromium } = require('playwright-core');
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Listen to frame lifecycle events on Page
+  // Emitted by Page in client/page.ts when server FrameManager fires FrameAttached/FrameNavigated/FrameDetached
+  page.on('frameattached', frame => {
+    console.log(`[Event: frameattached] New frame created. URL: ${frame.url()}`);
+  });
+
+  page.on('framenavigated', frame => {
+    console.log(`[Event: framenavigated] Frame navigated. Name: "${frame.name()}", URL: ${frame.url()}`);
+  });
+
+  page.on('framedetached', frame => {
+    console.log(`[Event: framedetached] Frame detached. URL: ${frame.url()}`);
+  });
+
+  await page.goto('https://example.com');
+
+  // Inspect frame tree
+  const mainFrame = page.mainFrame(); // top-level frame (Frame in client/frame.ts)
+  console.log('Main frame URL:', mainFrame.url());
+  console.log('Child frames count:', mainFrame.childFrames().length);
+
+  // Accessing elements inside iframes (same-origin or cross-origin OOPIF)
+  // FrameLocator in client/locator.ts delegates selector queries into the target frame context,
+  // regardless of whether the frame is in-process or out-of-process.
+  const iframeButton = page.frameLocator('iframe#payment-frame').getByRole('button', { name: 'Pay Now' });
+
+  console.log('FrameLocator constructed for iframe target.');
+  console.log('Under the hood, if payment-frame is cross-origin, crPage.ts attaches a child CDP session');
+  console.log('to route commands directly to the OOPIF renderer process.');
+
+  await context.close();
+  await browser.close();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/agi-training-notes/examples/14-downloads-and-dialogs.js
+++ b/agi-training-notes/examples/14-downloads-and-dialogs.js
@@ -1,0 +1,61 @@
+/**
+ * Example 14: Downloads, Uploads, and Dialog Handling
+ * 
+ * This script demonstrates interacting with the native browser events
+ * for downloading files, uploading files (without UI dialogs), and 
+ * handling JavaScript dialogs.
+ * 
+ * Note: This is a standalone, well-commented example for documentation
+ * purposes only and is not meant to be executed directly in this environment.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  // 1. Launch browser and create a context
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // 2. Dialog Handling
+  // Playwright intercepts Page.javascriptDialogOpening CDP events and wraps them
+  // into a Dialog object from packages/playwright-core/src/server/dialog.ts
+  page.on('dialog', async dialog => {
+    console.log(`Intercepted dialog: ${dialog.type()} with message: ${dialog.message()}`);
+    // Native browser execution is blocked until we accept or dismiss the dialog.
+    // This sends the Page.handleJavaScriptDialog CDP command.
+    await dialog.accept('User input text');
+  });
+
+  // 3. File Chooser (Upload Interception)
+  // When Page.setInterceptFileChooserDialog is enabled via CDP, clicking an input
+  // element triggers Page.fileChooserOpened instead of opening the OS dialog.
+  page.on('filechooser', async fileChooser => {
+    console.log(`Intercepted file chooser for multiple files? ${fileChooser.isMultiple()}`);
+    // This ultimately sends DOM.setFileInputFiles to Chromium.
+    await fileChooser.setFiles('/path/to/mock_upload.pdf');
+  });
+
+  // 4. Download Handling
+  // Chromium emits Browser.downloadWillBegin and Browser.downloadProgress, which
+  // playwright-core translates to Page.Events.Download.
+  page.on('download', async download => {
+    console.log(`Download started: ${download.url()} -> ${download.suggestedFilename()}`);
+    
+    // Playwright stores the artifact in a temporary directory until explicitly saved.
+    // Using Artifact.ts logic underneath to stream or copy the file.
+    const downloadError = await download.failure();
+    if (!downloadError) {
+      await download.saveAs('/path/to/save/downloaded_file.zip');
+    }
+  });
+
+  // 5. Direct Upload (Bypassing File Chooser)
+  // Bypasses the file chooser completely by directly sending the paths to the DOM element.
+  // This uses dom.ts to resolve the element and crPage.ts to invoke DOM.setFileInputFiles.
+  await page.goto('https://example.com/upload');
+  await page.setInputFiles('input[type="file"]', ['/path/to/upload1.png', '/path/to/upload2.png']);
+
+  // Cleanup
+  await browser.close();
+})();

--- a/agi-training-notes/examples/15-api-testing.js
+++ b/agi-training-notes/examples/15-api-testing.js
@@ -1,0 +1,71 @@
+/**
+ * Example 15: API Testing and Clock Mocking
+ * 
+ * This script demonstrates the APIRequestContext for executing network
+ * requests via Node.js natively while sharing cookie storage with the browser context,
+ * as well as the Clock API for mocking time natively within the page's JS environment.
+ * 
+ * Note: This is a standalone, well-commented example for documentation
+ * purposes only and is not meant to be executed directly in this environment.
+ */
+
+const { chromium, request } = require('playwright-core');
+
+(async () => {
+  // --- 1. API Testing (`APIRequestContext`) ---
+  // Global APIRequestContext: bypasses the browser entirely.
+  // Instantiates GlobalAPIRequestContext which uses Node's native http/https request.
+  const apiContext = await request.newContext({
+    baseURL: 'https://api.example.com',
+    extraHTTPHeaders: { 'Authorization': 'Bearer test-token' }
+  });
+
+  // Makes a request using http/https natively instead of the CDP network stack.
+  const response = await apiContext.get('/users/123');
+  console.log(`Status: ${response.status()}`);
+  console.log(`Body: ${await response.json()}`);
+  await apiContext.dispose();
+
+  // BrowserContextAPIRequestContext: Shares storage/cookies with a BrowserContext.
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  
+  // context.request yields a BrowserContextAPIRequestContext
+  // Under the hood, addCookies/cookies/storageState map directly to `context`.
+  const contextRequest = context.request;
+  
+  // Sets a cookie in the BrowserContext
+  await context.addCookies([{ name: 'session_id', value: 'xyz', domain: 'example.com', path: '/' }]);
+  
+  // This request natively includes the 'session_id' cookie because they share storage.
+  const authRes = await contextRequest.get('https://example.com/api/profile');
+  console.log(`Profile Fetch Status: ${authRes.status()}`);
+
+  // --- 2. Clock & Time Mocking ---
+  const page = await context.newPage();
+
+  // Initialize the mock clock (BrowserContext.clock)
+  // This reads packages/playwright-core/src/server/clock.ts and injects a SinonJS-based 
+  // rawClockSource.source into the page via _browserContext.addInitScript().
+  await page.clock.install({ time: new Date('2026-01-01T00:00:00Z').getTime() });
+
+  // Evaluate some time-dependent code in the page.
+  // The page's Date object is completely overridden by the injected script.
+  await page.evaluate(() => {
+    console.log(`Current mocked time: ${new Date().toISOString()}`);
+    
+    setTimeout(() => {
+      console.log('Timeout fired!');
+    }, 5000);
+  });
+
+  // Fast-forward the clock by 5000ms.
+  // This triggers `globalThis.__pwClock.controller.fastForward(5000)` inside the page.
+  await page.clock.fastForward(5000);
+
+  // You can also pause at a specific time.
+  await page.clock.pauseAt(new Date('2026-12-31T23:59:59Z').getTime());
+
+  // Cleanup
+  await browser.close();
+})();

--- a/agi-training-notes/examples/16-page-load-and-lifecycle.js
+++ b/agi-training-notes/examples/16-page-load-and-lifecycle.js
@@ -1,0 +1,50 @@
+/**
+ * Example 16: Page Load Detection & Lifecycle
+ * 
+ * This script demonstrates how Playwright tracks various lifecycle events
+ * (such as load, domcontentloaded, and networkidle), as well as
+ * tracking visual stability (fonts and animations) vs data readiness (responses).
+ * 
+ * Note: This is a standalone, well-commented example for documentation
+ * purposes only and is not meant to be executed directly in this environment.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // 1. Frame Lifecycle Events
+  // Calling page.goto inherently waits for the 'load' lifecycle event by default.
+  // The 'load' event is dispatched by the FrameManager when the frame completes its load.
+  await page.goto('https://example.com');
+
+  // Alternatively, you can wait for 'networkidle'.
+  // Under the hood, this requires the frame's _inflightRequests.size to be exactly 0
+  // for at least 500 milliseconds, tracked by a setTimeout inside frames.ts.
+  await page.waitForLoadState('networkidle');
+
+  // 2. Data Readiness
+  // You can wait for a specific network response, bypassing frame lifecycle events entirely.
+  // This taps into Events.Page.Response, tracked directly by the client's Page object.
+  const responsePromise = page.waitForResponse(response => {
+    return response.url().includes('/api/data') && response.status() === 200;
+  });
+  await page.evaluate(() => fetch('/api/data')); // trigger the request
+  const response = await responsePromise;
+  console.log(`Received data from ${response.url()}`);
+
+  // 3. Visual Stability (Screenshot)
+  // When capturing a screenshot, Playwright automatically checks visual stability.
+  // By passing `animations: 'disabled'`, it injects CSS to stop transitions/animations.
+  // It also implicitly evaluates `document.fonts.ready` in the utility world to ensure
+  // typography is fully resolved before snapping the image.
+  await page.screenshot({
+    path: 'stable-screenshot.png',
+    animations: 'disabled'
+  });
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/17-multi-tab-and-pages.js
+++ b/agi-training-notes/examples/17-multi-tab-and-pages.js
@@ -1,0 +1,56 @@
+/**
+ * Example 17: Multi-Tab & Page Switching
+ * 
+ * This script demonstrates Playwright's multi-tab tracking architecture.
+ * Playwright relies on Target.attachedToTarget events to track tabs and
+ * maintains independent CDP sessions per tab, avoiding any "active tab" lock.
+ * 
+ * Note: This is a standalone, well-commented example for documentation
+ * purposes only and is not meant to be executed directly in this environment.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  
+  // Creates a BrowserContext, acting as an isolated profile
+  const context = await browser.newContext();
+  
+  // context.pages() filters the internal _crPages map based on this context.
+  console.log(`Initial pages count: ${context.pages().length}`);
+
+  // 1. New Tab / Popup tracking
+  // Whenever the browser spawns a new tab (e.g. via window.open or target="_blank"),
+  // Chromium fires 'Target.attachedToTarget'. CRBrowser catches it, instantiates 
+  // a new CRPage with the openerId linked to the parent, and bubbles up a 'page' event.
+  context.on('page', async newPage => {
+    console.log(`New tab detected! URL: ${newPage.url()}`);
+    
+    // The relationship is recorded; we can fetch the opener page.
+    const opener = await newPage.opener();
+    if (opener) {
+      console.log(`Tab was opened by: ${opener.url()}`);
+    }
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+  
+  // Trigger a popup to fire the context.on('page') listener above
+  await page.evaluate(() => { window.open('https://example.com/popup', '_blank'); });
+
+  // 2. Active Tab & Visibility
+  // Playwright automation scripts do NOT depend on a tab being visually "active".
+  // Commands are routed to the specific child CDP session (FrameSession) belonging
+  // to each CRPage, allowing simultaneous background interactions.
+  const allPages = context.pages();
+  const backgroundTab = allPages[allPages.length - 1];
+
+  // However, if we *want* to emulate user visibility (e.g., to trigger page visibility
+  // APIs or requestAnimationFrame), we can bring a specific tab to the foreground.
+  // This fires the 'Page.bringToFront' CDP command under the hood.
+  await backgroundTab.bringToFront();
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/18-targeted-network-interception.js
+++ b/agi-training-notes/examples/18-targeted-network-interception.js
@@ -1,0 +1,39 @@
+/**
+ * Example 18: Targeted Network Interception
+ * 
+ * This script demonstrates waiting for a specific HTTP response
+ * instead of relying on global 'networkidle' heuristics.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Navigate to the application
+  await page.goto('https://example.com/dashboard');
+
+  // Trigger an action that kicks off an asynchronous data fetch, like
+  // opening a dropdown or applying a filter.
+  await page.locator('#open-dropdown-btn').click();
+
+  // Wait specifically for the dropdown data endpoint to return successfully.
+  // This uses page.waitForResponse() which tracks Events.Page.Response under the hood.
+  // The timeout defaults to the global DEFAULT_PLAYWRIGHT_TIMEOUT (30_000ms, defined in isomorphic/time.ts).
+  const response = await page.waitForResponse(response => {
+    return response.url().includes('/api/v1/dropdown-data') && response.status() === 200;
+  });
+
+  console.log(`Dropdown data successfully received from ${response.url()}`);
+
+  // Now we are deterministically guaranteed that the data has arrived,
+  // we can safely assert or interact with the populated UI elements.
+  await page.locator('.dropdown-item').first().click();
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/19-browser-side-polling.js
+++ b/agi-training-notes/examples/19-browser-side-polling.js
@@ -1,0 +1,41 @@
+/**
+ * Example 19: Browser-Side Predicate Polling
+ * 
+ * This script demonstrates waiting for the DOM to reflect a specific state
+ * using browser-side polling, which is useful for highly dynamic UIs
+ * where network traffic isn't a reliable indicator.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://example.com');
+
+  // Trigger some client-side rendering logic
+  await page.locator('#load-more-items-btn').click();
+
+  // Wait until the DOM reflects that the items have loaded.
+  // page.waitForFunction evaluates the predicate repeatedly within the browser context.
+  // By default, if the `polling` option is omitted, it defaults to 'raf',
+  // which uses requestAnimationFrame under the hood (verified in frames.ts).
+  await page.waitForFunction(() => {
+    // This executes entirely within the browser's JavaScript environment
+    return document.querySelectorAll('.dropdown-item').length > 1;
+  });
+
+  console.log('The DOM is ready with multiple dropdown items!');
+
+  // Alternatively, you can override the default 'raf' polling with a fixed ms interval.
+  await page.waitForFunction(() => {
+    return document.querySelector('#processing-spinner') === null;
+  }, undefined, { polling: 500 }); // Polls using setTimeout(next, 500) internally.
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/20-network-stubbing.js
+++ b/agi-training-notes/examples/20-network-stubbing.js
@@ -1,0 +1,49 @@
+/**
+ * Example 20: Network Stubbing and Mocking
+ * 
+ * This script demonstrates completely bypassing the network by stubbing 
+ * responses at the Playwright layer. This guarantees immediate deterministic 
+ * data without waiting for real backend infrastructure.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Intercept the request to the dropdown data API.
+  await page.route('**/api/v1/dropdown-data', async route => {
+    // Fulfill the request with our mock data.
+    // Under the hood, this calls route.fulfill() which sends the Fetch.fulfillRequest
+    // CDP command. This intercepts the request entirely within Chromium's Fetch domain.
+    // The physical network is never hit.
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          { id: 1, name: 'Mocked Item 1' },
+          { id: 2, name: 'Mocked Item 2' }
+        ]
+      })
+    });
+  });
+
+  // Navigate to the dashboard. The application will request the dropdown data,
+  // but it will instantly receive our mocked response over the CDP websocket.
+  await page.goto('https://example.com/dashboard');
+
+  // Because the network response is instant and deterministic, the UI should 
+  // populate immediately (or as fast as the front-end rendering framework can paint).
+  await page.locator('#open-dropdown-btn').click();
+  
+  // Wait for the specific mocked item to be rendered in the DOM.
+  await page.locator('text="Mocked Item 1"').waitFor();
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/21-click-and-retry-loop.js
+++ b/agi-training-notes/examples/21-click-and-retry-loop.js
@@ -1,0 +1,57 @@
+/**
+ * Example 21: "Click and Retry" Loop (Brute-Force Fallback)
+ * 
+ * This script demonstrates manually wrapping actions in a try/catch loop.
+ * Playwright's built-in `locator.click()` already uses an internal 
+ * `_retryPointerAction()` to poll for structural actionability (visible, stable, etc).
+ * 
+ * However, this manual loop is necessary when dealing with application-level
+ * rejections (e.g., clicking triggers an error because the frontend state isn't ready)
+ * or when bypassing standard actionability checks entirely using `{ force: true }`.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+// Example 100ms retry delay. This is a design choice, NOT a Playwright default.
+const RETRY_DELAY_MS = 100;
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://example.com/dashboard');
+
+  const dropdownBtn = page.locator('#open-dropdown-btn');
+  let success = false;
+  let attempts = 0;
+
+  // The custom retry loop
+  while (!success && attempts < 50) { // arbitrary max 50 attempts = ~5 seconds
+    try {
+      attempts++;
+      
+      // We use force: true to bypass Playwright's structural actionability checks.
+      // Or we could be executing a custom page.evaluate() script that throws
+      // an application-level error if the dropdown's internal data structure isn't ready.
+      await dropdownBtn.click({ force: true, timeout: 50 });
+      
+      // If we reach here, the click succeeded without throwing an error
+      success = true;
+    } catch (e) {
+      // The action failed (e.g., the element was detached mid-click, or a custom error was thrown)
+      // We catch the error, wait 100ms (our chosen delay), and try again.
+      await page.waitForTimeout(RETRY_DELAY_MS);
+    }
+  }
+
+  if (!success) {
+    throw new Error('Failed to click the dropdown button after multiple retries.');
+  }
+
+  console.log('Successfully brute-forced the interaction!');
+  await browser.close();
+})();

--- a/agi-training-notes/examples/22-video-recording-pipeline.js
+++ b/agi-training-notes/examples/22-video-recording-pipeline.js
@@ -1,0 +1,37 @@
+/**
+ * Example 22: FFmpeg Video Recording Pipeline
+ * 
+ * This script demonstrates Playwright's built-in video recording capabilities.
+ * Under the hood, this spawns a physical `ffmpeg` process via child_process
+ * with a hardcoded pipeline (vp8 codec, 25fps, 1M bitrate, no audio).
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  
+  // To record a video, you set the recordVideo option at the Context level.
+  // The dimensions are explicitly configured here.
+  const context = await browser.newContext({
+    recordVideo: {
+      dir: 'videos/', // Directory to output the .webm files
+      size: { width: 1024, height: 768 } // The FFmpeg -vf crop/pad dimensions
+    }
+  });
+
+  const page = await context.newPage();
+
+  // Any actions performed here will be encoded to VP8 at 25 fps.
+  // Playwright strictly omits audio using the ffmpeg '-an' flag.
+  await page.goto('https://example.com');
+  await page.locator('button').click();
+
+  // Closing the context flushes the remaining frames and gracefully terminates
+  // the ffmpeg child process via stdin closure.
+  await context.close();
+  await browser.close();
+})();

--- a/agi-training-notes/examples/23-environmental-settings.js
+++ b/agi-training-notes/examples/23-environmental-settings.js
@@ -1,0 +1,35 @@
+/**
+ * Example 23: Default Environmental Settings
+ * 
+ * This script demonstrates explicitly overriding environmental settings 
+ * that Playwright otherwise defaults behind the scenes.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+
+  // If these options were omitted, Playwright's validateBrowserContextOptions
+  // (in browserContext.ts) would enforce:
+  // - viewport: { width: 1280, height: 720 }
+  // - locale: 'en-US'
+  // 
+  // By contrast, timezoneId has no programmatic default fallback inside
+  // Playwright. If omitted, Playwright avoids sending Emulation.setTimezoneOverride
+  // and the browser inherits the underlying host machine's timezone natively.
+  const context = await browser.newContext({
+    viewport: { width: 1920, height: 1080 },
+    deviceScaleFactor: 2, // Emulates a retina display (defaults to 1 if omitted)
+    locale: 'fr-FR',
+    timezoneId: 'Europe/Paris' 
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+  
+  await browser.close();
+})();

--- a/agi-training-notes/examples/24-stability-and-opacity.js
+++ b/agi-training-notes/examples/24-stability-and-opacity.js
@@ -1,0 +1,40 @@
+/**
+ * Example 24: Auto-Waiting "Stable" Check vs Opacity
+ * 
+ * This script illustrates a limitation in Playwright's actionability checks.
+ * In `injectedScript.ts`, _checkElementIsStable() verifies stability by polling
+ * `getBoundingClientRect()` across animation frames. It does NOT check CSS
+ * opacity or computed visibility styles for transitions.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://example.com');
+
+  // Assume #fade-in-btn is inserted into the DOM with opacity: 0
+  // and slowly transitions to opacity: 1 over 2 seconds, but its bounding 
+  // rect coordinates are static.
+  
+  // Playwright's click() waits for: Visible, Stable, Receives Events, Enabled.
+  // Because its coordinates don't change, _checkElementIsStable() passes instantly.
+  // Playwright may successfully fire a click event on the element while it is 
+  // still completely invisible to the human eye!
+  await page.locator('#fade-in-btn').click();
+
+  // If you specifically need to wait for a CSS transition like opacity to finish,
+  // you must use a custom waitForFunction instead of relying on built-in stability.
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('#fade-in-btn');
+    return window.getComputedStyle(btn).opacity === '1';
+  });
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/25-video-cursor-overlay.js
+++ b/agi-training-notes/examples/25-video-cursor-overlay.js
@@ -1,0 +1,39 @@
+/**
+ * Example 25: Cursor Visibility in Video Recordings
+ * 
+ * This script demonstrates the distinction between headless video recordings
+ * and the "Screencast Annotation" overlay used by codegen/trace viewers.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  
+  // Normal video recordings contain NO cursor by default. Playwright's interactions
+  // are synthetic CDP `Input.dispatchMouseEvent` commands that do not drive
+  // the host OS's mouse pointer.
+  const context = await browser.newContext({
+    recordVideo: {
+      dir: 'videos/'
+    }
+  });
+
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+
+  // This click will happen, and the video will show the button reacting (e.g. 
+  // active states or navigation), but NO mouse cursor will travel across the screen.
+  await page.locator('button').click();
+
+  // If you see a cursor in a Playwright Trace Viewer or Codegen session,
+  // it is actually a fake DOM element injected into the page via 
+  // `injected.setScreencastAnnotation()` in `screencast.ts` when 
+  // `recordVideo.showActions` is explicitly enabled by the tooling.
+  // It is NOT a real OS pointer.
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/26-automation-detection.js
+++ b/agi-training-notes/examples/26-automation-detection.js
@@ -1,0 +1,38 @@
+/**
+ * Example 26: Automation Detection and navigator.webdriver
+ * 
+ * This script demonstrates the limits of Playwright's source code surface
+ * regarding browser fingerprinting and automation detection.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  // A search through Playwright's TypeScript source code (like chromiumSwitches.ts
+  // and chromium.ts) reveals that Playwright NEVER actively appends the 
+  // '--enable-automation' flag to the arguments list.
+  
+  // However, launchApp.ts references it in an exclusion list:
+  // ignoreDefaultArgs: ['--enable-automation']
+  // 
+  // This implies that '--enable-automation' is natively baked into the Chromium 
+  // binary's default headless mode behavior, and Playwright does not manually 
+  // inject it. 
+  const browser = await chromium.launch({
+    // If we wanted to ensure the flag was removed to reduce detection surface, 
+    // we would explicitly ignore it here:
+    ignoreDefaultArgs: ['--enable-automation']
+  });
+
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Evaluate inside the page to check if navigator.webdriver is true
+  const isWebdriver = await page.evaluate(() => navigator.webdriver);
+  console.log(`Is navigator.webdriver true? ${isWebdriver}`);
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/27-custom-selector-engines.js
+++ b/agi-training-notes/examples/27-custom-selector-engines.js
@@ -1,0 +1,36 @@
+/**
+ * Example 27: Custom Selector Engines
+ * 
+ * This script demonstrates registering a custom selector engine via 
+ * `selectors.register()`. The injected script object must implement 
+ * `query` and `queryAll` functions to interact with the DOM natively.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium, selectors } = require('playwright-core');
+
+(async () => {
+  // Register a custom engine called 'tag' that purely filters by tagName
+  await selectors.register('tag', {
+    // query returns a single Element or undefined
+    query(root, selector) {
+      return root.querySelector(selector);
+    },
+    // queryAll returns an Array of Elements
+    queryAll(root, selector) {
+      return Array.from(root.querySelectorAll(selector));
+    }
+  });
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
+
+  // Once registered globally, you can prefix locators with 'tag='
+  const button = page.locator('tag=button');
+  await button.click();
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/28-slowmo-dispatcher-delay.js
+++ b/agi-training-notes/examples/28-slowmo-dispatcher-delay.js
@@ -1,0 +1,31 @@
+/**
+ * Example 28: slowMo Dispatcher Delay
+ * 
+ * This script demonstrates the `slowMo` launch option.
+ * Under the hood, this delay is artificially inserted by the Playwright Server 
+ * Dispatcher (`dispatchers/dispatcher.ts`). After any action completes, 
+ * the server simply awaits a `setTimeout` for `slowMo` milliseconds before 
+ * returning the CDP response to the Node.js client.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  // `slowMo` is configured in milliseconds.
+  const browser = await chromium.launch({
+    slowMo: 250 // Wait 250ms after every action
+  });
+
+  const page = await browser.newPage();
+  
+  // This goto will resolve, and then the server dispatcher pauses 250ms
+  await page.goto('https://example.com');
+  
+  // The click executes, and the server dispatcher pauses another 250ms
+  await page.locator('button').click();
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/29-emulation-scope.js
+++ b/agi-training-notes/examples/29-emulation-scope.js
@@ -1,0 +1,34 @@
+/**
+ * Example 29: Emulation Scope
+ * 
+ * This script illustrates that emulation parameters like viewport, offline mode,
+ * geolocation, and userAgent are inherently bound to the BrowserContext.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  
+  // Emulation is defined globally for all pages residing within this context.
+  // It is captured in the BrowserContextOptions interface.
+  const context = await browser.newContext({
+    viewport: { width: 375, height: 667 }, // Emulate Mobile Viewport
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X)',
+    geolocation: { longitude: 48.858455, latitude: 2.294474 }, // Paris
+    offline: true, // Emulate no network connectivity
+    permissions: ['geolocation']
+  });
+
+  const page1 = await context.newPage();
+  const page2 = await context.newPage();
+
+  // Both page1 and page2 share the exact same emulated characteristics.
+  await page1.goto('https://example.com').catch(() => {}); // Will fail due to offline
+  await page2.goto('https://example.com').catch(() => {}); // Will fail due to offline
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/30-screenshot-masking.js
+++ b/agi-training-notes/examples/30-screenshot-masking.js
@@ -1,0 +1,30 @@
+/**
+ * Example 30: Visual Regression - Masking and Animation Freezing
+ * 
+ * This script demonstrates the `@playwright/test` visual regression feature
+ * `toHaveScreenshot`, focusing on its ability to accept Locator arrays for 
+ * masking, and its reuse of core animation freezing.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+test('visual regression masking', async ({ page }) => {
+  await page.goto('https://example.com');
+  
+  // The 'mask' option natively accepts an array of Locators. Playwright will 
+  // overlay a pink (#FF00FF) box over these elements during the screenshot.
+  // Under the hood, this leverages `page._expectScreenshot` which also 
+  // defaults to `animations: 'disabled'`, injecting the CSS rules:
+  // `*, *::before, *::after { transition: none !important; animation: none !important; }`
+  await expect(page).toHaveScreenshot('home.png', {
+    mask: [
+      page.locator('.dynamic-ads'),
+      page.locator('#live-clock')
+    ],
+    // Explicitly showing the default behavior (it is 'disabled' by default)
+    animations: 'disabled' 
+  });
+});

--- a/agi-training-notes/examples/31-accessibility-tree.js
+++ b/agi-training-notes/examples/31-accessibility-tree.js
@@ -1,0 +1,32 @@
+/**
+ * Example 31: Accessibility Tree
+ * 
+ * This script demonstrates how Playwright handles accessibility, highlighting
+ * the absence of a raw `page.accessibility.snapshot()` API (which Puppeteer has).
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+// Playwright relies on external libraries like @axe-core/playwright for audits.
+// const { injectAxe, getViolations } = require('axe-playwright'); // (Example)
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  
+  await page.goto('https://example.com');
+
+  // Instead of querying the raw accessibility tree as a data structure, 
+  // Playwright implements accessibility via the `getByRole` locator engine.
+  // This engine traverses the DOM and computes accessible names and roles 
+  // on the fly to fulfill the query.
+  const submitButton = page.getByRole('button', { name: 'Submit' });
+  await submitButton.click();
+
+  // There is NO `page.accessibility.snapshot()` in Playwright's TypeScript source.
+  // Full audits are pushed to the user ecosystem (e.g. @axe-core/playwright).
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/32-worker-websocket-hooks.js
+++ b/agi-training-notes/examples/32-worker-websocket-hooks.js
@@ -1,0 +1,43 @@
+/**
+ * Example 32: Worker, Service Worker, and WebSocket Hooks
+ * 
+ * This script demonstrates the hooks Playwright exposes for background execution
+ * contexts and WebSockets.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // 1. Web Workers: Captured via `page.on('worker')` yielding a `Worker` instance.
+  page.on('worker', worker => {
+    console.log(`Worker spawned: ${worker.url()}`);
+    // You can evaluate code directly inside the worker's execution context
+    worker.evaluate(() => console.log('Hello from inside the worker'));
+  });
+
+  // 2. Service Workers: Tracked at the Context level via `context.serviceWorkers()`
+  page.on('load', () => {
+    const sws = context.serviceWorkers();
+    console.log(`Currently active Service Workers: ${sws.length}`);
+  });
+
+  // 3. WebSockets: Captured via `page.on('websocket')` yielding a `WebSocket` instance.
+  page.on('websocket', ws => {
+    console.log(`WebSocket opened: ${ws.url()}`);
+    
+    // You can intercept or inspect frame data payloads natively.
+    ws.on('framesent', frame => console.log(`Sent: ${frame.payload}`));
+    ws.on('framereceived', frame => console.log(`Received: ${frame.payload}`));
+  });
+
+  await page.goto('https://example.com');
+  
+  await browser.close();
+})();

--- a/agi-training-notes/examples/33-cdp-session-access.js
+++ b/agi-training-notes/examples/33-cdp-session-access.js
@@ -1,0 +1,42 @@
+/**
+ * Example 33: Low-Level CDP Session Access
+ * 
+ * This script demonstrates how to bypass Playwright's high-level abstractions
+ * and issue raw Chrome DevTools Protocol (CDP) commands via `newCDPSession()`.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Create a raw CDP session bound to this specific page's Target
+  const session = await context.newCDPSession(page);
+
+  // Example: Throttle CPU to 4x slowdown
+  // Playwright's `protocol.d.ts` exposes Emulation.setCPUThrottlingRate natively
+  await session.send('Emulation.setCPUThrottlingRate', {
+    rate: 4
+  });
+
+  // Example: Emulate Network Conditions
+  // Playwright's `protocol.d.ts` exposes Network.emulateNetworkConditions
+  // (Note: The protocol marks this as deprecated in favor of emulateNetworkConditionsByRule
+  // in modern Chromium, but the command remains structurally available).
+  await session.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency: 200, // 200ms latency
+    downloadThroughput: 1024 * 50, // 50 kb/s
+    uploadThroughput: 1024 * 50
+  });
+
+  await page.goto('https://example.com');
+  
+  await session.detach();
+  await browser.close();
+})();

--- a/agi-training-notes/examples/34-code-coverage.js
+++ b/agi-training-notes/examples/34-code-coverage.js
@@ -1,0 +1,39 @@
+/**
+ * Example 34: Chromium Code Coverage
+ * 
+ * This script demonstrates the Chromium-specific code coverage feature.
+ * Backed by `crCoverage.ts`, Playwright exposes native V8 profiling APIs 
+ * directly on the Page object.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  // Start coverage collection (Chromium only feature)
+  // `resetOnNavigation` controls whether the accumulated coverage is cleared 
+  // upon subsequent navigations.
+  await page.coverage.startJSCoverage({ resetOnNavigation: false });
+  await page.coverage.startCSSCoverage({ resetOnNavigation: false });
+
+  await page.goto('https://example.com');
+  
+  // Wait for any dynamic scripts/styles to execute
+  await page.waitForLoadState('networkidle');
+
+  // Stop collection and retrieve the raw V8 coverage arrays
+  const jsCoverage = await page.coverage.stopJSCoverage();
+  const cssCoverage = await page.coverage.stopCSSCoverage();
+
+  // Example: Log the URLs of every executed script
+  for (const entry of jsCoverage) {
+    console.log(`Executed Script URL: ${entry.url}`);
+  }
+
+  await browser.close();
+})();

--- a/agi-training-notes/examples/35-automation-evasion-initscript.js
+++ b/agi-training-notes/examples/35-automation-evasion-initscript.js
@@ -1,0 +1,36 @@
+/**
+ * Example 35: Automation Evasion via InitScript
+ * 
+ * This script demonstrates the mechanics of `page.addInitScript()` for bot 
+ * evasion / browser fingerprinting modification.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch(); // Note: ignoreDefaultArgs: ['--enable-automation'] does nothing because Playwright never injects that flag to begin with.
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Playwright implements `addInitScript` under the hood by issuing the V8/CDP 
+  // command `Page.addScriptToEvaluateOnNewDocument`.
+  // Because V8 guarantees this command fires instantly upon a new document 
+  // instantiation—before the DOM is even populated and before ANY inline or 
+  // external scripts are fetched—it is structurally guaranteed to execute 
+  // before the target website's anti-bot scripts can run.
+  await page.addInitScript(() => {
+    // Override the navigator.webdriver property safely
+    Object.defineProperty(navigator, 'webdriver', {
+      get: () => undefined
+    });
+    
+    // This script will execute on the initial navigation, and re-execute 
+    // seamlessly across every subsequent navigation or iframe creation.
+  });
+
+  await page.goto('https://example.com');
+  await browser.close();
+})();

--- a/agi-training-notes/examples/36-video-fragmentation.js
+++ b/agi-training-notes/examples/36-video-fragmentation.js
@@ -1,0 +1,44 @@
+/**
+ * Example 36: Multi-Tab Video Fragmentation
+ * 
+ * This script demonstrates the structural fragmentation of `recordVideo`.
+ * Even though the video is configured at the Context level, Playwright natively
+ * spawns an independent video file for every new Page created.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+const fs = require('fs');
+
+(async () => {
+  const browser = await chromium.launch();
+  
+  // Configure recording at the Context level
+  const context = await browser.newContext({
+    recordVideo: { dir: 'videos/' }
+  });
+
+  // Tab 1 is created. `startAutomaticVideoRecording` assigns it a file 
+  // (e.g. videos/<page1-guid>.webm).
+  const page1 = await context.newPage();
+  await page1.goto('https://example.com');
+  await page1.click('a[target="_blank"]'); // Assume this opens Tab 2
+
+  // Tab 2 is caught.
+  const page2 = await context.waitForEvent('page');
+  
+  // Tab 2 is assigned its OWN separate video file (videos/<page2-guid>.webm).
+  // Neither video file contains metadata linking them together.
+  await page2.waitForLoadState();
+  await page2.close();
+
+  await page1.click('button');
+
+  await context.close();
+  await browser.close();
+  
+  // Result: Two totally unlinked .webm files exist in 'videos/'.
+  console.log(fs.readdirSync('videos/'));
+})();

--- a/agi-training-notes/examples/37-tracing-tab-correlation.js
+++ b/agi-training-notes/examples/37-tracing-tab-correlation.js
@@ -1,0 +1,57 @@
+/**
+ * Example 37: Tracing Tab Correlation
+ * 
+ * This script demonstrates the structural integrity of Playwright Traces
+ * for cross-tab workflows. Unlike `recordVideo`, Tracing is scoped to the 
+ * Context and groups all multi-tab events together under a single monotonic 
+ * process clock.
+ * 
+ * Note: This is an engineered pattern based on real Playwright primitives.
+ * It is meant for documentation purposes only and not to be executed directly.
+ */
+
+const { chromium } = require('playwright-core');
+const fs = require('fs');
+const unzipper = require('unzipper'); // Hypothetical trace extraction
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  
+  // Tracing captures everything across the context into one archive
+  await context.tracing.start({ snapshots: true, screenshots: true });
+
+  const page1 = await context.newPage();
+  await page1.goto('https://example.com');
+  await page1.click('a[target="_blank"]'); 
+  const page2 = await context.waitForEvent('page');
+  await page2.close();
+  
+  // Stop tracing and save the unified archive
+  await context.tracing.stop({ path: 'trace.zip' });
+  await browser.close();
+
+  // If you parse the trace's .trace file manually (e.g., extracting trace.zip):
+  // You will find a single JSONL event stream perfectly sequenced by `monotonicTime()`.
+  
+  // Example trace event demonstrating `openerPageId`:
+  // {
+  //   "type": "event",
+  //   "time": 12345.678,
+  //   "class": "BrowserContext",
+  //   "method": "page",
+  //   "params": { 
+  //     "pageId": "page-2-guid", 
+  //     "openerPageId": "page-1-guid" // PERFECT CORRELATION
+  //   }
+  // }
+  
+  // Example trace event demonstrating monotonic closure timing:
+  // {
+  //   "type": "event",
+  //   "time": 12350.123,
+  //   "class": "BrowserContext",
+  //   "method": "pageClosed",
+  //   "params": { "pageId": "page-2-guid" }
+  // }
+})();

--- a/agi-training-notes/examples/38-programmatic-pause.js
+++ b/agi-training-notes/examples/38-programmatic-pause.js
@@ -1,0 +1,29 @@
+const { chromium } = require('playwright-core');
+
+(async () => {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  console.log('Navigating to example.com...');
+  await page.goto('https://example.com');
+
+  console.log('Programmatically pausing execution. The Inspector UI will open.');
+  console.log('Script is blocked on this line until you click "Resume" or "Close".');
+  
+  // 1. page.pause() temporarily clears timeouts and sends a pause channel message.
+  // 2. Debugger.onBeforeCall intercepts it on the server and creates an unresolved promise.
+  // 3. BrowserContext emits PausedStateChanged, launching RecorderApp in a separate context.
+  await page.pause();
+
+  // 4. When the user clicks "Resume" (triggering __pw_resume binding or dispatcher.doResume)
+  //    or clicks the native window "Close" button (triggering the 'close' event in recorderApp.ts),
+  //    Debugger.resume() is called, resolving the promise.
+  // 5. The inspected browser and context remain ALIVE and execution continues here.
+  console.log('Execution resumed! The inspected browser context was NOT closed.');
+
+  console.log('Continuing script execution normally...');
+  await page.setContent('<h1>Execution Continued!</h1>');
+  
+  await browser.close();
+})();

--- a/agi-training-notes/scratch/browser_append.md
+++ b/agi-training-notes/scratch/browser_append.md
@@ -1,0 +1,311 @@
+
+---
+
+## BrowserContext
+
+The `BrowserContext` represents an isolated browser session, analogous to an incognito window. Each context has its own pages, cookies, cache, and storage state.
+
+### Properties & State
+
+### `BrowserContext.request`
+APIRequestContext instance for making network requests scoped to the context.
+**Returns:** `APIRequestContext`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.tracing`
+Tracing API for starting/stopping tracing for this context.
+**Returns:** `Tracing`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clock`
+Clock API for manipulating time and timers scoped to this context.
+**Returns:** `Clock`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.browser()`
+Returns the browser instance of the context. If it was launched as a persistent context, returns `null`.
+**Returns:** `Browser | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.isClosed()`
+Indicates whether the context has been closed.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Pages & Workers
+
+### `BrowserContext.newPage()`
+Creates a new page in the browser context.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.pages()`
+Returns all open pages in the context.
+**Returns:** `Page[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.backgroundPages()`
+**@deprecated** Background pages have been removed from Chromium together with Manifest V2 extensions.
+**Returns:** `Page[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.serviceWorkers()`
+Returns all service workers currently active in the context.
+**Returns:** `Worker[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Configuration & State Management
+
+### `BrowserContext.cookies(urls)`
+Gets cookies for all or specific URLs.
+**Returns:** `Promise<network.NetworkCookie[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.addCookies(cookies)`
+Adds cookies to the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clearCookies(options)`
+Clears context cookies.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.grantPermissions(permissions, options)`
+Grants specified permissions to the context or specific origins.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.clearPermissions()`
+Clears all granted permissions.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setGeolocation(geolocation)`
+Sets the geolocation of the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setExtraHTTPHeaders(headers)`
+Sets extra HTTP headers to be sent with every request in the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setOffline(offline)`
+Sets the context to offline or online mode.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setHTTPCredentials(httpCredentials)`
+Sets HTTP credentials for the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setDefaultNavigationTimeout(timeout)`
+Sets the default navigation timeout for the context.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setDefaultTimeout(timeout)`
+Sets the default timeout for the context.
+**Returns:** `void`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.storageState(options)`
+Returns storage state for the context, which can be used to create a new context with the same state.
+**Returns:** `Promise<StorageState>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.setStorageState(storageState)`
+Sets storage state for the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Network Routing
+
+### `BrowserContext.route(url, handler, options)`
+Intercepts and handles network requests.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.routeFromHAR(har, options)`
+Routes network requests from a HAR file.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.routeWebSocket(url, handler)`
+Intercepts WebSocket connections.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.unroute(url, handler)`
+Removes a route handler.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.unrouteAll(options)`
+Removes all routes configured for the context.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Scripts & Bindings
+
+### `BrowserContext.addInitScript(script, arg)`
+Adds a script to be evaluated in all pages upon creation.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.exposeBinding(name, callback)`
+Exposes a Node.js function as a global function on all pages, passing the source object.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.exposeFunction(name, callback)`
+Exposes a Node.js function as a global function on all pages.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Lifecycle & Events
+
+### `BrowserContext.close(options)`
+Closes the browser context. All pages in the context are also closed.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.waitForEvent(event, optionsOrPredicate)`
+Waits for an event to fire and passes its value into the predicate function.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.on(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.once(event, listener)`
+Adds a one-time event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.off(event, listener)`
+Removes an event listener. (Alias for `removeListener`).
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.addListener(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### `BrowserContext.removeListener(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+### Misc
+
+### `BrowserContext.newCDPSession(page)`
+Creates a new CDP session linked to a specific page or frame.
+**Returns:** `Promise<CDPSession>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browserContext.ts`)
+
+---
+
+## Browser
+
+A Browser is created via `chromium.launch()`, `firefox.launch()`, or `webkit.launch()`. It manages multiple `BrowserContext` instances.
+
+### Core Context Creation
+
+### `Browser.newContext(options)`
+Creates a new browser context.
+**Returns:** `Promise<BrowserContext>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.newPage(options)`
+Creates a new page in a new browser context.
+**Returns:** `Promise<Page>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Accessors & State
+
+### `Browser.browserType()`
+Returns the browser type (`chromium`, `firefox`, or `webkit`) that this browser belongs to.
+**Returns:** `BrowserType`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.contexts()`
+Returns an array of all open browser contexts.
+**Returns:** `BrowserContext[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.isConnected()`
+Indicates whether the browser is connected.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.version()`
+Returns the browser version.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Advanced & Tracing
+
+### `Browser.startTracing(page, options)`
+**Chromium-only.** Starts low-level Chromium tracing. (For Playwright Tracing, use `context.tracing`).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.stopTracing()`
+**Chromium-only.** Stops tracing and returns a buffer with the trace data.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.newBrowserCDPSession()`
+**Chromium-only.** Creates a new CDP session attached to the browser itself.
+**Returns:** `Promise<CDPSession>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Remote Connectivity
+
+### `Browser.bind(title, options)`
+Reserves a new CDP connection for remote browsers and returns its websocket endpoint.
+**Returns:** `Promise<{ endpoint: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.unbind()`
+Removes a previously bound CDP connection.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### Lifecycle & Events
+
+### `Browser.close(options)`
+Closes the browser and all of its contexts.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.on(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.once(event, listener)`
+Adds a one-time event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.off(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.addListener(event, listener)`
+Adds an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)
+
+### `Browser.removeListener(event, listener)`
+Removes an event listener.
+**Returns:** `this`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/browser.ts`)

--- a/agi-training-notes/scratch/extract.py
+++ b/agi-training-notes/scratch/extract.py
@@ -1,0 +1,38 @@
+import re
+
+def extract_members(file_path, interface_name):
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    # Find the interface definition
+    match = re.search(f'export interface {interface_name} extends [^{{]*{{(.*?)\n}}', content, re.DOTALL)
+    if not match:
+        match = re.search(f'export interface {interface_name} {{(.*?)\n}}', content, re.DOTALL)
+        
+    if not match:
+        print(f"Interface {interface_name} not found.")
+        return []
+        
+    body = match.group(1)
+    
+    # Extract members (methods and properties)
+    # Simple regex to find lines like:
+    #   methodName(...): returnType;
+    #   propertyName: type;
+    members = set()
+    for line in body.split('\n'):
+        line = line.strip()
+        if not line or line.startswith('//') or line.startswith('/*') or line.startswith('*'):
+            continue
+        # Check for properties or methods
+        m = re.match(r'^([a-zA-Z0-9_]+)\s*[<:\(]', line)
+        if m:
+            members.add(m.group(1))
+            
+    return sorted(list(members))
+
+file_path = '/Users/ashwinkaliappan/playwright-agi-training/upstream/playwright/packages/playwright-core/types/types.d.ts'
+for iface in ['Frame', 'Route', 'Request', 'Response']:
+    members = extract_members(file_path, iface)
+    print(f"--- {iface} ---")
+    print("\n".join(members))

--- a/agi-training-notes/scratch/network_append.md
+++ b/agi-training-notes/scratch/network_append.md
@@ -1,0 +1,545 @@
+
+---
+
+## Frame
+
+A `Frame` represents a single iframe or the main frame of a page. Most `Frame` methods mirror `Page` methods, but act exclusively within the context of the frame.
+
+### Accessors & Navigation
+
+### `Frame.page()`
+Returns the page containing this frame.
+**Returns:** `Page`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.name()`
+Returns the frame's name attribute as specified in the tag.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.url()`
+Returns the frame's current URL.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.parentFrame()`
+Returns the parent frame, if any. Detached frames and main frames return `null`.
+**Returns:** `Frame | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.childFrames()`
+Returns an array of child frames.
+**Returns:** `Frame[]`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isDetached()`
+Returns `true` if the frame has been detached from the DOM.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.title()`
+Returns the page title.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.goto(url, options)`
+Navigates the frame. (Unlike `page.goto`, this strictly targets this specific frame).
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.frameElement()`
+Returns the `iframe` or `frame` DOM element for this frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.content()`
+Gets the full HTML contents of the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setContent(html, options)`
+Sets the HTML contents of the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Locators
+
+### `Frame.locator(selector, options)`
+Returns a Locator pointing to a matching element within the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByTestId(testId)`
+Returns a Locator pointing to an element with a matching test-id inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByAltText(text, options)`
+Returns a Locator matching an element's `alt` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByLabel(text, options)`
+Returns a Locator matching a form element by its associated label inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByPlaceholder(text, options)`
+Returns a Locator matching an element's `placeholder` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByRole(role, options)`
+Returns a Locator matching an element by its ARIA role inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByText(text, options)`
+Returns a Locator matching a specific text node inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getByTitle(text, options)`
+Returns a Locator matching an element's `title` attribute inside the frame.
+**Returns:** `Locator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.frameLocator(selector)`
+Returns a FrameLocator pointing to a child iframe within this frame.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.pierceFrames(options)`
+Returns a FrameLocator piercing through all matching child iframes automatically.
+**Returns:** `FrameLocator`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Interactions & Evaluation
+
+### `Frame.click(selector, options)`
+Clicks an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dblclick(selector, options)`
+Double-clicks an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dragAndDrop(source, target, options)`
+Drags an element to a target within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.tap(selector, options)`
+Taps an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.fill(selector, value, options)`
+Fills an input element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.focus(selector, options)`
+Focuses an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.hover(selector, options)`
+Hovers an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.press(selector, key, options)`
+Focuses an element within the frame and presses a single key.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.selectOption(selector, values, options)`
+Selects options within a `<select>` element in the frame.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setInputFiles(selector, files, options)`
+Sets files on a file input within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.check(selector, options)`
+Checks a checkbox or radio button within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.uncheck(selector, options)`
+Unchecks a checkbox or radio button within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.setChecked(selector, checked, options)`
+Checks or unchecks an element based on the provided state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.type(selector, text, options)`
+**@deprecated** (Use `locator.fill()` instead). Types into an input element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.evaluate(pageFunction, arg)`
+Executes JavaScript inside the frame.
+**Returns:** `Promise<any>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.evaluateHandle(pageFunction, arg)`
+Executes JavaScript inside the frame and returns a JSHandle to the result.
+**Returns:** `Promise<JSHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.dispatchEvent(selector, type, eventInit, options)`
+Dispatches a DOM event on an element within the frame.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### State Queries
+
+### `Frame.textContent(selector, options)`
+Gets the text content of an element in the frame.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.innerText(selector, options)`
+Gets the rendered inner text of an element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.innerHTML(selector, options)`
+Gets the inner HTML of an element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.getAttribute(selector, name, options)`
+Gets a DOM attribute of an element in the frame.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.inputValue(selector, options)`
+Gets the input value of a form element in the frame.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isChecked(selector, options)`
+Returns whether a checkbox or radio is checked in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isDisabled(selector, options)`
+Returns whether an element is disabled in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isEditable(selector, options)`
+Returns whether an element is editable in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isEnabled(selector, options)`
+Returns whether an element is enabled in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isHidden(selector, options)`
+Returns whether an element is hidden in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.isVisible(selector, options)`
+Returns whether an element is visible in the frame.
+**Returns:** `Promise<boolean>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### Waiting & Overrides
+
+### `Frame.waitForFunction(pageFunction, arg, options)`
+Waits for a function to evaluate to a truthy value inside the frame.
+**Returns:** `Promise<JSHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForLoadState(state, options)`
+Waits for the frame to reach a specific load state.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForNavigation(options)`
+**@deprecated** (Use `waitForURL` instead). Waits for the frame to navigate.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForSelector(selector, options)`
+Waits for a selector to appear or disappear inside the frame.
+**Returns:** `Promise<ElementHandle | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForTimeout(timeout)`
+**@deprecated** (Use `page.waitForTimeout` for debugging only). Waits for a timeout.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.waitForURL(url, options)`
+Waits for the frame to navigate to the given URL.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.addScriptTag(options)`
+Adds a `<script>` tag to the frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+### `Frame.addStyleTag(options)`
+Adds a `<link rel="stylesheet">` or `<style>` tag to the frame.
+**Returns:** `Promise<ElementHandle>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/frame.ts`)
+
+---
+
+## Route
+
+The `Route` class represents an intercepted network request.
+
+### Methods
+
+### `Route.request()`
+Returns the intercepted request.
+**Returns:** `Request`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.abort(errorCode)`
+Aborts the route's request.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.continue(options)`
+Sends the route's request to the network with optional overrides.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fallback(options)`
+Continues the request, allowing subsequent matching handlers in the routing chain to be invoked.
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fetch(options)`
+Performs the request and fetches the response without fulfilling it immediately.
+**Returns:** `Promise<APIResponse>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Route.fulfill(options)`
+Fulfills the route's request with a given response (e.g. mocking a 200 OK with custom body).
+**Returns:** `Promise<void>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## Request
+
+The `Request` class represents an HTTP request sent by a page.
+
+### Methods
+
+### `Request.url()`
+Returns the URL of the request.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.resourceType()`
+Returns the resource type (e.g., `document`, `image`, `fetch`).
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.method()`
+Returns the HTTP method of the request.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postData()`
+Returns the request's post body, if any, as a string.
+**Returns:** `string | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postDataBuffer()`
+Returns the request's post body, if any, as a raw Buffer.
+**Returns:** `Buffer | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.postDataJSON()`
+Returns the parsed JSON of the request's post body, if any.
+**Returns:** `Object | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headers()`
+Returns an object containing the HTTP headers associated with the request.
+**Returns:** `{ [key: string]: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.allHeaders()`
+Returns a promise that resolves to an object with all HTTP headers.
+**Returns:** `Promise<{ [key: string]: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headersArray()`
+Returns a promise that resolves to an array of header objects (`{ name, value }`).
+**Returns:** `Promise<{ name: string, value: string }[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.headerValue(name)`
+Returns the value of the specified header.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.response()`
+Returns the matching `Response` object, or `null` if the request failed.
+**Returns:** `Promise<Response | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.frame()`
+Returns the `Frame` that initiated this request.
+**Returns:** `Frame`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.serviceWorker()`
+Returns the service worker that initiated this request, if any.
+**Returns:** `Worker | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.isNavigationRequest()`
+Returns `true` if the request is a main document navigation request.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.redirectedFrom()`
+Returns the request that was redirected to this request, if any.
+**Returns:** `Request | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.redirectedTo()`
+Returns the request this request was redirected to, if any.
+**Returns:** `Request | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.failure()`
+Returns the failure message if the request failed.
+**Returns:** `{ errorText: string } | null`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.timing()`
+Returns resource timing information for the request.
+**Returns:** `ResourceTiming`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Request.sizes()`
+Returns resource size information (e.g. body size, header size).
+**Returns:** `Promise<{ requestBodySize: number, requestHeadersSize: number, responseBodySize: number, responseHeadersSize: number }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+---
+
+## Response
+
+The `Response` class represents an HTTP response received by a page.
+
+### Methods
+
+### `Response.url()`
+Returns the URL of the response.
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.ok()`
+Returns `true` if the status code is between 200 and 299.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.status()`
+Returns the status code of the response (e.g., 200 for a success).
+**Returns:** `number`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.statusText()`
+Returns the status text of the response (e.g., "OK").
+**Returns:** `string`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.fromServiceWorker()`
+Returns `true` if this response was served from a Service Worker.
+**Returns:** `boolean`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headers()`
+Returns an object containing the HTTP headers associated with the response.
+**Returns:** `{ [key: string]: string }`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.allHeaders()`
+Returns a promise that resolves to an object with all HTTP headers.
+**Returns:** `Promise<{ [key: string]: string }>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headersArray()`
+Returns a promise that resolves to an array of header objects (`{ name, value }`).
+**Returns:** `Promise<{ name: string, value: string }[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headerValue(name)`
+Returns the value of the specified header.
+**Returns:** `Promise<string | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.headerValues(name)`
+Returns all values for the specified header.
+**Returns:** `Promise<string[]>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.finished()`
+Returns a promise that resolves when the response body finishes downloading.
+**Returns:** `Promise<Error | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.body()`
+Returns the raw body payload of the response as a Buffer.
+**Returns:** `Promise<Buffer>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.text()`
+Returns the text representation of the response body.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.json()`
+Returns the JSON representation of the response body.
+**Returns:** `Promise<object>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.request()`
+Returns the matching `Request` object.
+**Returns:** `Request`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.frame()`
+Returns the `Frame` that initiated this response.
+**Returns:** `Frame`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.serverAddr()`
+Returns the IP address and port of the server if available.
+**Returns:** `Promise<{ ipAddress: string, port: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.securityDetails()`
+Returns the security details if the response was received over a secure connection.
+**Returns:** `Promise<{ issuer?: string, protocol?: string, subjectName?: string, validFrom?: number, validTo?: number } | null>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)
+
+### `Response.httpVersion()`
+Returns the HTTP version of the response.
+**Returns:** `Promise<string>`
+**Source:** `packages/playwright-core/types/types.d.ts` (verified in `src/client/network.ts`)

--- a/agi-training-notes/tools/graphify-docs.mjs
+++ b/agi-training-notes/tools/graphify-docs.mjs
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(process.argv[2] || path.join(import.meta.dirname, '..'));
+const out = path.resolve(process.argv[3] || path.join(root, 'DOC_GRAPH.json'));
+const nodes = [];
+const edges = [];
+const nodeIds = new Set();
+const edgeIds = new Set();
+const sourceDocuments = [];
+
+function addNode(id, type, data = {}) {
+  if (nodeIds.has(id)) return;
+  nodeIds.add(id);
+  nodes.push({ id, type, ...data });
+}
+function addEdge(from, relation, to) {
+  const id = `${from}|${relation}|${to}`;
+  if (edgeIds.has(id)) return;
+  edgeIds.add(id);
+  edges.push({ from, relation, to });
+}
+function words(text) {
+  return new Set(text.toLowerCase().match(/[a-z][a-z0-9-]{2,}/g) || []);
+}
+function parseProvenance(content) {
+  const commit = content.match(/Source Commit:\s*`([a-f0-9]+)`/)?.[1];
+  const commitDate = content.match(/Commit Date:\s*`([^`]+)`/)?.[1];
+  return { commit, commitDate };
+}
+
+for (const file of ['NOTES.md', 'API_REFERENCE.md']) {
+  const full = path.join(root, file);
+  const content = fs.readFileSync(full, 'utf8');
+  const { commit, commitDate } = parseProvenance(content);
+  sourceDocuments.push({ file, commit, commit_date: commitDate });
+  const doc = `doc:${file}`;
+  addNode(doc, 'document', { file, commit, commit_date: commitDate });
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    const match = line.match(/^(#{1,4})\s+(.+?)\s*$/);
+    if (!match) return;
+    const section = `doc:${file}#${index + 1}`;
+    addNode(section, 'section', { title: match[2], file, line: index + 1, commit, commit_date: commitDate });
+    addEdge(doc, 'contains', section);
+    for (const word of words(match[2])) {
+      const topic = `topic:${word}`;
+      addNode(topic, 'topic', { name: word });
+      addEdge(section, 'about', topic);
+    }
+  });
+}
+
+const examples = path.join(root, 'examples');
+sourceDocuments.push({ file: 'examples/*.js' });
+for (const file of fs.readdirSync(examples).filter(name => name.endsWith('.js')).sort()) {
+  const title = file.replace(/\.js$/, '').replace(/^\d+-/, '').replace(/-/g, ' ');
+  const example = `example:${file}`;
+  addNode(example, 'example', { file: `examples/${file}`, title });
+  for (const word of words(title)) {
+    const topic = `topic:${word}`;
+    addNode(topic, 'topic', { name: word });
+    addEdge(example, 'illustrates', topic);
+  }
+}
+
+const pinnedCommits = [...new Set(sourceDocuments.map(doc => doc.commit).filter(Boolean))];
+const pinnedCommitDates = [...new Set(sourceDocuments.map(doc => doc.commit_date).filter(Boolean))];
+
+const graph = {
+  schema: 2,
+  generated_at: new Date().toISOString(),
+  pinned_commit: pinnedCommits.length === 1 ? pinnedCommits[0] : null,
+  pinned_commit_date: pinnedCommitDates.length === 1 ? pinnedCommitDates[0] : null,
+  source: 'NOTES.md, API_REFERENCE.md, examples/*.js',
+  source_documents: sourceDocuments,
+  nodes,
+  edges,
+};
+fs.writeFileSync(out, `${JSON.stringify(graph, null, 2)}\n`);
+console.log(JSON.stringify({ out, nodes: nodes.length, edges: edges.length }));

--- a/agi-training-notes/tools/query-doc-graph.mjs
+++ b/agi-training-notes/tools/query-doc-graph.mjs
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(process.argv[2] || path.join(import.meta.dirname, '..'));
+const query = process.argv.slice(3).join(' ').toLowerCase().trim();
+if (!query) throw new Error('usage: node tools/query-doc-graph.mjs <notes-dir> <topic words>');
+const graph = JSON.parse(fs.readFileSync(path.join(root, 'DOC_GRAPH.json'), 'utf8'));
+const terms = query.split(/\s+/);
+const topics = graph.nodes.filter(n => n.type === 'topic' && terms.some(t => n.name.includes(t)));
+const topicIds = new Set(topics.map(n => n.id));
+const refs = graph.edges.filter(e => topicIds.has(e.to)).map(e => e.from);
+const selected = graph.nodes.filter(n => refs.includes(n.id));
+console.log(JSON.stringify({ query, topics, references: selected }, null, 2));

--- a/doc-graph/README.md
+++ b/doc-graph/README.md
@@ -1,0 +1,144 @@
+# doc-graph
+
+A model-independent documentation graph indexer and retrieval service.
+
+`doc-graph` turns a project's Markdown documentation and runnable examples into a
+compact, rebuildable routing graph (`DOC_GRAPH.json` by default), then exposes
+ranked search and bounded source-excerpt retrieval through a CLI and a small HTTP
+API. It never invokes a model: it only selects and returns grounded source
+references that an external model can be prompted with.
+
+## Concepts
+
+| Node type | Purpose |
+| --- | --- |
+| `document` | A source document (e.g. `NOTES.md`). |
+| `section`  | A heading with its source file and exact line number. |
+| `topic`    | A keyword used to route queries. |
+| `example`  | A runnable example file and its title. |
+
+| Edge | Meaning |
+| --- | --- |
+| `document → contains → section` | A document contains a section. |
+| `section → about → topic` | A section is relevant to a topic. |
+| `example → illustrates → topic` | An example demonstrates a topic. |
+
+The graph records a schema version, a generation timestamp, per-document
+provenance (source commit and date when present), and source line references.
+
+## Install
+
+The package is dependency-free (Node.js built-ins only) and works from a clean
+checkout:
+
+```sh
+npm install          # nothing extra needed
+node doc-graph/bin/doc-graph.mjs --help
+```
+
+To expose the `doc-graph` command on your PATH:
+
+```sh
+npm link             # from within doc-graph/, or
+npm install -g .
+```
+
+## Configuration
+
+A project opts in by adding a `doc-graph.config.json` (or `.mjs`) to its root:
+
+```json
+{
+  "project": "playwright",
+  "documents": ["NOTES.md", "API_REFERENCE.md"],
+  "examples": ["examples/*.js"],
+  "output": "DOC_GRAPH.json",
+  "excerptLines": 80,
+  "maxExcerptLines": 200
+}
+```
+
+- `project` — name recorded in the graph (defaults to the directory name).
+- `documents` — glob(s) of source documents to index.
+- `examples` — glob(s) of runnable example files.
+- `output` — where to write the graph artifact (kept separate from source docs).
+- `provenance` — optional `{ "commitPattern", "datePattern" }` regexes used to
+  read provenance from document text.
+
+## CLI
+
+```sh
+# Build the graph for the current directory.
+doc-graph build
+
+# Ranked, bounded references.
+doc-graph search "shadow dom"
+
+# Ranked references plus source excerpts, ready for a model prompt.
+doc-graph context "shadow dom"
+
+# Start the HTTP API.
+doc-graph serve --port 8080
+
+# Start the MCP stdio server for internal tools.
+doc-graph-mcp /path/to/project
+```
+
+All commands accept `--root <dir>`, `--config <path>`, `--project <name>`,
+`--output <path>`, and repeatable `--documents <glob>` / `--examples <glob>`.
+
+## HTTP API
+
+```text
+GET /search?q=<query>&limit=<n>    → ranked references (file, line, provenance)
+GET /context?q=<query>&limit=<n>   → references plus bounded source excerpts
+GET /health                        → { ok, project }
+```
+
+## MCP
+
+`doc-graph-mcp` exposes the same read-only retrieval surface over MCP stdio.
+The server implements `initialize`, `tools/list`, `tools/call`, and `ping`.
+Internal tools can launch it as a subprocess; all protocol traffic stays on
+stdout and diagnostics should be handled by the parent process.
+
+Available tools:
+
+- `doc_graph_search` — ranked documentation and example references.
+- `doc_graph_context` — ranked references with bounded source excerpts.
+
+Example client configuration:
+
+```json
+{
+  "mcpServers": {
+    "project-docs": {
+      "command": "doc-graph-mcp",
+      "args": ["/path/to/project"]
+    }
+  }
+}
+```
+
+## Library
+
+```js
+import { buildGraph, loadGraph, search, retrieveContext } from 'doc-graph';
+
+const result = buildGraph('/path/to/project', {
+  project: 'example',
+  documents: ['NOTES.md'],
+  examples: ['examples/*.js'],
+  output: 'DOC_GRAPH.json',
+});
+
+const graph = loadGraph('/path/to/project', 'DOC_GRAPH.json');
+const refs = search(graph, 'shadow dom', { limit: 20 });
+const context = retrieveContext(graph, 'shadow dom', { limit: 10, root: '/path/to/project' });
+```
+
+## Tests
+
+```sh
+node --test doc-graph/test/
+```

--- a/doc-graph/bin/doc-graph-mcp.mjs
+++ b/doc-graph/bin/doc-graph-mcp.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { loadConfig, resolveConfig } from '../src/config.mjs';
+import { runMcpServer } from '../src/mcp.mjs';
+
+const root = path.resolve(process.argv[2] ?? process.cwd());
+const { config: fileConfig } = await loadConfig(root);
+const config = resolveConfig(root, fileConfig);
+runMcpServer({ root, config });

--- a/doc-graph/bin/doc-graph.mjs
+++ b/doc-graph/bin/doc-graph.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { runCli } from '../src/cli.mjs';
+
+try {
+  const code = await runCli();
+  if (code === 'serving') {
+    await new Promise(() => {});
+  } else if (typeof code === 'number' && code !== 0) {
+    process.exitCode = code;
+  }
+} catch (err) {
+  process.stderr.write(`${err?.message ?? err}\n`);
+  process.exitCode = 1;
+}

--- a/doc-graph/package.json
+++ b/doc-graph/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "doc-graph",
+  "version": "0.1.0",
+  "description": "Model-independent documentation graph indexer and retrieval service.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "doc-graph": "./bin/doc-graph.mjs",
+    "doc-graph-mcp": "./bin/doc-graph-mcp.mjs"
+  },
+  "exports": {
+    ".": "./src/index.mjs",
+    "./mcp": "./src/mcp.mjs",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test \"test/*.test.mjs\""
+  }
+}

--- a/doc-graph/src/cli.mjs
+++ b/doc-graph/src/cli.mjs
@@ -1,0 +1,137 @@
+import path from 'node:path';
+import { DEFAULT_CONFIG, loadConfig, resolveConfig, mergeConfig } from './config.mjs';
+import { buildGraph, loadGraph } from './indexer.mjs';
+import { search, retrieveContext } from './query.mjs';
+import { createServer } from './server.mjs';
+
+const HELP = `doc-graph — model-independent documentation graph indexer and retrieval
+
+Usage:
+  doc-graph build   [options]
+  doc-graph search  <query> [options]
+  doc-graph context <query> [options]
+  doc-graph serve   [options]
+
+Commands:
+  build     Index documents and examples, writing the graph artifact.
+  search    Ranked, bounded references for a query.
+  context   Ranked references plus source excerpts for prompting a model.
+  serve     Start an HTTP API with /search and /context endpoints.
+
+Common options:
+  --root <dir>            Project root directory (default: cwd).
+  --config <path>         Config file (doc-graph.config.json or .mjs).
+  --project <name>        Project name recorded in the graph.
+  --output <path>         Graph artifact output path (default: DOC_GRAPH.json).
+  --documents <glob>      Document glob; may be repeated.
+  --examples <glob>       Example glob; may be repeated.
+  --limit <n>             Max references to return.
+  --port <n>              HTTP port for serve (default: 8080).
+  --help, -h              Show this help.
+`;
+
+function parseArgs(argv) {
+  const args = { _: [], options: {} };
+  const flagNames = new Set(['root', 'config', 'project', 'output', 'documents', 'document', 'examples', 'example', 'limit', 'port', 'help', 'h']);
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      if (!flagNames.has(key))
+        throw new Error(`Unknown option: ${arg}`);
+      if (key === 'help') {
+        args.options.help = true;
+        continue;
+      }
+      const value = argv[i + 1];
+      if (value === undefined)
+        throw new Error(`Missing value for ${arg}`);
+      if (key === 'documents' || key === 'document' || key === 'examples' || key === 'example') {
+        (args.options[key] ??= []).push(value);
+      } else {
+        args.options[key] = value;
+      }
+      i++;
+      continue;
+    }
+    args._.push(arg);
+  }
+  return args;
+}
+
+function applyCliOverrides(config, options) {
+  const overrides = {};
+  if (options.project !== undefined)
+    overrides.project = options.project;
+  if (options.output !== undefined)
+    overrides.output = options.output;
+  if (options.documents !== undefined)
+    overrides.documents = [...(options.documents ?? []), ...(options.document ?? [])];
+  else if (options.document !== undefined)
+    overrides.documents = options.document;
+  if (options.examples !== undefined)
+    overrides.examples = [...(options.examples ?? []), ...(options.example ?? [])];
+  else if (options.example !== undefined)
+    overrides.examples = options.example;
+  return mergeConfig(config, overrides);
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.options.help || args._.length === 0) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  const command = args._[0];
+  const rest = args._.slice(1);
+  const root = path.resolve(args.options.root ?? process.cwd());
+  const { config: fileConfig } = await loadConfig(root, args.options.config);
+  const config = resolveConfig(root, fileConfig, applyCliOverrides(fileConfig ?? DEFAULT_CONFIG, args.options));
+
+  switch (command) {
+    case 'build': {
+      const result = buildGraph(root, config);
+      process.stdout.write(`${JSON.stringify({ output: result.output, stats: result.stats }, null, 2)}\n`);
+      return 0;
+    }
+    case 'search': {
+      const query = rest.join(' ').trim();
+      if (!query)
+        throw new Error('search requires a query');
+      const graph = loadGraph(root, config.output);
+      const result = search(graph, query, args.options.limit ? { limit: Number(args.options.limit) } : {});
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+    case 'context': {
+      const query = rest.join(' ').trim();
+      if (!query)
+        throw new Error('context requires a query');
+      const graph = loadGraph(root, config.output);
+      const result = retrieveContext(graph, query, {
+        limit: args.options.limit ? Number(args.options.limit) : 10,
+        excerptLines: config.excerptLines,
+        maxExcerptLines: config.maxExcerptLines,
+        root,
+      });
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return 0;
+    }
+    case 'serve': {
+      const port = Number(args.options.port ?? 8080);
+      const server = createServer({ root, config, graphPath: config.output });
+      await new Promise(resolve => server.listen(port, resolve));
+      process.stdout.write(`doc-graph serving ${config.project} on http://localhost:${port}\n`);
+      process.stdout.write('  GET /search?q=<query>&limit=<n>\n');
+      process.stdout.write('  GET /context?q=<query>&limit=<n>\n');
+      return 'serving';
+    }
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}

--- a/doc-graph/src/config.mjs
+++ b/doc-graph/src/config.mjs
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_CONFIG = {
+  project: null,
+  documents: ['NOTES.md', 'API_REFERENCE.md'],
+  examples: ['examples/*.js'],
+  output: 'DOC_GRAPH.json',
+  excerptLines: 80,
+  maxExcerptLines: 200,
+  provenance: {
+    commitPattern: 'Source Commit:\\s*`([a-f0-9]+)`',
+    datePattern: 'Commit Date:\\s*`([^`]+)`',
+  },
+};
+
+export function defaultProjectName(root, { basename = null, dirname = null } = {}) {
+  return basename ?? dirname ?? root;
+}
+
+export function mergeConfig(base, override) {
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(override ?? {})) {
+    if (value === undefined)
+      continue;
+    if (key === 'provenance' && value && typeof value === 'object') {
+      merged.provenance = { ...base.provenance, ...value };
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+export function findConfigFile(root, explicitPath = undefined) {
+  if (explicitPath) {
+    const full = path.isAbsolute(explicitPath) ? explicitPath : path.join(root, explicitPath);
+    if (!fs.existsSync(full))
+      throw new Error(`Config file not found: ${full}`);
+    return full;
+  }
+  for (const name of ['doc-graph.config.mjs', 'doc-graph.config.js', 'doc-graph.config.json']) {
+    const full = path.join(root, name);
+    if (fs.existsSync(full))
+      return full;
+  }
+  return null;
+}
+
+export async function loadConfig(root, explicitPath = undefined) {
+  const file = findConfigFile(root, explicitPath);
+  if (!file)
+    return { config: { ...DEFAULT_CONFIG }, file: null };
+  let raw;
+  if (file.endsWith('.json')) {
+    raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } else {
+    const mod = await import(pathToFileURL(file).href);
+    raw = mod.default ?? mod;
+  }
+  return { config: raw, file };
+}
+
+export function resolveConfig(root, configFile, overrides = {}) {
+  const base = { ...DEFAULT_CONFIG };
+  const fromFile = configFile ?? {};
+  const merged = mergeConfig(mergeConfig(base, fromFile), overrides);
+  const projectName = merged.project ?? path.basename(path.resolve(root));
+  return { ...merged, project: projectName };
+}
+

--- a/doc-graph/src/errors.mjs
+++ b/doc-graph/src/errors.mjs
@@ -1,0 +1,8 @@
+export class DocGraphError extends Error {
+  constructor(message, details = undefined) {
+    super(message);
+    this.name = 'DocGraphError';
+    if (details !== undefined)
+      this.details = details;
+  }
+}

--- a/doc-graph/src/glob.mjs
+++ b/doc-graph/src/glob.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.hg', '.svn']);
+
+function isHidden(name) {
+  return name.startsWith('.');
+}
+
+function listEntries(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries.filter(entry => !isHidden(entry.name) && !SKIP_DIRS.has(entry.name));
+}
+
+function segmentToRegex(segment) {
+  let out = '^';
+  for (const ch of segment) {
+    if (ch === '*')
+      out += '[^/]*';
+    else if (ch === '?')
+      out += '[^/]';
+    else
+      out += ch.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp(`${out}$`);
+}
+
+function collectFiles(dir, results) {
+  for (const entry of listEntries(dir)) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory())
+      collectFiles(full, results);
+    else if (entry.isFile())
+      results.push(full);
+  }
+}
+
+function walk(dir, segments, index, results, root) {
+  if (index >= segments.length)
+    return;
+  const segment = segments[index];
+  if (segment === '**') {
+    if (index === segments.length - 1) {
+      collectFiles(dir, results);
+      return;
+    }
+    // Match zero directories.
+    walk(dir, segments, index + 1, results, root);
+    // Match one or more directories.
+    for (const entry of listEntries(dir)) {
+      if (entry.isDirectory())
+        walk(path.join(dir, entry.name), segments, index, results, root);
+    }
+    return;
+  }
+
+  const regex = segmentToRegex(segment);
+  const isLast = index === segments.length - 1;
+  for (const entry of listEntries(dir)) {
+    if (!regex.test(entry.name))
+      continue;
+    const full = path.join(dir, entry.name);
+    if (isLast) {
+      if (entry.isFile())
+        results.push(full);
+    } else if (entry.isDirectory()) {
+      walk(full, segments, index + 1, results, root);
+    }
+  }
+}
+
+export function glob(pattern, root) {
+  const normalized = pattern.replace(/\\/g, '/').replace(/^\.\//, '');
+  const segments = normalized.split('/').filter(Boolean);
+  if (segments.length === 0)
+    return [];
+  const results = [];
+  walk(path.resolve(root), segments, 0, results, root);
+  const rel = results
+    .map(full => path.relative(root, full).split(path.sep).join('/'))
+    .filter(p => !p.startsWith('..'));
+  return [...new Set(rel)].sort();
+}
+
+export function hasMagic(pattern) {
+  return /[*?]/.test(pattern);
+}

--- a/doc-graph/src/index.mjs
+++ b/doc-graph/src/index.mjs
@@ -1,0 +1,10 @@
+export { SCHEMA_VERSION } from './schema.mjs';
+export { DocGraphError } from './errors.mjs';
+export { glob, hasMagic } from './glob.mjs';
+export { DEFAULT_CONFIG, loadConfig, resolveConfig, findConfigFile, mergeConfig } from './config.mjs';
+export { extractProvenance, readDocument } from './provenance.mjs';
+export { buildGraph, loadGraph, expandGlobs } from './indexer.mjs';
+export { search, retrieveContext, matchTopics } from './query.mjs';
+export { createServer } from './server.mjs';
+export { MCP_TOOLS, createMcpHandler, runMcpServer } from './mcp.mjs';
+export { runCli } from './cli.mjs';

--- a/doc-graph/src/indexer.mjs
+++ b/doc-graph/src/indexer.mjs
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { SCHEMA_VERSION } from './schema.mjs';
+import { DocGraphError } from './errors.mjs';
+import { glob, hasMagic } from './glob.mjs';
+import { extractProvenance, readDocument } from './provenance.mjs';
+
+function words(text) {
+  return new Set((text.toLowerCase().match(/[a-z][a-z0-9-]{2,}/g) || []));
+}
+
+function exampleTitle(file) {
+  const name = path.posix.basename(file).replace(/\.[^.]+$/, '');
+  return name.replace(/^\d+-/, '').replace(/[-_]/g, ' ');
+}
+
+export function expandGlobs(patterns, root, { allowEmpty = false } = {}) {
+  const list = Array.isArray(patterns) ? patterns : [patterns];
+  const files = new Set();
+  const missing = [];
+  for (const pattern of list) {
+    if (!pattern)
+      continue;
+    if (hasMagic(pattern)) {
+      const matches = glob(pattern, root);
+      if (matches.length === 0 && !allowEmpty)
+        missing.push(pattern);
+      for (const match of matches)
+        files.add(match);
+    } else {
+      const full = path.isAbsolute(pattern) ? pattern : path.join(root, pattern);
+      if (!fs.existsSync(full)) {
+        if (!allowEmpty)
+          missing.push(pattern);
+        continue;
+      }
+      const rel = path.relative(root, full).split(path.sep).join('/');
+      files.add(rel.startsWith('..') ? full : rel);
+    }
+  }
+  return { files: [...files].sort(), missing };
+}
+
+export function buildGraph(root, config) {
+  const documentsResult = expandGlobs(config.documents, root);
+  if (documentsResult.missing.length)
+    throw new DocGraphError(`No documents matched: ${documentsResult.missing.join(', ')}`, { missing: documentsResult.missing });
+
+  const examplesResult = expandGlobs(config.examples, root, { allowEmpty: true });
+
+  const nodes = [];
+  const edges = [];
+  const nodeIds = new Set();
+  const edgeIds = new Set();
+  const sourceDocuments = [];
+
+  const addNode = (id, type, data = {}) => {
+    if (nodeIds.has(id))
+      return;
+    nodeIds.add(id);
+    nodes.push({ id, type, ...data });
+  };
+  const addEdge = (from, relation, to) => {
+    const id = `${from}|${relation}|${to}`;
+    if (edgeIds.has(id))
+      return;
+    edgeIds.add(id);
+    edges.push({ from, relation, to });
+  };
+
+  for (const file of documentsResult.files) {
+    const { content } = readDocument(file, root);
+    const provenance = extractProvenance(content, config);
+    sourceDocuments.push({ file, ...provenance });
+    const docId = `doc:${file}`;
+    addNode(docId, 'document', { file, ...provenance });
+    const lines = content.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const match = line.match(/^(#{1,4})\s+(.+?)\s*$/);
+      if (!match)
+        return;
+      const sectionId = `doc:${file}#${index + 1}`;
+      addNode(sectionId, 'section', { title: match[2], file, line: index + 1, ...provenance });
+      addEdge(docId, 'contains', sectionId);
+      for (const word of words(match[2])) {
+        const topicId = `topic:${word}`;
+        addNode(topicId, 'topic', { name: word });
+        addEdge(sectionId, 'about', topicId);
+      }
+    });
+  }
+
+  for (const file of examplesResult.files) {
+    const exampleId = `example:${file}`;
+    addNode(exampleId, 'example', { file, title: exampleTitle(file) });
+    for (const word of words(exampleTitle(file))) {
+      const topicId = `topic:${word}`;
+      addNode(topicId, 'topic', { name: word });
+      addEdge(exampleId, 'illustrates', topicId);
+    }
+  }
+
+  const pinnedCommits = [...new Set(sourceDocuments.map(doc => doc.commit).filter(Boolean))];
+  const pinnedCommitDates = [...new Set(sourceDocuments.map(doc => doc.commit_date).filter(Boolean))];
+
+  const graph = {
+    schema: SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    project: config.project,
+    pinned_commit: pinnedCommits.length === 1 ? pinnedCommits[0] : null,
+    pinned_commit_date: pinnedCommitDates.length === 1 ? pinnedCommitDates[0] : null,
+    source: [config.documents, config.examples].flat().join(', '),
+    source_documents: sourceDocuments,
+    source_examples: examplesResult.files,
+    nodes,
+    edges,
+  };
+
+  const outputPath = path.isAbsolute(config.output) ? config.output : path.join(root, config.output);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(graph, null, 2)}\n`);
+
+  return {
+    graph,
+    output: outputPath,
+    stats: {
+      documents: documentsResult.files.length,
+      examples: examplesResult.files.length,
+      nodes: nodes.length,
+      edges: edges.length,
+      topics: nodes.filter(n => n.type === 'topic').length,
+      sections: nodes.filter(n => n.type === 'section').length,
+    },
+  };
+}
+
+export function loadGraph(root, output) {
+  const outputPath = path.isAbsolute(output) ? output : path.join(root, output);
+  if (!fs.existsSync(outputPath))
+    throw new DocGraphError(`Graph not found: ${outputPath}. Run \`doc-graph build\` first.`);
+  return JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+}

--- a/doc-graph/src/mcp.mjs
+++ b/doc-graph/src/mcp.mjs
@@ -1,0 +1,95 @@
+import readline from 'node:readline';
+import { loadGraph } from './indexer.mjs';
+import { search, retrieveContext } from './query.mjs';
+
+const PROTOCOL_VERSION = '2025-06-18';
+
+export const MCP_TOOLS = [
+  {
+    name: 'doc_graph_search',
+    description: 'Search indexed project documentation and examples for relevant references.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Documentation question or keywords.' },
+        limit: { type: 'integer', minimum: 1, maximum: 100, description: 'Maximum references to return.' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'doc_graph_context',
+    description: 'Retrieve ranked documentation references with bounded source excerpts.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Documentation question or keywords.' },
+        limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum references to return.' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+  },
+];
+
+const rpcResponse = (id, result) => ({ jsonrpc: '2.0', id, result });
+const rpcError = (id, code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
+const toolResult = value => ({
+  content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+  structuredContent: value,
+});
+
+export function createMcpHandler({ root, config, graphPath }) {
+  const output = graphPath ?? config.output;
+  return async message => {
+    if (!message || message.jsonrpc !== '2.0' || message.id === undefined)
+      return null;
+    if (message.method === 'initialize')
+      return rpcResponse(message.id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: 'doc-graph', version: '0.1.0' },
+      });
+    if (message.method === 'ping') return rpcResponse(message.id, {});
+    if (message.method === 'tools/list') return rpcResponse(message.id, { tools: MCP_TOOLS });
+    if (message.method !== 'tools/call') return rpcError(message.id, -32601, `Method not found: ${message.method}`);
+
+    const name = message.params?.name;
+    const args = message.params?.arguments ?? {};
+    if (!MCP_TOOLS.some(tool => tool.name === name)) return rpcError(message.id, -32602, `Unknown tool: ${name}`);
+    if (typeof args.query !== 'string' || !args.query.trim()) return rpcError(message.id, -32602, 'The "query" argument is required.');
+    const limit = args.limit === undefined ? undefined : Number(args.limit);
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100))
+      return rpcError(message.id, -32602, 'The "limit" argument must be an integer between 1 and 100.');
+
+    try {
+      const graph = loadGraph(root, output);
+      const value = name === 'doc_graph_search'
+        ? search(graph, args.query.trim(), limit ? { limit } : {})
+        : retrieveContext(graph, args.query.trim(), {
+          limit: limit ?? 10,
+          excerptLines: config.excerptLines,
+          maxExcerptLines: config.maxExcerptLines,
+          root,
+        });
+      return rpcResponse(message.id, toolResult(value));
+    } catch (err) {
+      return rpcResponse(message.id, { ...toolResult({ error: err.message }), isError: true });
+    }
+  };
+}
+
+export function runMcpServer({ root, config, graphPath, input = process.stdin, output = process.stdout } = {}) {
+  const handle = createMcpHandler({ root, config, graphPath });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  rl.on('line', async line => {
+    if (!line.trim()) return;
+    let message;
+    try { message = JSON.parse(line); }
+    catch { output.write(`${JSON.stringify(rpcError(null, -32700, 'Invalid JSON'))}\n`); return; }
+    const result = await handle(message);
+    if (result) output.write(`${JSON.stringify(result)}\n`);
+  });
+  return rl;
+}

--- a/doc-graph/src/provenance.mjs
+++ b/doc-graph/src/provenance.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function extractProvenance(content, config = {}) {
+  const prov = config?.provenance ?? {};
+  const commitPattern = prov.commitPattern ?? 'Source Commit:\\s*`([a-f0-9]+)`';
+  const datePattern = prov.datePattern ?? 'Commit Date:\\s*`([^`]+)`';
+
+  const commitMatch = content.match(new RegExp(commitPattern, 'i'));
+  const dateMatch = content.match(new RegExp(datePattern, 'i'));
+
+  const result = {};
+  if (commitMatch)
+    result.commit = commitMatch[1];
+  if (dateMatch)
+    result.commit_date = dateMatch[1];
+  return result;
+}
+
+export function readDocument(file, root) {
+  const full = path.isAbsolute(file) ? file : path.join(root, file);
+  const content = fs.readFileSync(full, 'utf8');
+  return { full, content };
+}

--- a/doc-graph/src/query.mjs
+++ b/doc-graph/src/query.mjs
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function tokenize(query) {
+  return [...new Set(query.toLowerCase().trim().split(/\s+/).filter(Boolean))];
+}
+
+export function matchTopics(graph, terms) {
+  const topics = [];
+  const topicTerms = new Map();
+  for (const node of graph.nodes) {
+    if (node.type !== 'topic')
+      continue;
+    const matched = [];
+    for (const term of terms) {
+      if (node.name === term)
+        matched.push({ term, exact: true });
+      else if (node.name.includes(term))
+        matched.push({ term, exact: false });
+    }
+    if (matched.length) {
+      topics.push(node);
+      topicTerms.set(node.id, matched);
+    }
+  }
+  return { topics, topicTerms };
+}
+
+function referenceScore(node, matchedTerms) {
+  let score = 0;
+  const exact = matchedTerms.filter(m => m.exact);
+  score += exact.length * 2;
+  score += matchedTerms.length - exact.length;
+  if (node.title) {
+    const title = node.title.toLowerCase();
+    for (const term of matchedTerms.map(m => m.term)) {
+      if (title.includes(term))
+        score += 1;
+    }
+  }
+  return score;
+}
+
+export function search(graph, query, { limit = 20 } = {}) {
+  const terms = tokenize(query);
+  if (!terms.length)
+    return { query, terms: [], topics: [], references: [], total: 0 };
+
+  const { topics, topicTerms } = matchTopics(graph, terms);
+  const topicIds = new Set(topics.map(n => n.id));
+
+  const refMatches = new Map();
+  for (const edge of graph.edges) {
+    if (!topicIds.has(edge.to))
+      continue;
+    const termsForTopic = topicTerms.get(edge.to);
+    const entry = refMatches.get(edge.from) ?? { node: null, matched: new Map() };
+    const node = graph.nodes.find(n => n.id === edge.from);
+    if (!node)
+      continue;
+    entry.node = node;
+    for (const m of termsForTopic) {
+      const prev = entry.matched.get(m.term);
+      if (!prev || (m.exact && !prev.exact))
+        entry.matched.set(m.term, m);
+    }
+    refMatches.set(edge.from, entry);
+  }
+
+  const references = [...refMatches.values()]
+    .filter(entry => entry.node)
+    .map(entry => {
+      const matchedTerms = [...entry.matched.values()];
+      return {
+        id: entry.node.id,
+        type: entry.node.type,
+        file: entry.node.file,
+        line: entry.node.line ?? null,
+        title: entry.node.title ?? null,
+        commit: entry.node.commit ?? null,
+        commit_date: entry.node.commit_date ?? null,
+        score: referenceScore(entry.node, matchedTerms),
+        matched: matchedTerms.map(m => m.term).sort(),
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.type.localeCompare(b.type) || (a.title ?? '').localeCompare(b.title ?? ''));
+
+  const bounded = references.slice(0, limit);
+  return { query, terms, topics, references: bounded, total: references.length };
+}
+
+function readFileLines(root, file) {
+  const full = path.isAbsolute(file) ? file : path.join(root, file);
+  if (!fs.existsSync(full))
+    return null;
+  return fs.readFileSync(full, 'utf8').split(/\r?\n/);
+}
+
+function sectionExcerpt(lines, line, excerptLines) {
+  const start = Math.max(0, line - 1);
+  let end = Math.min(lines.length, start + excerptLines);
+  for (let i = start; i < end && i < lines.length; i++) {
+    if (i !== start && /^#{1,4}\s+/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return {
+    excerpt: lines.slice(start, end).join('\n'),
+    excerptStart: start + 1,
+    excerptEnd: end,
+  };
+}
+
+function exampleExcerpt(lines, maxExcerptLines) {
+  if (lines.length <= maxExcerptLines) {
+    return {
+      excerpt: lines.join('\n'),
+      excerptStart: 1,
+      excerptEnd: lines.length,
+    };
+  }
+  const head = lines.slice(0, maxExcerptLines);
+  return {
+    excerpt: `${head.join('\n')}\n... (${lines.length} lines total, truncated)`,
+    excerptStart: 1,
+    excerptEnd: maxExcerptLines,
+  };
+}
+
+export function retrieveContext(graph, query, { limit = 10, excerptLines = 80, maxExcerptLines = 200, root = process.cwd() } = {}) {
+  const { references } = search(graph, query, { limit });
+  const enriched = references.map(ref => {
+    const lines = readFileLines(root, ref.file);
+    if (lines === null) {
+      return { ...ref, excerpt: null, missing: true };
+    }
+    if (ref.type === 'section') {
+      const { excerpt, excerptStart, excerptEnd } = sectionExcerpt(lines, ref.line, excerptLines);
+      return { ...ref, excerpt, excerptStart, excerptEnd };
+    }
+    const { excerpt, excerptStart, excerptEnd } = exampleExcerpt(lines, maxExcerptLines);
+    return { ...ref, excerpt, excerptStart, excerptEnd };
+  });
+  return { query, references: enriched, total: references.length };
+}

--- a/doc-graph/src/schema.mjs
+++ b/doc-graph/src/schema.mjs
@@ -1,0 +1,1 @@
+export const SCHEMA_VERSION = 2;

--- a/doc-graph/src/server.mjs
+++ b/doc-graph/src/server.mjs
@@ -1,0 +1,63 @@
+import http from 'node:http';
+import { loadGraph } from './indexer.mjs';
+import { search, retrieveContext } from './query.mjs';
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload, null, 2);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+export function createServer({ root, config, graphPath }) {
+  const output = graphPath ?? config.output;
+  return http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const route = url.pathname;
+
+    if (route === '/health') {
+      sendJson(res, 200, { ok: true, project: config.project });
+      return;
+    }
+
+    if (route !== '/search' && route !== '/context') {
+      sendJson(res, 404, { error: 'Not found', endpoints: ['/search', '/context', '/health'] });
+      return;
+    }
+
+    const q = url.searchParams.get('q')?.trim() ?? '';
+    if (!q) {
+      sendJson(res, 400, { error: 'Missing required query parameter "q"' });
+      return;
+    }
+    const limitParam = url.searchParams.get('limit');
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+
+    let graph;
+    try {
+      graph = loadGraph(root, output);
+    } catch (err) {
+      sendJson(res, 500, { error: err.message });
+      return;
+    }
+
+    try {
+      if (route === '/search') {
+        const result = search(graph, q, limit ? { limit } : {});
+        sendJson(res, 200, result);
+      } else {
+        const result = retrieveContext(graph, q, {
+          limit: limit ?? 10,
+          excerptLines: config.excerptLines,
+          maxExcerptLines: config.maxExcerptLines,
+          root,
+        });
+        sendJson(res, 200, result);
+      }
+    } catch (err) {
+      sendJson(res, 500, { error: err.message });
+    }
+  });
+}

--- a/doc-graph/test/cli.test.mjs
+++ b/doc-graph/test/cli.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { writeProject, cleanup } from './helpers.mjs';
+
+const BIN = path.resolve(import.meta.dirname, '..', 'bin', 'doc-graph.mjs');
+
+function run(args, cwd) {
+  return spawnSync(process.execPath, [BIN, ...args], { cwd, encoding: 'utf8' });
+}
+
+test('cli --help prints usage', () => {
+  const result = run(['--help'], process.cwd());
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /doc-graph/);
+  assert.match(result.stdout, /build/);
+  assert.match(result.stdout, /search/);
+  assert.match(result.stdout, /context/);
+});
+
+test('cli build writes the graph and reports stats', () => {
+  const root = writeProject();
+  try {
+    const result = run(['build'], root);
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(fs.existsSync(path.join(root, 'DOC_GRAPH.json')));
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.stats.documents, 2);
+    assert.equal(report.stats.examples, 3);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('cli search and context answer queries', () => {
+  const root = writeProject();
+  try {
+    assert.equal(run(['build'], root).status, 0);
+    const search = run(['search', 'browser', 'launch'], root);
+    assert.equal(search.status, 0, search.stderr);
+    const searchBody = JSON.parse(search.stdout);
+    assert.ok(searchBody.references.length > 0);
+
+    const context = run(['context', 'locator'], root);
+    assert.equal(context.status, 0, context.stderr);
+    const contextBody = JSON.parse(context.stdout);
+    assert.ok(contextBody.references.length > 0);
+    assert.ok(contextBody.references[0].excerpt.length > 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('cli search without a query fails cleanly', () => {
+  const root = writeProject();
+  try {
+    assert.equal(run(['build'], root).status, 0);
+    const result = run(['search'], root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /requires a query/);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/doc-graph/test/config.test.mjs
+++ b/doc-graph/test/config.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { loadConfig, resolveConfig, DEFAULT_CONFIG } from '../src/index.mjs';
+import { makeTempDir } from './helpers.mjs';
+
+test('loadConfig returns defaults when no config file exists', async () => {
+  const root = makeTempDir();
+  try {
+    const { config, file } = await loadConfig(root);
+    assert.equal(file, null);
+    assert.deepEqual(config, DEFAULT_CONFIG);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('loadConfig reads a JSON config file', async () => {
+  const root = makeTempDir();
+  try {
+    fs.writeFileSync(path.join(root, 'doc-graph.config.json'), JSON.stringify({
+      project: 'custom',
+      documents: ['docs/**/*.md'],
+      output: 'out/graph.json',
+    }));
+    const { config, file } = await loadConfig(root);
+    assert.ok(file.endsWith('doc-graph.config.json'));
+    assert.equal(config.project, 'custom');
+    assert.deepEqual(config.documents, ['docs/**/*.md']);
+    assert.equal(config.output, 'out/graph.json');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('loadConfig reads a .mjs config file with a default export', async () => {
+  const root = makeTempDir();
+  try {
+    fs.writeFileSync(path.join(root, 'doc-graph.config.mjs'), 'export default { project: "mjs-project", documents: ["a.md"] };\n');
+    const { config } = await loadConfig(root);
+    assert.equal(config.project, 'mjs-project');
+    assert.deepEqual(config.documents, ['a.md']);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('resolveConfig applies defaults, file config, and overrides in order', () => {
+  const root = '/tmp/example';
+  const resolved = resolveConfig(root, { project: 'from-file', documents: ['x.md'] }, { output: 'override.json' });
+  assert.equal(resolved.project, 'from-file');
+  assert.deepEqual(resolved.documents, ['x.md']);
+  assert.equal(resolved.output, 'override.json');
+  assert.deepEqual(resolved.examples, DEFAULT_CONFIG.examples);
+});
+
+test('resolveConfig defaults project name to the directory basename', () => {
+  const resolved = resolveConfig('/tmp/my-project', {}, {});
+  assert.equal(resolved.project, 'my-project');
+});

--- a/doc-graph/test/fixtures/second-project/doc-graph.config.json
+++ b/doc-graph/test/fixtures/second-project/doc-graph.config.json
@@ -1,0 +1,6 @@
+{
+  "project": "acme-docs",
+  "documents": ["docs/**/*.md"],
+  "examples": ["snippets/**/*.py"],
+  "output": "graph.json"
+}

--- a/doc-graph/test/fixtures/second-project/docs/guides/getting-started.md
+++ b/doc-graph/test/fixtures/second-project/docs/guides/getting-started.md
@@ -1,0 +1,13 @@
+# Getting Started
+
+This guide walks through installing the Acme SDK and making a first request.
+
+## Installation
+
+## Configuration
+
+Set the API key before constructing a client.
+
+## Webhook Delivery
+
+Webhooks are delivered asynchronously to a configured endpoint.

--- a/doc-graph/test/fixtures/second-project/docs/index.md
+++ b/doc-graph/test/fixtures/second-project/docs/index.md
@@ -1,0 +1,16 @@
+# Acme SDK
+
+> **Provenance**
+> - Source Commit: `deadbeefdeadbeefdeadbeefdeadbeefdeadbeef`
+> - Commit Date: `2026-08-20`
+
+The Acme SDK is a hypothetical framework used only to demonstrate that
+`doc-graph` indexes projects whose layout differs from the Playwright notes.
+
+## Authentication
+
+## Session Management
+
+## Retry and Backoff
+
+The HTTP client retries failed requests with exponential backoff.

--- a/doc-graph/test/fixtures/second-project/snippets/hello.py
+++ b/doc-graph/test/fixtures/second-project/snippets/hello.py
@@ -1,0 +1,2 @@
+def hello():
+    print("hello acme")

--- a/doc-graph/test/fixtures/second-project/snippets/retry-backoff.py
+++ b/doc-graph/test/fixtures/second-project/snippets/retry-backoff.py
@@ -1,0 +1,11 @@
+import time
+
+
+def retry_with_backoff(fn, attempts=3):
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except Exception:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(2 ** attempt)

--- a/doc-graph/test/helpers.mjs
+++ b/doc-graph/test/helpers.mjs
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export function makeTempDir(prefix = 'doc-graph-test-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export function writeProject() {
+  const root = makeTempDir();
+  fs.writeFileSync(path.join(root, 'NOTES.md'), `# Architecture Notes
+
+> **Provenance**
+> - Source Commit: \`abc123abc123abc123abc123abc123abc123abc1\`
+> - Commit Date: \`2026-08-06\`
+
+## Browser Launch Mechanism
+
+## Context and Page Ownership
+
+## Locator Architecture
+
+## Tracing and Frames
+`);
+  fs.writeFileSync(path.join(root, 'API_REFERENCE.md'), `# API Reference
+
+> **Provenance**
+> - Source Commit: \`abc123abc123abc123abc123abc123abc123abc1\`
+> - Commit Date: \`2026-08-06\`
+
+## Page
+
+### Page.goto
+
+### Page.goBack
+
+## Locator
+
+### Locator.click
+
+### Locator.fill
+`);
+  fs.mkdirSync(path.join(root, 'examples'));
+  fs.writeFileSync(path.join(root, 'examples', '01-launch-browser.js'), `// launch a browser\n`);
+  fs.writeFileSync(path.join(root, 'examples', '02-locator-basics.js'), `// locator basics\n`);
+  fs.writeFileSync(path.join(root, 'examples', '03-tracing-pipeline.js'), `// tracing pipeline\n`);
+  return root;
+}
+
+export function cleanup(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/doc-graph/test/indexer.test.mjs
+++ b/doc-graph/test/indexer.test.mjs
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { buildGraph, loadGraph, SCHEMA_VERSION, DocGraphError } from '../src/index.mjs';
+import { writeProject, cleanup } from './helpers.mjs';
+
+test('builds a graph with documents, sections, topics, and examples', () => {
+  const root = writeProject();
+  try {
+    const { graph, stats } = buildGraph(root, {
+      project: 'playwright',
+      documents: ['NOTES.md', 'API_REFERENCE.md'],
+      examples: ['examples/*.js'],
+      output: 'DOC_GRAPH.json',
+    });
+
+    assert.equal(graph.schema, SCHEMA_VERSION);
+    assert.equal(graph.project, 'playwright');
+    assert.ok(graph.generated_at);
+    assert.equal(graph.pinned_commit, 'abc123abc123abc123abc123abc123abc123abc1');
+    assert.equal(graph.pinned_commit_date, '2026-08-06');
+
+    const documents = graph.nodes.filter(n => n.type === 'document');
+    assert.equal(documents.length, 2);
+    assert.ok(documents.every(d => d.commit === 'abc123abc123abc123abc123abc123abc123abc1'));
+
+    const sections = graph.nodes.filter(n => n.type === 'section');
+    assert.equal(sections.length, 12);
+    const browserSection = sections.find(s => s.title === 'Browser Launch Mechanism');
+    assert.equal(browserSection.file, 'NOTES.md');
+    assert.equal(browserSection.line, 7);
+
+    const topics = graph.nodes.filter(n => n.type === 'topic');
+    assert.ok(topics.length > 0);
+    assert.ok(topics.some(t => t.name === 'browser'));
+
+    const examples = graph.nodes.filter(n => n.type === 'example');
+    assert.equal(examples.length, 3);
+    assert.equal(stats.examples, 3);
+
+    const contains = graph.edges.filter(e => e.relation === 'contains');
+    assert.equal(contains.length, sections.length);
+    const about = graph.edges.filter(e => e.relation === 'about');
+    assert.ok(about.length > 0);
+    const illustrates = graph.edges.filter(e => e.relation === 'illustrates');
+    assert.ok(illustrates.length > 0);
+
+    assert.ok(fs.existsSync(path.join(root, 'DOC_GRAPH.json')));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('records source line references and provenance per section', () => {
+  const root = writeProject();
+  try {
+    const { graph } = buildGraph(root, {
+      project: 'playwright',
+      documents: ['NOTES.md'],
+      examples: [],
+      output: 'DOC_GRAPH.json',
+    });
+    const section = graph.nodes.find(n => n.type === 'section' && n.title === 'Locator Architecture');
+    assert.equal(section.line, 11);
+    assert.equal(section.commit, 'abc123abc123abc123abc123abc123abc123abc1');
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('throws a DocGraphError for missing document files', () => {
+  const root = writeProject();
+  try {
+    assert.throws(() => buildGraph(root, {
+      project: 'playwright',
+      documents: ['NOTES.md', 'MISSING.md'],
+      examples: [],
+      output: 'DOC_GRAPH.json',
+    }), DocGraphError);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('tolerates missing examples glob', () => {
+  const root = writeProject();
+  try {
+    const { graph } = buildGraph(root, {
+      project: 'playwright',
+      documents: ['NOTES.md'],
+      examples: ['examples/*.py'],
+      output: 'DOC_GRAPH.json',
+    });
+    assert.equal(graph.source_examples.length, 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('writes to a configurable output path and preserves schema', () => {
+  const root = writeProject();
+  try {
+    buildGraph(root, {
+      project: 'playwright',
+      documents: ['NOTES.md'],
+      examples: [],
+      output: 'artifacts/graph.json',
+    });
+    assert.ok(fs.existsSync(path.join(root, 'artifacts', 'graph.json')));
+    const loaded = loadGraph(root, 'artifacts/graph.json');
+    assert.equal(loaded.schema, SCHEMA_VERSION);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('loadGraph throws when the graph is missing', () => {
+  const root = writeProject();
+  try {
+    assert.throws(() => loadGraph(root, 'DOC_GRAPH.json'), DocGraphError);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/doc-graph/test/mcp.test.mjs
+++ b/doc-graph/test/mcp.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGraph } from '../src/index.mjs';
+import { createMcpHandler, MCP_TOOLS } from '../src/mcp.mjs';
+import { writeProject, cleanup } from './helpers.mjs';
+
+function fixture() {
+  const root = writeProject();
+  buildGraph(root, {
+    project: 'fixture',
+    documents: ['NOTES.md', 'API_REFERENCE.md'],
+    examples: ['examples/*.js'],
+    output: 'DOC_GRAPH.json',
+  });
+  return root;
+}
+
+test('MCP initializes and lists read-only documentation tools', async () => {
+  const root = fixture();
+  try {
+    const handle = createMcpHandler({ root, config: { output: 'DOC_GRAPH.json' } });
+    const initialized = await handle({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    assert.equal(initialized.result.serverInfo.name, 'doc-graph');
+    const listed = await handle({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+    assert.deepEqual(listed.result.tools.map(tool => tool.name), MCP_TOOLS.map(tool => tool.name));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('MCP tool calls return structured search and context results', async () => {
+  const root = fixture();
+  try {
+    const handle = createMcpHandler({ root, config: { output: 'DOC_GRAPH.json', excerptLines: 20, maxExcerptLines: 50 } });
+    const search = await handle({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'doc_graph_search', arguments: { query: 'browser launch', limit: 3 } } });
+    assert.ok(search.result.structuredContent.references.length > 0);
+    assert.equal(search.result.content[0].type, 'text');
+    const context = await handle({ jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'doc_graph_context', arguments: { query: 'browser launch' } } });
+    assert.ok(context.result.structuredContent.references.some(ref => ref.excerpt));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('MCP rejects unknown tools and invalid arguments', async () => {
+  const root = fixture();
+  try {
+    const handle = createMcpHandler({ root, config: { output: 'DOC_GRAPH.json' } });
+    const unknown = await handle({ jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'delete_docs' } });
+    assert.equal(unknown.error.code, -32602);
+    const invalid = await handle({ jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: 'doc_graph_search', arguments: { query: '' } } });
+    assert.equal(invalid.error.code, -32602);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/doc-graph/test/query.test.mjs
+++ b/doc-graph/test/query.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildGraph, loadGraph, search, retrieveContext } from '../src/index.mjs';
+import { writeProject, cleanup } from './helpers.mjs';
+
+function buildFixture() {
+  const root = writeProject();
+  const { graph } = buildGraph(root, {
+    project: 'playwright',
+    documents: ['NOTES.md', 'API_REFERENCE.md'],
+    examples: ['examples/*.js'],
+    output: 'DOC_GRAPH.json',
+  });
+  return { root, graph };
+}
+
+test('search returns ranked, bounded references with file paths and line numbers', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = search(graph, 'browser launch');
+    assert.ok(result.total > 0);
+    assert.equal(result.references.length, result.total <= 20 ? result.total : 20);
+    const first = result.references[0];
+    assert.ok(first.file);
+    assert.ok(first.line !== null || first.type === 'example');
+    assert.ok(Array.isArray(first.matched));
+    assert.ok(first.score > 0);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('search matches example nodes for a topic', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = search(graph, 'tracing');
+    assert.ok(result.references.some(r => r.type === 'example' && r.file === 'examples/03-tracing-pipeline.js'));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('search respects the limit option', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = search(graph, 'locator', { limit: 3 });
+    assert.ok(result.references.length <= 3);
+    assert.ok(result.total >= result.references.length);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('search ranks exact topic matches above partial matches', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = search(graph, 'locator');
+    assert.ok(result.references.length > 0);
+    const scores = result.references.map(r => r.score);
+    for (let i = 1; i < scores.length; i++)
+      assert.ok(scores[i - 1] >= scores[i], 'references should be sorted by descending score');
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('context returns source excerpts suitable for prompting a model', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = retrieveContext(graph, 'browser launch', { limit: 5, root });
+    assert.ok(result.references.length > 0);
+    const section = result.references.find(r => r.type === 'section');
+    assert.ok(section, 'expected at least one section reference');
+    assert.ok(section.file);
+    assert.ok(section.line !== null);
+    assert.ok(typeof section.excerpt === 'string');
+    assert.ok(section.excerpt.length > 0);
+    assert.ok(section.excerpt.includes('Browser Launch Mechanism'));
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('context marks stale references whose source file is missing', () => {
+  const { root, graph } = buildFixture();
+  try {
+    fs.rmSync(path.join(root, 'NOTES.md'));
+    const result = retrieveContext(graph, 'browser launch', { limit: 20, root });
+    const stale = result.references.find(r => r.file === 'NOTES.md');
+    assert.ok(stale);
+    assert.equal(stale.excerpt, null);
+    assert.equal(stale.missing, true);
+  } finally {
+    cleanup(root);
+  }
+});
+
+test('search for an unknown query returns no references', () => {
+  const { root, graph } = buildFixture();
+  try {
+    const result = search(graph, 'zzzzznonexistent');
+    assert.equal(result.total, 0);
+    assert.equal(result.references.length, 0);
+  } finally {
+    cleanup(root);
+  }
+});

--- a/doc-graph/test/second-project.test.mjs
+++ b/doc-graph/test/second-project.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { loadConfig, resolveConfig, buildGraph, loadGraph, search, retrieveContext, SCHEMA_VERSION } from '../src/index.mjs';
+
+const FIXTURE = path.resolve(import.meta.dirname, 'fixtures', 'second-project');
+
+test('second project with a different layout indexes without code changes', async () => {
+  const { config } = await loadConfig(FIXTURE);
+  const resolved = resolveConfig(FIXTURE, config, {});
+
+  assert.equal(resolved.project, 'acme-docs');
+  assert.deepEqual(resolved.documents, ['docs/**/*.md']);
+  assert.deepEqual(resolved.examples, ['snippets/**/*.py']);
+
+  const { graph, stats } = buildGraph(FIXTURE, resolved);
+
+  assert.equal(graph.schema, SCHEMA_VERSION);
+  assert.equal(graph.project, 'acme-docs');
+
+  const documents = graph.nodes.filter(n => n.type === 'document');
+  assert.equal(documents.length, 2);
+  assert.ok(documents.some(d => d.file === 'docs/index.md'));
+  assert.ok(documents.some(d => d.file === 'docs/guides/getting-started.md'));
+
+  const examples = graph.nodes.filter(n => n.type === 'example');
+  assert.equal(examples.length, 2);
+  assert.ok(examples.some(e => e.file === 'snippets/hello.py'));
+  assert.ok(examples.some(e => e.file === 'snippets/retry-backoff.py'));
+
+  assert.equal(stats.documents, 2);
+  assert.equal(stats.examples, 2);
+
+  const output = path.join(FIXTURE, 'graph.json');
+  assert.ok(fs.existsSync(output));
+  fs.rmSync(output, { force: true });
+});
+
+test('second project provenance is captured', async () => {
+  const { config } = await loadConfig(FIXTURE);
+  const resolved = resolveConfig(FIXTURE, config, {});
+  const { graph } = buildGraph(FIXTURE, resolved);
+  try {
+    const indexDoc = graph.nodes.find(n => n.type === 'document' && n.file === 'docs/index.md');
+    assert.equal(indexDoc.commit, 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
+    assert.equal(indexDoc.commit_date, '2026-08-20');
+  } finally {
+    fs.rmSync(path.join(FIXTURE, 'graph.json'), { force: true });
+  }
+});
+
+test('second project search and context work', async () => {
+  const { config } = await loadConfig(FIXTURE);
+  const resolved = resolveConfig(FIXTURE, config, {});
+  buildGraph(FIXTURE, resolved);
+  try {
+    const graph = loadGraph(FIXTURE, 'graph.json');
+
+    const result = search(graph, 'webhook');
+    assert.ok(result.references.some(r => r.file === 'docs/guides/getting-started.md'));
+
+    const exampleResult = search(graph, 'retry backoff');
+    assert.ok(exampleResult.references.some(r => r.type === 'example' && r.file === 'snippets/retry-backoff.py'));
+
+    const context = retrieveContext(graph, 'configuration', { limit: 10, root: FIXTURE });
+    assert.ok(context.references.length > 0);
+    assert.ok(context.references[0].excerpt.length > 0);
+  } finally {
+    fs.rmSync(path.join(FIXTURE, 'graph.json'), { force: true });
+  }
+});

--- a/doc-graph/test/server.test.mjs
+++ b/doc-graph/test/server.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGraph, createServer } from '../src/index.mjs';
+import { writeProject, cleanup } from './helpers.mjs';
+
+async function startServer(config) {
+  const server = createServer(config);
+  await new Promise(resolve => server.listen(0, resolve));
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+  return { server, base };
+}
+
+function fixture() {
+  const root = writeProject();
+  const { graph } = buildGraph(root, {
+    project: 'playwright',
+    documents: ['NOTES.md', 'API_REFERENCE.md'],
+    examples: ['examples/*.js'],
+    output: 'DOC_GRAPH.json',
+  });
+  return { root, graph };
+}
+
+test('GET /health returns ok', async () => {
+  const { root } = fixture();
+  const { server, base } = await startServer({ root, config: { project: 'playwright', output: 'DOC_GRAPH.json' } });
+  try {
+    const res = await fetch(`${base}/health`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.project, 'playwright');
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    cleanup(root);
+  }
+});
+
+test('GET /search returns ranked references with provenance', async () => {
+  const { root } = fixture();
+  const { server, base } = await startServer({ root, config: { project: 'playwright', output: 'DOC_GRAPH.json', excerptLines: 80, maxExcerptLines: 200 } });
+  try {
+    const res = await fetch(`${base}/search?q=browser+launch&limit=5`);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type'), /application\/json/);
+    const body = await res.json();
+    assert.ok(body.references.length > 0);
+    assert.ok(body.references.length <= 5);
+    assert.ok(body.references[0].file);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    cleanup(root);
+  }
+});
+
+test('GET /context returns source excerpts', async () => {
+  const { root } = fixture();
+  const { server, base } = await startServer({ root, config: { project: 'playwright', output: 'DOC_GRAPH.json', excerptLines: 80, maxExcerptLines: 200 } });
+  try {
+    const res = await fetch(`${base}/context?q=locator`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.references.length > 0);
+    assert.ok(body.references[0].excerpt.length > 0);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    cleanup(root);
+  }
+});
+
+test('GET /search without q returns 400', async () => {
+  const { root } = fixture();
+  const { server, base } = await startServer({ root, config: { project: 'playwright', output: 'DOC_GRAPH.json' } });
+  try {
+    const res = await fetch(`${base}/search`);
+    assert.equal(res.status, 400);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    cleanup(root);
+  }
+});
+
+test('unknown route returns 404', async () => {
+  const { root } = fixture();
+  const { server, base } = await startServer({ root, config: { project: 'playwright', output: 'DOC_GRAPH.json' } });
+  try {
+    const res = await fetch(`${base}/nope`);
+    assert.equal(res.status, 404);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    cleanup(root);
+  }
+});


### PR DESCRIPTION
## Summary

- add a reusable, model-independent documentation graph package
- add configurable CLI and HTTP search/context retrieval
- add MCP stdio support for internal tools
- add provenance, second-project fixtures, and focused tests
- add Playwright documentation notes and generated graph artifact

## Validation

- `npm test` in `doc-graph`: 33/33 tests passing
- MCP stdio initialize/tools/list smoke test passing
- browser examples and browser binaries were not executed or downloaded
