### PR TITLE
fix(mcp): preserve screenshot image resolution

### DIFF
--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -20,7 +20,6 @@ import path from 'path';
 import debug from 'debug';
 import { actionInContext, renderCode, substituteSecrets } from './codegen';
 import { renderModalStates } from './tab';
-import { scaleImageToFitMessage } from './screenshot';
 
 import { outputDir as resolveOutputDir } from './context';
 
@@ -223,10 +222,8 @@ export class Response {
 
     // Image attachments.
     if (this._context.config.imageResponses !== 'omit') {
-      for (const imageResult of this._imageResults) {
-        const scaledData = scaleImageToFitMessage(imageResult.data, imageResult.imageType);
-        content.push({ type: 'image', data: scaledData.toString('base64'), mimeType: `image/${imageResult.imageType}` });
-      }
+      for (const imageResult of this._imageResults)
+        content.push({ type: 'image', data: imageResult.data.toString('base64'), mimeType: `image/${imageResult.imageType}` });
     }
 
     return {

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -16,13 +16,9 @@
 
 import path from 'path';
 
-import jpegjs from 'jpeg-js';
-import { PNG } from 'pngjs';
 import * as z from 'zod';
 import { formatObject } from '@isomorphic/stringUtils';
 
-import { scaleImageToSize } from '@isomorphic/imageUtils';
-import { decodeWebp, encodeWebp, isLosslessWebp } from '@utils/webp/webp';
 import { defineTabTool } from './tool';
 import { optionalElementSchema } from './snapshot';
 
@@ -89,33 +85,6 @@ const screenshot = defineTabTool({
       await response.registerImageResult(data, fileType);
   }
 });
-
-export function scaleImageToFitMessage(buffer: Buffer, imageType: 'png' | 'jpeg' | 'webp'): Buffer {
-  // https://docs.claude.com/en/docs/build-with-claude/vision#evaluate-image-size
-  // Not more than 1.15 megapixel, linear size not more than 1568.
-
-  const decode = () => {
-    if (imageType === 'png')
-      return PNG.sync.read(buffer);
-    if (imageType === 'webp')
-      return decodeWebp(buffer);
-    return jpegjs.decode(buffer, { maxMemoryUsageInMB: 512 });
-  };
-  const image = decode();
-  const pixels = image.width * image.height;
-
-  const shrink = Math.min(1568 / image.width, 1568 / image.height, Math.sqrt(1.15 * 1024 * 1024 / pixels));
-  if (shrink > 1)
-    return buffer;
-
-  const width = image.width * shrink | 0;
-  const height = image.height * shrink | 0;
-  const scaledImage = scaleImageToSize(image, { width, height });
-  if (imageType === 'webp')
-    return encodeWebp(scaledImage, isLosslessWebp(buffer) ? { lossless: true } : { quality: 80 });
-  // eslint-disable-next-line no-restricted-syntax
-  return imageType === 'png' ? PNG.sync.write(scaledImage as any) : jpegjs.encode(scaledImage, 80).data;
-}
 
 export default [
   screenshot,

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -307,7 +307,7 @@ test('browser_take_screenshot (fullPage: true)', async ({ startClient, server },
   });
 });
 
-test('browser_take_screenshot size cap', async ({ startClient, server, mcpBrowser }, testInfo) => {
+test('browser_take_screenshot preserves image dimensions', async ({ startClient, server, mcpBrowser }, testInfo) => {
   test.skip(!['chrome', 'msedge', 'chromium'].includes(mcpBrowser ?? ''), 'Non-chrome has unusual full page size');
 
   const { client } = await startClient({
@@ -315,8 +315,8 @@ test('browser_take_screenshot size cap', async ({ startClient, server, mcpBrowse
   });
 
   const expectations = [
-    { title: '2000x500', pageWidth: 2000, pageHeight: 500, expectedWidth: 1568, expectedHeight: 720 * 1568 / 2000 | 0 },
-    { title: '2000x2000', pageWidth: 2000, pageHeight: 2000, expectedWidth: 1098, expectedHeight: 1098 },
+    { title: '2000x500', pageWidth: 2000, pageHeight: 500, expectedWidth: 2000, expectedHeight: 720 },
+    { title: '2000x2000', pageWidth: 2000, pageHeight: 2000, expectedWidth: 2000, expectedHeight: 2000 },
     { title: '1280x800', pageWidth: 1280, pageHeight: 800, expectedWidth: 1280, expectedHeight: 800 },
   ];
 


### PR DESCRIPTION
image responses silently resize screenshots to Claude specific limits

return the original screenshot bytes so each MCP client can apply model specific processing

fixes <https://github.com/microsoft/playwright/issues/42362>