### PR TITLE
fix(trace): keep client paths out of remote launch options

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -109,7 +109,7 @@ export class PlaywrightServer {
         }
 
         const isExtension = this._options.mode === 'extension';
-        launchOptions = filterLaunchOptions(launchOptions, isExtension || !!this._options.unsafe);
+        launchOptions = filterLaunchOptions(launchOptions, isExtension, !!this._options.unsafe);
 
         // Always override artifacts dir with the one from server options.
         if (this._options.artifactsDir)
@@ -365,7 +365,8 @@ function launchOptionsHash(options: LaunchOptionsWithTimeout) {
   return JSON.stringify(copy);
 }
 
-function filterLaunchOptions(options: LaunchOptionsWithTimeout, allowUnsafe: boolean): LaunchOptionsWithTimeout {
+function filterLaunchOptions(options: LaunchOptionsWithTimeout, isExtension: boolean, unsafe: boolean): LaunchOptionsWithTimeout {
+  const allowUnsafe = isExtension || unsafe;
   return {
     channel: options.channel,
     args: allowUnsafe ? options.args : undefined,
@@ -378,8 +379,8 @@ function filterLaunchOptions(options: LaunchOptionsWithTimeout, allowUnsafe: boo
     firefoxUserPrefs: (isUnderTest() || allowUnsafe) ? options.firefoxUserPrefs : undefined,
     slowMo: options.slowMo,
     executablePath: (isUnderTest() || allowUnsafe) ? options.executablePath : undefined,
-    downloadsPath: allowUnsafe ? options.downloadsPath : undefined,
-    artifactsDir: (isUnderTest() || allowUnsafe) ? options.artifactsDir : undefined,
+    downloadsPath: (isUnderTest() || isExtension) ? options.downloadsPath : undefined,
+    artifactsDir: (isUnderTest() || isExtension) ? options.artifactsDir : undefined,
   };
 }
 

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -27,12 +27,14 @@ export class RunServer implements PlaywrightServer {
   private _process!: TestChildProcess;
   _wsEndpoint!: string;
 
-  async start(childProcess: CommonFixtures['childProcess'], options?: { mode?: 'extension' | 'default', env?: NodeJS.ProcessEnv, artifactsDir?: string }) {
+  async start(childProcess: CommonFixtures['childProcess'], options?: { mode?: 'extension' | 'default', env?: NodeJS.ProcessEnv, artifactsDir?: string, unsafe?: boolean }) {
     const command = ['node', path.join(__dirname, '..', '..', 'packages', 'playwright-core', 'cli.js'), 'run-server'];
     if (options?.mode === 'extension')
       command.push('--mode=extension');
     if (options?.artifactsDir)
       command.push(`--artifacts-dir=${options.artifactsDir}`);
+    if (options?.unsafe)
+      command.push('--unsafe');
     this._process = childProcess({
       command,
       env: { NODE_OPTIONS: process.env.NODE_OPTIONS, ...options?.env },

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -1162,6 +1162,43 @@ test('should refuse connecting when versions do not match', async ({ connect, ch
   expect(error.message).toContain('client version: v' + getPlaywrightVersion(true));
 });
 
+test('should filter local paths from unsafe launch options', async ({ connect, childProcess, server }, testInfo) => {
+  test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42394' });
+  server.setRoute('/download', (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', 'attachment');
+    res.end('Hello world');
+  });
+  const artifactsDir = testInfo.outputPath('artifacts');
+  const downloadsPath = testInfo.outputPath('downloads');
+  fs.writeFileSync(artifactsDir, 'not a directory');
+  fs.writeFileSync(downloadsPath, 'not a directory');
+  const remoteServer = new RunServer();
+  await remoteServer.start(childProcess, { unsafe: true, env: { PWTEST_UNDER_TEST: undefined } });
+  const browser = await connect(remoteServer.wsEndpoint(), {
+    headers: {
+      'x-playwright-launch-options': JSON.stringify({ artifactsDir, downloadsPath }),
+    },
+  });
+  const context = await browser.newContext();
+  await context.tracing.start({ snapshots: true });
+  const page = await context.newPage();
+  await page.setContent(`<a href="${server.PREFIX}/download">download</a>`);
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a'),
+  ]);
+  expect(await download.failure()).toBeNull();
+  const tracePath = testInfo.outputPath('trace.zip');
+  await context.tracing.stop({ path: tracePath });
+  await context.close();
+  await browser.close();
+  await remoteServer.close();
+
+  const { actions } = await parseTraceRaw(tracePath);
+  expect(actions).toContain('Set content');
+});
+
 test('should timeout after redirect when connecting over http', async ({ connect, server }) => {
   server.setRedirect('/connect/json', '/connect/slow');
   let aborted = false;


### PR DESCRIPTION
remote browser servers can receive Playwright Test worker paths and try to write trace files on the client filesystem

remove `artifactsDir` and `tracesDir` from remote launch options

fixes <https://github.com/microsoft/playwright/issues/42394>