### PR TITLE
chore(html): render step waterfall beside duration text

### DIFF
--- a/packages/html-reporter/src/testResultView.css
+++ b/packages/html-reporter/src/testResultView.css
@@ -103,12 +103,16 @@
   flex: none;
   white-space: nowrap;
   margin-left: 4px;
+  min-width: 48px;
+  text-align: right;
+}
+
+.step-waterfall {
+  flex: none;
   position: relative;
   width: 80px;
   height: 20px;
-  line-height: 20px;
-  text-align: right;
-  padding: 0 4px;
+  margin-left: 4px;
   border-radius: 4px;
   background-color: var(--color-canvas-subtle);
   overflow: hidden;
@@ -120,10 +124,6 @@
   bottom: 0;
   min-width: 2px;
   background-color: var(--color-severe-muted);
-}
-
-.step-duration-text {
-  position: relative;
 }
 
 :root.light-mode {

--- a/packages/html-reporter/src/testResultView.tsx
+++ b/packages/html-reporter/src/testResultView.tsx
@@ -296,10 +296,10 @@ const StepTreeItem: React.FC<{
       aria-label='contains attachment'>
       {icons.indirectAttachment()}
     </span>}
-    <span className='step-duration'>
+    <span className='step-waterfall'>
       <span className='step-waterfall-block' style={waterfallBlockStyle(step, waterfall)}></span>
-      <span className='step-duration-text'>{msToString(step.duration)}</span>
     </span>
+    <span className='step-duration'>{msToString(step.duration)}</span>
   </div>} loadChildren={step.steps.length || step.snippet ? () => {
     const snippet = step.snippet ? [<CodeSnippet testId='test-snippet' key='line' code={step.snippet} />] : [];
     const steps = step.steps.map((s, i) => <StepTreeItem key={i} step={s} depth={depth + 1} result={result} test={test} filterText={filterText} waterfall={waterfall} />);


### PR DESCRIPTION
## Summary
- Move the step waterfall bar out of the duration box background into its own track next to the duration text, so the text no longer overlaps the bar.

<img width="247" height="376" alt="image" src="https://github.com/user-attachments/assets/46f54dad-d3b7-452e-bbc1-2a3e433d708c" />
