### PR TITLE
fix(web): make sortable grid column headers keyboard accessible

### DIFF
--- a/packages/web/src/components/gridView.css
+++ b/packages/web/src/components/gridView.css
@@ -66,6 +66,20 @@
   white-space: nowrap;
 }
 
+.grid-view-header-cell-button {
+  all: unset;
+  display: flex;
+  align-items: center;
+  flex: auto;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.grid-view-header-cell-button:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .grid-view-header-cell-title {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/web/src/components/gridView.tsx
+++ b/packages/web/src/components/gridView.tsx
@@ -75,17 +75,24 @@ export function GridView<T>(model: GridViewProps<T>) {
     <div className='vbox'>
       <div className='grid-view-header'>
         {model.columns.map((column, i) => {
+          const title = <>
+            <span className='grid-view-header-cell-title'>{model.columnTitle(column)}</span>
+            <span className='codicon codicon-triangle-up' />
+            <span className='codicon codicon-triangle-down' />
+          </>;
           return <div
             key={model.columnTitle(column)}
             className={'grid-view-header-cell ' + sortingHeader(column, model.sorting)}
             style={{
               width: i < model.columns.length - 1 ? model.columnWidths.get(column) : undefined,
             }}
-            onClick={() => model.setSorting && toggleSorting(column)}
           >
-            <span className='grid-view-header-cell-title'>{model.columnTitle(column)}</span>
-            <span className='codicon codicon-triangle-up' />
-            <span className='codicon codicon-triangle-down' />
+            {model.setSorting ? <button
+              className='grid-view-header-cell-button'
+              onClick={() => toggleSorting(column)}
+            >
+              {title}
+            </button> : title}
           </div>;
         })}
       </div>

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -518,6 +518,21 @@ test('should have network requests', async ({ showTraceViewer }) => {
   await expect(traceViewer.networkRequests.filter({ hasText: '404GET404text' })).toHaveCSS('background-color', 'rgb(242, 222, 222)');
 });
 
+test('should sort network columns from the keyboard', async ({ showTraceViewer }) => {
+  const traceViewer = await showTraceViewer(traceFile);
+  await traceViewer.selectAction('Navigate');
+  await traceViewer.showNetworkTab();
+
+  const nameColumn = traceViewer.page.getByRole('button', { name: 'Name', exact: true });
+  await expect(nameColumn).toBeVisible();
+
+  await nameColumn.focus();
+  await expect(nameColumn).toBeFocused();
+
+  await nameColumn.press('Enter');
+  await expect(traceViewer.networkRequests.first()).toContainText('404');
+});
+
 test('should attribute network requests to service workers', async ({ runAndTrace, page, context, server, browserName }) => {
   test.skip(browserName !== 'chromium', 'Service worker requests are only reported in Chromium');
   const traceViewer = await runAndTrace(async () => {


### PR DESCRIPTION
The sortable column headers in `GridView` carry their `onClick` on a plain `<div>` with no role, no `tabIndex` and no key handler, so they cannot be reached or activated from the keyboard and are not announced as controls. `GridView` backs the trace viewer's Network tab, so sorting by Name, Method, Status, Content-Type, Size or Duration is keyboard-inaccessible.

This follows the pattern from #42310 and #42336 and uses a real `<button>` with `all: unset` rather than `role="button"` on a div, with the same `:focus-visible` outline treatment as `.expandable-title-button`.

The button is only rendered when the grid is actually sortable. Previously the header was always clickable and the handler was guarded with `model.setSorting &&`, but `toggleSorting` already does `model.setSorting?.()` internally, so that guard was redundant. Moving the condition to render time means a non-sortable column no longer presents an inert clickable element.

One test in `trace-viewer.spec.ts`, written in the style of the one added in #42449: focus the Name header, confirm focus, press Enter, and assert the `404` request sorts to the top. The default order is `frame.html, style.css, 404, script.js` per the existing `should have network requests` test, so that assertion is not vacuous. Without the change the test fails at the first assertion, because no button exists to find.

Verified locally on chromium: the full `trace-viewer.spec.ts` passes at 121/121, and every test matching `network` passes at 152 passed / 5 skipped. `tsc` reports nothing in `packages/web` and eslint is clean on the changed file.

I did not add `aria-sort`, since doing it properly needs `role="columnheader"` inside `role="row"`/`role="grid"` and that restructures the component. Happy to follow up separately if you would like the full grid semantics.
