### PR TITLE
fix(reporter): include host in navigation and request subtitles

### DIFF
--- a/docs/src/test-reporter-api/class-teststep.md
+++ b/docs/src/test-reporter-api/class-teststep.md
@@ -119,7 +119,7 @@ separate line.
 // title `Click`, subtitle `getByRole('button')`
 await page.getByRole('button').click();
 
-// title `Navigate`, subtitle `/index.html`
+// title `Navigate`, subtitle `example.com/index.html`
 await page.goto('https://example.com/index.html');
 ```
 

--- a/packages/isomorphic/protocolFormatter.ts
+++ b/packages/isomorphic/protocolFormatter.ts
@@ -44,7 +44,7 @@ function _formatProtocolParam(params: Record<string, any> | undefined, alternati
           return urlObject.protocol;
         if (['about:', 'chrome:', 'edge:'].includes(urlObject.protocol))
           return params[name];
-        return urlObject.pathname + urlObject.search;
+        return urlObject.host + urlObject.pathname + urlObject.search;
       } catch (error) {
         if (params[name] !== undefined)
           return params[name];

--- a/packages/playwright/types/testReporter.d.ts
+++ b/packages/playwright/types/testReporter.d.ts
@@ -928,7 +928,7 @@ export interface TestStep {
    * // title `Click`, subtitle `getByRole('button')`
    * await page.getByRole('button').click();
    *
-   * // title `Navigate`, subtitle `/index.html`
+   * // title `Navigate`, subtitle `example.com/index.html`
    * await page.goto('https://example.com/index.html');
    * ```
    *

