### PR TITLE
test(chromium): update referer expectations

### DIFF
--- a/tests/page/page-route.spec.ts
+++ b/tests/page/page-route.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Route } from 'playwright-core';
+import { chromiumVersionLessThan } from '../config/utils';
 import { test as it, expect } from './pageTest';
 
 it('should intercept @smoke', async ({ page, server }) => {
@@ -273,11 +274,11 @@ it('should pause intercepted fetch request until continue', async ({ page, serve
   expect(status).toBe(200);
 });
 
-it('should work with custom referer headers', async ({ page, server, browserName }) => {
+it('should work with custom referer headers', async ({ page, server, browserName, browserVersion }) => {
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   await page.route('**/*', route => {
     // See https://github.com/microsoft/playwright/issues/8999
-    if (browserName === 'chromium')
+    if (browserName === 'chromium' && chromiumVersionLessThan(browserVersion, '154.0.8014.0'))
       expect(route.request().headers()['referer']).toBe(server.EMPTY_PAGE + ', ' + server.EMPTY_PAGE);
     else
       expect(route.request().headers()['referer']).toBe(server.EMPTY_PAGE);

--- a/tests/page/page-set-extra-http-headers.spec.ts
+++ b/tests/page/page-set-extra-http-headers.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import { chromiumVersionLessThan } from '../config/utils';
 import { test as it, expect } from './pageTest';
 
 it('should work @smoke', async ({ page, server }) => {
@@ -61,8 +62,8 @@ it('should throw for non-string header values', async ({ page }) => {
   expect(error2.message).toContain('Expected value of header "foo" to be String, but "boolean" is found.');
 });
 
-it('should not duplicate referer header', async ({ page, server, browserName }) => {
-  it.fail(browserName === 'chromium', 'Request has referer and Referer');
+it('should not duplicate referer header', async ({ page, server, browserName, browserVersion }) => {
+  it.fail(browserName === 'chromium' && chromiumVersionLessThan(browserVersion, '154.0.8014.0'), 'Request has referer and Referer');
   await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
   const response = await page.goto(server.EMPTY_PAGE);
   expect(response.ok()).toBe(true);


### PR DESCRIPTION
the Chromium DevTools protocol stops reporting duplicate referer header case variants in 154.0.8014.0

scope the old expectations to earlier Chromium versions