### PR TITLE
test(mcp): activate page before reading the clipboard

### DIFF
--- a/tests/mcp/clipboard.spec.ts
+++ b/tests/mcp/clipboard.spec.ts
@@ -37,6 +37,12 @@ test('clipboard write without permission dialog', async ({ startClient, server, 
   expect(writeResult).toHaveResponse({
     result: '"Write successful"',
   });
+  // Chromium 153+ only allows reading the clipboard once the page has been
+  // activated by a real input event, so interact with it first.
+  await client.callTool({
+    name: 'browser_press_key',
+    arguments: { key: 'a' },
+  });
   const readResult = await client.callTool({
     name: 'browser_evaluate',
     arguments: {


### PR DESCRIPTION
## Summary
- Chromium 153 (rolled in r1243) only allows reading the clipboard once the page has been activated by a real input event. The initial page of a persistent context is never activated, so `readText()` silently resolved with `""` instead of the written value.
- Press a key before reading. `Tab` does not work here — it moves focus out of the document body and the read then fails with `Document is not focused`.