### PR TITLE
fix(mcp): disable chromium sandbox on linux for undefined channel

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -225,10 +225,12 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   }
 
   if (browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
-    if (process.platform === 'linux')
-      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
-    else
+    if (process.platform === 'linux') {
+      const channel = browser.launchOptions.channel;
+      browser.launchOptions.chromiumSandbox = channel !== undefined && channel !== 'chromium' && channel !== 'chrome-for-testing';
+    } else {
       browser.launchOptions.chromiumSandbox = true;
+    }
   }
 
   if (browser.isolated && browser.userDataDir)


### PR DESCRIPTION
Fixes #42452

When using MCP on Linux with the default bundled chromium (where `channel` is undefined), the browser launch would fail with `Chromium sandboxing failed!`.

This PR treats an `undefined` channel the same as `'chromium'` and `'chrome-for-testing'` when deciding the `chromiumSandbox` default for Linux in `validateBrowserConfig`. This matches the behavior of the bundled browser in other launch contexts and ensures it works out of the box.