### PR TITLE
fix(mcp): disable the chromium sandbox for the bundled browser on linux

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -226,7 +226,7 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
 
   if (browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
     if (process.platform === 'linux')
-      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
+      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== undefined && browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
     else
       browser.launchOptions.chromiumSandbox = true;
   }

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -225,10 +225,13 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   }
 
   if (browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
-    if (process.platform === 'linux')
-      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== undefined && browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
-    else
+    if (process.platform === 'linux') {
+      const { channel, executablePath } = browser.launchOptions;
+      const bundled = !executablePath && (channel === undefined || channel === 'chromium' || channel === 'chrome-for-testing');
+      browser.launchOptions.chromiumSandbox = !bundled;
+    } else {
       browser.launchOptions.chromiumSandbox = true;
+    }
   }
 
   if (browser.isolated && browser.userDataDir)

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -157,6 +157,17 @@ test.describe('sandbox', () => {
       expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
+  test('chromium sandbox for the bundled browser', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'chromium' } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+    if (process.platform === 'linux')
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+    else
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
   test('sandbox not set for non-chromium browsers', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'firefox' }, emptyEnv);
     expect(config.browser.launchOptions.chromiumSandbox).toBeUndefined();

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -157,7 +157,9 @@ test.describe('sandbox', () => {
       expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
-  test('chromium sandbox for the bundled browser', async ({}, testInfo) => {
+  test('chromium sandbox for the bundled browser', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42452' },
+  }, async ({}, testInfo) => {
     const configFile = testInfo.outputPath('config.json');
     await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'chromium' } }));
     const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
@@ -166,6 +168,16 @@ test.describe('sandbox', () => {
       expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
     else
       expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
+  test('chromium sandbox for a custom executablePath', async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    const fileConfig: Config = {
+      browser: { browserName: 'chromium', launchOptions: { executablePath: '/usr/bin/google-chrome' } },
+    };
+    await fs.promises.writeFile(configFile, JSON.stringify(fileConfig));
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
   test('sandbox not set for non-chromium browsers', async () => {


### PR DESCRIPTION
## Summary
- On linux `validateBrowserConfig` turns the sandbox off only for the `chromium` and `chrome-for-testing` channels, but an undefined channel resolves to the same downloaded build, so `browserName: 'chromium'` with no channel launches with the sandbox on and dies with `Chromium sandboxing failed!`.
- Treat an undefined channel like those two, which also matches `BrowserType.launch` never enabling the sandbox on its own.
- An explicit `executablePath` keeps the sandbox, since that browser is not the bundled build.

Fixes https://github.com/microsoft/playwright/issues/42452