### PR TITLE
fix(test): support multiple contexts with --debug=cli

### DIFF
--- a/packages/playwright/src/mcp/test/browserBackend.ts
+++ b/packages/playwright/src/mcp/test/browserBackend.ts
@@ -117,12 +117,25 @@ async function generatePausedMessage(tools: typeof import('playwright-core/lib/c
   return lines.join('\n');
 }
 
+const kDaemonSymbol = Symbol('daemon');
+const kSessionNameSymbol = Symbol('sessionName');
+
 export async function runDaemonForContext(testInfo: TestInfoImpl, context: playwright.BrowserContext) {
   if (testInfo._configInternal.configCLIOverrides.debug !== 'cli')
     return false;
 
-  const sessionName = `tw-${crypto.randomBytes(3).toString('hex')}`;
-  await context.browser()!.bind(sessionName, { workspaceDir: testInfo.project.testDir });
+  const browser = context.browser()!;
+  let sessionName: string | undefined = (browser as any)[kSessionNameSymbol];
+  if (!sessionName) {
+    sessionName = `tw-${crypto.randomBytes(3).toString('hex')}`;
+    await browser.bind(sessionName, { workspaceDir: testInfo.project.testDir });
+    (browser as any)[kSessionNameSymbol] = sessionName;
+  }
+
+  // Only pause and print debugging instructions once per test.
+  if ((testInfo as any)[kDaemonSymbol])
+    return false;
+  (testInfo as any)[kDaemonSymbol] = true;
 
   /* eslint-disable-next-line no-console */
   console.log([

--- a/tests/mcp/cli-test.spec.ts
+++ b/tests/mcp/cli-test.spec.ts
@@ -114,3 +114,82 @@ test('debug test with custom fixture using browser.newContext', async ({ cliEnv,
 
   await cli(`--session=${session}`, 'resume');
 });
+
+test('debug test that creates multiple contexts', async ({ cliEnv, cli, childProcess }) => {
+  await writeFiles({
+    'subdir/a.test.ts': `
+      import { test as base, expect } from '@playwright/test';
+      const test = base.extend<{}, { precreatedContext: import('@playwright/test').BrowserContext }>({
+        precreatedContext: [async ({ browser }, use) => {
+          const context = await browser.newContext();
+          await use(context);
+          await context.close();
+        }, { scope: 'worker' }],
+      });
+      test('example test', async ({ page, precreatedContext }) => {
+        await page.setContent('<title>My Page</title><body><button>Submit</button></body>');
+        await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+      });
+    `,
+  });
+
+  const testProcess = childProcess({
+    command: [process.argv[0], testEntrypoint, 'test', '--debug=cli'],
+    cwd: test.info().outputPath('subdir'),
+    env: cliEnv,
+  });
+
+  await testProcess.waitForOutput('playwright-cli attach');
+  const session = testProcess.output.match(/attach ([a-zA-Z0-9-_]+)/)[1];
+
+  const { output: attachOutput } = await cli('attach', session);
+  expect(attachOutput).toContain('### Paused');
+  expect(attachOutput).toContain(`- Set content at subdir${path.sep}a.test.ts:11`);
+
+  const { output: stepOutput } = await cli(`--session=${session}`, 'step-over');
+  expect(stepOutput).toContain('### Paused');
+
+  const snapshotResult = await cli(`--session=${session}`, 'snapshot');
+  expect(snapshotResult.inlineSnapshot).toContain('button "Submit"');
+
+  await cli(`--session=${session}`, 'resume');
+  await testProcess.exited;
+  expect(testProcess.output).toContain('1 passed');
+});
+
+test('debug multiple tests in the same worker', async ({ cliEnv, cli, childProcess }) => {
+  await writeFiles({
+    'subdir/a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('test one', async ({ page }) => {
+        await page.setContent('<title>My Page</title><body><button>One</button></body>');
+      });
+      test('test two', async ({ page }) => {
+        await page.setContent('<title>My Page</title><body><button>Two</button></body>');
+      });
+    `,
+  });
+
+  const testProcess = childProcess({
+    command: [process.argv[0], testEntrypoint, 'test', '--debug=cli'],
+    cwd: test.info().outputPath('subdir'),
+    env: cliEnv,
+  });
+
+  await testProcess.waitForOutput('playwright-cli attach');
+  const session = testProcess.output.match(/attach ([a-zA-Z0-9-_]+)/)[1];
+
+  for (const buttonName of ['One', 'Two']) {
+    await expect(async () => {
+      const { output } = await cli('attach', session);
+      expect(output).toContain('### Paused');
+    }).toPass();
+    await cli(`--session=${session}`, 'step-over');
+    const snapshotResult = await cli(`--session=${session}`, 'snapshot');
+    expect(snapshotResult.inlineSnapshot).toContain(`button "${buttonName}"`);
+    await cli(`--session=${session}`, 'resume');
+  }
+
+  await testProcess.exited;
+  expect(testProcess.output).toContain('2 passed');
+});


### PR DESCRIPTION
## Summary
- `browser.bind()` was called for every context created in a test, so a second `browser.newContext()` failed with `Server is already started`. Bind the browser once and reuse the session name.
- The same crash happened for the second test in a worker, so `--debug=cli` only ever worked for a single test with a single context. Pausing and printing the attach instructions is now done once per test.

Fixes https://github.com/microsoft/playwright/issues/42485