### PR TITLE
fix(mcp): disable the chromium sandbox for the bundled browser on linux

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -225,10 +225,13 @@ async function validateBrowserConfig(browser: MergedConfig['browser']): Promise<
   }
 
   if (browserName === 'chromium' && browser.launchOptions.chromiumSandbox === undefined) {
-    if (process.platform === 'linux')
-      browser.launchOptions.chromiumSandbox = browser.launchOptions.channel !== 'chromium' && browser.launchOptions.channel !== 'chrome-for-testing';
-    else
+    if (process.platform === 'linux') {
+      // Downloaded chromium builds (undefined channel, 'chromium', 'chrome-for-testing') lack the setuid sandbox helper on linux.
+      const { channel } = browser.launchOptions;
+      browser.launchOptions.chromiumSandbox = channel !== undefined && channel !== 'chromium' && channel !== 'chrome-for-testing';
+    } else {
       browser.launchOptions.chromiumSandbox = true;
+    }
   }
 
   if (browser.isolated && browser.userDataDir)

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -157,6 +157,19 @@ test.describe('sandbox', () => {
       expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
+  test('chromium sandbox disabled for browserName chromium without channel', {
+    annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42452' },
+  }, async ({}, testInfo) => {
+    const configFile = testInfo.outputPath('config.json');
+    await fs.promises.writeFile(configFile, JSON.stringify({ browser: { browserName: 'chromium' } }));
+    const config = await resolveCLIConfigForMCP({ config: configFile }, emptyEnv);
+    expect(config.browser.launchOptions.channel).toBeUndefined();
+    if (process.platform === 'linux')
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
+    else
+      expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
+  });
+
   test('sandbox not set for non-chromium browsers', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'firefox' }, emptyEnv);
     expect(config.browser.launchOptions.chromiumSandbox).toBeUndefined();


### PR DESCRIPTION
## Summary
- An undefined channel with `browserName: 'chromium'` resolves to the same downloaded build as the `chromium` and `chrome-for-testing` channels, so treat it the same when defaulting `chromiumSandbox` on linux.

Fixes https://github.com/microsoft/playwright/issues/42452