### PR TITLE
fix(recorder): support re-enabling recorder on the same context

### DIFF
--- a/packages/playwright-core/src/server/browserContext.ts
+++ b/packages/playwright-core/src/server/browserContext.ts
@@ -159,14 +159,14 @@ export abstract class BrowserContext<EM extends EventMap = EventMap> extends Sdk
       this._debugger.setPauseAt();
       this._debugger.on(Debugger.Events.PausedStateChanged, () => {
         if (this._debugger.isPaused())
-          RecorderApp.showInspectorNoReply(this);
+          RecorderApp.enable(this, {}).catch(() => {});
       });
     }
 
     // When PWDEBUG=1, show inspector for each context.
     if (debugMode() === 'inspector') {
       this._debugger.setPauseAt({ next: true });
-      await RecorderApp.show(this, { pauseOnNextStatement: true });
+      await RecorderApp.enable(this, { pauseOnNextStatement: true });
     }
 
     if (debugMode() === 'console')

--- a/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/browserContextDispatcher.ts
@@ -34,7 +34,6 @@ import { DisposableDispatcher } from './disposableDispatcher';
 import { TracingDispatcher } from './tracingDispatcher';
 import { WebSocketRouteDispatcher } from './webSocketRouteDispatcher';
 import { WritableStreamDispatcher } from './writableStreamDispatcher';
-import { Recorder } from '../recorder';
 import { RecorderApp } from '../recorder/recorderApp';
 import { ElementHandleDispatcher } from './elementHandlerDispatcher';
 import { JSHandleDispatcher } from './jsHandleDispatcher';
@@ -356,13 +355,11 @@ export class BrowserContextDispatcher extends Dispatcher<BrowserContext, channel
   }
 
   async enableRecorder(params: channels.BrowserContextEnableRecorderParams, progress: Progress): Promise<void> {
-    await progress.race(RecorderApp.show(this._context, params));
+    await progress.race(RecorderApp.enable(this._context, params));
   }
 
   async disableRecorder(params: channels.BrowserContextDisableRecorderParams, progress: Progress): Promise<void> {
-    const recorder = await progress.race(Recorder.existingForContext(this._context));
-    if (recorder)
-      await progress.race(recorder.setMode('none'));
+    await progress.race(RecorderApp.disable(this._context));
   }
 
   async exposeConsoleApi(params: channels.BrowserContextExposeConsoleApiParams, progress: Progress): Promise<void> {

--- a/packages/playwright-core/src/server/recorder/recorderApp.ts
+++ b/packages/playwright-core/src/server/recorder/recorderApp.ts
@@ -19,6 +19,7 @@ import path from 'path';
 
 import mime from 'mime';
 import { isUnderTest } from '@utils/debug';
+import { eventsHelper } from '@utils/eventsHelper';
 import { languageSet } from '@isomorphic/codegen/languages';
 import { generateCode } from '@isomorphic/codegen/language';
 import { libPath } from '../../package';
@@ -36,6 +37,7 @@ import type { Language, LanguageGeneratorOptions } from '@isomorphic/codegen/typ
 import type * as channels from '../channels';
 import type { Progress } from '../progress';
 import type { AriaTemplateNode } from '@isomorphic/ariaSnapshot';
+import type { RegisteredListener } from '@utils/eventsHelper';
 
 export type RecorderAppParams = channels.BrowserContextEnableRecorderParams & {
   browserName: string;
@@ -175,32 +177,34 @@ export class RecorderApp {
     });
   }
 
