### PR TITLE
docs(test): document mouse-outside-viewport screenshot helper

### DIFF
--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -76,7 +76,7 @@ export async function expectPageToHaveScreenshotWithMouseAtOrigin(
   screenshotName: string | ReadonlyArray<string>,
   options?: PageAssertionsToHaveScreenshotOptions,
 ) {
-  await page.mouse.move(0, 0);
+  await page.mouse.move(-1, -1);
   await expect(page).toHaveScreenshot(screenshotName, options);
 }
 ```

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -59,6 +59,36 @@ await expect(page).toHaveScreenshot('landing.webp');
 > Note that `toHaveScreenshot()` also accepts an array of path segments to the snapshot file such as `expect().toHaveScreenshot(['relative', 'path', 'to', 'snapshot.png'])`.
 > However, this path must stay within the snapshots directory for each test file (i.e. `a.spec.js-snapshots`), otherwise it will throw.
 
+Mouse actions such as [`method: Locator.click`] leave the pointer at its last position. If the page changes afterwards, another element can end up under the pointer and appear hovered in the screenshot. To avoid this, move the mouse before taking the screenshot, for example to the viewport origin when no element there responds to hover.
+
+<details>
+<summary>Helper for repeated named screenshots</summary>
+
+```ts title="test-utils.ts"
+import {
+  expect,
+  type Page,
+  type PageAssertionsToHaveScreenshotOptions,
+} from '@playwright/test';
+
+export async function expectPageToHaveScreenshotWithMouseAtOrigin(
+  page: Page,
+  screenshotName: string,
+  options?: PageAssertionsToHaveScreenshotOptions,
+) {
+  await page.mouse.move(0, 0);
+  await expect(page).toHaveScreenshot(screenshotName, options);
+}
+```
+
+```ts title="example.spec.ts"
+await expectPageToHaveScreenshotWithMouseAtOrigin(page, 'landing.png', {
+  fullPage: true,
+});
+```
+
+</details>
+
 ## Updating screenshots
 
 Sometimes you need to update the reference screenshot, for example when the page has changed. Do this with the  `--update-snapshots` flag.

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -71,7 +71,7 @@ import {
   type PageAssertionsToHaveScreenshotOptions,
 } from '@playwright/test';
 
-export async function expectPageToHaveScreenshotWithMouseAtOrigin(
+export async function expectPageToHaveScreenshotWithMouseOutsideViewport(
   page: Page,
   screenshotName: string | ReadonlyArray<string>,
   options?: PageAssertionsToHaveScreenshotOptions,
@@ -82,7 +82,7 @@ export async function expectPageToHaveScreenshotWithMouseAtOrigin(
 ```
 
 ```ts title="example.spec.ts"
-await expectPageToHaveScreenshotWithMouseAtOrigin(page, 'landing.png', {
+await expectPageToHaveScreenshotWithMouseOutsideViewport(page, 'landing.png', {
   fullPage: true,
 });
 ```

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -73,7 +73,7 @@ import {
 
 export async function expectPageToHaveScreenshotWithMouseAtOrigin(
   page: Page,
-  screenshotName: string,
+  screenshotName: string | ReadonlyArray<string>,
   options?: PageAssertionsToHaveScreenshotOptions,
 ) {
   await page.mouse.move(0, 0);

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -59,7 +59,7 @@ await expect(page).toHaveScreenshot('landing.webp');
 > Note that `toHaveScreenshot()` also accepts an array of path segments to the snapshot file such as `expect().toHaveScreenshot(['relative', 'path', 'to', 'snapshot.png'])`.
 > However, this path must stay within the snapshots directory for each test file (i.e. `a.spec.js-snapshots`), otherwise it will throw.
 
-Mouse actions such as [`method: Locator.click`] leave the pointer at its last position. If the page changes afterwards, another element can end up under the pointer and appear hovered in the screenshot. To avoid this, move the mouse before taking the screenshot, for example to the viewport origin when no element there responds to hover.
+Mouse actions such as [`method: Locator.click`] leave the pointer at its last position. If the page changes afterwards, another element can end up under the pointer and appear hovered in the screenshot. To avoid this, move the mouse outside the viewport before taking the screenshot.
 
 <details>
 <summary>Helper for repeated named screenshots</summary>

--- a/docs/src/test-snapshots-js.md
+++ b/docs/src/test-snapshots-js.md
@@ -59,42 +59,21 @@ await expect(page).toHaveScreenshot('landing.webp');
 > Note that `toHaveScreenshot()` also accepts an array of path segments to the snapshot file such as `expect().toHaveScreenshot(['relative', 'path', 'to', 'snapshot.png'])`.
 > However, this path must stay within the snapshots directory for each test file (i.e. `a.spec.js-snapshots`), otherwise it will throw.
 
-Mouse actions such as [`method: Locator.click`] leave the pointer at its last position. If the page changes afterwards, another element can end up under the pointer and appear hovered in the screenshot. To avoid this, move the mouse outside the viewport before taking the screenshot.
-
-<details>
-<summary>Helper for repeated named screenshots</summary>
-
-```ts title="test-utils.ts"
-import {
-  expect,
-  type Page,
-  type PageAssertionsToHaveScreenshotOptions,
-} from '@playwright/test';
-
-export async function expectPageToHaveScreenshotWithMouseOutsideViewport(
-  page: Page,
-  screenshotName: string | ReadonlyArray<string>,
-  options?: PageAssertionsToHaveScreenshotOptions,
-) {
-  await page.mouse.move(-1, -1);
-  await expect(page).toHaveScreenshot(screenshotName, options);
-}
-```
-
-```ts title="example.spec.ts"
-await expectPageToHaveScreenshotWithMouseOutsideViewport(page, 'landing.png', {
-  fullPage: true,
-});
-```
-
-</details>
-
 ## Updating screenshots
 
 Sometimes you need to update the reference screenshot, for example when the page has changed. Do this with the  `--update-snapshots` flag.
 
 ```bash
 npx playwright test --update-snapshots
+```
+
+## Hover effects
+
+Screenshots capture any hover effects present in the page at the moment. To avoid hover effects, move the mouse to a position that does not trigger them, or hover an element that has no effects, before taking the screenshot:
+
+```js
+await page.mouse.move(-1, -1);
+await expect(page).toHaveScreenshot();
 ```
 
 ## Options


### PR DESCRIPTION
Mouse actions leave the pointer at their last position. If a navigation or re-render places another element under that position, `expect(page).toHaveScreenshot()` can capture an unrelated hover state.

Playwright keeps this browser behavior as-is in Firefox:

> @aslushnikov in [comment 1532168395](https://github.com/microsoft/playwright/issues/22755#issuecomment-1532168395): But a quick workaround would be to move mouse away before taking screenshot.

Chromium also preserves the last mouse position:

> @dgozman in [comment 2493986807](https://github.com/microsoft/playwright/issues/33441#issuecomment-2493986807): We move it to `(0;0)` expecting that to be the most predictable position with the least number of side effects.

This adds concise guidance to the Visual comparisons page and a collapsed helper for repeated named screenshots. The helper moves the mouse to `-1, -1` before calling `toHaveScreenshot()` and forwards its screenshot options.

The documentation notes that projects should choose another coordinate when an element at the viewport origin responds to hover.

- [x] Explain how preserved mouse position can affect screenshots
- [x] Add a collapsed helper for repeated named screenshots
- [x] Forward Playwright screenshot assertion options
