### PR TITLE
fix(cli): stop daemon when socket disappears

### DIFF
--- a/packages/playwright-core/src/tools/cli-daemon/daemon.ts
+++ b/packages/playwright-core/src/tools/cli-daemon/daemon.ts
@@ -45,6 +45,29 @@ async function socketExists(socketPath: string): Promise<boolean> {
   return false;
 }
 
+async function monitorSocketPath(socketPath: string): Promise<void> {
+  if (process.platform === 'win32')
+    return;
+
+  const socketStat = await fs.promises.stat(socketPath);
+
+  async function checkSocketPath() {
+    const currentStat = await fs.promises.stat(socketPath).catch(() => undefined);
+    if (!currentStat || !currentStat.isSocket() || currentStat.dev !== socketStat.dev || currentStat.ino !== socketStat.ino) {
+      gracefullyProcessExitDoNotHang(0);
+      return;
+    }
+    scheduleSocketCheck();
+  }
+
+  function scheduleSocketCheck() {
+    const timer = setTimeout(() => void checkSocketPath(), 1000);
+    timer.unref();
+  }
+
+  scheduleSocketCheck();
+}
+
 export async function startCliDaemonServer(
   sessionName: string,
   browserContext: playwright.BrowserContext,
@@ -118,6 +141,7 @@ export async function startCliDaemonServer(
   });
 
   await saveSessionFile(clientInfo, sessionConfig);
+  await monitorSocketPath(socketPath);
   return socketPath;
 }
 

--- a/tests/mcp/cli-session.spec.ts
+++ b/tests/mcp/cli-session.spec.ts
@@ -15,10 +15,20 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { test, expect, daemonFolder } from './cli-fixtures';
 import { killProcessGroup } from '../config/commonFixtures';
 import playwright from '../../packages/playwright-core';
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 test('list', async ({ cli, server }) => {
   const { output: emptyOutput } = await cli('list');
@@ -108,6 +118,30 @@ test('session stops when browser exits', async ({ cli, server }) => {
   await cli('close');
   const { output: listAfter } = await cli('list');
   expect(listAfter).toContain('(no browsers)');
+});
+
+test('session stops when temporary socket directory disappears', async ({ cli, server }) => {
+  test.skip(process.platform === 'win32');
+
+  // Keep this short because macOS limits Unix socket paths to 103 bytes.
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'p-'));
+  const removedTempDir = tempDir + '.removed';
+  try {
+    const { daemonPid } = await cli('open', server.HELLO_WORLD, {
+      env: {
+        PWTEST_SOCKETS_DIR: '',
+        TMPDIR: tempDir,
+      },
+    });
+    expect(daemonPid).toBeDefined();
+    expect(isProcessAlive(daemonPid)).toBe(true);
+
+    await fs.promises.rename(tempDir, removedTempDir);
+    await expect.poll(() => isProcessAlive(daemonPid)).toBe(false);
+  } finally {
+    await fs.promises.rm(tempDir, { force: true, recursive: true });
+    await fs.promises.rm(removedTempDir, { force: true, recursive: true });
+  }
 });
 
 test('session reopen with different config', async ({ cli, server }, testInfo) => {


### PR DESCRIPTION
detached browser daemons stay alive after losing their control socket

monitor the socket identity and exit gracefully when it disappears or is replaced

fixes <https://github.com/microsoft/playwright/issues/42428>