--- a/tests/library/tracing.spec.ts
+++ b/tests/library/tracing.spec.ts
@@ -42,13 +42,13 @@ test('should collect trace with resources, but no js', async ({ context, page, s
   const { events, actions } = await parseTraceRaw(testInfo.outputPath('trace.zip'));
   expect(events[0].type).toBe('context-options');
   expect(actions).toEqual([
-    'Navigate /frames/frame.html',
+    `Navigate ${server.HOST}/frames/frame.html`,
     'Set content',
     `Click locator('text="Click"')`,
     'Mouse move',
     'Double click',
     'Insert "abc"',
-    'Navigate /input/fileupload.html',
+    `Navigate ${server.HOST}/input/fileupload.html`,
     `Set input files locator('input[type="file"]')`,
     'Wait for timeout',
     'Close page',
@@ -85,9 +85,9 @@ test('should use the correct title for event driven callbacks', async ({ context
   expect(events[0].type).toBe('context-options');
   expect(actions).toEqual([
     'Route requests',
-    'Navigate /empty.html',
+    `Navigate ${server.HOST}/empty.html`,
     'Continue request',
-    'Navigate /grid.html',
+    `Navigate ${server.HOST}/grid.html`,
     'Evaluate',
     'Reload',
     'Evaluate',
@@ -223,14 +223,14 @@ test('should record context API request trace independently', async ({ context, 
   await context.request.tracing.stop({ path: apiTracePath });
 
   const browserTrace = await parseTraceRaw(browserTracePath);
-  expect(browserTrace.actions).toContain('Navigate /one-style.html');
-  expect(browserTrace.actions).not.toContain('POST /simple.json');
+  expect(browserTrace.actions).toContain(`Navigate ${server.HOST}/one-style.html`);
+  expect(browserTrace.actions).not.toContain(`POST ${server.HOST}/simple.json`);
   expect(browserTrace.events.some(event => event.type === 'resource-snapshot' && event.snapshot.request.url.endsWith('/simple.json'))).toBe(false);
   expect(browserTrace.events.some(event => event.type === 'resource-snapshot' && event.snapshot.request.url.endsWith('/one-style.html'))).toBe(true);
 
   const apiTrace = await parseTraceRaw(apiTracePath);
-  expect(apiTrace.actions).toContain('POST /simple.json');
-  expect(apiTrace.actions).not.toContain('Navigate /one-style.html');
+  expect(apiTrace.actions).toContain(`POST ${server.HOST}/simple.json`);
+  expect(apiTrace.actions).not.toContain(`Navigate ${server.HOST}/one-style.html`);
   const apiAction = apiTrace.actionObjects.find(action => action.class === 'APIRequestContext' && action.method === 'fetch')!;
   expect(relativeStack(apiAction, apiTrace.stacks)).toEqual(['tracing.spec.ts']);
   expect(apiTrace.events.filter(event => event.type === 'resource-snapshot').map(event => event.snapshot.request.url)).toEqual([apiURL]);
@@ -253,7 +253,7 @@ test('should collect two traces', async ({ context, page, server }, testInfo) =>
     const { events, actions } = await parseTraceRaw(testInfo.outputPath('trace1.zip'));
     expect(events[0].type).toBe('context-options');
     expect(actions).toEqual([
-      'Navigate /empty.html',
+      `Navigate ${server.HOST}/empty.html`,
       'Set content',
       `Click locator('text="Click"')`,
     ]);
@@ -297,7 +297,7 @@ test('should respect tracesDir and name', async ({ browserType, server, mode }, 
 
   {
     const { resources, actions } = await parseTraceRaw(testInfo.outputPath('trace1.zip'));
-    expect(actions).toEqual(['Navigate /one-style.html']);
+    expect(actions).toEqual([`Navigate ${server.HOST}/one-style.html`]);
     expect(resourceNames(resources)).toEqual([
       'resources/XXX.css',
       'resources/XXX.html',
@@ -309,7 +309,7 @@ test('should respect tracesDir and name', async ({ browserType, server, mode }, 
 
   {
     const { resources, actions } = await parseTraceRaw(testInfo.outputPath('trace2.zip'));
-    expect(actions).toEqual(['Navigate /har.html']);
+    expect(actions).toEqual([`Navigate ${server.HOST}/har.html`]);
     expect(resourceNames(resources)).toEqual([
       'resources/XXX.css',
       'resources/XXX.html',

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -98,7 +98,7 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
     '  Fixture "page"',
     '    Create page',
     'Navigate about:blank',
-    'GET /empty.html',
+    `GET ${server.HOST}/empty.html`,
     'After Hooks',
     '  Fixture "page"',
     '  Fixture "context"',
@@ -109,7 +109,7 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
   expect(trace2.model.renderActionTree()).toEqual([
     'Before Hooks',
     'Create request context',
-    'GET /empty.html',
+    `GET ${server.HOST}/empty.html`,
     'After Hooks',
   ]);
   const trace3 = await parseTrace(testInfo.outputPath('test-results', 'a-fail', 'trace.zip'));
@@ -122,7 +122,7 @@ test('should record api trace', async ({ runInlineTest, server }, testInfo) => {
     '  Fixture "page"',
     '    Create page',
     'Navigate about:blank',
-    'GET /empty.html',
+    `GET ${server.HOST}/empty.html`,
     'Expect "toBe"',
     'After Hooks',
     '  Fixture "page"',
@@ -420,7 +420,7 @@ test('should not override trace file in afterAll', async ({ runInlineTest, serve
     '  afterAll hook',
     '    Fixture "request"',
     '      Create request context',
-    '    GET /empty.html',
+    `    GET ${server.HOST}/empty.html`,
     '    Fixture "request"',
     'Worker Cleanup',
     '  Fixture "browser"',
@@ -580,7 +580,7 @@ test(`trace:retain-on-failure should create trace if request context is disposed
   }, { trace: 'retain-on-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-passing-test', 'trace.zip');
   const trace = await parseTrace(tracePath);
-  expect(trace.model.renderActionTree()).toContain('GET /empty.html');
+  expect(trace.model.renderActionTree()).toContain(`GET ${server.HOST}/empty.html`);
   expect(result.failed).toBe(1);
 });
 
@@ -1240,7 +1240,7 @@ test('trace:retain-on-first-failure should create trace if request context is di
   }, { trace: 'retain-on-first-failure' });
   const tracePath = test.info().outputPath('test-results', 'a-fail', 'trace.zip');
   const trace = await parseTrace(tracePath);
-  expect(trace.model.renderActionTree()).toContain('GET /empty.html');
+  expect(trace.model.renderActionTree()).toContain(`GET ${server.HOST}/empty.html`);
   expect(result.failed).toBe(1);
 });
 
@@ -1387,8 +1387,8 @@ test('should not nest top level expect into unfinished api calls ', {
     '    Create context',
     '  Fixture "page"',
     '    Create page',
-    'Navigate /index',
-    'GET /hang',
+    `Navigate ${server.HOST}/index`,
+    `GET ${server.HOST}/hang`,
     `Expect "toBeVisible" getByText('Hello!')`,
     'After Hooks',
     '  Fixture "page"',

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -1250,9 +1250,9 @@ pw:api    |Wait for navigation @ a.test.ts:5
 pw:api    |Navigate data: @ a.test.ts:6
 pw:api    |Click locator('button') @ a.test.ts:8
 pw:api    |Click getByRole('button') @ a.test.ts:9
-pw:api    |GET /empty.html @ a.test.ts:10
+pw:api    |GET ${server.HOST}/empty.html @ a.test.ts:10
 pw:api    |↪ error: <error message>
-pw:api    |GET /empty.html @ a.test.ts:11
+pw:api    |GET ${server.HOST}/empty.html @ a.test.ts:11
 pw:api    |↪ error: <error message>
 hook      |After Hooks
 fixture   |  Fixture "request"
@@ -1464,7 +1464,7 @@ fixture   |  Fixture "context"
 pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
-pw:api    |Navigate /empty.html @ a.test.ts:4
+pw:api    |Navigate ${server.HOST}/empty.html @ a.test.ts:4
 pw:api    |Set content @ a.test.ts:5
 test.step |custom step @ a.test.ts:6
 pw:api    |  Wait for event "response" @ a.test.ts:7
@@ -1511,7 +1511,7 @@ fixture   |  Fixture "page"
 pw:api    |    Create page
 pw:api    |Wait for event "request" @ a.test.ts:5
 pw:api    |Wait for event "response" @ a.test.ts:6
-pw:api    |Navigate /empty.html @ a.test.ts:7
+pw:api    |Navigate ${server.HOST}/empty.html @ a.test.ts:7
 hook      |After Hooks
 fixture   |  Fixture "page"
 fixture   |  Fixture "context"
@@ -1554,8 +1554,8 @@ pw:api    |    Create context
 fixture   |  Fixture "page"
 pw:api    |    Create page
 test.step |custom step @ a.test.ts:4
-pw:api    |  Navigate /empty.html @ a.test.ts:12
-pw:api    |  GET /empty.html @ a.test.ts:6
+pw:api    |  Navigate ${server.HOST}/empty.html @ a.test.ts:12
+pw:api    |  GET ${server.HOST}/empty.html @ a.test.ts:6
 expect    |  Expect "toBe" @ a.test.ts:8
 hook      |After Hooks
 fixture   |  Fixture "page"


### PR DESCRIPTION
## Summary
- Render `{url}` step subtitles as host plus path instead of path only, so navigations outside `baseURL` are distinguishable in the trace viewer, HTML report and reporters.

Fixes https://github.com/microsoft/playwright/issues/42473