-  static async show(context: BrowserContext, params: channels.BrowserContextEnableRecorderParams) {
+  static async enable(context: BrowserContext, params: channels.BrowserContextEnableRecorderParams) {
     if (process.env.PW_CODEGEN_NO_INSPECTOR)
       return;
     const recorder = await Recorder.forContext(context, params);
-    if (params.recorderMode === 'api') {
-      const browserName = context._browser.options.name;
-      await ProgrammaticRecorderApp.run(context, recorder, browserName, params);
-      return;
+    if (!(context as any)[recorderAppSymbol]) {
+      const app = params.recorderMode === 'api'
+        ? new ProgrammaticRecorderApp(context, recorder, params)
+        : await RecorderApp._show(recorder, context, params);
+      (context as any)[recorderAppSymbol] = app;
     }
-    await RecorderApp._show(recorder, context, params);
+    if (params.mode)
+      await recorder.setMode(params.mode);
+  }
+
+  static async disable(context: BrowserContext) {
+    const recorder = await Recorder.existingForContext(context);
+    if (recorder)
+      await recorder.setMode('none');
+    const app = (context as any)[recorderAppSymbol] as RecorderApp | ProgrammaticRecorderApp | undefined;
+    delete (context as any)[recorderAppSymbol];
+    await app?.close();
   }
 
   async close() {
     await this._page.close(nullProgress);
   }
 
-  static showInspectorNoReply(context: BrowserContext) {
-    if (process.env.PW_CODEGEN_NO_INSPECTOR)
-      return;
-    void Recorder.forContext(context, {}).then(recorder => RecorderApp._show(recorder, context, {})).catch(() => {});
-  }
-
-  private static async _show(recorder: Recorder, inspectedContext: BrowserContext, params: channels.BrowserContextEnableRecorderParams) {
-    if ((inspectedContext as any)[recorderAppSymbol])
-      return;
-    (inspectedContext as any)[recorderAppSymbol] = true;
+  private static async _show(recorder: Recorder, inspectedContext: BrowserContext, params: channels.BrowserContextEnableRecorderParams): Promise<RecorderApp> {
     const sdkLanguage = inspectedContext._browser.sdkLanguage();
     const isChromium = inspectedContext._browser.options.browserType === 'chromium';
     const headed = !!inspectedContext._browser.options.headful;
@@ -238,6 +242,7 @@ export class RecorderApp {
     const recorderApp = new RecorderApp(recorder, appParams, page, appContext._browser.options.wsEndpoint);
     await recorderApp._init(inspectedContext);
     (inspectedContext as any).recorderAppForTest = recorderApp;
+    return recorderApp;
   }
 
   private _wireListeners(recorder: Recorder) {
@@ -353,12 +358,14 @@ function determinePrimaryGeneratorId(sdkLanguage: Language): string {
 }
 
 export class ProgrammaticRecorderApp {
-  static async run(inspectedContext: BrowserContext, recorder: Recorder, browserName: string, params: channels.BrowserContextEnableRecorderParams) {
+  private _listeners: RegisteredListener[];
+
+  constructor(inspectedContext: BrowserContext, recorder: Recorder, params: channels.BrowserContextEnableRecorderParams) {
     let lastAction: actions.ActionInContext | undefined;
     const languages = [...languageSet()];
 
     const languageGeneratorOptions = {
-      browserName: browserName,
+      browserName: inspectedContext._browser.options.name,
       launchOptions: { headless: false, ...params.launchOptions, tracesDir: undefined },
       contextOptions: { ...params.contextOptions },
       deviceName: params.device,
@@ -366,24 +373,30 @@ export class ProgrammaticRecorderApp {
     };
     const languageGenerator = languages.find(l => l.id === params.language) ?? languages.find(l => l.id === 'playwright-test')!;
 
-    recorder.on(RecorderEvent.ActionAdded, actionInContext => {
-      const page = findPageByGuid(inspectedContext, actionInContext.pageGuid);
-      if (!page)
-        return;
-      lastAction = actionInContext;
-      const code = languageGenerator.generateAction(actionInContext, languageGeneratorOptions);
-      inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'actionAdded', data: actionInContext.action, page, code });
-    });
-    recorder.on(RecorderEvent.SignalAdded, signalInContext => {
-      const page = findPageByGuid(inspectedContext, signalInContext.pageGuid);
-      if (!page)
-        return;
-      // The signal belongs to the last action, so re-generate its code with the signal
-      // included (e.g. a popup or download wait around the action).
-      lastAction?.signals.push(signalInContext.signal);
-      const code = lastAction ? languageGenerator.generateAction(lastAction, languageGeneratorOptions) : '';
-      inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'signalAdded', data: signalInContext.signal, page, code });
-    });
+    this._listeners = [
+      eventsHelper.addEventListener(recorder, RecorderEvent.ActionAdded, actionInContext => {
+        const page = findPageByGuid(inspectedContext, actionInContext.pageGuid);
+        if (!page)
+          return;
+        lastAction = actionInContext;
+        const code = languageGenerator.generateAction(actionInContext, languageGeneratorOptions);
+        inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'actionAdded', data: actionInContext.action, page, code });
+      }),
+      eventsHelper.addEventListener(recorder, RecorderEvent.SignalAdded, signalInContext => {
+        const page = findPageByGuid(inspectedContext, signalInContext.pageGuid);
+        if (!page)
+          return;
+        // The signal belongs to the last action, so re-generate its code with the signal
+        // included (e.g. a popup or download wait around the action).
+        lastAction?.signals.push(signalInContext.signal);
+        const code = lastAction ? languageGenerator.generateAction(lastAction, languageGeneratorOptions) : '';
+        inspectedContext.emit(BrowserContext.Events.RecorderEvent, { event: 'signalAdded', data: signalInContext.signal, page, code });
+      }),
+    ];
+  }
+
+  close() {
+    eventsHelper.removeEventListeners(this._listeners);
   }
 }
 

--- a/tests/library/inspector/recorder-api.spec.ts
+++ b/tests/library/inspector/recorder-api.spec.ts
@@ -163,6 +163,35 @@ test('should disable recorder', async ({ context }) => {
   expect(log.action('click')).toHaveLength(2);
 });
 
+test('should record again after disable', async ({ context }) => {
+  const log = await startRecording(context);
+  const page = await context.newPage();
+  await page.setContent(`<button onclick="console.log('click')">Submit</button>`);
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect.poll(() => log.action('click').length).toBe(1);
+  await (context as any)._disableRecorder();
+
+  const log2 = await startRecording(context);
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect.poll(() => log2.action('click').length).toBe(1);
+  // Give it some time to produce duplicate actions - there should be none.
+  await page.waitForTimeout(1000);
+  expect(log2.action('click')).toHaveLength(1);
+});
+
+test('disable should close the inspector window', async ({ context, openRecorder }) => {
+  const { recorder } = await openRecorder();
+  await (context as any)._disableRecorder();
+  await expect.poll(() => recorder.recorderPage.isClosed()).toBe(true);
+
+  // With the window closed, programmatic recording can start on the same context.
+  const log = await startRecording(context);
+  const page = await context.newPage();
+  await page.setContent(`<button onclick="console.log('click')">Submit</button>`);
+  await page.getByRole('button', { name: 'Submit' }).click();
+  await expect.poll(() => log.action('click').length).toBe(1);
+});
+
 test('page.pickLocator should return locator for picked element', async ({ page }) => {
   await page.setContent(`<button>Submit</button>`);
 


### PR DESCRIPTION
## Summary
- `RecorderApp.show` is renamed to `enable` and now supports repeated `enableRecorder` calls on the same context: at most one recorder app (inspector window or programmatic) is active per context, and `params.mode` is applied explicitly since `Recorder.forContext` ignores params of an existing recorder — enable after disable used to silently record nothing.
- `ProgrammaticRecorderApp` unsubscribes its recorder listeners on close, `disableRecorder` now closes the active app of either kind, so recording can be re-enabled in a different mode.

Extracted from #42359.