### PR TITLE
docs(cli): document skill installation in SKILL.md

### DIFF
--- a/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
@@ -359,13 +359,13 @@ When local version is available, use `npx playwright cli` in all commands. Other
 npm install -g @playwright/cli@latest
 ```
 
-Install or update this skill itself:
+Install or update this skill:
 
 ```bash
 # install into the workspace (.claude/skills, or .agents/skills with --skills=agents)
-playwright-cli install --skills=claude
+playwright-cli install --skills
 # install into the home directory to share the skill across all workspaces
-playwright-cli install --skills=claude --global
+playwright-cli install --skills -g
 ```
 
 ## Example: Form submission

--- a/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
+++ b/packages/playwright-core/src/tools/skills/playwright-cli/SKILL.md
@@ -359,6 +359,15 @@ When local version is available, use `npx playwright cli` in all commands. Other
 npm install -g @playwright/cli@latest
 ```
 
+Install or update this skill itself:
+
+```bash
+# install into the workspace (.claude/skills, or .agents/skills with --skills=agents)
+playwright-cli install --skills=claude
+# install into the home directory to share the skill across all workspaces
+playwright-cli install --skills=claude --global
+```
+
 ## Example: Form submission
 
 ```bash


### PR DESCRIPTION
## Summary
- `SKILL.md` documented only the CLI install, so the file that actually reaches an agent's context never mentioned `install --skills`, which is also how a skill gets updated. Added it next to the existing install instructions, in the same form the CLI guide uses.

Fixes https://github.com/microsoft/playwright/issues/42459