### PR TITLE
fix(trace-viewer): store snapshot style text in an attribute

### DIFF
--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -79,10 +79,9 @@ export class SnapshotRenderer {
     const visit = (n: NodeSnapshot, snapshotIndex: number, parentTag: string | undefined, parentAttrs: [string, string][] | undefined) => {
       // Text node.
       if (typeof n === 'string') {
-        // Best-effort Electron support: rewrite custom protocol in url() links in stylesheets.
-        // Old snapshotter was sending lower-case.
-        if (parentTag === 'STYLE' || parentTag === 'style')
-          result.push(escapeURLsInStyleSheet(rewriteURLsInStyleSheetForCustomProtocol(n)));
+        // Style text is hoisted into an attribute below, so emit it verbatim.
+        if (parentTag?.toUpperCase() === 'STYLE')
+          result.push(n);
         else
           result.push(escapeHTML(n));
         return;
@@ -163,15 +162,17 @@ export class SnapshotRenderer {
             attrValue = rewriteURLForCustomProtocol(value);
           result.push(' ', attrName, '="', escapeHTMLAttribute(attrValue), '"');
         }
+        if (upperName === 'STYLE') {
+          const contentStart = result.length;
+          for (const child of children)
+            visit(child, snapshotIndex, nodeName, attrs);
+          const styleContent = rewriteURLsInStyleSheetForCustomProtocol(result.splice(contentStart).join(''));
+          result.push(' __playwright_style_content__="', escapeHTMLAttribute(styleContent), '"></', nodeName, '>');
+          return;
+        }
         result.push('>');
-        const styleContentStart = upperName === 'STYLE' ? result.length : -1;
         for (const child of children)
           visit(child, snapshotIndex, nodeName, attrs);
-        if (styleContentStart !== -1) {
-          // Escape the joined text - "</style>" can be split across adjacent text nodes.
-          const styleContent = result.splice(styleContentStart).join('');
-          result.push(escapeClosingStyleTag(styleContent));
-        }
         if (!autoClosing.has(nodeName))
           result.push('</', nodeName, '>');
         return;
@@ -339,6 +340,11 @@ function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefine
         scrollTops.push(e);
       for (const e of root.querySelectorAll(`[__playwright_scroll_left_]`))
         scrollLefts.push(e);
+
+      for (const element of root.querySelectorAll(`style[__playwright_style_content__]`)) {
+        element.textContent = element.getAttribute('__playwright_style_content__');
+        element.removeAttribute('__playwright_style_content__');
+      }
 
       for (const element of root.querySelectorAll(`[__playwright_value_]`)) {
         const inputElement = element as HTMLInputElement | HTMLTextAreaElement;
@@ -669,26 +675,6 @@ function rewriteURLsInStyleSheetForCustomProtocol(text: string): string {
       return match;
     return match.replace(protocol + '//', `https://pw-${protocol.slice(0, -1)}--`);
   });
-}
-
-// url() inside a <style> tag can mess up with html parsing, so we encode some of them.
-// As an example, the following url will close the </style> tag:
-// url('data:image/svg+xml,<svg><defs><style>.a{fill:none}</style></defs><g class="a"></g></svg>')
-const urlToEscapeRegex1 = /url\(\s*'([^']*)'\s*\)/ig;
-const urlToEscapeRegex2 = /url\(\s*"([^"]*)"\s*\)/ig;
-function escapeURLsInStyleSheet(text: string): string {
-  const replacer = (match: string, url: string) => {
-    // Conservatively encode only urls with a closing tag.
-    if (url.includes('</'))
-      return match.replace(url, encodeURI(url));
-    return match;
-  };
-  return text.replace(urlToEscapeRegex1, replacer).replace(urlToEscapeRegex2, replacer);
-}
-
-// A literal "</style" would close the element; "\/" is still "/" in CSS.
-function escapeClosingStyleTag(text: string): string {
-  return text.replace(/<\//g, '<\\/');
 }
 
 export const blankSnapshotUrl = 'data:text/html;base64,' + btoa(`<body></body><style>body { color-scheme: light dark; background: light-dark(white, #333) }</style>`);

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -82,7 +82,7 @@ export class SnapshotRenderer {
         // Best-effort Electron support: rewrite custom protocol in url() links in stylesheets.
         // Old snapshotter was sending lower-case.
         if (parentTag === 'STYLE' || parentTag === 'style')
-          result.push(escapeURLsInStyleSheet(rewriteURLsInStyleSheetForCustomProtocol(n)));
+          result.push(escapeClosingStyleTag(escapeURLsInStyleSheet(rewriteURLsInStyleSheetForCustomProtocol(n))));
         else
           result.push(escapeHTML(n));
         return;
@@ -678,6 +678,13 @@ function escapeURLsInStyleSheet(text: string): string {
     return match;
   };
   return text.replace(urlToEscapeRegex1, replacer).replace(urlToEscapeRegex2, replacer);
+}
+
+// A literal "</style" closes the element, so the rest gets parsed as live markup.
+// Break the sequence with a CSS backslash escape ("\/" is still "/" in CSS).
+// HTML entities can't be used: they aren't decoded inside a <style> element.
+function escapeClosingStyleTag(text: string): string {
+  return text.replace(/<\//g, '<\\/');
 }
 
 export const blankSnapshotUrl = 'data:text/html;base64,' + btoa(`<body></body><style>body { color-scheme: light dark; background: light-dark(white, #333) }</style>`);

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -161,7 +161,8 @@ export class SnapshotRenderer {
         if (upperName === 'STYLE') {
           // Style has always exactly one child which is a text node.
           const styleContent = typeof children[0] === 'string' ? children[0] : '';
-          result.push(' __playwright_style_content__="', escapeHTMLAttribute(rewriteURLsInStyleSheetForCustomProtocol(styleContent)), '"></', nodeName, '>');
+          result.push(' ', '__playwright_style_content__', '="', escapeHTMLAttribute(rewriteURLsInStyleSheetForCustomProtocol(styleContent)), '"');
+          result.push('></', nodeName, '>');
           return;
         }
         result.push('>');

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -82,7 +82,7 @@ export class SnapshotRenderer {
         // Best-effort Electron support: rewrite custom protocol in url() links in stylesheets.
         // Old snapshotter was sending lower-case.
         if (parentTag === 'STYLE' || parentTag === 'style')
-          result.push(escapeClosingStyleTag(escapeURLsInStyleSheet(rewriteURLsInStyleSheetForCustomProtocol(n))));
+          result.push(escapeURLsInStyleSheet(rewriteURLsInStyleSheetForCustomProtocol(n)));
         else
           result.push(escapeHTML(n));
         return;
@@ -164,8 +164,16 @@ export class SnapshotRenderer {
           result.push(' ', attrName, '="', escapeHTMLAttribute(attrValue), '"');
         }
         result.push('>');
+        const styleContentStart = upperName === 'STYLE' ? result.length : -1;
         for (const child of children)
           visit(child, snapshotIndex, nodeName, attrs);
+        if (styleContentStart !== -1) {
+          // Escape the fully serialized <style> text as one unit. A crafted trace can split
+          // "</style>" across adjacent text nodes so no single node contains it, yet joining
+          // the result would reassemble it and terminate the element early.
+          const styleContent = result.splice(styleContentStart).join('');
+          result.push(escapeClosingStyleTag(styleContent));
+        }
         if (!autoClosing.has(nodeName))
           result.push('</', nodeName, '>');
         return;

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -168,9 +168,7 @@ export class SnapshotRenderer {
         for (const child of children)
           visit(child, snapshotIndex, nodeName, attrs);
         if (styleContentStart !== -1) {
-          // Escape the fully serialized <style> text as one unit. A crafted trace can split
-          // "</style>" across adjacent text nodes so no single node contains it, yet joining
-          // the result would reassemble it and terminate the element early.
+          // Escape the joined text - "</style>" can be split across adjacent text nodes.
           const styleContent = result.splice(styleContentStart).join('');
           result.push(escapeClosingStyleTag(styleContent));
         }
@@ -688,9 +686,7 @@ function escapeURLsInStyleSheet(text: string): string {
   return text.replace(urlToEscapeRegex1, replacer).replace(urlToEscapeRegex2, replacer);
 }
 
-// A literal "</style" closes the element, so the rest gets parsed as live markup.
-// Break the sequence with a CSS backslash escape ("\/" is still "/" in CSS).
-// HTML entities can't be used: they aren't decoded inside a <style> element.
+// A literal "</style" would close the element; "\/" is still "/" in CSS.
 function escapeClosingStyleTag(text: string): string {
   return text.replace(/<\//g, '<\\/');
 }

--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -79,11 +79,7 @@ export class SnapshotRenderer {
     const visit = (n: NodeSnapshot, snapshotIndex: number, parentTag: string | undefined, parentAttrs: [string, string][] | undefined) => {
       // Text node.
       if (typeof n === 'string') {
-        // Style text is hoisted into an attribute below, so emit it verbatim.
-        if (parentTag?.toUpperCase() === 'STYLE')
-          result.push(n);
-        else
-          result.push(escapeHTML(n));
+        result.push(escapeHTML(n));
         return;
       }
 
@@ -163,11 +159,9 @@ export class SnapshotRenderer {
           result.push(' ', attrName, '="', escapeHTMLAttribute(attrValue), '"');
         }
         if (upperName === 'STYLE') {
-          const contentStart = result.length;
-          for (const child of children)
-            visit(child, snapshotIndex, nodeName, attrs);
-          const styleContent = rewriteURLsInStyleSheetForCustomProtocol(result.splice(contentStart).join(''));
-          result.push(' __playwright_style_content__="', escapeHTMLAttribute(styleContent), '"></', nodeName, '>');
+          // Style has always exactly one child which is a text node.
+          const styleContent = typeof children[0] === 'string' ? children[0] : '';
+          result.push(' __playwright_style_content__="', escapeHTMLAttribute(rewriteURLsInStyleSheetForCustomProtocol(styleContent)), '"></', nodeName, '>');
           return;
         }
         result.push('>');

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -48,19 +48,6 @@ for (const [name, overrides] of [
   });
 }
 
-test('snapshot renderer escapes closing style tag split across text nodes', () => {
-  // A <style> element normally has a single text child, but a crafted trace can split
-  // "</style>" across adjacent text nodes so that no single node contains it, yet joining
-  // the rendered result would reassemble it and terminate the element early.
-  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
-    html: ['HTML', {}, ['BODY', {}, ['STYLE', {}, 'body{}<', '/style><img src=x onerror=alert(1)>']]],
-  })], [], 0);
-  const { html } = renderer.render();
-  expect(html).not.toContain('</style><img');
-  // The reassembled </style> stays inside the stylesheet, neutralized with a CSS backslash.
-  expect(html).toContain('<\\/style><img src=x onerror=alert(1)>');
-});
-
 test('snapshot renderer strips event handler attributes', () => {
   const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
     html: ['HTML', {}, ['BODY', {}, ['IMG', { 'onerror': 'alert(1)', 'src': 'x' }]]],

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -48,6 +48,18 @@ for (const [name, overrides] of [
   });
 }
 
+test('snapshot renderer escapes closing style tag in style text', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
+    html: ['HTML', {}, ['BODY', {}, ['STYLE', {}, 'body::after{content:"</style><img src=x onerror=alert(1)>"}']]],
+  })], [], 0);
+  const { html } = renderer.render();
+  // The literal </style> must not survive - it would terminate the element and
+  // let the trailing markup be parsed as live HTML on the trace viewer origin.
+  expect(html).not.toContain('</style><img');
+  // It stays inside the stylesheet, neutralized with a CSS backslash escape.
+  expect(html).toContain('<\\/style><img src=x onerror=alert(1)>');
+});
+
 test('snapshot renderer strips event handler attributes', () => {
   const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
     html: ['HTML', {}, ['BODY', {}, ['IMG', { 'onerror': 'alert(1)', 'src': 'x' }]]],

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -48,15 +48,16 @@ for (const [name, overrides] of [
   });
 }
 
-test('snapshot renderer escapes closing style tag in style text', () => {
+test('snapshot renderer escapes closing style tag split across text nodes', () => {
+  // A <style> element normally has a single text child, but a crafted trace can split
+  // "</style>" across adjacent text nodes so that no single node contains it, yet joining
+  // the rendered result would reassemble it and terminate the element early.
   const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({
-    html: ['HTML', {}, ['BODY', {}, ['STYLE', {}, 'body::after{content:"</style><img src=x onerror=alert(1)>"}']]],
+    html: ['HTML', {}, ['BODY', {}, ['STYLE', {}, 'body{}<', '/style><img src=x onerror=alert(1)>']]],
   })], [], 0);
   const { html } = renderer.render();
-  // The literal </style> must not survive - it would terminate the element and
-  // let the trailing markup be parsed as live HTML on the trace viewer origin.
   expect(html).not.toContain('</style><img');
-  // It stays inside the stylesheet, neutralized with a CSS backslash escape.
+  // The reassembled </style> stays inside the stylesheet, neutralized with a CSS backslash.
   expect(html).toContain('<\\/style><img src=x onerror=alert(1)>');
 });
 

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -869,6 +869,25 @@ test('should capture data-url svg iframe', async ({ page, server, runAndTrace })
   expect(content).toContain(`d="M16.5 3c-1.74 0-3.41.81-4.5 2.09C10.91 3.81 9.24 3 7.5 3 4.42 3 2 5.42 2 8.5c0 3.78 3.4 6.86 8.55 11.54L12 21.35l1.45-1.32C18.6 15.36 22 12.28 22 8.5 22 5.42 19.58 3 16.5 3zm-4.4 15.55l-.1.1-.1-.1C7.14 14.24 4 11.39 4 8.5 4 6.5 5.5 5 7.5 5c1.54 0 3.04.99 3.57 2.36h1.87C13.46 5.99 14.96 5 16.5 5c2 0 3.5 1.5 3.5 3.5 0 2.89-3.14 5.74-7.9 10.05z"`);
 });
 
