### PR TITLE
fix(chromium): restore automation launch flag

### DIFF
--- a/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
+++ b/packages/playwright-core/src/server/chromium/chromiumSwitches.ts
@@ -87,6 +87,7 @@ export const chromiumSwitches = (options?: { android?: boolean }) => [
   '--unsafely-disable-devtools-self-xss-warnings',
   // Edge can potentially restart on Windows (msRelaunchNoCompatLayer) which looses its file descriptors (stdout/stderr) and CDP (3/4). Disable until fixed upstream.
   '--edge-skip-compat-layer-relaunch',
+  '--enable-automation',
   // This disables Chrome for Testing infobar that is visible in the persistent context.
   // The switch is ignored everywhere else, including Chromium/Chrome/Edge.
   '--disable-infobars',

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -90,11 +90,18 @@ async function createIsolatedBrowser(config: FullConfig, clientInfo: ClientInfo)
   testDebug('create browser (isolated)');
   const browserType = playwright[config.browser.browserName];
   const tracesDir = await computeTracesDir(config, clientInfo);
+  const configIgnoreDefaultArgs = config.browser.launchOptions?.ignoreDefaultArgs;
   const browser = await browserType.launch({
     tracesDir,
     ...config.browser.launchOptions,
     handleSIGINT: false,
     handleSIGTERM: false,
+    ignoreDefaultArgs: configIgnoreDefaultArgs === true
+      ? true
+      : [
+        '--enable-automation',
+        ...Array.isArray(configIgnoreDefaultArgs) ? configIgnoreDefaultArgs : [],
+      ],
   }).catch(error => {
     throwIfExecutableMissing(error, config);
     throw error;
@@ -175,6 +182,7 @@ async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInf
       ? true
       : [
         '--disable-extensions',
+        '--enable-automation',
         ...Array.isArray(configIgnoreDefaultArgs) ? configIgnoreDefaultArgs : [],
       ],
   };


### PR DESCRIPTION
removing `--enable-automation` lets managed Edge hand off the browser process during SAML login

restore the default flag while preserving MCP launch behavior through an internal launch setting

regression from <https://github.com/microsoft/playwright/pull/40190>

fixes <https://github.com/microsoft/playwright/issues/42379>