### PR TITLE
fix(server): keep pages alive when a reuse-mode connection drops

### DIFF
--- a/packages/playwright-core/src/remote/playwrightServer.ts
+++ b/packages/playwright-core/src/remote/playwrightServer.ts
@@ -222,6 +222,10 @@ export class PlaywrightServer {
     return {
       preLaunchedBrowser: browser,
       denyLaunch: true,
+      // The browser is shared between sequential connections, so that
+      // pages created by one connection can be kept alive after it drops
+      // (e.g. to debug or record them) and picked up by the next one.
+      sharedBrowser: true,
       dispose: async () => {
         // Don't close the pages so that user could debug them,
         // but close all the empty contexts to clean up.

--- a/tests/library/debug-controller.spec.ts
+++ b/tests/library/debug-controller.spec.ts
@@ -296,6 +296,38 @@ test('should reset routes before reuse', async ({ server, connectedBrowserFactor
   await browser2.close();
 });
 
+test('should keep pages alive when the test connection drops', async ({ backend, connectedBrowserFactory }, testInfo) => {
+  testInfo.annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37822' });
+
+  const pageCounts: number[] = [];
+  backend.on('stateChanged', params => pageCounts.push(params.pageCount));
+  await backend.setReportStateChanged({ enabled: true }, undefined);
+
+  // Emulates "Debug Test": the test process creates its own context and page.
+  const browser1 = await connectedBrowserFactory();
+  const context1 = await browser1.newContext();
+  const page1 = await context1.newPage();
+  await page1.setContent('<button>Submit</button>');
+  const contextEmpty = await browser1.newContext();
+  expect(contextEmpty.pages()).toHaveLength(0);
+  await expect.poll(() => pageCounts[pageCounts.length - 1]).toBe(1);
+
+  // Emulates the user hitting "Stop" during debugging: the test process is
+  // killed and its connection drops without a graceful close.
+  await browser1.close();
+
+  // The next connection (e.g. "Record at cursor") still sees the page alive:
+  // contexts with pages are kept around for debugging, empty ones are cleaned up.
+  const browser2 = await connectedBrowserFactory();
+  const contexts = browser2.contexts();
+  expect(contexts).toHaveLength(1);
+  const page = contexts[0].pages()[0];
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+
+  // The backend never reported the debugged page as closed.
+  expect(pageCounts).not.toContain(0);
+});
+
 test('should highlight inside iframe', async ({ backend, connectedBrowser }, testInfo) => {
   testInfo.annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/33146' });
 


### PR DESCRIPTION
## Summary
- mark the shared browser as `sharedBrowser: true` in reuse-browsers mode, so contexts created by a connection are no longer treated as isolated and killed wholesale by the connection cleanup when the connection drops
- contexts with pages now survive the drop (per the mode's existing design: "Don't close the pages so that user could debug them") and are picked up by the next connection; empty contexts are still cleaned up on disconnect
- this restores the pre-1.54 behavior where stopping a debug session in the VS Code extension keeps the browser open for inspection and recording (regression traced to 71088f6 by the extension maintainer in the issue)

Fixes https://github.com/microsoft/playwright/issues/37822

The extension-side hardening (backend teardown on transient zero page count) is in the companion PR: https://github.com/microsoft/playwright-vscode/pull/808

Related: #42458 fixes stale recorder actions leaking between "Record at cursor" sessions (https://github.com/microsoft/playwright/issues/42218).