### PR TITLE
fix(mcp): create the parent directory for an explicit output file name

### DIFF
--- a/packages/playwright-core/src/tools/backend/pdf.ts
+++ b/packages/playwright-core/src/tools/backend/pdf.ts
@@ -20,7 +20,7 @@ import { formatObject } from '@isomorphic/stringUtils';
 import { defineTabTool } from './tool';
 
 const pdfSchema = z.object({
-  filename: z.string().optional().describe('File name to save the pdf to. Defaults to `page-{timestamp}.pdf` if not specified. Prefer relative file names to stay within the output directory.'),
+  filename: z.string().optional().describe('File name to save the pdf to. Defaults to `page-{timestamp}.pdf` in the output directory if not specified. An explicit name is resolved against the working directory, not the output directory.'),
 });
 
 const pdf = defineTabTool({

--- a/packages/playwright-core/src/tools/backend/response.ts
+++ b/packages/playwright-core/src/tools/backend/response.ts
@@ -87,10 +87,14 @@ export class Response {
 
   async resolveClientFile(template: FilenameTemplate, title: string): Promise<ResolvedFile> {
     let fileName: string;
-    if (template.suggestedFilename)
+    if (template.suggestedFilename) {
       fileName = await this.resolveClientFilename(template.suggestedFilename);
-    else
+      // outputFile() creates the parent directory for auto-named files, do the same
+      // for an explicit one so that "sub/page.png" does not fail with ENOENT.
+      await fs.promises.mkdir(path.dirname(fileName), { recursive: true });
+    } else {
       fileName = await this._context.outputFile(template, { origin: 'llm' });
+    }
     const relativeName = this._computeRelativeTo(fileName);
     const printableLink = `- [${title}](${relativeName})`;
     return { fileName, relativeName, printableLink };

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -28,7 +28,7 @@ type ImageFormat = 'png' | 'jpeg' | 'webp';
 
 const screenshotSchema = optionalElementSchema.extend({
   type: z.enum(['png', 'jpeg', 'webp']).optional().describe('Image format for the screenshot. If unset, inferred from the filename extension, otherwise png.'),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg|webp}` if not specified. Prefer relative file names to stay within the output directory.'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg|webp}` in the output directory if not specified. An explicit name is resolved against the working directory, not the output directory.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
   scale: z.enum(['css', 'device']).default('css').describe('Image resolution scale. "css" produces a screenshot sized in CSS pixels (smaller, consistent across devices). "device" produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.'),
 });

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -246,6 +246,26 @@ test('browser_take_screenshot (filename: "output.png")', async ({ client, server
   expect(files[0]).toMatch(/^output\.png$/);
 });
 
+test('browser_take_screenshot (filename with a subdirectory)', async ({ client, server }, testInfo) => {
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    code: expect.stringContaining(`page.goto('http://localhost`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: {
+      filename: 'sub/dir/output.png',
+    },
+  })).toHaveResponse({
+    result: expect.stringContaining('output.png'),
+  });
+
+  expect(fs.existsSync(testInfo.outputPath('sub', 'dir', 'output.png'))).toBeTruthy();
+});
+
 test('browser_take_screenshot (imageResponses=omit)', async ({ startClient, server }, testInfo) => {
   const outputDir = testInfo.outputPath('output');
   const { client } = await startClient({


### PR DESCRIPTION
Fixes #42487

### The ENOENT

Every tool that takes a `filename` resolves it through `Response.resolveClientFile()`, and only one of that method's two branches creates the directory it is about to write into:

- no `filename` → `Context.outputFile()`, which resolves against the output directory **and** `mkdir -p`s the parent;
- explicit `filename` → `Response.resolveClientFilename()` → `Context.workspaceFile()`, which resolves against the client workspace and creates nothing.

So a name containing a subdirectory fails with a raw ENOENT, as reported:

```
browser_take_screenshot { "filename": "sub/shot.png" }
Error: ENOENT: no such file or directory, open '<cwd>/sub/shot.png'
```

The `mkdir` added here runs after `workspaceFile()` has already applied its `checkFile()` allowed-roots check, so it can only create directories under roots the caller was allowed to write to in the first place. `resolveClientFilename()` itself is left alone, because it is also the read path for `browser_file_upload`, `browser_drop`, `browser_set_storage_state` and `browser_run_code_unsafe`, where creating a directory for a path that does not exist would be wrong.

### The descriptions

The issue also reports that a relative `filename` does not land in `--output-dir`. That half is what the code intends rather than a bug: an explicit name is resolved against the client workspace (an MCP root, `_meta.cwd` for the CLI, otherwise the server's cwd), and three existing tests pin it (`screenshot.spec.ts` "filename: \"output.png\"", `storage.spec.ts` "saves to custom filename", `roots.spec.ts` "should return relative paths when root is specified").

What is wrong is the parameter description on `browser_take_screenshot` and `browser_pdf_save`, which tells the model the opposite:

> Prefer relative file names to stay within the output directory.

This corrects those two strings to describe the actual behaviour. If you would rather keep the description and route relative names into the output directory instead, that is a bigger change and I am happy to redo it that way. I went with the direction the tests already commit to.

### Test

`browser_take_screenshot (filename with a subdirectory)` in `tests/mcp/screenshot.spec.ts`. On `main` it fails with exactly the ENOENT above; with the change it passes.

Verified on macOS arm64 (M1 Max): the full `tests/mcp` chromium project, 639 passed / 107 skipped / 0 failed, plus `npm run tsc`, `npx eslint` on the touched files and `node utils/lint_tests.js`.

### On the contribution policy

CONTRIBUTING asks that an issue be assigned before a PR goes up, and #42487 is not assigned to anyone. I have commented there asking; close this without ceremony if you would rather own it.
