### PR TITLE
fix(chromium): replay execution contexts when connecting to Android WebView

### DIFF
--- a/packages/playwright-core/src/client/browserType.ts
+++ b/packages/playwright-core/src/client/browserType.ts
@@ -168,6 +168,7 @@ export class BrowserType extends ChannelOwner<channels.BrowserTypeChannel> imple
       slowMo: params.slowMo,
       isLocal: params.isLocal,
       noDefaults: params.noDefaults,
+      isWebView: (params as any).isWebView,
       artifactsDir: params.artifactsDir,
     }, new TimeoutSettings().timeout(params));
     return await this._browserFromConnectResult(result);

--- a/packages/playwright-core/src/client/channels.d.ts
+++ b/packages/playwright-core/src/client/channels.d.ts
@@ -1950,6 +1950,7 @@ export type BrowserTypeConnectOverCDPParams = {
   slowMo?: number,
   isLocal?: boolean,
   noDefaults?: boolean,
+  isWebView?: boolean,
   artifactsDir?: string,
   transport?: Binary,
 };
@@ -1959,6 +1960,7 @@ export type BrowserTypeConnectOverCDPOptions = {
   slowMo?: number,
   isLocal?: boolean,
   noDefaults?: boolean,
+  isWebView?: boolean,
   artifactsDir?: string,
   transport?: Binary,
 };

--- a/packages/playwright-core/src/server/android/android.ts
+++ b/packages/playwright-core/src/server/android/android.ts
@@ -329,10 +329,10 @@ export class AndroidDevice extends SdkObject {
     const webView = this._webViews.get(socketName);
     if (!webView)
       throw new Error('WebView has been closed');
-    return await this._connectToBrowser(progress, socketName);
+    return await this._connectToBrowser(progress, socketName, {}, /* isWebView */ true);
   }
 
