### PR TITLE
fix(ui-mode): make the filter summary reachable from the keyboard

### DIFF
--- a/packages/trace-viewer/src/ui/uiModeFiltersView.css
+++ b/packages/trace-viewer/src/ui/uiModeFiltersView.css
@@ -35,6 +35,22 @@
   cursor: pointer;
 }
 
+/* the summary is a button, strip the browser chrome so it still reads as text */
+.filter-summary {
+  all: unset;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  user-select: none;
+  cursor: pointer;
+}
+
+.filter-summary:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .filter-label {
   color: var(--vscode-disabledForeground);
 }

--- a/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
+++ b/packages/trace-viewer/src/ui/uiModeFiltersView.tsx
@@ -55,11 +55,11 @@ export const FiltersView: React.FC<{
             runTests();
         }} />}>
     </Expandable>
-    <div className='filter-summary' title={'Status: ' + statusLine + '\nProjects: ' + projectsLine + (onlyChanged ? '\nOnly changed' : '')} onClick={() => setExpanded(!expanded)}>
+    <button className='filter-summary' aria-expanded={expanded} title={'Status: ' + statusLine + '\nProjects: ' + projectsLine + (onlyChanged ? '\nOnly changed' : '')} onClick={() => setExpanded(!expanded)}>
       <span className='filter-label'>Status:</span> {statusLine}
       <span className='filter-label'>Projects:</span> {projectsLine}
       {onlyChanged && <><span className='filter-label'>Only changed</span></>}
-    </div>
+    </button>
     {expanded && <>
       <div className='hbox' style={{ marginLeft: 14, maxHeight: 200, overflowY: 'auto' }}>
         <div className='filter-list' role='list' data-testid='status-filters'>

--- a/tests/playwright-test/ui-mode-test-filters.spec.ts
+++ b/tests/playwright-test/ui-mode-test-filters.spec.ts
@@ -72,6 +72,25 @@ test('should display native tags and filter by them on click', async ({ runUITes
   `);
 });
 
+test('should toggle filters from the keyboard', async ({ runUITest }) => {
+  const { page } = await runUITest(basicTestTree);
+  const summary = page.locator('.filter-summary');
+
+  await expect(summary).toHaveRole('button');
+  await expect(summary).toHaveAttribute('aria-expanded', 'false');
+
+  await summary.focus();
+  await expect(summary).toBeFocused();
+
+  await summary.press('Enter');
+  await expect(page.getByTestId('status-filters')).toBeVisible();
+  await expect(summary).toHaveAttribute('aria-expanded', 'true');
+
+  await summary.press('Space');
+  await expect(page.getByTestId('status-filters')).toBeHidden();
+  await expect(summary).toHaveAttribute('aria-expanded', 'false');
+});
+
 test('should filter by status', async ({ runUITest }) => {
   const { page } = await runUITest(basicTestTree);
 


### PR DESCRIPTION
Closes #42439

## problem

the filter summary under the search input in UI Mode toggles the status and project filters when you click it, but it is a `div` with an `onClick`:

```tsx
<div className='filter-summary' title={...} onClick={() => setExpanded(!expanded)}>
```

so tab skips it, enter and space do nothing, and a screen reader announces it as ordinary text rather than a control that expands something. the chevron next to it is already a button, which makes the summary the odd one out rather than a deliberate choice.

## fix

make it a real `button` with `aria-expanded`.

using a native button rather than `role='button'` plus `tabIndex` plus a keydown handler means focus, enter, space and the button role all come from the platform. it also matches `Expandable` right above it, which already renders its toggle as a `button` with `aria-expanded`.

the css resets the button chrome the same way `.expandable-title-button` does and adds the same focus ring, so it looks the way it did:

```css
.filter-summary {
  all: unset;
  display: block;
  /* ...the previous properties... */
}

.filter-summary:focus-visible {
  outline: 1px solid var(--vscode-focusBorder);
  outline-offset: -1px;
}
```

one thing worth calling out: the original properties lived in a rule shared with `.filter-title`, so the reset is in its own `.filter-summary` block rather than added to the shared one. `.filter-title` is untouched.

## test

`should toggle filters from the keyboard` in `ui-mode-test-filters.spec.ts`, close to your snippet in the issue, plus the aria state and the space key:

```ts
await expect(summary).toHaveRole('button');
await expect(summary).toHaveAttribute('aria-expanded', 'false');
await summary.focus();
await expect(summary).toBeFocused();
await summary.press('Enter');
await expect(page.getByTestId('status-filters')).toBeVisible();
await expect(summary).toHaveAttribute('aria-expanded', 'true');
await summary.press('Space');
await expect(page.getByTestId('status-filters')).toBeHidden();
```

on `main` it fails at the first assertion, `toHaveRole('button')`.

## verification

| check | result |
|---|---|
| new test on `main`, rebuilt | fails |
| new test with the change | passes |
| `ui-mode-test-filters` | 12 passed |
| every `ui-mode` spec | 139 passed |
| eslint on both changed files | clean |

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i reproduced the behaviour, checked how `Expandable` solves the same problem before picking an approach, and ran the ui mode suites locally before opening this.
