### PR TITLE
fix(utils): clamp negative delay in raceAgainstDeadline

### DIFF
--- a/packages/isomorphic/timeoutRunner.ts
+++ b/packages/isomorphic/timeoutRunner.ts
@@ -32,7 +32,7 @@ export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: num
     new Promise<{ timedOut: true }>(resolve => {
       if (!deadline)
         return;
-      timer = setTimeout(() => resolve({ timedOut: true }), deadline - monotonicTime());
+      timer = setTimeout(() => resolve({ timedOut: true }), Math.max(0, deadline - monotonicTime()));
     }),
   ]).finally(() => {
     clearTimeout(timer);

--- a/tests/library/unit/timeout-runner.spec.ts
+++ b/tests/library/unit/timeout-runner.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { raceAgainstDeadline } from '../../../packages/isomorphic/timeoutRunner';
+import { monotonicTime } from '../../../packages/isomorphic/time';
+
+test('raceAgainstDeadline should not emit TimeoutNegativeWarning for a passed deadline', async () => {
+  const warnings: string[] = [];
+  const onWarning = (w: Error) => warnings.push(w.name);
+  process.on('warning', onWarning);
+  try {
+    const result = await raceAgainstDeadline(() => new Promise<void>(() => {}), monotonicTime() - 1);
+    await new Promise(f => setImmediate(f));
+    expect(result.timedOut).toBe(true);
+    expect(warnings).not.toContain('TimeoutNegativeWarning');
+  } finally {
+    process.off('warning', onWarning);
+  }
+});


### PR DESCRIPTION
`raceAgainstDeadline` computes the timer delay as `deadline - monotonicTime()` without clamping. When the deadline has already passed by the time the race is wired up (which happens whenever the caller checked the deadline a few microseconds earlier, or never checked at all), the delay is negative and Node prints:

```
(node:2411) TimeoutNegativeWarning: -0.044 is a negative number.
Timeout duration was set to 1.
```

Node already clamps the delay to 1 ms and the promise resolves `{ timedOut: true }` as intended, so behaviour is correct; only the warning is spurious. It shows up as stderr noise in CI logs for anyone using the test runner.

`pollAgainstDeadline` guards against this before calling `raceAgainstDeadline`, but the direct callers (`webServerPlugin`, `testType`, `recorderUtils`) do not, so the fix belongs in `raceAgainstDeadline` itself.

### Change

Clamp the delay with `Math.max(0, ...)` in `packages/isomorphic/timeoutRunner.ts`.

### Test

`tests/library/unit/timeout-runner.spec.ts` races a never-resolving callback against a deadline 1 ms in the past and asserts that `timedOut` is `true` and no `TimeoutNegativeWarning` is emitted. Fails on `main`, passes with this change.
