### PR TITLE
docs(csharp): fix nonexistent method names in guide examples

### DIFF
--- a/docs/src/extensibility.md
+++ b/docs/src/extensibility.md
@@ -155,7 +155,7 @@ button_count = page.locator("tag=button").count()
 ```csharp
 // Register the engine. Selectors will be prefixed with "tag=".
 // The script is evaluated in the page context.
-await playwright.Selectors.Register("tag", new() {
+await playwright.Selectors.RegisterAsync("tag", new() {
   Script = @"
   // Must evaluate to a selector engine instance.
   {

--- a/docs/src/mock.md
+++ b/docs/src/mock.md
@@ -76,7 +76,7 @@ await page.RouteAsync("*/**/api/v1/fruits", async route => {
 await page.GotoAsync("https://demo.playwright.dev/api-mocking");
 
 // Assert that the Strawberry fruit is visible
-await Expect(page.GetByTextAsync("Strawberry")).ToBeVisibleAsync();
+await Expect(page.GetByText("Strawberry")).ToBeVisibleAsync();
 ```
 
 ```java
@@ -188,7 +188,7 @@ await page.RouteAsync("*/**/api/v1/fruits", async (route) => {
 await page.GotoAsync("https://demo.playwright.dev/api-mocking");
 
 // Assert that the Loquat fruit is visible
-await Expect(page.GetByTextAsync("Loquat", new () { Exact = true })).ToBeVisibleAsync();
+await Expect(page.GetByText("Loquat", new () { Exact = true })).ToBeVisibleAsync();
 ```
 
 ```java

--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -147,7 +147,7 @@ page.wait_for_url("**/login")
 
 ```csharp
 await page.GetByText("Click me").ClickAsync();
-await page.WaitForURL("**/login");
+await page.WaitForURLAsync("**/login");
 ```
 
 ## Back/Forward Cache (BFCache)


### PR DESCRIPTION
Three guides call C# methods that do not exist in the .NET API: `GetByTextAsync` in `mock.md` (twice), `Selectors.Register` in `extensibility.md`, and `page.WaitForURL` in `navigations.md`.

`GetByText` is synchronous and returns a locator, while `RegisterAsync` and `WaitForURLAsync` both carry the `Async` suffix. The API reference already spells all three correctly, so this only brings the guides in line with it.