### PR TITLE
docs(browsercontext): undeprecate setHTTPCredentials

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1522,7 +1522,12 @@ its geolocation.
 ## async method: BrowserContext.setHTTPCredentials
 * since: v1.8
 * langs: js
-* deprecated: Browsers may cache credentials after successful authentication. Create a new browser context instead.
+
+Sets the credentials for HTTP authentication for this browser context.
+
+:::note
+Browsers may cache credentials per origin after a successful authentication, so changing credentials for an origin that has already been authenticated may have no effect.
+:::
 
 ### param: BrowserContext.setHTTPCredentials.httpCredentials
 * since: v1.8

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -10602,7 +10602,11 @@ export interface BrowserContext {
   }): Promise<void>;
 
   /**
-   * @deprecated Browsers may cache credentials after successful authentication. Create a new browser context instead.
+   * Sets the credentials for HTTP authentication for this browser context.
+   *
+   * **NOTE** Browsers may cache credentials per origin after a successful authentication, so changing credentials for
+   * an origin that has already been authenticated may have no effect.
+   *
    * @param httpCredentials Pass an array to use different credentials for different origins. The first entry that matches the request origin
    * is used, and entries with no origin match any request.
    */

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -10602,7 +10602,11 @@ export interface BrowserContext {
   }): Promise<void>;
 
   /**
-   * @deprecated Browsers may cache credentials after successful authentication. Create a new browser context instead.
+   * Sets the credentials for HTTP authentication for this browser context.
+   *
+   * **NOTE** Browsers may cache credentials per origin after a successful authentication, so changing credentials for
+   * an origin that has already been authenticated may have no effect.
+   *
    * @param httpCredentials Pass an array to use different credentials for different origins. The first entry that matches the request origin
    * is used, and entries with no origin match any request.
    */


### PR DESCRIPTION
## Summary
- Remove the `deprecated` annotation from `BrowserContext.setHTTPCredentials`.
- Document instead that browsers may cache credentials per origin, so changing credentials for an already-authenticated origin may have no effect.