### PR TITLE
docs(test): clarify context option inheritance

### DIFF
--- a/docs/src/test-use-options-js.md
+++ b/docs/src/test-use-options-js.md
@@ -261,7 +261,7 @@ However, most common ones like `headless` or `viewport` are available directly i
 
 ### Explicit Context Creation and Option Inheritance
 
-If using the built-in `browser` fixture, calling [`method: Browser.newContext`] will create a context with options inherited from the config:
+While a test or hook runs, every browser context created through the Playwright instance used by the test runner inherits context options from the `use` section.  This includes contexts created with the built-in `browser` fixture, a separately launched browser, [`method: BrowserType.launchPersistentContext`], or a direct `playwright-core` import that resolves to the same instance.  Explicit context options take precedence:
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';


### PR DESCRIPTION
the test options documentation limits context inheritance to the built in `browser` fixture

document that all contexts created through the test runner Playwright instance inherit `use` context options unless explicitly overridden

fixes <https://github.com/microsoft/playwright/issues/42398>