### PR TITLE
chore(ci): bump azure/login to v3.0.2

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -81,7 +81,7 @@ runs:
       env:
         PW_TAG: "@${{ inputs.bot-name }}"
     - name: Azure Login
-      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       if: ${{ !cancelled() && env.PLAYWRIGHT_SETUP_COMPLETE == 'true' && github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
       with:
         client-id: ${{ inputs.flakiness-client-id }}

--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Azure Login
       if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       with:
         client-id: ${{ secrets.AZURE_BLOB_REPORTS_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_BLOB_REPORTS_TENANT_ID }}

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -51,7 +51,7 @@ jobs:
     # main repo, where the secrets are present; forks fall back to Docker Hub.
     - name: Azure Login
       if: ${{ github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       with:
         client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
@@ -114,7 +114,7 @@ jobs:
 
     - name: Azure Login
       if: ${{ !cancelled() && github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
       with:
         client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}


### PR DESCRIPTION
## Summary
- Bump all pinned `azure/login` usages to `v3.0.2` (`tests_bidi.yml`, `tests_docker.yml`, `actions/run-test/action.yml`).
- `actions/run-test` moves v2.3.0 → v3.0.2 (node24 runtime); the other workflows were already on v3.