### PR TITLE
feat(video): allow configuring screencast bitrate

### DIFF
--- a/docs/src/api/class-screencast.md
+++ b/docs/src/api/class-screencast.md
@@ -31,6 +31,12 @@ await page.screencast.start({
 await page.screencast.stop();
 ```
 
+### option: Screencast.start.bitrate
+* since: v1.63
+- `bitrate` <[int]>
+
+Video bitrate in bits per second. Defaults to `1_000_000`. Only applies when [`option: Screencast.start.path`] is provided.
+
 ### option: Screencast.start.onFrame
 * since: v1.59
 - `onFrame` <[function]\([Object]\): [Promise]>

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -18649,6 +18649,7 @@ export interface Screencast {
    * @param options
    */
   start(options?: {
+    bitrate?: number;
     onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any;
     path?: string;
     size?: {

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -4468,6 +4468,7 @@ export type PageScreencastStartParams = {
     height: number,
   },
   quality?: number,
+  bitrate?: number,
   sendFrames?: boolean,
   record?: boolean,
 };
@@ -4477,6 +4478,7 @@ export type PageScreencastStartOptions = {
     height: number,
   },
   quality?: number,
+  bitrate?: number,
   sendFrames?: boolean,
   record?: boolean,
 };

--- a/packages/playwright-core/src/client/screencast.ts
+++ b/packages/playwright-core/src/client/screencast.ts
@@ -39,7 +39,7 @@ export class Screencast implements api.Screencast {
     });
   }
 
-  async start(options: { onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any, path?: string, size?: { width: number, height: number }, quality?: number } = {}): Promise<DisposableStub> {
+  async start(options: { bitrate?: number, onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any, path?: string, size?: { width: number, height: number }, quality?: number } = {}): Promise<DisposableStub> {
     if (this._started)
       throw new Error('Screencast is already started');
     this._started = true;
@@ -48,6 +48,7 @@ export class Screencast implements api.Screencast {
     const result = await this._page._channel.screencastStart({
       size: options.size,
       quality: options.quality,
+      bitrate: options.bitrate,
       sendFrames: !!options.onFrame,
       record: !!options.path,
     }, kNoTimeout);

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -4469,6 +4469,7 @@ export type PageScreencastStartParams = {
     height: number,
   },
   quality?: number,
+  bitrate?: number,
   sendFrames?: boolean,
   record?: boolean,
 };
@@ -4478,6 +4479,7 @@ export type PageScreencastStartOptions = {
     height: number,
   },
   quality?: number,
+  bitrate?: number,
   sendFrames?: boolean,
   record?: boolean,
 };

--- a/packages/playwright-core/src/server/videoRecorder.ts
+++ b/packages/playwright-core/src/server/videoRecorder.ts
@@ -33,6 +33,7 @@ import type { Screencast, ScreencastClient } from './screencast';
 import type { Page, PageDelegate } from './page';
 
 const fps = 25;
+const defaultVideoBitrate = 1_000_000;
 
 export class VideoRecorder {
   private _screencast: Screencast;
@@ -44,8 +45,9 @@ export class VideoRecorder {
     this._screencast = screencast;
   }
 
-  start(options: { fileName?: string, size?: { width: number, height: number } }) {
+  start(options: { bitrate?: number, fileName?: string, size?: { width: number, height: number } }) {
     assert(!this._artifact);
+    assert(options.bitrate === undefined || (Number.isInteger(options.bitrate) && options.bitrate > 0), 'Expected options.bitrate to be a positive integer.');
     // Do this first, it likes to throw.
     const ffmpegPath = registry.findExecutable('ffmpeg')!.executablePathOrDie(this._screencast.page.browserContext._browser.sdkLanguage());
     const outputFile = options.fileName ?? path.join(this._screencast.page.browserContext._browser.options.artifactsDir, createGuid() + '.webm');
@@ -61,7 +63,7 @@ export class VideoRecorder {
     // another client (e.g. tracing) started the screencast first, and padding a smaller frame
     // into the requested size would leave gray borders.
     const { size } = this._screencast.addClient(this._client);
-    this._videoRecorder = new FfmpegVideoRecorder(ffmpegPath, size, outputFile, this._screencast.page.delegate);
+    this._videoRecorder = new FfmpegVideoRecorder(ffmpegPath, size, outputFile, options.bitrate || defaultVideoBitrate, this._screencast.page.delegate);
     this._artifact = new Artifact(this._screencast.page.browserContext, outputFile);
     return this._artifact;
   }
@@ -98,6 +100,7 @@ export function startAutomaticVideoRecording(page: Page) {
 }
 
 class FfmpegVideoRecorder {
+  private _bitrate: number;
   private _size: types.Size;
   private _process: ChildProcess | null = null;
   private _gracefullyClose: (() => Promise<void>) | null = null;
@@ -109,12 +112,13 @@ class FfmpegVideoRecorder {
   private _launchPromise: Promise<Error | null>;
   private _outputFile: string;
 
-  constructor(ffmpegPath: string, size: types.Size, outputFile: string, page: PageDelegate) {
+  constructor(ffmpegPath: string, size: types.Size, outputFile: string, bitrate: number, page: PageDelegate) {
     if (!outputFile.endsWith('.webm'))
       throw new Error('File must have .webm extension');
     this._outputFile = outputFile;
     this._ffmpegPath = ffmpegPath;
     this._size = size;
+    this._bitrate = bitrate;
     this._launchPromise = this._launch(page).catch(e => e);
   }
 
@@ -138,8 +142,8 @@ class FfmpegVideoRecorder {
     //     Suggested here: https://trac.ffmpeg.org/wiki/Encode/VP8
     //   "-crf 8" - constant quality mode, 4-63, lower means better quality.
     //   "-deadline realtime -speed 8" - do not use too much cpu to keep up with incoming frames.
-    //   "-b:v 1M" - video bitrate. Default value is too low for vp8
-    //     Suggested here: https://trac.ffmpeg.org/wiki/Encode/VP8
+    //   "-b:v <bitrate>" - target video bitrate. Defaults to 1 Mbps because the VP8
+    //     encoder default is too low. Suggested here: https://trac.ffmpeg.org/wiki/Encode/VP8
     //   Note that we can switch to "-qmin 20 -qmax 50 -crf 30" for smaller video size but worse quality.
     //
     // We use "pad" and "crop" video filters (-vf option) to resize incoming frames
@@ -165,7 +169,7 @@ class FfmpegVideoRecorder {
     const w = this._size.width;
     const h = this._size.height;
     const videoFilterArgs = page.getFFmpegVideoFilterArgs?.({ width: w, height: h }) ?? `pad=${w}:${h}:0:0:gray,crop=${w}:${h}:0:0`;
-    const args = `-loglevel error -f matroska -fpsprobesize 0 -probesize 32 -analyzeduration 0 -i pipe:0 -y -an -r ${fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -speed 8 -b:v 1M -threads 1 -vf ${videoFilterArgs}`.split(' ');
+    const args = `-loglevel error -f matroska -fpsprobesize 0 -probesize 32 -analyzeduration 0 -i pipe:0 -y -an -r ${fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -speed 8 -b:v ${this._bitrate} -threads 1 -vf ${videoFilterArgs}`.split(' ');
     args.push(this._outputFile);
 
     const { launchedProcess, gracefullyClose } = await launchProcess({

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -92,7 +92,7 @@ export type FilenameTemplate = {
   date?: Date;
 };
 
-type VideoParams = { size?: { width: number; height: number } };
+type VideoParams = { bitrate?: number; size?: { width: number; height: number } };
 
 export class Context {
   readonly config: ContextConfig;

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -25,6 +25,7 @@ const videoStart = defineTool({
     title: 'Start video',
     description: 'Start video recording',
     inputSchema: z.object({
+      bitrate: z.number().int().min(1).optional().describe('Video bitrate in bits per second. Defaults to 1000000.'),
       filename: z.string().optional().describe('Filename to save the video.'),
       size: z.object({
         width: z.number().describe('Video width'),
@@ -36,7 +37,7 @@ const videoStart = defineTool({
 
   handle: async (context, params, response) => {
     const resolvedFile = await response.resolveClientFile({ prefix: 'video', ext: 'webm', suggestedFilename: params.filename }, 'Video');
-    await context.startVideoRecording(resolvedFile.fileName, { size: params.size });
+    await context.startVideoRecording(resolvedFile.fileName, { bitrate: params.bitrate, size: params.size });
     response.addTextResult('Video recording started.');
   },
 });

--- a/packages/playwright-core/src/tools/cli-daemon/commands.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/commands.ts
@@ -974,12 +974,13 @@ const videoStart = declareCommand({
     filename: z.string().optional().describe('Filename to save the video.'),
   }),
   options: z.object({
+    bitrate: numberArg.pipe(z.number().int().min(1)).optional().describe('Video bitrate in bits per second. Defaults to 1000000.'),
     size: z.string().optional().describe('Video frame size, e.g. "800x600". If not specified, the size of the recorded video will fit 800x800.'),
   }),
   toolName: 'browser_start_video',
-  toolParams: ({ filename, size }) => {
+  toolParams: ({ bitrate, filename, size }) => {
     const parsedSize = size ? size.split('x').map(Number) : undefined;
-    return { filename, size: parsedSize ? { width: parsedSize[0], height: parsedSize[1] } : undefined };
+    return { bitrate, filename, size: parsedSize ? { width: parsedSize[0], height: parsedSize[1] } : undefined };
   }
 });
 

--- a/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
@@ -170,7 +170,7 @@ playwright-cli tracing-stop
 playwright-cli recording-start
 playwright-cli recording-stop
 
-playwright-cli video-start video.webm
+playwright-cli video-start video.webm --bitrate=8000000
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 

--- a/packages/playwright-core/src/tools/skills/playwright-cli/references/video-recording.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/references/video-recording.md
@@ -9,7 +9,7 @@ Capture browser automation sessions as video for debugging, documentation, or ve
 playwright-cli open
 
 # Start recording
-playwright-cli video-start demo.webm
+playwright-cli video-start demo.webm --bitrate=8000000
 
 # Add a chapter marker for section transitions
 playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
@@ -33,8 +33,8 @@ playwright-cli video-stop
 
 ```bash
 # Include context in filename
-playwright-cli video-start recordings/login-flow-2024-01-15.webm
-playwright-cli video-start recordings/checkout-test-run-42.webm
+playwright-cli video-start recordings/login-flow-2024-01-15.webm --bitrate=8000000
+playwright-cli video-start recordings/checkout-test-run-42.webm --bitrate=8000000
 ```
 
 ### 2. Record entire hero scripts.
@@ -50,7 +50,7 @@ It allows inserting appropriate pauses between the actions and annotating the vi
 
 ```js
 async page => {
-  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 }, bitrate: 8_000_000 });
   await page.goto('https://demo.playwright.dev/todomvc');
 
   // Show a chapter card — blurs the page and shows a dialog.

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -18649,6 +18649,7 @@ export interface Screencast {
    * @param options
    */
   start(options?: {
+    bitrate?: number;
     onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any;
     path?: string;
     size?: {

--- a/packages/protocol/spec/page.yml
+++ b/packages/protocol/spec/page.yml
@@ -581,6 +581,7 @@ Page:
             width: int
             height: int
         quality: int?
+        bitrate: int?
         sendFrames: boolean?
         record: boolean?
       returns:

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -2597,6 +2597,7 @@ scheme.PageScreencastStartParams = tObject({
     height: tInt,
   })),
   quality: tOptional(tInt),
+  bitrate: tOptional(tInt),
   sendFrames: tOptional(tBoolean),
   record: tOptional(tBoolean),
 });

--- a/tests/library/screencast.spec.ts
+++ b/tests/library/screencast.spec.ts
@@ -184,7 +184,7 @@ test('start/stop twice without path creates two files in artifactsDir', async ({
   const context = await browser.newContext({ viewport: size });
   const page = await context.newPage();
 
-  await page.screencast.start({ path: testInfo.outputPath('video1.webm'), size });
+  await page.screencast.start({ path: testInfo.outputPath('video1.webm'), size, bitrate: 2_000_000 });
   await page.evaluate(() => document.body.style.backgroundColor = 'red');
   await ensureSomeFrames(page);
   await page.screencast.stop();
@@ -199,6 +199,18 @@ test('start/stop twice without path creates two files in artifactsDir', async ({
 
   await context.close();
   await browser.close();
+});
+
+test('start validates bitrate', async ({ browser }, testInfo) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await expect(page.screencast.start({
+    bitrate: 0,
+    path: testInfo.outputPath('video.webm'),
+  })).rejects.toThrow('Expected options.bitrate to be a positive integer.');
+
+  await context.close();
 });
 
 test('start should work when recordVideo is set', async ({ browser }, testInfo) => {

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -235,7 +235,7 @@ test('tracing-start-stop', async ({ cli, server }, testInfo) => {
 
 test('video-start-stop', async ({ cli, server }) => {
   await cli('open', server.HELLO_WORLD);
-  const { output: videoStartOutput } = await cli('video-start', 'recordings/video.webm', '--size=400x300');
+  const { output: videoStartOutput } = await cli('video-start', 'recordings/video.webm', '--bitrate=8000000', '--size=400x300');
   expect(videoStartOutput).toContain('Video recording started.');
   const { output: tabNewOutput } = await cli('tab-new');
   expect(tabNewOutput).toContain('1: (current) [](about:blank)');

--- a/utils/generate_types/overrides.d.ts
+++ b/utils/generate_types/overrides.d.ts
@@ -249,6 +249,7 @@ export interface WebSocketRoute {
 
 export interface Screencast {
   start(options?: {
+    bitrate?: number;
     onFrame?: (frame: { data: Buffer, timestamp: number, viewportWidth: number, viewportHeight: number }) => Promise<any>|any;
     path?: string;
     size?: {


### PR DESCRIPTION
video recordings use a fixed bitrate that can make UI details unreadable during motion

add a `bitrate` option to screencast recording and `video-start` while preserving the existing default

fixes <https://github.com/microsoft/playwright/issues/42375>