-  private async _connectToBrowser(progress: Progress, socketName: string, options: types.BrowserContextOptions = {}): Promise<BrowserContext> {
+  private async _connectToBrowser(progress: Progress, socketName: string, options: types.BrowserContextOptions = {}, isWebView?: boolean): Promise<BrowserContext> {
     const socket = await this._waitForLocalAbstract(progress, socketName);
     try {
       const androidBrowser = new AndroidBrowser(this, socket);
@@ -363,6 +363,7 @@ export class AndroidDevice extends SdkObject {
         protocolLogger: helper.debugProtocolLogger(),
         browserLogsCollector: new RecentLogsCollector(),
         originalLaunchOptions: {},
+        isWebView,
       };
       validateBrowserContextOptions(options, browserOptions);
 

--- a/packages/playwright-core/src/server/browser.ts
+++ b/packages/playwright-core/src/server/browser.ts
@@ -65,6 +65,7 @@ export type BrowserOptions = {
   originalLaunchOptions: types.LaunchOptions;
   userDataDir?: string;
   noDefaults?: boolean;
+  isWebView?: boolean;
 };
 
 export abstract class Browser extends SdkObject {

--- a/packages/playwright-core/src/server/channels.d.ts
+++ b/packages/playwright-core/src/server/channels.d.ts
@@ -1951,6 +1951,7 @@ export type BrowserTypeConnectOverCDPParams = {
   slowMo?: number,
   isLocal?: boolean,
   noDefaults?: boolean,
+  isWebView?: boolean,
   artifactsDir?: string,
   transport?: Binary,
 };
@@ -1960,6 +1961,7 @@ export type BrowserTypeConnectOverCDPOptions = {
   slowMo?: number,
   isLocal?: boolean,
   noDefaults?: boolean,
+  isWebView?: boolean,
   artifactsDir?: string,
   transport?: Binary,
 };

--- a/packages/playwright-core/src/server/chromium/chromium.ts
+++ b/packages/playwright-core/src/server/chromium/chromium.ts
@@ -87,7 +87,7 @@ export class Chromium extends BrowserType {
     return await this._connectOverCDPInternal(progress, params.endpointURL!, params);
   }
 
-  async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: types.LaunchOptions & { headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean, artifactsDir?: string }, onClose?: () => Promise<void>) {
+  async _connectOverCDPInternal(progress: Progress, endpointURL: string, options: types.LaunchOptions & { headers?: types.HeadersArray, isLocal?: boolean, noDefaults?: boolean, isWebView?: boolean, artifactsDir?: string }, onClose?: () => Promise<void>) {
     let headersMap: { [key: string]: string; } | undefined;
     if (options.headers)
       headersMap = headersArrayToObject(options.headers, false);
@@ -115,7 +115,7 @@ export class Chromium extends BrowserType {
     return this._connectOverCDPImpl(progress, chromeTransport, closeAndWait, options, onClose);
   }
 
-  private async _connectOverCDPImpl(progress: Progress, transport: ConnectionTransport, closeAndWait: () => Promise<void>, options: types.LaunchOptions & { isLocal?: boolean, noDefaults?: boolean, artifactsDir?: string }, onClose?: () => Promise<void>) {
+  private async _connectOverCDPImpl(progress: Progress, transport: ConnectionTransport, closeAndWait: () => Promise<void>, options: types.LaunchOptions & { isLocal?: boolean, noDefaults?: boolean, isWebView?: boolean, artifactsDir?: string }, onClose?: () => Promise<void>) {
     let artifactsDir: string;
     const tempDirectories: string[] = [];
     if (options.artifactsDir) {
@@ -155,6 +155,7 @@ export class Chromium extends BrowserType {
         tracesDir: options.tracesDir || artifactsDir,
         originalLaunchOptions: {},
         noDefaults: options.noDefaults,
+        isWebView: options.isWebView,
       };
       validateBrowserContextOptions(persistent, browserOptions);
       const browser = await progress.race(CRBrowser.connect(this.attribution.playwright, transport, browserOptions));

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -464,6 +464,7 @@ class FrameSession {
   }
 
   async _initialize(hasUIWindow: boolean) {
+    const browserOptions = this._crPage._browserContext._browser.options;
     if (!this._page.isStorageStatePage && hasUIWindow &&
       !this._crPage._browserContext._browser.isClank() &&
       !this._crPage._browserContext._options.noDefaultViewport) {
@@ -539,7 +540,7 @@ class FrameSession {
       this._client.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true }),
     ];
     if (!this._page.isStorageStatePage) {
-      const skipDefaultOverrides = this._crPage._browserContext._browser.options.noDefaults &&
+      const skipDefaultOverrides = browserOptions.noDefaults &&
           this._crPage._browserContext === this._crPage._browserContext._browser._defaultContext;
       if (this._crPage._browserContext.needsPlaywrightBinding())
         promises.push(this.exposePlaywrightBinding());
@@ -562,7 +563,7 @@ class FrameSession {
         promises.push(emulateLocale(this._client, options.locale));
       if (options.timezoneId)
         promises.push(emulateTimezone(this._client, options.timezoneId));
-      if (!this._crPage._browserContext._browser.options.headful)
+      if (!browserOptions.headful)
         promises.push(this._setDefaultFontFamilies(this._client));
       promises.push(this._updateGeolocation(true));
       if (!skipDefaultOverrides)
@@ -574,6 +575,19 @@ class FrameSession {
     promises.push(this._client.send('Runtime.runIfWaitingForDebugger'));
     promises.push(this._firstNonInitialNavigationCommittedPromise);
     await Promise.all(promises);
+
+    if (browserOptions.isWebView) {
+      // Android WebView's devtools endpoint sometimes acknowledges Runtime.enable
+      // without replaying the pre-existing execution contexts. Cycle
+      // Runtime.disable/enable until the default context is reported.
+      for (let attempt = 0; attempt < 10; ++attempt) {
+        if ([...this._contextIdToContext.values()].some(context => context.world === 'main'))
+          break;
+        await this._client._sendMayFail('Runtime.disable');
+        await this._client._sendMayFail('Runtime.enable');
+        await new Promise(f => setTimeout(f, 250));
+      }
+    }
   }
 
   dispose() {

--- a/packages/protocol/spec/browserType.yml
+++ b/packages/protocol/spec/browserType.yml
@@ -50,6 +50,7 @@ BrowserType:
         slowMo: float?
         isLocal: boolean?
         noDefaults: boolean?
+        isWebView: boolean?
         artifactsDir: string?
         transport: binary?
       returns:

--- a/packages/protocol/src/validator.ts
+++ b/packages/protocol/src/validator.ts
@@ -1062,6 +1062,7 @@ scheme.BrowserTypeConnectOverCDPParams = tObject({
   slowMo: tOptional(tFloat),
   isLocal: tOptional(tBoolean),
   noDefaults: tOptional(tBoolean),
+  isWebView: tOptional(tBoolean),
   artifactsDir: tOptional(tString),
   transport: tOptional(tBinary),
 });


### PR DESCRIPTION
Android WebView's devtools endpoint sometimes acknowledges `Runtime.enable` without replaying the pre-existing execution contexts, leaving the main world unknown forever and any page interaction hanging.

After frame session initialization, if no default (main world) execution context has been reported, cycle `Runtime.disable`/`Runtime.enable` until it shows up (250ms between attempts, bounded at 10). A healthy endpoint pays nothing: replayed `executionContextCreated` events arrive before the `Runtime.enable` response on the ordered transport, so the first check exits the loop immediately. Re-announced contexts from the re-enable are already handled by `frame.contextCreated`, which replaces an existing world context.

The workaround is gated on a new internal `isWebView` connect-over-CDP option so regular Chrome over CDP is unaffected; Playwright's own Android webview attach (`AndroidDevice.connectToWebView`) sets the bit automatically, while Clank launch does not.