### PR TITLE
fix(trace-viewer): show full URL when navigation leaves baseURL

### DIFF
--- a/packages/isomorphic/protocolFormatter.ts
+++ b/packages/isomorphic/protocolFormatter.ts
@@ -28,11 +28,11 @@ export type CallMetainfo = {
   subtitle?: string;
 };
 
-export function formatProtocolParam(params: Record<string, any> | undefined, alternatives: string, sdkLanguage?: Language): string | undefined {
-  return _formatProtocolParam(params, alternatives, sdkLanguage)?.replaceAll('\n', '\\n');
+export function formatProtocolParam(params: Record<string, any> | undefined, alternatives: string, sdkLanguage?: Language, baseURL?: string): string | undefined {
+  return _formatProtocolParam(params, alternatives, sdkLanguage, baseURL)?.replaceAll('\n', '\\n');
 }
 
-function _formatProtocolParam(params: Record<string, any> | undefined, alternatives: string, sdkLanguage?: Language): string | undefined {
+function _formatProtocolParam(params: Record<string, any> | undefined, alternatives: string, sdkLanguage?: Language, baseURL?: string): string | undefined {
   if (!params)
     return undefined;
 
@@ -43,6 +43,8 @@ function _formatProtocolParam(params: Record<string, any> | undefined, alternati
         if (urlObject.protocol === 'data:')
           return urlObject.protocol;
         if (['about:', 'chrome:', 'edge:'].includes(urlObject.protocol))
+          return params[name];
+        if (baseURL !== undefined && !isSameOrigin(urlObject, baseURL))
           return params[name];
         return urlObject.pathname + urlObject.search;
       } catch (error) {
@@ -64,6 +66,14 @@ function _formatProtocolParam(params: Record<string, any> | undefined, alternati
   }
 }
 
+function isSameOrigin(url: URL, baseURL: string): boolean {
+  try {
+    return new URL(baseURL).origin === url.origin;
+  } catch {
+    return true;
+  }
+}
+
 function deepParam(params: Record<string, any>, name: string): string | undefined {
   const tokens = name.split('.');
   let current = params;
@@ -77,20 +87,20 @@ function deepParam(params: Record<string, any>, name: string): string | undefine
   return String(current);
 }
 
-export function renderTitleForCall(metadata: CallMetainfo, sdkLanguage?: Language): string {
+export function renderTitleForCall(metadata: CallMetainfo, sdkLanguage?: Language, baseURL?: string): string {
   const titleFormat = metadata.title ?? getMetainfo(metadata)?.title ?? metadata.method;
   return titleFormat.replace(/\{([^}]+)\}/g, (fullMatch, p1) => {
-    return formatProtocolParam(metadata.params, p1, sdkLanguage) ?? fullMatch;
+    return formatProtocolParam(metadata.params, p1, sdkLanguage, baseURL) ?? fullMatch;
   });
 }
 
-export function renderSubtitleForCall(metadata: CallMetainfo, sdkLanguage?: Language): string | undefined {
+export function renderSubtitleForCall(metadata: CallMetainfo, sdkLanguage?: Language, baseURL?: string): string | undefined {
   const subtitleFormat = metadata.subtitle ?? getMetainfo(metadata)?.subtitle;
   if (subtitleFormat === undefined)
     return undefined;
   let allParamsResolved = true;
   const subtitle = subtitleFormat.replace(/\{([^}]+)\}/g, (fullMatch, p1) => {
-    const param = formatProtocolParam(metadata.params, p1, sdkLanguage);
+    const param = formatProtocolParam(metadata.params, p1, sdkLanguage, baseURL);
     if (param === undefined)
       allParamsResolved = false;
     return param ?? fullMatch;
@@ -98,9 +108,9 @@ export function renderSubtitleForCall(metadata: CallMetainfo, sdkLanguage?: Lang
   return allParamsResolved ? subtitle : undefined;
 }
 
-export function renderFullTitleForCall(metadata: CallMetainfo, sdkLanguage?: Language): string {
-  const title = renderTitleForCall(metadata, sdkLanguage);
-  const subtitle = renderSubtitleForCall(metadata, sdkLanguage);
+export function renderFullTitleForCall(metadata: CallMetainfo, sdkLanguage?: Language, baseURL?: string): string {
+  const title = renderTitleForCall(metadata, sdkLanguage, baseURL);
+  const subtitle = renderSubtitleForCall(metadata, sdkLanguage, baseURL);
   return subtitle ? `${title} ${subtitle}` : title;
 }
 

--- a/packages/isomorphic/trace/traceModel.ts
+++ b/packages/isomorphic/trace/traceModel.ts
@@ -229,7 +229,7 @@ export class TraceModel {
     const { rootItem } = buildActionTree(actions);
     const actionTree: string[] = [];
     const visit = (actionItem: ActionTreeItem, indent: string) => {
-      const title = renderFullTitleForCall({ ...actionItem.action, type: actionItem.action.class });
+      const title = renderFullTitleForCall({ ...actionItem.action, type: actionItem.action.class }, undefined, this.options.baseURL);
       actionTree.push(`${indent}${title || actionItem.id}`);
       for (const child of actionItem.children)
         visit(child, indent + '  ');

--- a/packages/playwright-core/src/server/debugger.ts
+++ b/packages/playwright-core/src/server/debugger.ts
@@ -201,7 +201,7 @@ export class Debugger extends SdkObject<DebuggerEventMap> implements Instrumenta
         continue;
       updates.push({
         id: call.metadata.id,
-        title: renderFullTitleForCall(call.metadata, this._context._browser.sdkLanguage()) ?? '',
+        title: renderFullTitleForCall(call.metadata, this._context._browser.sdkLanguage(), this._context._options.baseURL) ?? '',
         location: call.metadata.location,
         newLogEntries: call.metadata.log.slice(call.sentLogCount),
         actionPoint: call.actionPoint,

--- a/packages/playwright-core/src/server/dispatchers/debuggerDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/debuggerDispatcher.ts
@@ -53,7 +53,7 @@ export class DebuggerDispatcher extends Dispatcher<Debugger, channels.DebuggerCh
         line: metadata.location?.line,
         column: metadata.location?.column,
       },
-      title: renderFullTitleForCall(metadata, sdkObject.attribution.playwright.options.sdkLanguage),
+      title: renderFullTitleForCall(metadata, sdkObject.attribution.playwright.options.sdkLanguage, this.parentScope()._object._options.baseURL),
     };
   }
 

--- a/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/frameDispatcher.ts
@@ -280,7 +280,7 @@ export class FrameDispatcher extends Dispatcher<Frame, channels.FrameChannel, Br
   }
 
   async expect(params: channels.FrameExpectParams, progress: Progress): Promise<channels.FrameExpectResult> {
-    progress.log(`${renderFullTitleForCall(progress.metadata, this._frame._page.browserContext._browser.sdkLanguage())}${progress.timeout ? ` with timeout ${progress.timeout}ms` : ''}`);
+    progress.log(`${renderFullTitleForCall(progress.metadata, this._frame._page.browserContext._browser.sdkLanguage(), this._frame._page.browserContext._options.baseURL)}${progress.timeout ? ` with timeout ${progress.timeout}ms` : ''}`);
     const expectedValue = params.expectedValue ? parseArgument(params.expectedValue) : undefined;
     try {
       await this._frame.expect(progress, params.selector, { ...params, expectedValue });

--- a/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
+++ b/packages/playwright-core/src/server/dispatchers/pageDispatcher.ts
@@ -236,7 +236,7 @@ export class PageDispatcher extends Dispatcher<Page, channels.PageChannel, Brows
       frame: (params.locator.frame as FrameDispatcher)._object,
       selector: params.locator.selector,
     } : undefined;
-    progress.log(`${renderFullTitleForCall(progress.metadata, this._page.browserContext._browser.sdkLanguage())}${progress.timeout ? ` with timeout ${progress.timeout}ms` : ''}`);
+    progress.log(`${renderFullTitleForCall(progress.metadata, this._page.browserContext._browser.sdkLanguage(), this._page.browserContext._options.baseURL)}${progress.timeout ? ` with timeout ${progress.timeout}ms` : ''}`);
     return await this._page.expectScreenshot(progress, {
       ...params,
       locator,

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -454,7 +454,7 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
         status = 'in-progress';
       if (this._debugger.isPaused(metadata))
         status = 'paused';
-      logs.push(metadataToCallLog(metadata, status, this._currentLanguage));
+      logs.push(metadataToCallLog(metadata, status, this._currentLanguage, this._context._options.baseURL));
     }
     this._callLogs = logs;
     this.emit(RecorderEvent.CallLogsUpdated, logs);

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -63,9 +63,9 @@ async function resolvesToFrame(progress: Progress, selector: string, frame: Fram
   }
 }
 
-export function metadataToCallLog(metadata: CallMetadata, status: CallLogStatus, sdkLanguage: Language): CallLog {
-  const title = renderTitleForCall(metadata, sdkLanguage);
-  const subtitle = renderSubtitleForCall(metadata, sdkLanguage);
+export function metadataToCallLog(metadata: CallMetadata, status: CallLogStatus, sdkLanguage: Language, baseURL: string | undefined): CallLog {
+  const title = renderTitleForCall(metadata, sdkLanguage, baseURL);
+  const subtitle = renderSubtitleForCall(metadata, sdkLanguage, baseURL);
   if (metadata.error)
     status = 'error';
   let duration = metadata.endTime ? metadata.endTime - metadata.startTime : undefined;

--- a/packages/playwright-core/src/server/screencast.ts
+++ b/packages/playwright-core/src/server/screencast.ts
@@ -169,7 +169,7 @@ export class Screencast implements InstrumentationListener {
     if (!box && (sdkObject instanceof ElementHandle))
       box = await sdkObject.boundingBox(nullProgress) || undefined;
 
-    const actionTitle = renderFullTitleForCall(progress.metadata, this.page.browserContext._browser.sdkLanguage());
+    const actionTitle = renderFullTitleForCall(progress.metadata, this.page.browserContext._browser.sdkLanguage(), this.page.browserContext._options.baseURL);
     const utility = await progress.race(page.mainFrame().utilityContext());
 
     // Run this outside of the progress timer.

--- a/packages/playwright-core/src/tools/trace/traceActions.ts
+++ b/packages/playwright-core/src/tools/trace/traceActions.ts
@@ -26,7 +26,8 @@ import type { ActionEntry } from '@isomorphic/trace/entries';
 
 export async function traceActions(options: { grep?: string, errorsOnly?: boolean }) {
   const trace = await loadTrace();
-  const actions = filterActions(trace.model.actions, options);
+  const baseURL = trace.model.options.baseURL;
+  const actions = filterActions(trace.model.actions, options, baseURL);
 
   // Tree view
   const { rootItem } = buildActionTree(actions);
@@ -37,8 +38,8 @@ export async function traceActions(options: { grep?: string, errorsOnly?: boolea
     const ordinal = trace.callIdToOrdinal.get(action.callId) ?? '?';
     const ts = formatTimestamp(action.startTime, trace.model.startTime);
     const duration = action.endTime ? msToString(action.endTime - action.startTime) : 'running';
-    const title = actionTitle(action);
-    const subtitle = actionSubtitle(action);
+    const title = actionTitle(action, baseURL);
+    const subtitle = actionSubtitle(action, baseURL);
     const error = action.error ? '  ✗' : '';
     const prefix = `  ${(ordinal + '.').padStart(4)} ${ts}  ${indent}`;
     console.log(`${prefix}${title.padEnd(Math.max(1, 55 - indent.length))} ${duration.padStart(8)}${error}`);
@@ -51,11 +52,11 @@ export async function traceActions(options: { grep?: string, errorsOnly?: boolea
     visit(child, '');
 }
 
-function filterActions(actions: ActionEntry[], options: { grep?: string, errorsOnly?: boolean }): ActionEntry[] {
+function filterActions(actions: ActionEntry[], options: { grep?: string, errorsOnly?: boolean }, baseURL?: string): ActionEntry[] {
   let result = actions.filter(a => a.group !== 'configuration');
   if (options.grep) {
     const pattern = new RegExp(options.grep, 'i');
-    result = result.filter(a => pattern.test(actionFullTitle(a)));
+    result = result.filter(a => pattern.test(actionFullTitle(a, baseURL)));
   }
   if (options.errorsOnly)
     result = result.filter(a => !!a.error);
@@ -71,7 +72,7 @@ export async function traceAction(actionId: string) {
     return;
   }
 
-  const title = actionFullTitle(action);
+  const title = actionFullTitle(action, trace.model.options.baseURL);
   console.log(`\n  ${title}\n`);
 
   // Time

--- a/packages/playwright-core/src/tools/trace/traceErrors.ts
+++ b/packages/playwright-core/src/tools/trace/traceErrors.ts
@@ -29,7 +29,7 @@ export async function traceErrors() {
 
   for (const error of model.errorDescriptors) {
     if (error.action) {
-      const title = actionFullTitle(error.action);
+      const title = actionFullTitle(error.action, model.options.baseURL);
       console.log(`\n  ✗ ${title}`);
     } else {
       console.log(`\n  ✗ Error`);

--- a/packages/playwright-core/src/tools/trace/traceUtils.ts
+++ b/packages/playwright-core/src/tools/trace/traceUtils.ts
@@ -106,16 +106,16 @@ export function formatTimestamp(ms: number, base: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}.${millis.toString().padStart(3, '0')}`;
 }
 
-export function actionTitle(action: ActionEntry): string {
-  return renderTitleForCall({ ...action, type: action.class }) || `${action.class}.${action.method}`;
+export function actionTitle(action: ActionEntry, baseURL?: string): string {
+  return renderTitleForCall({ ...action, type: action.class }, undefined, baseURL) || `${action.class}.${action.method}`;
 }
 
-export function actionSubtitle(action: ActionEntry): string | undefined {
-  return renderSubtitleForCall({ ...action, type: action.class });
+export function actionSubtitle(action: ActionEntry, baseURL?: string): string | undefined {
+  return renderSubtitleForCall({ ...action, type: action.class }, undefined, baseURL);
 }
 
-export function actionFullTitle(action: ActionEntry): string {
-  return renderFullTitleForCall({ ...action, type: action.class }) || `${action.class}.${action.method}`;
+export function actionFullTitle(action: ActionEntry, baseURL?: string): string {
+  return renderFullTitleForCall({ ...action, type: action.class }, undefined, baseURL) || `${action.class}.${action.method}`;
 }
 
 export async function saveOutputFile(fileName: string, content: string | Buffer, explicitOutput?: string): Promise<string> {

--- a/packages/trace-viewer/src/ui/actionList.tsx
+++ b/packages/trace-viewer/src/ui/actionList.tsx
@@ -92,11 +92,11 @@ export const ActionList: React.FC<ActionListProps> = ({
       return false;
     if (!actionFilterText)
       return true;
-    const { title, subtitle } = renderTitleForCall(item.action, sdkLanguage);
+    const { title, subtitle } = renderTitleForCall(item.action, sdkLanguage, model?.options.baseURL);
     const text = subtitle ? `${title} ${subtitle}` : title;
     const isIncluded = text.toLowerCase().includes(actionFilterText.toLowerCase());
     return isIncluded ? true : 'if-needed';
-  }, [selectedTime, actionFilterText, sdkLanguage]);
+  }, [selectedTime, actionFilterText, sdkLanguage, model]);
 
   const onSelectedAction = React.useCallback((item: ActionTreeItem) => {
     onSelected?.(item.action);
@@ -156,7 +156,7 @@ export const renderAction = (
     time = 'Timed out';
   else if (!isLive)
     time = '-';
-  const { elements, title, subtitle } = renderTitleForCall(action, sdkLanguage);
+  const { elements, title, subtitle } = renderTitleForCall(action, sdkLanguage, model?.options.baseURL);
   return <div className='action-title vbox'>
     <div className='hbox'>
       <span className='action-title-method' title={title}>{elements}</span>
@@ -177,7 +177,7 @@ export const renderAction = (
   </div>;
 };
 
-export function renderTitleForCall(action: ActionTraceEvent, sdkLanguage?: Language): { elements: React.ReactNode[], title: string, subtitle?: string } {
+export function renderTitleForCall(action: ActionTraceEvent, sdkLanguage?: Language, baseURL?: string): { elements: React.ReactNode[], title: string, subtitle?: string } {
   let titleFormat = action.title ?? getMetainfo({ type: action.class, method: action.method })?.title ?? action.method;
   titleFormat = titleFormat.replace(/\n/g, ' ');
 
@@ -194,7 +194,7 @@ export function renderTitleForCall(action: ActionTraceEvent, sdkLanguage?: Langu
     elements.push(chunk);
     title.push(chunk);
 
-    const param = formatProtocolParam(action.params, quotedText, sdkLanguage);
+    const param = formatProtocolParam(action.params, quotedText, sdkLanguage, baseURL);
     if (param === undefined) {
       elements.push(fullMatch);
       title.push(fullMatch);
@@ -214,7 +214,7 @@ export function renderTitleForCall(action: ActionTraceEvent, sdkLanguage?: Langu
     title.push(chunk);
   }
 
-  const subtitle = renderSubtitleForCall({ type: action.class, method: action.method, params: action.params, subtitle: action.subtitle }, sdkLanguage);
+  const subtitle = renderSubtitleForCall({ type: action.class, method: action.method, params: action.params, subtitle: action.subtitle }, sdkLanguage, baseURL);
   return { elements, title: title.join(''), subtitle };
 }
 

--- a/packages/trace-viewer/src/ui/callTab.tsx
+++ b/packages/trace-viewer/src/ui/callTab.tsx
@@ -25,12 +25,14 @@ import type { Language } from '@isomorphic/locatorGenerators';
 import { PlaceholderPanel } from './placeholderPanel';
 import type { ActionEntry } from '@isomorphic/trace/entries';
 import { renderTitleForCall } from './actionList';
+import { useTraceModel } from './traceModelContext';
 
 export const CallTab: React.FunctionComponent<{
   action: ActionEntry | undefined,
   startTimeOffset: number,
   sdkLanguage: Language | undefined,
 }> = ({ action, startTimeOffset, sdkLanguage }) => {
+  const model = useTraceModel();
   // We never need the waitForEventInfo (`info`).
   const paramKeys = React.useMemo(() => Object.keys(action?.params ?? {}).filter(name => name !== 'info'), [action]);
 
@@ -41,7 +43,7 @@ export const CallTab: React.FunctionComponent<{
   const startTimeMillis = action.startTime - startTimeOffset;
   const startTime = msToString(startTimeMillis);
 
-  const { title, subtitle } = renderTitleForCall(action, sdkLanguage);
+  const { title, subtitle } = renderTitleForCall(action, sdkLanguage, model?.options.baseURL);
 
   return (
     <div className='call-tab'>

--- a/packages/trace-viewer/src/ui/errorsTab.tsx
+++ b/packages/trace-viewer/src/ui/errorsTab.tsx
@@ -53,6 +53,7 @@ export function useErrorsTabModel(model: TraceModel | undefined): ErrorsTabModel
 }
 
 function ErrorView({ message, error, sdkLanguage, revealInSource }: { message: string, error: ErrorDescription, sdkLanguage: Language, revealInSource: (error: ErrorDescription) => void }) {
+  const model = useTraceModel();
   let location: string | undefined;
   let longLocation: string | undefined;
   const stackFrame = error.stack?.[0];
@@ -71,7 +72,7 @@ function ErrorView({ message, error, sdkLanguage, revealInSource }: { message: s
       color: 'var(--vscode-errorForeground)',
       flex: 0,
     }}>
-      {error.action && renderAction(error.action, { sdkLanguage })}
+      {error.action && renderAction(error.action, { model, sdkLanguage })}
       {location && <div className='action-location'>
         @ <button type='button' title={longLocation} aria-label={`Go to source: ${longLocation}`} onClick={() => revealInSource(error)}>{location}</button>
       </div>}

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -174,6 +174,11 @@ test('should show tracing.group in the action list with location', async ({ runA
   await expect(traceViewer.sourceCodeTab.locator('.source-line-running')).toContainText('buddy beaver');
 });
 
+test('should print the whole url when navigating away from the base url', async ({ showTraceViewer, server }) => {
+  const traceViewer = await showTraceViewer(traceFile);
+  await expect(traceViewer.actionTitles.filter({ hasText: 'Navigate' }).last()).toContainText(server.PREFIX + '/frames/frame.html');
+});
+
 test('should open simple trace viewer', async ({ showTraceViewer }) => {
   const traceViewer = await showTraceViewer(traceFile);
   await expect(traceViewer.actionTitles).toHaveText([

--- a/tests/library/unit/protocol-formatter.spec.ts
+++ b/tests/library/unit/protocol-formatter.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test as it, expect } from '@playwright/test';
+import { iso as _iso } from '../../../packages/playwright-core/lib/coreBundle';
+
+const { renderFullTitleForCall } = _iso;
+
+const goto = (url: string) => ({ type: 'Frame', method: 'goto', params: { url } });
+
+it('should hide the origin of same-origin urls', () => {
+  expect(renderFullTitleForCall(goto('https://example.com/foo?bar=1'), 'javascript', 'https://example.com')).toBe('Navigate /foo?bar=1');
+  expect(renderFullTitleForCall(goto('https://example.com/foo?bar=1'), 'javascript', 'https://example.com/base/path')).toBe('Navigate /foo?bar=1');
+});
+
+it('should print the whole url when the origin differs from the base url', () => {
+  expect(renderFullTitleForCall(goto('https://another.com/foo?bar=1'), 'javascript', 'https://example.com')).toBe('Navigate https://another.com/foo?bar=1');
+  // Different port and different scheme are different origins as well.
+  expect(renderFullTitleForCall(goto('https://example.com:8443/foo'), 'javascript', 'https://example.com')).toBe('Navigate https://example.com:8443/foo');
+  expect(renderFullTitleForCall(goto('http://example.com/foo'), 'javascript', 'https://example.com')).toBe('Navigate http://example.com/foo');
+});
+
+it('should hide the origin when there is no base url to compare against', () => {
+  expect(renderFullTitleForCall(goto('https://example.com/foo?bar=1'), 'javascript')).toBe('Navigate /foo?bar=1');
+  expect(renderFullTitleForCall(goto('https://example.com/foo?bar=1'), 'javascript', 'not a url')).toBe('Navigate /foo?bar=1');
+});
+
+it('should not affect non-http urls', () => {
+  expect(renderFullTitleForCall(goto('data:text/html,<div>hi</div>'), 'javascript', 'https://example.com')).toBe('Navigate data:');
+  expect(renderFullTitleForCall(goto('about:blank'), 'javascript', 'https://example.com')).toBe('Navigate about:blank');
+  expect(renderFullTitleForCall(goto('not a url'), 'javascript', 'https://example.com')).toBe('Navigate not a url');
+});


### PR DESCRIPTION
## Summary
- Action titles that render a `{url}` param always dropped the origin via `protocolFormatter`
- Keep path-only titles when the URL stays on the context `baseURL` origin
- Print the full URL when the origin differs (SSO/captcha/off-site navigations)
- Thread `baseURL` through formatter call sites (trace viewer, recorder, debugger, screencast, trace CLI)
- Unit coverage + one trace-viewer regression

Fixes https://github.com/microsoft/playwright/issues/42473

Credit: approach based on @rf-molsson's draft commit `462a0fa`.

## Test plan
- [x] `npx playwright test --config=tests/library/playwright.config.ts tests/library/unit/protocol-formatter.spec.ts`
- [x] `npx playwright test --config=tests/library/playwright.config.ts --project=chromium-library -g "navigating away from the base url"`