### PR TITLE
test(connect): fix unsafe launch options test with channels and tracing

### DIFF
--- a/tests/config/browserTest.ts
+++ b/tests/config/browserTest.ts
@@ -176,7 +176,7 @@ const test = baseTest.extend<BrowserTestTestFixtures & { _contextFactory: Contex
         server = remoteServer;
       } else {
         const runServer = new RunServer();
-        await runServer.start(childProcess, { artifactsDir: options?.artifactsDir });
+        await runServer.start(childProcess, { artifactsDir: options?.artifactsDir, unsafe: options?.unsafe, env: options?.env });
         server = runServer;
       }
       return server;

--- a/tests/config/remoteServer.ts
+++ b/tests/config/remoteServer.ts
@@ -71,6 +71,10 @@ export type RemoteServerOptions = {
   startStopAndRunHttp?: boolean;
   sharedBrowser?: boolean;
   artifactsDir?: string;
+  // Only supported by the 'run-server' kind.
+  unsafe?: boolean;
+  // Only supported by the 'run-server' kind.
+  env?: NodeJS.ProcessEnv;
 };
 
 export class RemoteServer implements PlaywrightServer {

--- a/tests/library/browsertype-connect.spec.ts
+++ b/tests/library/browsertype-connect.spec.ts
@@ -30,18 +30,24 @@ const { createHttpServer } = utils;
 import { kTargetClosedErrorMessage } from '../config/errors';
 import { RunServer } from '../config/remoteServer';
 
+type ConnectTestOptions = {
+  redirectPortForTest?: number;
+  launchOptions?: Record<string, any>;
+};
+
 type ExtraFixtures = {
-  connect: (wsEndpoint: string, options?: ConnectOptions, redirectPortForTest?: number) => Promise<Browser>,
+  connect: (wsEndpoint: string, options?: ConnectOptions, testOptions?: ConnectTestOptions) => Promise<Browser>,
   dummyServerPort: number,
   ipV6ServerPort: number,
 };
 const test = playwrightTest.extend<ExtraFixtures>({
   connect: async ({ browserType }, use) => {
     let browser: Browser | undefined;
-    await use(async (wsEndpoint, options = {}, redirectPortForTest): Promise<Browser> => {
-      (options as any).__testHookRedirectPortForwarding = redirectPortForTest;
+    await use(async (wsEndpoint, options = {}, testOptions = {}): Promise<Browser> => {
+      (options as any).__testHookRedirectPortForwarding = testOptions.redirectPortForTest;
+      const launchOptions = { ...(browserType as any)._playwright._defaultLaunchOptions, ...testOptions.launchOptions };
       options.headers = {
-        'x-playwright-launch-options': JSON.stringify((browserType as any)._playwright._defaultLaunchOptions || {}),
+        'x-playwright-launch-options': JSON.stringify(launchOptions),
         ...options.headers,
       };
       browser = await browserType.connect(wsEndpoint, options);
@@ -898,7 +904,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + testInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' } as any, dummyServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, { redirectPortForTest: dummyServerPort });
         const page = await browser.newPage();
         {
           await page.setContent('empty');
@@ -929,7 +935,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + testInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, ipV6ServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, { redirectPortForTest: ipV6ServerPort });
         const page = await browser.newPage();
         {
           await page.setContent('empty');
@@ -960,7 +966,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + workerInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, dummyServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, { redirectPortForTest: dummyServerPort });
         const page = await browser.newPage();
         {
           const response = await page.request.get(`http://localhost:${examplePort}/foo.html`);
@@ -991,7 +997,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + workerInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, ipV6ServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, { redirectPortForTest: ipV6ServerPort });
         const page = await browser.newPage();
         {
           const response = await page.request.get(`http://localhost:${examplePort}/foo.html`);
@@ -1020,7 +1026,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + workerInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, dummyServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: '*' }, { redirectPortForTest: dummyServerPort });
         const page = await browser.newPage();
         await page.goto(`http://local.playwright:${examplePort}/foo.html`);
         expect(await page.content()).toContain('from-dummy-server');
@@ -1051,7 +1057,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
         });
         const examplePort = 20_000 + workerInfo.workerIndex * 3;
         const remoteServer = await startRemoteServer(kind);
-        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: 'localhost' }, dummyServerPort);
+        const browser = await connect(remoteServer.wsEndpoint(), { exposeNetwork: 'localhost' }, { redirectPortForTest: dummyServerPort });
         const page = await browser.newPage();
 
         // localhost should be proxied.
@@ -1084,7 +1090,7 @@ for (const kind of ['launchServer', 'run-server'] as const) {
           headers: {
             'x-playwright-proxy': '*',
           },
-        }, dummyServerPort);
+        }, { redirectPortForTest: dummyServerPort });
         const page = await browser.newPage();
 
         // local.playwright should fail on the client side.
@@ -1162,8 +1168,10 @@ test('should refuse connecting when versions do not match', async ({ connect, ch
   expect(error.message).toContain('client version: v' + getPlaywrightVersion(true));
 });
 
-test('should filter local paths from unsafe launch options', async ({ connect, childProcess, server }, testInfo) => {
+test('should filter local paths from unsafe launch options', async ({ connect, startRemoteServer, server, trace }, testInfo) => {
   test.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42394' });
+  test.skip(trace === 'on', 'the test starts its own tracing');
+
   server.setRoute('/download', (req, res) => {
     res.setHeader('Content-Type', 'application/octet-stream');
     res.setHeader('Content-Disposition', 'attachment');
@@ -1173,13 +1181,8 @@ test('should filter local paths from unsafe launch options', async ({ connect, c
   const downloadsPath = testInfo.outputPath('downloads');
   fs.writeFileSync(artifactsDir, 'not a directory');
   fs.writeFileSync(downloadsPath, 'not a directory');
-  const remoteServer = new RunServer();
-  await remoteServer.start(childProcess, { unsafe: true, env: { PWTEST_UNDER_TEST: undefined } });
-  const browser = await connect(remoteServer.wsEndpoint(), {
-    headers: {
-      'x-playwright-launch-options': JSON.stringify({ artifactsDir, downloadsPath }),
-    },
-  });
+  const remoteServer = await startRemoteServer('run-server', { unsafe: true, env: { PWTEST_UNDER_TEST: undefined } });
+  const browser = await connect(remoteServer.wsEndpoint(), {}, { launchOptions: { artifactsDir, downloadsPath } });
   const context = await browser.newContext();
   await context.tracing.start({ snapshots: true });
   const page = await context.newPage();
@@ -1193,7 +1196,6 @@ test('should filter local paths from unsafe launch options', async ({ connect, c
   await context.tracing.stop({ path: tracePath });
   await context.close();
   await browser.close();
-  await remoteServer.close();
 
   const { actions } = await parseTraceRaw(tracePath);
   expect(actions).toContain('Set content');


### PR DESCRIPTION
## Summary
- `should filter local paths from unsafe launch options` now uses the standard `startRemoteServer`/`connect` fixtures instead of starting the run-server and building the `x-playwright-launch-options` header by hand, so `channel`/`executablePath` survive and the test works on channel bots like chrome-beta.
- The `connect` fixture takes a separate test options bag with `redirectPortForTest` and `launchOptions`.
- Skip the test when tracing is on, since it starts its own tracing.