### PR TITLE
chore: bump WebKit version to 26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎭 Playwright
 
-[![npm version](https://img.shields.io/npm/v/playwright.svg)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-153.0.8010.12-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-155.0-blue.svg?logo=firefoxbrowser)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.5-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop --> [![Join Discord](https://img.shields.io/badge/join-discord-informational)](https://aka.ms/playwright/discord)
+[![npm version](https://img.shields.io/npm/v/playwright.svg)](https://www.npmjs.com/package/playwright) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-153.0.8010.12-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-155.0-blue.svg?logo=firefoxbrowser)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.6-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop --> [![Join Discord](https://img.shields.io/badge/join-discord-informational)](https://aka.ms/playwright/discord)
 
 ## [Documentation](https://playwright.dev) | [API reference](https://playwright.dev/docs/api/class-playwright)
 
@@ -297,7 +297,7 @@ The [Playwright VS Code extension](https://marketplace.visualstudio.com/items?it
 |          | Linux | macOS | Windows |
 |   :---   | :---: | :---: | :---:   |
 | Chromium<sup>1</sup> <!-- GEN:chromium-version -->153.0.8010.12<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| WebKit <!-- GEN:webkit-version -->26.5<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| WebKit <!-- GEN:webkit-version -->26.6<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Firefox <!-- GEN:firefox-version -->155.0<!-- GEN:stop --> | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 Headless and headed execution on all platforms. <sup>1</sup> Uses [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing) by default.

--- a/packages/isomorphic/deviceDescriptorsSource.json
+++ b/packages/isomorphic/deviceDescriptorsSource.json
@@ -1,6 +1,6 @@
 {
   "Blackberry PlayBook": {
-    "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/26.5 Safari/536.2+",
+    "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/26.6 Safari/536.2+",
     "viewport": {
       "width": 600,
       "height": 1024
@@ -11,7 +11,7 @@
     "defaultBrowserType": "webkit"
   },
   "Blackberry PlayBook landscape": {
-    "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/26.5 Safari/536.2+",
+    "userAgent": "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/26.6 Safari/536.2+",
     "viewport": {
       "width": 1024,
       "height": 600
@@ -22,7 +22,7 @@
     "defaultBrowserType": "webkit"
   },
   "BlackBerry Z30": {
-    "userAgent": "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/26.5 Mobile Safari/537.10+",
+    "userAgent": "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/26.6 Mobile Safari/537.10+",
     "viewport": {
       "width": 360,
       "height": 640
@@ -33,7 +33,7 @@
     "defaultBrowserType": "webkit"
   },
   "BlackBerry Z30 landscape": {
-    "userAgent": "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/26.5 Mobile Safari/537.10+",
+    "userAgent": "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/26.6 Mobile Safari/537.10+",
     "viewport": {
       "width": 640,
       "height": 360
@@ -44,7 +44,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy Note 3": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 360,
       "height": 640
@@ -55,7 +55,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy Note 3 landscape": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 640,
       "height": 360
@@ -66,7 +66,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy Note II": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 360,
       "height": 640
@@ -77,7 +77,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy Note II landscape": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 640,
       "height": 360
@@ -88,7 +88,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy S III": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 360,
       "height": 640
@@ -99,7 +99,7 @@
     "defaultBrowserType": "webkit"
   },
   "Galaxy S III landscape": {
-    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.5 Mobile Safari/534.30",
+    "userAgent": "Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/26.6 Mobile Safari/534.30",
     "viewport": {
       "width": 640,
       "height": 360
@@ -504,7 +504,7 @@
     "defaultBrowserType": "chromium"
   },
   "iPad (gen 5)": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 768,
       "height": 1024
@@ -515,7 +515,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 5) landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 1024,
       "height": 768
@@ -526,7 +526,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 6)": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 768,
       "height": 1024
@@ -537,7 +537,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 6) landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 1024,
       "height": 768
@@ -548,7 +548,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 7)": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 810,
       "height": 1080
@@ -559,7 +559,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 7) landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 1080,
       "height": 810
@@ -570,7 +570,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 11)": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/19E241 Safari/604.1",
     "viewport": {
       "width": 656,
       "height": 944
@@ -581,7 +581,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad (gen 11) landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/19E241 Safari/604.1",
     "viewport": {
       "width": 944,
       "height": 656
@@ -592,7 +592,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad Mini": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 768,
       "height": 1024
@@ -603,7 +603,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad Mini landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 1024,
       "height": 768
@@ -614,7 +614,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad Pro 11": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 834,
       "height": 1194
@@ -625,7 +625,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPad Pro 11 landscape": {
-    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 1194,
       "height": 834
@@ -636,7 +636,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 6": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 375,
       "height": 667
@@ -647,7 +647,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 6 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 667,
       "height": 375
@@ -658,7 +658,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 6 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 414,
       "height": 736
@@ -669,7 +669,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 6 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 736,
       "height": 414
@@ -680,7 +680,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 7": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 375,
       "height": 667
@@ -691,7 +691,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 7 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 667,
       "height": 375
@@ -702,7 +702,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 7 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 414,
       "height": 736
@@ -713,7 +713,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 7 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 736,
       "height": 414
@@ -724,7 +724,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 8": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 375,
       "height": 667
@@ -735,7 +735,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 8 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 667,
       "height": 375
@@ -746,7 +746,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 8 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 414,
       "height": 736
@@ -757,7 +757,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 8 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 736,
       "height": 414
@@ -768,7 +768,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone SE": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/14E304 Safari/602.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.6 Mobile/14E304 Safari/602.1",
     "viewport": {
       "width": 320,
       "height": 568
@@ -779,7 +779,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone SE landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/14E304 Safari/602.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.6 Mobile/14E304 Safari/602.1",
     "viewport": {
       "width": 568,
       "height": 320
@@ -790,7 +790,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone SE (3rd gen)": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/602.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.6 Mobile/19E241 Safari/602.1",
     "viewport": {
       "width": 375,
       "height": 667
@@ -801,7 +801,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone SE (3rd gen) landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.5 Mobile/19E241 Safari/602.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/26.6 Mobile/19E241 Safari/602.1",
     "viewport": {
       "width": 667,
       "height": 375
@@ -812,7 +812,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone X": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 375,
       "height": 812
@@ -823,7 +823,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone X landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.5 Mobile/15A372 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/26.6 Mobile/15A372 Safari/604.1",
     "viewport": {
       "width": 812,
       "height": 375
@@ -834,7 +834,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone XR": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 414,
       "height": 896
@@ -845,7 +845,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone XR landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "viewport": {
       "width": 896,
       "height": 414
@@ -856,7 +856,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 414,
       "height": 896
@@ -871,7 +871,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 414,
       "height": 896
@@ -886,7 +886,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -901,7 +901,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -916,7 +916,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 414,
       "height": 896
@@ -931,7 +931,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 11 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 414,
       "height": 896
@@ -946,7 +946,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -961,7 +961,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -976,7 +976,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -991,7 +991,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1006,7 +1006,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1021,7 +1021,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1036,7 +1036,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Mini": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -1051,7 +1051,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 12 Mini landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -1066,7 +1066,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1081,7 +1081,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1096,7 +1096,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1111,7 +1111,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1126,7 +1126,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1141,7 +1141,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1156,7 +1156,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Mini": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -1171,7 +1171,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 13 Mini landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 375,
       "height": 812
@@ -1186,7 +1186,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1201,7 +1201,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1216,7 +1216,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1231,7 +1231,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 428,
       "height": 926
@@ -1246,7 +1246,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1261,7 +1261,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1276,7 +1276,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1291,7 +1291,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 14 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1306,7 +1306,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1321,7 +1321,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1336,7 +1336,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1351,7 +1351,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1366,7 +1366,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1381,7 +1381,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1396,7 +1396,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1411,7 +1411,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 15 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1426,7 +1426,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1441,7 +1441,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 393,
       "height": 852
@@ -1456,7 +1456,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Plus": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1471,7 +1471,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Plus landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 430,
       "height": 932
@@ -1486,7 +1486,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1501,7 +1501,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1516,7 +1516,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 440,
       "height": 956
@@ -1531,7 +1531,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 440,
       "height": 956
@@ -1546,7 +1546,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16e": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1561,7 +1561,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 16e landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1576,7 +1576,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1591,7 +1591,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17 landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1606,7 +1606,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone Air": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 420,
       "height": 912
@@ -1621,7 +1621,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone Air landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 420,
       "height": 912
@@ -1636,7 +1636,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17 Pro": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1651,7 +1651,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17 Pro landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 402,
       "height": 874
@@ -1666,7 +1666,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17 Pro Max": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 440,
       "height": 956
@@ -1681,7 +1681,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17 Pro Max landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 440,
       "height": 956
@@ -1696,7 +1696,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17e": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -1711,7 +1711,7 @@
     "defaultBrowserType": "webkit"
   },
   "iPhone 17e landscape": {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1",
+    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1",
     "screen": {
       "width": 390,
       "height": 844
@@ -2677,7 +2677,7 @@
     "defaultBrowserType": "firefox"
   },
   "Desktop Safari": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Safari/605.1.15",
     "screen": {
       "width": 1792,
       "height": 1120

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "webkit",
-      "revision": "2358",
+      "revision": "2359",
       "installByDefault": true,
       "revisionOverrides": {
         "mac14": "2251",

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -30,7 +30,7 @@
         "mac14": "2251",
         "mac14-arm64": "2251"
       },
-      "browserVersion": "26.5",
+      "browserVersion": "26.6",
       "title": "WebKit"
     },
     {

--- a/packages/playwright-core/browsers.json
+++ b/packages/playwright-core/browsers.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "webkit",
-      "revision": "2359",
+      "revision": "2358",
       "installByDefault": true,
       "revisionOverrides": {
         "mac14": "2251",

--- a/packages/playwright-core/src/server/webkit/wkBrowser.ts
+++ b/packages/playwright-core/src/server/webkit/wkBrowser.ts
@@ -33,7 +33,7 @@ import type { Protocol } from './protocol';
 import type { PageProxyMessageReceivedPayload } from './wkConnection';
 import type * as channels from '../channels';
 
-const BROWSER_VERSION = '26.5';
+const BROWSER_VERSION = '26.6';
 const DEFAULT_USER_AGENT = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${BROWSER_VERSION} Safari/605.1.15`;
 
 export class WKBrowser extends Browser {


### PR DESCRIPTION
## Summary
- Bump reported WebKit version to 26.6 (upstream is at 626.1)