### PR TITLE
test: skip crash tests on webkit debian-13

### DIFF
--- a/tests/library/page-event-crash.spec.ts
+++ b/tests/library/page-event-crash.spec.ts
@@ -37,6 +37,7 @@ test.beforeEach(({ platform, browserName, channel }) => {
   test.slow(platform === 'linux' && (browserName === 'webkit'), 'WebKit/Linux tests are consistently slower on some Linux environments. Most likely WebContent process is not getting terminated properly and is causing the slowdown.');
   test.skip(channel === 'webkit-wsl', 'WebKit on WSL is even slower than above ^^ - skipping for now');
   test.skip(browserName === 'chromium' && utils.hostPlatform.startsWith('ubuntu24.04'), 'never dispatches the crash event');
+  test.skip(browserName === 'webkit' && utils.hostPlatform.startsWith('debian13'), 'never dispatches the crash event');
 });
 
 test('should emit crash event when page crashes', async ({ page, crash }) => {


### PR DESCRIPTION
## Summary
- WebKit on debian-13 never dispatches the crash event, so all 7 tests in `page-event-crash.spec.ts` time out on that bot.