### PR TITLE
fix(aria): treat searchbox as textbox in embedded control accname

### DIFF
--- a/packages/injected/src/roleUtils.ts
+++ b/packages/injected/src/roleUtils.ts
@@ -746,7 +746,8 @@ function getTextAlternativeInternal(element: Element, options: AccessibleNameOpt
     const isOwnLabel = [...(element as (HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)).labels || []].includes(element as any);
     const isOwnLabelledBy = (labelledBy || []).includes(element);
     if (!isOwnLabel && !isOwnLabelledBy) {
-      if (role === 'textbox') {
+      // Searchbox is a subclass of textbox, so it is handled the same way.
+      if (role === 'textbox' || role === 'searchbox') {
         options.visitedElements.add(element);
         if (tagName === 'INPUT' || tagName === 'TEXTAREA')
           return compositeString((element as HTMLInputElement | HTMLTextAreaElement).value, element, options.collectElements);

--- a/tests/library/role-utils.spec.ts
+++ b/tests/library/role-utils.spec.ts
@@ -471,6 +471,22 @@ test('control embedded in a target element', async ({ page }) => {
   expect.soft(await getNameAndRole(page, 'h1')).toEqual({ role: 'heading', name: 'Foo bar' });
 });
 
+test('searchbox embedded control should contribute its value', async ({ page }) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42341' });
+
+  await page.setContent(`
+    <button id="b1" aria-labelledby="l1"></button><div id="l1" hidden><input type="text" value="Query"></div>
+    <button id="b2" aria-labelledby="l2"></button><div id="l2" hidden><input type="search" value="Query"></div>
+    <label for="c1">Flash the screen <input type="search" value="5"> times.</label>
+    <input type="checkbox" id="c1">
+    <h1><input type="search" value="Foo bar"></h1>
+  `);
+  expect.soft(await getNameAndRole(page, '#b1')).toEqual({ role: 'button', name: 'Query' });
+  expect.soft(await getNameAndRole(page, '#b2')).toEqual({ role: 'button', name: 'Query' });
+  expect.soft(await getNameAndRole(page, '#c1')).toEqual({ role: 'checkbox', name: 'Flash the screen 5 times.' });
+  expect.soft(await getNameAndRole(page, 'h1')).toEqual({ role: 'heading', name: 'Foo bar' });
+});
+
 test('svg role=presentation', async ({ page, server }) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/26809' });
 


### PR DESCRIPTION
## Summary
- accname step 2C matched only `role === 'textbox'`, so an embedded `<input type=search>` (role `searchbox`) contributed nothing to the accessible name of its labeller or ancestor.
- `searchbox` is a subclass of `textbox`; the same file already pairs the two roles in `kAriaReadonlyRoles`, `kAriaDisabledRoles` and `kAriaInvalidRoles`.
- Verified against Chromium's own accname via CDP: it returns the search input's value in all three embedding shapes, matching `type=text`.

Fixes https://github.com/microsoft/playwright/issues/42341