### PR TITLE
docs(cli): use npx playwright cli for local installs

### DIFF
--- a/docs/src/getting-started-cli.md
+++ b/docs/src/getting-started-cli.md
@@ -31,7 +31,7 @@ Alternatively, install `@playwright/cli` as a local dependency and use `npx`:
 
 ```bash
 npm install -D @playwright/cli@latest
-npx playwright-cli --help
+npx playwright cli --help
 ```
 
 ### Installing skills


### PR DESCRIPTION
## Summary
- Getting started page said `npx playwright-cli`; the local install entry point is `npx playwright cli`, matching the playwright-cli README and skill.

Fixes https://github.com/microsoft/playwright/issues/42426