### PR TITLE
test(webkit): reenable WebSocket handshake HAR coverage

### DIFF
--- a/tests/library/har-websocket.spec.ts
+++ b/tests/library/har-websocket.spec.ts
@@ -98,7 +98,6 @@ it('should only have one websocket entry', async ({ contextFactory, server }, te
 });
 
 it('should include websocket handshake headers and status', async ({ contextFactory, server, browserName, isMac, macVersion }, testInfo) => {
-  it.fixme(browserName === 'webkit' && isMac && macVersion >= 26, 'NWLoader does not reflect the wire handshake headers (Sec-WebSocket-Key, Connection, Upgrade) in NSURLSessionWebSocketTask.currentRequest');
   server.onceWebSocketConnection(ws => {
     ws.on('message', () => ws.close());
   });


### PR DESCRIPTION
the upstream WebKit fix restores the reported WebSocket handshake headers on macOS 26

remove the platform skip so the existing HAR assertions run again

see <https://github.com/microsoft/playwright/issues/42205>