### PR TITLE
fix(trace-viewer): serve snapshots with a strict script-src policy

### DIFF
--- a/packages/isomorphic/trace/snapshotRenderer.ts
+++ b/packages/isomorphic/trace/snapshotRenderer.ts
@@ -16,7 +16,7 @@
 
 import { escapeHTMLAttribute, escapeHTML } from '../stringUtils';
 
-import type { FrameSnapshot, NodeNameAttributesChildNodesSnapshot, NodeSnapshot, RenderedFrameSnapshot, ResourceSnapshot, SubtreeReferenceSnapshot } from './trace';
+import type { FrameSnapshot, NodeNameAttributesChildNodesSnapshot, NodeSnapshot, ResourceSnapshot, SubtreeReferenceSnapshot } from './trace';
 import type { PageEntry } from './entries';
 import type { LRUCache } from '../lruCache';
 
@@ -37,8 +37,18 @@ function isSubtreeReferenceSnapshot(n: NodeSnapshot): n is SubtreeReferenceSnaps
   return Array.isArray(n) && Array.isArray(n[0]);
 }
 
+export type RenderedSnapshotHtml = { html: string, scriptNonce: string };
+
+export type RenderedFrameSnapshot = {
+  html: string;
+  scriptNonce: string;
+  pageId: string;
+  frameId: string;
+  index: number;
+};
+
 export class SnapshotRenderer {
-  private _htmlCache: LRUCache<SnapshotRenderer, string>;
+  private _htmlCache: LRUCache<SnapshotRenderer, RenderedSnapshotHtml>;
   private _snapshots: FrameSnapshot[];
   private _index: number;
   readonly snapshotName: string | undefined;
@@ -47,7 +57,7 @@ export class SnapshotRenderer {
   private _callId: string;
   private _screencastFrames: PageEntry['screencastFrames'];
 
-  constructor(htmlCache: LRUCache<SnapshotRenderer, string>, resources: ResourceSnapshot[], snapshots: FrameSnapshot[], screencastFrames: PageEntry['screencastFrames'], index: number) {
+  constructor(htmlCache: LRUCache<SnapshotRenderer, RenderedSnapshotHtml>, resources: ResourceSnapshot[], snapshots: FrameSnapshot[], screencastFrames: PageEntry['screencastFrames'], index: number) {
     this._htmlCache = htmlCache;
     this._resources = resources;
     this._snapshots = snapshots;
@@ -178,21 +188,24 @@ export class SnapshotRenderer {
     };
 
     const snapshot = this._snapshot;
-    const html = this._htmlCache.getOrCompute(this, () => {
+    const { html, scriptNonce } = this._htmlCache.getOrCompute(this, () => {
       visit(snapshot.html, this._index, undefined, undefined);
       // Sanitize doctype to prevent injection from crafted trace files.
       // Valid doctype names (from document.doctype.name) only contain alphanumeric characters.
       const safeDoctype = snapshot.doctype?.replace(/[^a-zA-Z0-9]/g, '');
       const prefix = safeDoctype ? `<!DOCTYPE ${safeDoctype}>` : '';
+      // The nonce allows our bootstrap script to run under the strict `script-src` policy
+      // that the snapshot is served with. See SnapshotServer.serveSnapshot().
+      const scriptNonce = generateNonce();
       const html = prefix + [
         // Hide the document in order to prevent flickering. We will unhide once script has processed shadow.
         '<style>*,*::before,*::after { visibility: hidden }</style>',
-        `<script>${snapshotScript(this.viewport(), this._callId, this.snapshotName)}</script>`
+        `<script nonce="${scriptNonce}">${snapshotScript(this.viewport(), this._callId, this.snapshotName)}</script>`
       ].join('') + result.join('');
-      return { value: html, size: html.length };
+      return { value: { html, scriptNonce }, size: html.length };
     });
 
-    return { html, pageId: snapshot.pageId, frameId: snapshot.frameId, index: this._index };
+    return { html, scriptNonce, pageId: snapshot.pageId, frameId: snapshot.frameId, index: this._index };
   }
 
   resourceByUrl(url: string, method: string): ResourceSnapshot | undefined {
@@ -294,6 +307,12 @@ declare global {
   interface Window {
     __playwright_frame_bounding_rects__: FrameBoundingRectsInfo;
   }
+}
+
+function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function snapshotScript(viewport: ViewportSize, ...targetIds: (string | undefined)[]) {

--- a/packages/isomorphic/trace/snapshotServer.ts
+++ b/packages/isomorphic/trace/snapshotServer.ts
@@ -36,7 +36,14 @@ export class SnapshotServer {
 
     const renderedSnapshot = snapshot.render();
     this._snapshotIds.set(snapshotUrl, snapshot);
-    return new Response(renderedSnapshot.html, { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+    return new Response(renderedSnapshot.html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        // Only allow our own bootstrap script.
+        'Content-Security-Policy': `script-src 'nonce-${renderedSnapshot.scriptNonce}'; object-src 'none'`,
+      },
+    });
   }
 
   async serveClosestScreenshot(callId: string, searchParams: URLSearchParams): Promise<Response> {

--- a/packages/isomorphic/trace/snapshotStorage.ts
+++ b/packages/isomorphic/trace/snapshotStorage.ts
@@ -17,6 +17,7 @@
 import { rewriteURLForCustomProtocol, SnapshotRenderer } from './snapshotRenderer';
 import { LRUCache } from '../lruCache';
 
+import type { RenderedSnapshotHtml } from './snapshotRenderer';
 import type { ActionPhase, FrameSnapshot, ResourceSnapshot } from './trace';
 import type { PageEntry } from './entries';
 
@@ -24,7 +25,7 @@ import type { PageEntry } from './entries';
 export class SnapshotStorage {
   private _snapshotsByFrameId = new Map<string, FrameSnapshot[]>();
   private _renderersByCallIdAndPhase = new Map<string, SnapshotRenderer[]>();
-  private _cache = new LRUCache<SnapshotRenderer, string>(100_000_000);  // 100MB per each trace
+  private _cache = new LRUCache<SnapshotRenderer, RenderedSnapshotHtml>(100_000_000);  // 100MB per each trace
   private _resources: ResourceSnapshot[] = [];
   private _resourceUrlsWithOverrides = new Set<string>();
 

--- a/packages/isomorphic/trace/versions/traceV9.ts
+++ b/packages/isomorphic/trace/versions/traceV9.ts
@@ -253,13 +253,6 @@ export type FrameSnapshot = {
   isMainFrame: boolean,
 };
 
-export type RenderedFrameSnapshot = {
-  html: string;
-  pageId: string;
-  frameId: string;
-  index: number;
-};
-
 export type ResourceSnapshotTraceEvent = {
   type: 'resource-snapshot',
   snapshot: ResourceSnapshot,

--- a/packages/trace-viewer/src/sw/main.ts
+++ b/packages/trace-viewer/src/sw/main.ts
@@ -167,7 +167,7 @@ async function doFetch(event: FetchEvent): Promise<Response> {
       const callId = decodeURIComponent(relativePath.substring('/snapshot/'.length));
       const response = loadedTrace!.snapshotServer.serveSnapshot(callId, url.searchParams, url.href);
       if (isDeployedAsHttps)
-        response.headers.set('Content-Security-Policy', 'upgrade-insecure-requests');
+        response.headers.append('Content-Security-Policy', 'upgrade-insecure-requests');
       return response;
     }
 

--- a/tests/library/snapshot-renderer.spec.ts
+++ b/tests/library/snapshot-renderer.spec.ts
@@ -43,10 +43,23 @@ for (const [name, overrides] of [
   test(`snapshot renderer escapes attacker-controlled ${name} in script context`, () => {
     const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot(overrides)], [], 0);
     const { html } = renderer.render();
-    expect(html.match(/<script>/g)).toHaveLength(1);
+    expect(html.match(/<script[ >]/g)).toHaveLength(1);
     expect(html.match(/<\/script>/g)).toHaveLength(1);
   });
 }
+
+test('snapshot renderer nonces the bootstrap script', () => {
+  const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot()], [], 0);
+  const { html, scriptNonce } = renderer.render();
+  expect(scriptNonce).toMatch(/^[0-9a-f]{32}$/);
+  expect(html).toContain(`<script nonce="${scriptNonce}">`);
+  // The html is cached, so repeated renders must keep returning the nonce that is
+  // baked into it - it is sent back in the Content-Security-Policy header.
+  expect(renderer.render().scriptNonce).toBe(scriptNonce);
+  // A different snapshot gets a different nonce.
+  const other = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot()], [], 0);
+  expect(other.render().scriptNonce).not.toBe(scriptNonce);
+});
 
 test('snapshot renderer strips event handler attributes', () => {
   const renderer = new SnapshotRenderer(new LRUCache(1_000_000), [], [makeSnapshot({

--- a/tests/library/trace-viewer.spec.ts
+++ b/tests/library/trace-viewer.spec.ts
@@ -2717,6 +2717,22 @@ test('should neutralize meta http-equiv refresh during rendering', async ({ runA
   await expect(traceViewer.page).toHaveTitle(/Playwright Trace Viewer/);
 });
 
+test('snapshots should be served with a script-src policy', async ({ runAndTrace, page, server }) => {
+  const traceViewer = await runAndTrace(async () => {
+    await page.goto(server.EMPTY_PAGE);
+    await page.setContent('<div>hello</div>');
+  });
+  const frame = await traceViewer.snapshotFrame('Set content');
+  await expect(frame.locator('div')).toHaveText('hello');
+  const scripted = await frame.locator('body').evaluate(body => {
+    const script = body.ownerDocument.createElement('script');
+    script.textContent = `document.body.setAttribute('data-scripted', 'yes')`;
+    body.appendChild(script);
+    return body.getAttribute('data-scripted');
+  });
+  expect(scripted).toBe(null);
+});
+
 test('snapshot iframes should be sandboxed', async ({ runAndTrace, page, server }) => {
   const traceViewer = await runAndTrace(async () => {
     await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
## Summary
- Snapshots are served from the trace viewer's own origin, so script running inside one would gain access to that origin. The renderer already strips `<script>`, event handlers and other script vectors from the untrusted trace — this adds a second line of defense.
- Each rendered snapshot gets a nonce on its single bootstrap script and is served with `script-src 'nonce-...'; object-src 'none'`. No `default-src`, so images, styles, fonts and nested snapshot frames keep loading.
- The recorder (`InjectedScript`/`Recorder` in `snapshotTab`) is unaffected — it runs in the trace viewer's realm, and its only path to `window.eval` is `customEngines`, which trace viewer passes as empty.