### PR TITLE
chore(reporters): rename chrome-trace reporter to perfetto

### DIFF
--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -101,7 +101,7 @@ See [`property: TestConfig.quiet`].
 
 ## property: FullConfig.reporter
 * since: v1.10
-- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"chrome-trace">>
+- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"perfetto">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -448,7 +448,7 @@ export default defineConfig({
 
 ## property: TestConfig.reporter
 * since: v1.10
-- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"chrome-trace">>
+- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"perfetto">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -431,32 +431,32 @@ JUnit report supports following configuration options and environment variables:
 | `PLAYWRIGHT_JUNIT_SUITE_ID` |  | Value of the `id` attribute on the root `<testsuites/>` report entry. | Empty string.
 | `PLAYWRIGHT_JUNIT_SUITE_NAME` |  | Value of the `name` attribute on the root `<testsuites/>` report entry. | Empty string.
 
-### Chrome tracing reporter
+### Perfetto reporter
 
-Chrome tracing reporter produces a [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview) json file that can be opened in [`chrome://tracing`](chrome://tracing) or in the [Perfetto UI](https://ui.perfetto.dev). It renders the test run as a timeline with a lane per worker, where every test is a slice containing its before/after hooks, fixtures and steps as nested slices. Every slice carries the details of the test or step in its trace event arguments, including source locations, [`property: TestStep.params`], tags, annotations, errors, stdio and paths to the attachment files.
+Perfetto reporter produces a [Trace Event Format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview) json file that can be opened in the [Perfetto UI](https://ui.perfetto.dev) or in `chrome://tracing`. It renders the test run as a timeline with a lane per worker, where every test is a slice containing its before/after hooks, fixtures and steps as nested slices. Every slice carries the details of the test or step in its trace event arguments, including source locations, [`property: TestStep.params`], tags, annotations, errors, stdio and paths to the attachment files.
 
 ```bash
-npx playwright test --reporter=chrome-trace
+npx playwright test --reporter=perfetto
 ```
 
-By default the report is written to `test-results/chrome-trace.json`. When the output file name ends with `.gz`, the
+By default the report is written to `test-results/perfetto.json`. When the output file name ends with `.gz`, the
 report is gzipped on the fly, which both viewers accept and which is worth it for large test runs.
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  reporter: [['chrome-trace', { outputFile: 'chrome-trace.json.gz' }]],
+  reporter: [['perfetto', { outputFile: 'perfetto.json.gz' }]],
 });
 ```
 
-Chrome tracing report supports following configuration options and environment variables:
+Perfetto report supports following configuration options and environment variables:
 
 | Environment Variable Name | Reporter Config Option| Description | Default
 |---|---|---|---|
-| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_DIR` | | Directory to save the output file. Ignored if output file is specified. | `test-results`
-| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_NAME` | | Base file name for the output, relative to the output dir. | `chrome-trace.json`
-| `PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE` | `outputFile` | Full path to the output file. If defined, `PLAYWRIGHT_CHROME_TRACE_OUTPUT_DIR` and `PLAYWRIGHT_CHROME_TRACE_OUTPUT_NAME` will be ignored. | `undefined`
+| `PLAYWRIGHT_PERFETTO_OUTPUT_DIR` | | Directory to save the output file. Ignored if output file is specified. | `test-results`
+| `PLAYWRIGHT_PERFETTO_OUTPUT_NAME` | | Base file name for the output, relative to the output dir. | `perfetto.json`
+| `PLAYWRIGHT_PERFETTO_OUTPUT_FILE` | `outputFile` | Full path to the output file. If defined, `PLAYWRIGHT_PERFETTO_OUTPUT_DIR` and `PLAYWRIGHT_PERFETTO_OUTPUT_NAME` will be ignored. | `undefined`
 
 ### GitHub Actions annotations
 

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -289,7 +289,7 @@ export function toReporters(reporters: BuiltInReporter | ReporterDescription[] |
   return reporters;
 }
 
-export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob', 'chrome-trace'] as const;
+export const builtInReporters = ['list', 'line', 'dot', 'json', 'junit', 'null', 'github', 'html', 'blob', 'perfetto'] as const;
 export type BuiltInReporter = typeof builtInReporters[number];
 
 export type ContextReuseMode = 'none' | 'when-possible';

--- a/packages/playwright/src/reporters/perfetto.ts
+++ b/packages/playwright/src/reporters/perfetto.ts
@@ -26,7 +26,7 @@ import { stripAnsiEscapes } from '../util';
 
 import type { ReporterV2 } from './reporterV2';
 import type { Writable } from 'stream';
-import type { ChromeTraceReporterOptions } from '../../types/test';
+import type { PerfettoReporterOptions } from '../../types/test';
 import type { FullConfig, FullResult, Location, Suite, TestCase, TestError, TestResult, TestStep } from '../../types/testReporter';
 
 type TraceEvent = {
@@ -57,7 +57,7 @@ const kStatusColors: Record<string, string> = {
 const kProcessId = 1;
 const kRunThreadId = 0;
 
-class ChromeTraceReporter implements ReporterV2 {
+class PerfettoReporter implements ReporterV2 {
   private _config!: FullConfig;
   private _suite!: Suite;
   private _resolvedOutputFile: string;
@@ -65,11 +65,11 @@ class ChromeTraceReporter implements ReporterV2 {
   private _laneEndTime = new Map<number, number>();
   private _globalErrors: { error: TestError, timestamp: number }[] = [];
 
-  constructor(options: ChromeTraceReporterOptions & CommonReporterOptions) {
-    this._resolvedOutputFile = resolveOutputFile('CHROME_TRACE', {
+  constructor(options: PerfettoReporterOptions & CommonReporterOptions) {
+    this._resolvedOutputFile = resolveOutputFile('PERFETTO', {
       ...options,
       default: {
-        fileName: 'chrome-trace.json',
+        fileName: 'perfetto.json',
         outputDir: 'test-results',
       },
     })!.outputFile;
@@ -339,4 +339,4 @@ function concatChunks(chunks: (string | Buffer)[]): string {
   return chunks.map(chunk => typeof chunk === 'string' ? chunk : chunk.toString('utf8')).join('');
 }
 
-export default ChromeTraceReporter;
+export default PerfettoReporter;

--- a/packages/playwright/src/runner/reporters.ts
+++ b/packages/playwright/src/runner/reporters.ts
@@ -19,7 +19,6 @@ import { calculateSha1 } from '@utils/crypto';
 import { loadReporter } from './loadUtils';
 import { formatError } from '../reporters/base';
 import { BlobReporter } from '../reporters/blob';
-import ChromeTraceReporter from '../reporters/chromeTrace';
 import DotReporter from '../reporters/dot';
 import EmptyReporter from '../reporters/empty';
 import GitHubReporter from '../reporters/github';
@@ -29,6 +28,7 @@ import JUnitReporter from '../reporters/junit';
 import LineReporter from '../reporters/line';
 import ListReporter from '../reporters/list';
 import ListModeReporter from '../reporters/listModeReporter';
+import PerfettoReporter from '../reporters/perfetto';
 import { wrapReporterAsV2 } from '../reporters/reporterV2';
 
 import type { ReporterDescription } from '../../types/test';
@@ -41,7 +41,7 @@ import type { TestRunOptions } from './tasks';
 export async function createReporters(config: FullConfigInternal, mode: 'list' | 'test' | 'merge', descriptions?: ReporterDescription[], runOptions?: TestRunOptions): Promise<ReporterV2[]> {
   const defaultReporters: { [key in commonConfig.BuiltInReporter]: new(arg: any) => ReporterV2 } = {
     'blob': BlobReporter,
-    'chrome-trace': ChromeTraceReporter,
+    'perfetto': PerfettoReporter,
     'dot': mode === 'list' ? ListModeReporter : DotReporter,
     'line': mode === 'list' ? ListModeReporter : LineReporter,
     'list': mode === 'list' ? ListModeReporter : ListReporter,

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -25,7 +25,7 @@ export type ListReporterOptions = { printSteps?: boolean, printFailuresInline?: 
 export type GitHubReporterOptions = { omitTags?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean, includeRetries?: boolean, omitTags?: boolean };
 export type JsonReporterOptions = { outputFile?: string };
-export type ChromeTraceReporterOptions = { outputFile?: string };
+export type PerfettoReporterOptions = { outputFile?: string };
 export type HtmlReporterOptions = {
   outputFolder?: string;
   open?: 'always' | 'never' | 'on-failure';
@@ -47,7 +47,7 @@ export type ReporterDescription = Readonly<
   ['github'] | ['github', GitHubReporterOptions] |
   ['junit'] | ['junit', JUnitReporterOptions] |
   ['json'] | ['json', JsonReporterOptions] |
-  ['chrome-trace'] | ['chrome-trace', ChromeTraceReporterOptions] |
+  ['perfetto'] | ['perfetto', PerfettoReporterOptions] |
   ['html'] | ['html', HtmlReporterOptions] |
   ['null'] |
   [string] | [string, any]
@@ -919,7 +919,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    * ```
    *
    */
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'chrome-trace', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'perfetto', string> | ReporterDescription[];
   /**
    * Global options for all tests, for example
    * [testOptions.browserName](https://playwright.dev/docs/api/class-testoptions#test-options-browser-name). Learn more

--- a/tests/playwright-test/reporter-perfetto.spec.ts
+++ b/tests/playwright-test/reporter-perfetto.spec.ts
@@ -31,7 +31,7 @@ type TraceEvent = {
   args?: any;
 };
 
-function readTrace(baseDir: string, fileName: string = 'test-results/chrome-trace.json') {
+function readTrace(baseDir: string, fileName: string = 'test-results/perfetto.json') {
   const file = path.join(baseDir, fileName);
   const content = fileName.endsWith('.gz') ? zlib.gunzipSync(fs.readFileSync(file)).toString('utf8') : fs.readFileSync(file, 'utf8');
   return JSON.parse(content) as {
@@ -74,8 +74,8 @@ const testFiles = {
   `,
 };
 
-test('should write a chrome tracing report', async ({ runInlineTest }, testInfo) => {
-  const result = await runInlineTest(testFiles, { reporter: 'chrome-trace' });
+test('should write a perfetto report', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest(testFiles, { reporter: 'perfetto' });
   expect(result.exitCode).toBe(1);
 
   const report = readTrace(testInfo.outputPath());
@@ -121,7 +121,7 @@ test('should write a chrome tracing report', async ({ runInlineTest }, testInfo)
 });
 
 test('should nest steps within the test slice', async ({ runInlineTest }, testInfo) => {
-  const result = await runInlineTest(testFiles, { reporter: 'chrome-trace' });
+  const result = await runInlineTest(testFiles, { reporter: 'perfetto' });
   expect(result.exitCode).toBe(1);
 
   const events = slices(readTrace(testInfo.outputPath()).traceEvents);
@@ -165,7 +165,7 @@ test('should use a lane per worker', async ({ runInlineTest }, testInfo) => {
       import { test, expect } from '@playwright/test';
       test('two', async ({}) => { await new Promise(f => setTimeout(f, 500)); });
     `,
-  }, { reporter: 'chrome-trace', workers: 2 });
+  }, { reporter: 'perfetto', workers: 2 });
   expect(result.exitCode).toBe(0);
 
   const events = readTrace(testInfo.outputPath()).traceEvents;
@@ -185,7 +185,7 @@ test('should report attachment files', async ({ runInlineTest }, testInfo) => {
         await test.info().attach('file', { path: file });
       });
     `,
-  }, { reporter: 'chrome-trace' });
+  }, { reporter: 'perfetto' });
   expect(result.exitCode).toBe(0);
 
   const one = findSlice(readTrace(testInfo.outputPath()).traceEvents, 'one')!;
@@ -204,7 +204,7 @@ test('should report step params', async ({ runInlineTest }, testInfo) => {
         await test.step('my step', async () => {}, { params: { foo: 'bar', count: 7 } });
       });
     `,
-  }, { reporter: 'chrome-trace' });
+  }, { reporter: 'perfetto' });
   expect(result.exitCode).toBe(0);
 
   const events = slices(readTrace(testInfo.outputPath()).traceEvents);
@@ -218,7 +218,7 @@ test('should report step params', async ({ runInlineTest }, testInfo) => {
 test('should respect outputFile option', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
-      module.exports = { reporter: [['chrome-trace', { outputFile: 'reports/my-trace.json' }]] };
+      module.exports = { reporter: [['perfetto', { outputFile: 'reports/my-trace.json' }]] };
     `,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -232,7 +232,7 @@ test('should respect outputFile option', async ({ runInlineTest }, testInfo) => 
 test('should gzip the report when output file ends with .gz', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'playwright.config.ts': `
-      module.exports = { reporter: [['chrome-trace', { outputFile: 'chrome-trace.json.gz' }]] };
+      module.exports = { reporter: [['perfetto', { outputFile: 'perfetto.json.gz' }]] };
     `,
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
@@ -241,18 +241,18 @@ test('should gzip the report when output file ends with .gz', async ({ runInline
   });
   expect(result.exitCode).toBe(0);
 
-  const gzipped = fs.readFileSync(testInfo.outputPath('chrome-trace.json.gz'));
+  const gzipped = fs.readFileSync(testInfo.outputPath('perfetto.json.gz'));
   expect(gzipped.subarray(0, 2)).toEqual(Buffer.from([0x1f, 0x8b]));
-  expect(findSlice(readTrace(testInfo.outputPath(), 'chrome-trace.json.gz').traceEvents, 'one')).toBeTruthy();
+  expect(findSlice(readTrace(testInfo.outputPath(), 'perfetto.json.gz').traceEvents, 'one')).toBeTruthy();
 });
 
-test('should respect PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
+test('should respect PLAYWRIGHT_PERFETTO_OUTPUT_FILE', async ({ runInlineTest }, testInfo) => {
   const result = await runInlineTest({
     'a.test.ts': `
       import { test, expect } from '@playwright/test';
       test('one', async ({}) => {});
     `,
-  }, { reporter: 'chrome-trace' }, { PLAYWRIGHT_CHROME_TRACE_OUTPUT_FILE: testInfo.outputPath('env-trace.json') });
+  }, { reporter: 'perfetto' }, { PLAYWRIGHT_PERFETTO_OUTPUT_FILE: testInfo.outputPath('env-trace.json') });
   expect(result.exitCode).toBe(0);
   expect(findSlice(readTrace(testInfo.outputPath(), 'env-trace.json').traceEvents, 'one')).toBeTruthy();
 });
@@ -265,7 +265,7 @@ test('should report retries as separate slices', async ({ runInlineTest }, testI
         expect(testInfo.retry).toBe(1);
       });
     `,
-  }, { reporter: 'chrome-trace', retries: 1 });
+  }, { reporter: 'perfetto', retries: 1 });
   expect(result.exitCode).toBe(0);
 
   const flaky = slices(readTrace(testInfo.outputPath()).traceEvents).filter(e => e.name === 'flaky');
@@ -283,7 +283,7 @@ test('should report global errors as instant events', async ({ runInlineTest }, 
     'b.test.ts': `
       throw new Error('Oh my!');
     `,
-  }, { reporter: 'chrome-trace' });
+  }, { reporter: 'perfetto' });
   expect(result.exitCode).toBe(1);
 
   const errors = readTrace(testInfo.outputPath()).traceEvents.filter(e => e.ph === 'i');

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -24,7 +24,7 @@ export type ListReporterOptions = { printSteps?: boolean, printFailuresInline?: 
 export type GitHubReporterOptions = { omitTags?: boolean };
 export type JUnitReporterOptions = { outputFile?: string, stripANSIControlSequences?: boolean, includeProjectInTestName?: boolean, includeRetries?: boolean, omitTags?: boolean };
 export type JsonReporterOptions = { outputFile?: string };
-export type ChromeTraceReporterOptions = { outputFile?: string };
+export type PerfettoReporterOptions = { outputFile?: string };
 export type HtmlReporterOptions = {
   outputFolder?: string;
   open?: 'always' | 'never' | 'on-failure';
@@ -46,7 +46,7 @@ export type ReporterDescription = Readonly<
   ['github'] | ['github', GitHubReporterOptions] |
   ['junit'] | ['junit', JUnitReporterOptions] |
   ['json'] | ['json', JsonReporterOptions] |
-  ['chrome-trace'] | ['chrome-trace', ChromeTraceReporterOptions] |
+  ['perfetto'] | ['perfetto', PerfettoReporterOptions] |
   ['html'] | ['html', HtmlReporterOptions] |
   ['null'] |
   [string] | [string, any]
@@ -69,7 +69,7 @@ type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 
 interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
   projects?: Project<TestArgs, WorkerArgs>[];
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'chrome-trace', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'perfetto', string> | ReporterDescription[];
   use?: UseOptions<TestArgs, WorkerArgs>;
   webServer?: TestConfigWebServer | TestConfigWebServer[];
 }


### PR DESCRIPTION
## Summary
- Rename the `chrome-trace` reporter to `perfetto`: reporter id, source file, options type, `PLAYWRIGHT_PERFETTO_*` env vars, default output file `perfetto.json`, docs and tests.