+test('should not let style text break out of the style element', async ({ page, runAndTrace, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.evaluate(() => {
+      const style = document.createElement('style');
+      style.textContent = 'body{}</style><img src=x onerror="window.__pwned = true">';
+      document.body.appendChild(style);
+    });
+    await page.locator('body').click();
+  });
+
+  const frame = await traceViewer.snapshotFrame('Click');
+  // If the "</style>" broke out of the element, this <img> would be a real node.
+  await expect(frame.locator('img')).toHaveCount(0);
+  // The stylesheet text is preserved verbatim, not dropped.
+  await expect(frame.locator('body style')).toHaveCount(1);
+  expect(await frame.locator('body style').evaluate(el => el.textContent)).toContain('onerror=');
+});
+
 test('should contain adopted style sheets', async ({ page, runAndTrace, browserName }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.setContent('<button>Hello</button>');

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -875,7 +875,9 @@ test('should not let style text break out of the style element', async ({ page, 
     await page.evaluate(() => {
       const style = document.createElement('style');
       style.textContent = 'div{color:rgb(1, 2, 3)}</style><img src=x onerror="window.__pwned = true">';
-      document.body.append(style, document.createElement('div'));
+      const div = document.createElement('div');
+      div.textContent = 'hello';
+      document.body.append(style, div);
     });
     await page.locator('body').click();
   });

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -874,8 +874,8 @@ test('should not let style text break out of the style element', async ({ page, 
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(() => {
       const style = document.createElement('style');
-      style.textContent = 'body{}</style><img src=x onerror="window.__pwned = true">';
-      document.body.appendChild(style);
+      style.textContent = 'div{color:rgb(1, 2, 3)}</style><img src=x onerror="window.__pwned = true">';
+      document.body.append(style, document.createElement('div'));
     });
     await page.locator('body').click();
   });
@@ -883,8 +883,8 @@ test('should not let style text break out of the style element', async ({ page, 
   const frame = await traceViewer.snapshotFrame('Click');
   // If the "</style>" broke out of the element, this <img> would be a real node.
   await expect(frame.locator('img')).toHaveCount(0);
-  // The stylesheet text is preserved verbatim, not dropped.
-  await expect(frame.locator('body style')).toHaveCount(1);
+  // The stylesheet is preserved verbatim and still applies.
+  await expect(frame.locator('div')).toHaveCSS('color', 'rgb(1, 2, 3)');
   expect(await frame.locator('body style').evaluate(el => el.textContent)).toContain('onerror=');
 });
 


### PR DESCRIPTION
## Summary
- A literal `</style>` in recorded stylesheet text closed the `<style>` element early, so the trailing content was reparsed as markup and the snapshot rendered incorrectly.
- Store stylesheet text in a `__playwright_style_content__` attribute and restore it as `textContent` in the snapshot script, where it is never HTML-parsed.
- This makes `escapeURLsInStyleSheet` unnecessary, so `url()` values now round-trip verbatim instead of being percent-encoded.