### PR TITLE
chore(trace): use a single id for calls and test runner steps

### DIFF
--- a/packages/isomorphic/trace/trace.ts
+++ b/packages/isomorphic/trace/trace.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export type * from './versions/traceV9';
+export type * from './versions/traceV10';

--- a/packages/isomorphic/trace/traceLoader.ts
+++ b/packages/isomorphic/trace/traceLoader.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { parseClientSideCallMetadata } from './traceUtils';
-
 import { SnapshotStorage } from './snapshotStorage';
 import { TraceModernizer } from './traceModernizer';
 
@@ -72,6 +70,11 @@ export class TraceLoader {
       modernizer.appendTrace(network);
       unzipProgress?.(++done, total);
 
+      const stacks = await this._backend.readText(prefix + '.stacks');
+      if (stacks)
+        modernizer.appendStacks(stacks);
+      unzipProgress?.(++done, total);
+
       contextEntry.actions = modernizer.actions().sort((a1, a2) => a1.startTime - a2.startTime);
 
       if (!backend.isLive()) {
@@ -87,14 +90,6 @@ export class TraceLoader {
           }
         }
       }
-
-      const stacks = await this._backend.readText(prefix + '.stacks');
-      if (stacks) {
-        const callMetadata = parseClientSideCallMetadata(JSON.parse(stacks));
-        for (const action of contextEntry.actions)
-          action.stack = action.stack || callMetadata.get(action.callId);
-      }
-      unzipProgress?.(++done, total);
 
       for (const resource of contextEntry.resources) {
         if (resource.request.postData?._file)

--- a/packages/isomorphic/trace/traceModel.ts
+++ b/packages/isomorphic/trace/traceModel.ts
@@ -288,8 +288,6 @@ function mergeActionsAndUpdateTiming(contexts: ContextEntry[]) {
   return result;
 }
 
-let lastTmpStepId = 0;
-
 function mergeActionsAndUpdateTimingSameTrace(contexts: ContextEntry[]): ActionEntry[] {
   const map = new Map<string, ActionEntry>();
 
@@ -311,37 +309,31 @@ function mergeActionsAndUpdateTimingSameTrace(contexts: ContextEntry[]): ActionE
   }
 
   for (const context of libraryContexts) {
-    for (const action of context.actions) {
-      // Never merge stepless events.
-      map.set(action.stepId || `tmp-step@${++lastTmpStepId}`, { ...action });
-    }
+    for (const action of context.actions)
+      map.set(action.callId, { ...action });
   }
 
-  const nonPrimaryIdToPrimaryId = new Map<string, string>();
   for (const context of testRunnerContexts) {
     for (const action of context.actions) {
-      const existing = action.stepId && map.get(action.stepId);
-      if (existing) {
-        nonPrimaryIdToPrimaryId.set(action.callId, existing.callId);
-        if (action.error)
-          existing.error = action.error;
-        if (action.attachments)
-          existing.attachments = action.attachments;
-        if (action.annotations)
-          existing.annotations = action.annotations;
-        if (action.parentId)
-          existing.parentId = nonPrimaryIdToPrimaryId.get(action.parentId) ?? action.parentId;
-        if (action.group)
-          existing.group = action.group;
-        // For the events that are present in the test runner context, always take
-        // their time from the test runner context to preserve client side order.
-        existing.startTime = action.startTime;
-        existing.endTime = action.endTime;
+      const existing = map.get(action.callId);
+      if (!existing) {
+        map.set(action.callId, { ...action });
         continue;
       }
+      if (action.error)
+        existing.error = action.error;
+      if (action.attachments)
+        existing.attachments = action.attachments;
+      if (action.annotations)
+        existing.annotations = action.annotations;
       if (action.parentId)
-        action.parentId = nonPrimaryIdToPrimaryId.get(action.parentId) ?? action.parentId;
-      map.set(action.stepId || `tmp-step@${++lastTmpStepId}`, { ...action });
+        existing.parentId = action.parentId;
+      if (action.group)
+        existing.group = action.group;
+      // For the events that are present in the test runner context, always take
+      // their time from the test runner context to preserve client side order.
+      existing.startTime = action.startTime;
+      existing.endTime = action.endTime;
     }
   }
   return [...map.values()];

--- a/packages/isomorphic/trace/traceModernizer.ts
+++ b/packages/isomorphic/trace/traceModernizer.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { defaultCallId, parseClientSideCallMetadata } from './traceUtils';
+
+import type { SerializedStack } from './traceUtils';
 import type * as trace from './trace';
 import type * as traceV3 from './versions/traceV3';
 import type * as traceV4 from './versions/traceV4';
@@ -46,6 +49,7 @@ export class TraceModernizer {
   private _consoleObjects = new Map<string, { type: string, text: string, location: { url: string, lineNumber: number, columnNumber: number }, args?: { preview: string, value: string }[] }>();
   private _apiRequestRef: string | undefined;
   private _snapshotPhases = new Map<string, trace.ActionPhase>();
+  private _legacyCallIdToStepId = new Map<string, string>();
 
   constructor(contextEntry: ContextEntry, snapshotStorage: SnapshotStorage) {
     this._contextEntry = contextEntry;
@@ -55,6 +59,18 @@ export class TraceModernizer {
   appendTrace(trace: string) {
     for (const line of trace.split('\n'))
       this._appendEvent(line);
+  }
+
+  appendStacks(stacks: string) {
+    const data = JSON.parse(stacks);
+    const normalized: SerializedStack[] = data.stacks.map(([id, ...rest]: any) => {
+      // Transform legacy numeric call ids into string ids.
+      const callId = typeof id === 'number' ? defaultCallId(id) : id;
+      return [this._legacyCallIdToStepId.get(callId) ?? callId, ...rest];
+    });
+    const callMetadata = parseClientSideCallMetadata({ files: data.files, stacks: normalized });
+    for (const action of this._actionMap.values())
+      action.stack = action.stack || callMetadata.get(action.callId);
   }
 
   actions(): ActionEntry[] {
@@ -469,6 +485,21 @@ export class TraceModernizer {
 
   _modernize_8_to_9(events: traceV8.TraceEvent[]): trace.TraceEvent[] {
     for (const event of events) {
+      // The library and the test runner used to mint their own id for the same call and reconcile
+      // them through a `stepId` side-channel. Now they share a single id - adopt the step id as the
+      // call id, remembering the mapping for the ids that `appendStacks` will see.
+      if (event.type === 'before' || event.type === 'action') {
+        if (event.stepId && event.stepId !== event.callId)
+          this._legacyCallIdToStepId.set(event.callId, event.stepId);
+        delete event.stepId;
+        if (event.parentId)
+          event.parentId = this._legacyCallIdToStepId.get(event.parentId) ?? event.parentId;
+      }
+      if (event.type === 'before' || event.type === 'input' || event.type === 'after' || event.type === 'action' || event.type === 'log')
+        event.callId = this._legacyCallIdToStepId.get(event.callId) ?? event.callId;
+      if (event.type === 'frame-snapshot')
+        event.snapshot.callId = this._legacyCallIdToStepId.get(event.snapshot.callId) ?? event.snapshot.callId;
+
       // Actions used to point at their snapshots by name, now snapshots know their own phase.
       if (event.type === 'before' || event.type === 'input' || event.type === 'after' || event.type === 'action') {
         const action = event as traceV8.ActionTraceEvent;

--- a/packages/isomorphic/trace/traceModernizer.ts
+++ b/packages/isomorphic/trace/traceModernizer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defaultCallId, parseClientSideCallMetadata } from './traceUtils';
+import { legacyCallId, parseClientSideCallMetadata } from './traceUtils';
 
 import type { SerializedStack } from './traceUtils';
 import type * as trace from './trace';
@@ -24,6 +24,7 @@ import type * as traceV5 from './versions/traceV5';
 import type * as traceV6 from './versions/traceV6';
 import type * as traceV7 from './versions/traceV7';
 import type * as traceV8 from './versions/traceV8';
+import type * as traceV9 from './versions/traceV9';
 import type { ActionEntry, ContextEntry, PageEntry } from './entries';
 import type { SnapshotStorage } from './snapshotStorage';
 
@@ -34,7 +35,7 @@ export class TraceVersionError extends Error {
   }
 }
 
-const latestVersion: trace.VERSION = 9;
+const latestVersion: trace.VERSION = 10;
 
 // Ensures distinct api request refs across contexts of the same trace.
 let lastApiRequestRefOrdinal = 0;
@@ -65,7 +66,7 @@ export class TraceModernizer {
     const data = JSON.parse(stacks);
     const normalized: SerializedStack[] = data.stacks.map(([id, ...rest]: any) => {
       // Transform legacy numeric call ids into string ids.
-      const callId = typeof id === 'number' ? defaultCallId(id) : id;
+      const callId = typeof id === 'number' ? legacyCallId(id) : id;
       return [this._legacyCallIdToStepId.get(callId) ?? callId, ...rest];
     });
     const callMetadata = parseClientSideCallMetadata({ files: data.files, stacks: normalized });
@@ -483,23 +484,8 @@ export class TraceModernizer {
     return result;
   }
 
-  _modernize_8_to_9(events: traceV8.TraceEvent[]): trace.TraceEvent[] {
+  _modernize_8_to_9(events: traceV8.TraceEvent[]): traceV9.TraceEvent[] {
     for (const event of events) {
-      // The library and the test runner used to mint their own id for the same call and reconcile
-      // them through a `stepId` side-channel. Now they share a single id - adopt the step id as the
-      // call id, remembering the mapping for the ids that `appendStacks` will see.
-      if (event.type === 'before' || event.type === 'action') {
-        if (event.stepId && event.stepId !== event.callId)
-          this._legacyCallIdToStepId.set(event.callId, event.stepId);
-        delete event.stepId;
-        if (event.parentId)
-          event.parentId = this._legacyCallIdToStepId.get(event.parentId) ?? event.parentId;
-      }
-      if (event.type === 'before' || event.type === 'input' || event.type === 'after' || event.type === 'action' || event.type === 'log')
-        event.callId = this._legacyCallIdToStepId.get(event.callId) ?? event.callId;
-      if (event.type === 'frame-snapshot')
-        event.snapshot.callId = this._legacyCallIdToStepId.get(event.snapshot.callId) ?? event.snapshot.callId;
-
       // Actions used to point at their snapshots by name, now snapshots know their own phase.
       if (event.type === 'before' || event.type === 'input' || event.type === 'after' || event.type === 'action') {
         const action = event as traceV8.ActionTraceEvent;
@@ -515,22 +501,22 @@ export class TraceModernizer {
       if (event.type === 'after' || event.type === 'action') {
         for (const attachment of event.attachments || []) {
           if (attachment.sha1) {
-            (attachment as trace.AfterActionTraceEventAttachment).file = 'resources/' + attachment.sha1;
+            (attachment as traceV9.AfterActionTraceEventAttachment).file = 'resources/' + attachment.sha1;
             delete attachment.sha1;
           }
         }
       }
       if (event.type === 'screencast-frame' && event.sha1) {
-        (event as any as trace.ScreencastFrameTraceEvent).file = 'resources/' + event.sha1;
+        (event as any as traceV9.ScreencastFrameTraceEvent).file = 'resources/' + event.sha1;
         delete (event as any).sha1;
       }
 
       if (event.type === 'frame-snapshot') {
         if (event.snapshot.snapshotName)
-          (event.snapshot as trace.FrameSnapshot).phase = this._snapshotPhases.get(event.snapshot.snapshotName);
+          (event.snapshot as traceV9.FrameSnapshot).phase = this._snapshotPhases.get(event.snapshot.snapshotName);
         for (const override of event.snapshot.resourceOverrides || []) {
           if (override.sha1) {
-            (override as trace.ResourceOverride).file = 'resources/' + override.sha1;
+            (override as traceV9.ResourceOverride).file = 'resources/' + override.sha1;
             delete override.sha1;
           }
         }
@@ -551,10 +537,30 @@ export class TraceModernizer {
         if (event.snapshot._apiRequest) {
           if (!this._apiRequestRef)
             this._apiRequestRef = 'api-request-context@' + (++lastApiRequestRefOrdinal);
-          (event as trace.ResourceSnapshotTraceEvent).snapshot._apiRequestRef = this._apiRequestRef;
+          (event as traceV9.ResourceSnapshotTraceEvent).snapshot._apiRequestRef = this._apiRequestRef;
           delete event.snapshot._apiRequest;
         }
       }
+    }
+    return events as traceV9.TraceEvent[];
+  }
+
+  _modernize_9_to_10(events: traceV9.TraceEvent[]): trace.TraceEvent[] {
+    for (const event of events) {
+      // The library and the test runner used to mint their own id for the same call and reconcile
+      // them through a `stepId` side-channel. Now they share a single id - adopt the step id as the
+      // call id, remembering the mapping for the ids that `appendStacks` will see.
+      if (event.type === 'before' || event.type === 'action') {
+        if (event.stepId && event.stepId !== event.callId)
+          this._legacyCallIdToStepId.set(event.callId, event.stepId);
+        delete event.stepId;
+        if (event.parentId)
+          event.parentId = this._legacyCallIdToStepId.get(event.parentId) ?? event.parentId;
+      }
+      if (event.type === 'before' || event.type === 'input' || event.type === 'after' || event.type === 'action' || event.type === 'log')
+        event.callId = this._legacyCallIdToStepId.get(event.callId) ?? event.callId;
+      if (event.type === 'frame-snapshot')
+        event.snapshot.callId = this._legacyCallIdToStepId.get(event.snapshot.callId) ?? event.snapshot.callId;
     }
     return events as trace.TraceEvent[];
   }

--- a/packages/isomorphic/trace/traceUtils.ts
+++ b/packages/isomorphic/trace/traceUtils.ts
@@ -18,19 +18,23 @@ import type { StackFrame } from './trace';
 import type { ClientSideCallMetadata } from '@protocol/structs';
 
 export type SerializedStackFrame = [number, number, number, string];
-export type SerializedStack = [number, SerializedStackFrame[]];
+export type SerializedStack = [string, SerializedStackFrame[]];
 
 export type SerializedClientSideCallMetadata = {
   files: string[];
   stacks: SerializedStack[];
 };
 
+export function defaultCallId(ordinal: number): string {
+  return `call@${ordinal}`;
+}
+
 export function parseClientSideCallMetadata(data: SerializedClientSideCallMetadata): Map<string, StackFrame[]> {
   const result = new Map<string, StackFrame[]>();
   const { files, stacks } = data;
   for (const s of stacks) {
     const [id, ff] = s;
-    result.set(`call@${id}`, ff.map(f => ({ file: files[f[0]], line: f[1], column: f[2], function: f[3] })));
+    result.set(id, ff.map(f => ({ file: files[f[0]], line: f[1], column: f[2], function: f[3] })));
   }
   return result;
 }

--- a/packages/isomorphic/trace/traceUtils.ts
+++ b/packages/isomorphic/trace/traceUtils.ts
@@ -29,9 +29,9 @@ let lastIdOrdinal = 0;
 
 // Use a unique prefix for each client to avoid id clashes in a trace.
 export function createCallIdGenerator(): () => string {
-  const alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
   let prefix = '';
-  for (let i = 0; i < 3; i++)
+  for (let i = 0; i < 4; i++)
     prefix += alphabet[Math.floor(Math.random() * alphabet.length)];
   return () => `${prefix}@${++lastIdOrdinal}`;
 }

--- a/packages/isomorphic/trace/traceUtils.ts
+++ b/packages/isomorphic/trace/traceUtils.ts
@@ -25,7 +25,19 @@ export type SerializedClientSideCallMetadata = {
   stacks: SerializedStack[];
 };
 
-export function defaultCallId(ordinal: number): string {
+let lastIdOrdinal = 0;
+
+// Use a unique prefix for each client to avoid id clashes in a trace.
+export function createCallIdGenerator(): () => string {
+  const alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  let prefix = '';
+  for (let i = 0; i < 3; i++)
+    prefix += alphabet[Math.floor(Math.random() * alphabet.length)];
+  return () => `${prefix}@${++lastIdOrdinal}`;
+}
+
+export function legacyCallId(ordinal: number): string {
+  // Traces recorded before the call ids became strings used this format.
   return `call@${ordinal}`;
 }
 

--- a/packages/isomorphic/trace/versions/traceV10.ts
+++ b/packages/isomorphic/trace/versions/traceV10.ts
@@ -14,153 +14,9 @@
  * limitations under the License.
  */
 
-// This is a frozen copy of the trace format, keep it self-contained.
-
-// see http://www.softwareishard.com/blog/har-12-spec/
-type HAREntry = {
-  pageref?: string;
-  startedDateTime: string;
-  time: number;
-  request: Request;
-  response: Response;
-  cache: Cache;
-  timings: Timings;
-  serverIPAddress?: string;
-  connection?: string;
-  _frameref?: string;
-  _monotonicTime?: number;
-  _serverPort?: number;
-  _securityDetails?: SecurityDetails;
-  _wasAborted?: boolean;
-  _wasFulfilled?: boolean;
-  _wasContinued?: boolean;
-  _serviceWorkerRef?: string;
-  _apiRequestRef?: string;
-  _resourceType?: string;
-  _webSocketMessages?: WebSocketMessage[];
-};
-
-type WebSocketMessage = {
-  type: 'send' | 'receive';
-  time: number;
-  opcode: number;
-  data: string;
-};
-
-type Request = {
-  method: string;
-  url: string;
-  httpVersion: string;
-  cookies: Cookie[];
-  headers: Header[];
-  queryString: QueryParameter[];
-  postData?: PostData;
-  headersSize: number;
-  bodySize: number;
-  comment?: string;
-};
-
-type Response = {
-  status: number;
-  statusText: string;
-  httpVersion: string;
-  cookies: Cookie[];
-  headers: Header[];
-  content: Content;
-  redirectURL: string;
-  headersSize: number;
-  bodySize: number;
-  comment?: string;
-  _transferSize?: number;
-  _failureText?: string
-};
-
-type Cookie = {
-  name: string;
-  value: string;
-  path?: string;
-  domain?: string;
-  expires?: string;
-  httpOnly?: boolean;
-  secure?: boolean;
-  sameSite?: string;
-  comment?: string;
-};
-
-type Header = {
-  name: string;
-  value: string;
-  comment?: string;
-};
-
-type QueryParameter = {
-  name: string;
-  value: string;
-  comment?: string;
-};
-
-type PostData = {
-  mimeType: string;
-  params: Param[];
-  text: string;
-  comment?: string;
-  _file?: string;
-};
-
-type Param = {
-  name: string;
-  value?: string;
-  fileName?: string;
-  contentType?: string;
-  comment?: string;
-};
-
-type Content = {
-  size: number;
-  compression?: number;
-  mimeType: string;
-  text?: string;
-  encoding?: string;
-  comment?: string;
-  _file?: string;
-};
-
-type Cache = {
-  beforeRequest?: CacheState | null;
-  afterRequest?: CacheState | null;
-  comment?: string;
-};
-
-type CacheState = {
-  expires?: string;
-  lastAccess: string;
-  eTag: string;
-  hitCount: number;
-  comment?: string;
-};
-
-type Timings = {
-  blocked?: number;
-  dns?: number;
-  connect?: number;
-  send: number;
-  wait: number;
-  receive: number;
-  ssl?: number;
-  comment?: string;
-};
-
-type SecurityDetails = {
-  protocol?: string;
-  subjectName?: string;
-  issuer?: string;
-  validFrom?: number;
-  validTo?: number;
-};
-
-type Language = 'javascript' | 'python' | 'java' | 'csharp' | 'jsonl';
-type Point = { x: number, y: number };
-type Rect = Size & Point;
+import type { Entry as HAREntry } from './har';
+import type { Language } from '../../locatorGenerators';
+import type { Point, Rect } from '../../types';
 
 export type Size = { width: number, height: number };
 
@@ -216,7 +72,8 @@ export type SerializedError = {
 // 7 => released in ~1.45
 // 8 => released in 1.53
 // 9 => released in 1.63
-export type VERSION = 9;
+// 10 => not released yet
+export type VERSION = 10;
 
 export type BrowserContextEventOptions = {
   baseURL?: string,
@@ -292,7 +149,6 @@ export type BeforeActionTraceEvent = {
   class: string;
   method: string;
   params: Record<string, any>;
-  stepId?: string;
   stack?: StackFrame[];
   parentId?: string;
   group?: string;

--- a/packages/isomorphic/trace/versions/traceV9.ts
+++ b/packages/isomorphic/trace/versions/traceV9.ts
@@ -148,7 +148,6 @@ export type BeforeActionTraceEvent = {
   class: string;
   method: string;
   params: Record<string, any>;
-  stepId?: string;
   stack?: StackFrame[];
   parentId?: string;
   group?: string;

--- a/packages/playwright-core/src/client/channelOwner.ts
+++ b/packages/playwright-core/src/client/channelOwner.ts
@@ -196,7 +196,7 @@ export abstract class ChannelOwner<T extends channels.Channel = channels.Channel
     let apiName = stackTrace.apiName;
     if (apiName.startsWith('_') || apiName.includes('._'))
       apiName = options?.title ?? apiName;
-    const apiZone: ApiZone = { title: options?.title, apiName, frames: stackTrace.frames, internal: options?.internal ?? false, reported: false, userData: undefined, stepId: undefined };
+    const apiZone: ApiZone = { title: options?.title, apiName, frames: stackTrace.frames, internal: options?.internal ?? false, reported: false, userData: undefined, callId: undefined };
 
     try {
       const result = await currentZone().with('apiZone', apiZone).run(async () => await func(apiZone));
@@ -254,6 +254,6 @@ type ApiZone = {
   internal?: boolean;
   reported: boolean;
   userData: any;
-  stepId?: string;
+  callId?: string;
   error?: Error;
 };

--- a/packages/playwright-core/src/client/clientInstrumentation.ts
+++ b/packages/playwright-core/src/client/clientInstrumentation.ts
@@ -20,12 +20,12 @@ import type { StackFrame } from './channels';
 import type { Page } from './page';
 import type { BrowserContextOptions } from './types';
 
-// Instrumentation can mutate the data, for example change the stepId.
+// Instrumentation can mutate the data, for example assign the callId.
 export interface ApiCallData {
   title?: string;
   frames: StackFrame[];
   userData: any;
-  stepId?: string;
+  callId?: string;
   error?: Error;
 }
 

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -20,6 +20,7 @@ import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
 import { emptyZone } from '@utils/zones';
 import { ValidationError, findValidator, maybeFindValidator } from '@protocol/validator';
+import { defaultCallId } from '@isomorphic/trace/traceUtils';
 import { EventEmitter } from './eventEmitter';
 import { Android, AndroidDevice, AndroidSocket } from './android';
 import { Artifact } from './artifact';
@@ -73,8 +74,8 @@ export type ChannelOwnerFactory = (parent: ChannelOwner, type: string, guid: str
 export class Connection extends EventEmitter {
   readonly _objects = new Map<string, ChannelOwner>();
   onmessage = (message: object): void => {};
-  private _lastId = 0;
-  private _callbacks = new Map<number, { resolve: (a: any) => void, reject: (a: Error) => void, signal: AbortSignal | undefined, title: string | undefined, type: string, method: string }>();
+  private _lastOrdinal = 0;
+  private _callbacks = new Map<string, { resolve: (a: any) => void, reject: (a: Error) => void, signal: AbortSignal | undefined, title: string | undefined, type: string, method: string }>();
   private _rootObject: Root;
   private _closedError: Error | undefined;
   private _isRemote = false;
@@ -175,7 +176,7 @@ export class Connection extends EventEmitter {
       this._tracingCount--;
   }
 
-  async sendMessageToServer(object: ChannelOwner, method: string, params: any, options: { apiName?: string, title?: string, internal?: boolean, frames?: channels.StackFrame[], stepId?: string, signal?: AbortSignal, timeout: number }): Promise<any> {
+  async sendMessageToServer(object: ChannelOwner, method: string, params: any, options: { apiName?: string, title?: string, internal?: boolean, frames?: channels.StackFrame[], callId?: string, signal?: AbortSignal, timeout: number }): Promise<any> {
     // Fire-and-forget: server intentionally never replies to __waitInfo__,
     // so silently drop it after the connection is closed or the object was collected.
     if (method === '__waitInfo__' && (this._closedError || object._wasCollected))
@@ -191,14 +192,14 @@ export class Connection extends EventEmitter {
 
     const guid = object._guid;
     const type = object._type;
-    const id = ++this._lastId;
+    const id = options.callId ?? defaultCallId(++this._lastOrdinal);
     const message = { id, guid, method, params };
     if (debugLogger.isEnabled('channel')) {
       // Do not include metadata in debug logs to avoid noise.
       debugLogger.log('channel', 'SEND> ' + JSON.stringify(message));
     }
     const location = options.frames?.[0] ? { file: options.frames[0].file, line: options.frames[0].line, column: options.frames[0].column } : undefined;
-    const metadata: channels.Metadata = { title: options.title, location, internal: options.internal, stepId: options.stepId, timeout: options.timeout };
+    const metadata: channels.Metadata = { title: options.title, location, internal: options.internal, timeout: options.timeout };
     if (this._tracingCount && options.frames && type !== 'LocalUtils')
       this._localUtils?.addStackToTracingNoReply({ callData: { stack: options.frames ?? [], id } }).catch(() => {});
     // We need to exit zones before calling into the server, otherwise

--- a/packages/playwright-core/src/client/connection.ts
+++ b/packages/playwright-core/src/client/connection.ts
@@ -20,7 +20,7 @@ import { isUnderTest } from '@utils/debug';
 import { debugLogger } from '@utils/debugLogger';
 import { emptyZone } from '@utils/zones';
 import { ValidationError, findValidator, maybeFindValidator } from '@protocol/validator';
-import { defaultCallId } from '@isomorphic/trace/traceUtils';
+import { createCallIdGenerator } from '@isomorphic/trace/traceUtils';
 import { EventEmitter } from './eventEmitter';
 import { Android, AndroidDevice, AndroidSocket } from './android';
 import { Artifact } from './artifact';
@@ -74,7 +74,7 @@ export type ChannelOwnerFactory = (parent: ChannelOwner, type: string, guid: str
 export class Connection extends EventEmitter {
   readonly _objects = new Map<string, ChannelOwner>();
   onmessage = (message: object): void => {};
-  private _lastOrdinal = 0;
+  private _nextCallId = createCallIdGenerator();
   private _callbacks = new Map<string, { resolve: (a: any) => void, reject: (a: Error) => void, signal: AbortSignal | undefined, title: string | undefined, type: string, method: string }>();
   private _rootObject: Root;
   private _closedError: Error | undefined;
@@ -192,7 +192,7 @@ export class Connection extends EventEmitter {
 
     const guid = object._guid;
     const type = object._type;
-    const id = options.callId ?? defaultCallId(++this._lastOrdinal);
+    const id = options.callId ?? this._nextCallId();
     const message = { id, guid, method, params };
     if (debugLogger.isEnabled('channel')) {
       // Do not include metadata in debug logs to avoid noise.

--- a/packages/playwright-core/src/server/dispatchers/dispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/dispatcher.ts
@@ -297,7 +297,7 @@ export class DispatcherConnection {
   }
 
   async dispatch(message: object) {
-    const { id, guid, method, params, metadata } = message as any;
+    const { id, guid, method, params, metadata } = message as { id: string, guid: string, method: string, params: any, metadata: any };
     const dispatcher = this._dispatcherByGuid.get(guid);
     if (method === '__waitInfo__') {
       // Fire-and-forget: silently drop if the target is gone.
@@ -306,7 +306,7 @@ export class DispatcherConnection {
       return;
     }
     if (method === '__abort__') {
-      const entry = this._activeProgressControllers.get(`call@${params.id}`);
+      const entry = this._activeProgressControllers.get(params.id);
       if (!entry)
         return;
       entry.abortError = new AbortError(params.reason);
@@ -342,11 +342,10 @@ export class DispatcherConnection {
 
     const sdkObject = dispatcher._object;
     const callMetadata: CallMetadata = {
-      id: `call@${id}`,
+      id,
       location: validMetadata.location,
       title: validMetadata.title,
       internal: validMetadata.internal,
-      stepId: validMetadata.stepId,
       objectId: sdkObject.guid,
       startTime: monotonicTime(),
       endTime: 0,
@@ -358,7 +357,7 @@ export class DispatcherConnection {
     };
 
     const abortControllerEntry: { controller?: ProgressController, abortError?: Error } = {};
-    this._activeProgressControllers.set(callMetadata.id, abortControllerEntry);
+    this._activeProgressControllers.set(id, abortControllerEntry);
     const swapProgressController = () => {
       const controller = dispatcher.createProgressController(callMetadata, abortControllerEntry.abortError);
       abortControllerEntry.controller = controller;
@@ -403,7 +402,7 @@ export class DispatcherConnection {
       await afterController.run(progress => sdkObject.instrumentation.onAfterCall(progress, sdkObject), 3000).catch(() => {});
       if (metainfo?.slowMo)
         await this._doSlowMo(sdkObject);
-      this._activeProgressControllers.delete(callMetadata.id);
+      this._activeProgressControllers.delete(id);
     }
 
     if (response.error)
@@ -417,7 +416,7 @@ export class DispatcherConnection {
       await new Promise(f => setTimeout(f, slowMo));
   }
 
-  private async _dispatchWaitInfo(id: number, dispatcher: DispatcherScope, params: any, metadata: any) {
+  private async _dispatchWaitInfo(id: string, dispatcher: DispatcherScope, params: any, metadata: any) {
     // Fire-and-forget notification: never reply, never throw to the caller.
     let info: channels.WaitInfo;
     let validMetadata: channels.Metadata;
@@ -432,11 +431,10 @@ export class DispatcherConnection {
     const sdkObject = dispatcher._object;
     if (info.phase === 'before') {
       const callMetadata: CallMetadata = {
-        id: `call@${id}`,
+        id,
         location: validMetadata.location,
         title: validMetadata.title,
         internal: validMetadata.internal,
-        stepId: validMetadata.stepId,
         objectId: sdkObject.guid,
         startTime: monotonicTime(),
         endTime: 0,

--- a/packages/playwright-core/src/server/instrumentation.ts
+++ b/packages/playwright-core/src/server/instrumentation.ts
@@ -96,8 +96,6 @@ export type CallMetadata = {
   // Client is making an internal call that should not show up in
   // the inspector or trace.
   internal?: boolean;
-  // Test runner step id.
-  stepId?: string;
   location?: { file: string, line?: number, column?: number };
   log: string[];
   error?: SerializedError;

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -263,7 +263,6 @@ export class Tracing extends SdkObject implements InstrumentationListener, Snaps
       class: 'Tracing',
       method: 'tracingGroup',
       params: { },
-      stepId: metadata.stepId,
       stack: stackFrames,
     };
     if (this._currentGroupId())
@@ -782,7 +781,6 @@ function createBeforeActionTraceEvent(metadata: CallMetadata, parentId?: string)
     class: metadata.type,
     method: metadata.method,
     params: metadata.timeout ? { ...metadata.params, timeout: metadata.timeout } : metadata.params,
-    stepId: metadata.stepId,
   };
   if (parentId)
     event.parentId = parentId;

--- a/packages/playwright-core/src/server/trace/recorder/tracing.ts
+++ b/packages/playwright-core/src/server/trace/recorder/tracing.ts
@@ -55,7 +55,7 @@ import type { Progress } from '../../progress';
 import type * as types from '../../types';
 import type { Screencast, ScreencastClient } from '../../screencast';
 
-const version: trace.VERSION = 9;
+const version: trace.VERSION = 10;
 
 export type TracerOptions = {
   name?: string;

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -106,11 +106,11 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
         const zone = currentZone().data<TestStepInternal>('stepZone');
         const isExpectCall = (channel.type === 'Frame' && channel.method === 'expect') || (channel.type === 'Page' && channel.method === 'expectScreenshot');
         if (zone && zone.category === 'expect' && isExpectCall) {
-          data.stepId = zone.stepId;
+          data.callId = zone.stepId;
           return;
         }
 
-        // In the general case, create a step for each api call and connect them through the stepId.
+        // In the general case, create a step for each api call, use it as a callId.
         const params = renderParamsForCall({ type: channel.type, method: channel.method, params: channel.params });
         const step = testInfo._addStep({
           location: data.frames[0],
@@ -120,7 +120,7 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
           params,
           group: getActionGroup({ type: channel.type, method: channel.method }),
         }, tracingGroupSteps[tracingGroupSteps.length - 1]);
-        data.stepId = step.stepId;
+        data.callId = step.stepId;
         if (channel.type === 'Tracing' && channel.method === 'tracingGroup') {
           // The step will end later, when the corresponding "tracing.groupEnd" call finishes.
           tracingGroupSteps.push(step);

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -82,6 +82,9 @@ export const emtpyTestInfoCallbacks: TestInfoCallbacks = {
   onTestPaused: () => Promise.reject(new Error('TestInfoImpl not initialized')),
 };
 
+// Keep step ids globally unique, to avoid cross-test callId collisions on the same playwright instance.
+let lastStepId = 0;
+
 export class TestInfoImpl implements TestInfo {
   private _callbacks: TestInfoCallbacks;
   private _snapshotNames: SnapshotNames = { lastAnonymousSnapshotIndex: 0, lastNamedSnapshotIndex: {} };
@@ -93,7 +96,6 @@ export class TestInfoImpl implements TestInfo {
   readonly _uniqueSymbol;
 
   private _interruptedPromise = new ManualPromise<void>();
-  _lastStepId = 0;
   private readonly _requireFile: string;
   readonly _projectInternal: commonConfig.FullProjectInternal;
   readonly _configInternal: FullConfigInternal;
@@ -284,7 +286,7 @@ export class TestInfoImpl implements TestInfo {
   }
 
   _addStep(data: Readonly<TestStepData>, parentStep?: TestStepInternal): TestStepInternal {
-    const stepId = `${data.category}@${++this._lastStepId}`;
+    const stepId = `${data.category}@${++lastStepId}`;
 
     if (data.category === 'hook' || data.category === 'fixture') {
       // Predefined steps form a fixed hierarchy - use the current one as parent.

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -21,7 +21,7 @@ import { ManualPromise } from '@isomorphic/manualPromise';
 import { captureRawStack, stringifyStackFrames, filteredStackTrace } from '@utils/stackTrace';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { monotonicTime } from '@isomorphic/time';
-import { createGuid } from '@utils/crypto';
+import { createCallIdGenerator } from '@isomorphic/trace/traceUtils';
 import { sanitizeForFilePath, trimLongString } from '@utils/fileUtils';
 import { currentZone } from '@utils/zones';
 
@@ -83,7 +83,7 @@ export const emtpyTestInfoCallbacks: TestInfoCallbacks = {
 };
 
 // Keep step ids globally unique, to avoid cross-test callId collisions on the same playwright instance.
-let lastStepId = 0;
+const nextStepId = createCallIdGenerator();
 
 export class TestInfoImpl implements TestInfo {
   private _callbacks: TestInfoCallbacks;
@@ -286,7 +286,7 @@ export class TestInfoImpl implements TestInfo {
   }
 
   _addStep(data: Readonly<TestStepData>, parentStep?: TestStepInternal): TestStepInternal {
-    const stepId = `${data.category}@${++lastStepId}`;
+    const stepId = nextStepId();
 
     if (data.category === 'hook' || data.category === 'fixture') {
       // Predefined steps form a fixed hierarchy - use the current one as parent.
@@ -527,7 +527,7 @@ export class TestInfoImpl implements TestInfo {
     if (step) {
       step.attachmentIndices.push(index);
     } else {
-      const stepId = `attach@${createGuid()}`;
+      const stepId = nextStepId();
       this._tracing.appendBeforeActionForStep({ stepId, title: `Attach ${escapeWithQuotes(attachment.name, '"')}`, category: 'test.attach', stack: [] });
       this._tracing.appendAfterActionForStep(stepId, undefined, [attachment]);
     }

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -277,7 +277,6 @@ export class TestTracing {
     this._appendTraceEvent({
       type: 'before',
       callId: options.stepId,
-      stepId: options.stepId,
       parentId: options.parentId,
       startTime: monotonicTime(),
       class: 'Test',

--- a/packages/playwright/src/worker/testTracing.ts
+++ b/packages/playwright/src/worker/testTracing.ts
@@ -34,7 +34,7 @@ import type EventEmitter from 'events';
 
 export type Attachment = TestInfo['attachments'][0];
 export const testTraceEntryName = 'test.trace';
-const version: trace.VERSION = 9;
+const version: trace.VERSION = 10;
 let traceOrdinal = 0;
 
 type TraceFixtureValue =  PlaywrightWorkerOptions['trace'] | undefined;

--- a/packages/protocol/spec/core.yml
+++ b/packages/protocol/spec/core.yml
@@ -23,14 +23,12 @@ Metadata:
         column: int?
     title: string?
     internal: boolean?
-    # Test runner step id.
-    stepId: string?
     timeout: float?
 
 ClientSideCallMetadata:
   type: object
   properties:
-    id: int
+    id: string
     stack:
       type: array?
       items: StackFrame

--- a/packages/protocol/src/structs.d.ts
+++ b/packages/protocol/src/structs.d.ts
@@ -91,12 +91,11 @@ export type Metadata = {
   },
   title?: string,
   internal?: boolean,
-  stepId?: string,
   timeout?: number,
 };
 
 export type ClientSideCallMetadata = {
-  id: number,
+  id: string,
   stack?: StackFrame[],
 };
 

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -1084,11 +1084,10 @@ scheme.Metadata = tObject({
   })),
   title: tOptional(tString),
   internal: tOptional(tBoolean),
-  stepId: tOptional(tString),
   timeout: tOptional(tFloat),
 });
 scheme.ClientSideCallMetadata = tObject({
-  id: tInt,
+  id: tString,
   stack: tOptional(tArray(tType('StackFrame'))),
 });
 scheme.SDKLanguage = tEnum(['javascript', 'python', 'java', 'csharp']);


### PR DESCRIPTION
## Summary
- The client instrumentation now assigns the protocol message id, so an api call and its test runner step share a single id. `Metadata.stepId` is gone; the id is minted in one place, the client connection, and only when nothing assigned one.
- Ids are minted with a random 3-character prefix per client connection, so that ids of different clients do not clash when they end up in a single trace.
- `stepId` is no longer written to the trace. Since v9 shipped in 1.63, this is a new trace version 10: `traceV9` is frozen as a self-contained copy of the shipped format, and `_modernize_9_to_10` rewrites the ids of older traces on the fly. `TraceModernizer` also owns client-side stacks via `appendStacks()`.
- `TraceModel` merges actions by call id, so `nonPrimaryIdToPrimaryId` goes away.
- `ClientSideCallMetadata.id` becomes a string — the language ports need to send the message id there instead of an int.

## Design choice

This is done to unify ids between steps and actions. Alternatively, we could use the `callId` as a step id, except for expect calls where the step is created much earlier than the call is made, and rewriting the id is too late.
