### PR TITLE
docs: fix incorrect defaults and broken samples in guides

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -1216,7 +1216,7 @@ Logger sink for Playwright logging.
 ## browser-option-timeout
 - `timeout` <[float]>
 
-Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0` to
+Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0` to
 disable timeout.
 
 ## browser-option-artifactsdir

--- a/docs/src/dialogs.md
+++ b/docs/src/dialogs.md
@@ -23,7 +23,7 @@ page.getByRole(AriaRole.BUTTON).click();
 
 ```python async
 page.on("dialog", lambda dialog: dialog.accept())
-await page.get_by_role("button".click())
+await page.get_by_role("button").click()
 ```
 
 ```python sync
@@ -105,7 +105,7 @@ async def handle_dialog(dialog):
     assert dialog.type == 'beforeunload'
     await dialog.dismiss()
 
-page.on('dialog', lambda: handle_dialog)
+page.on('dialog', handle_dialog)
 await page.close(run_before_unload=True)
 ```
 
@@ -114,7 +114,7 @@ def handle_dialog(dialog):
     assert dialog.type == 'beforeunload'
     dialog.dismiss()
 
-page.on('dialog', lambda: handle_dialog)
+page.on('dialog', handle_dialog)
 page.close(run_before_unload=True)
 ```
 

--- a/docs/src/handles.md
+++ b/docs/src/handles.md
@@ -168,7 +168,7 @@ int length = (int) page.evaluate("a => a.length", myArrayHandle);
 Map<String, Object> arg = new HashMap<>();
 arg.put("myArray", myArrayHandle);
 arg.put("newElement", 2);
-page.evaluate("arg => arg.myArray.add(arg.newElement)", arg);
+page.evaluate("arg => arg.myArray.push(arg.newElement)", arg);
 
 // Release the object when it is no longer needed.
 myArrayHandle.dispose();
@@ -225,7 +225,7 @@ var myArrayHandle = await page.EvaluateHandleAsync(@"() => {
 var length = await page.EvaluateAsync<int>("a => a.length", myArrayHandle);
 
 // Add one more element to the array using the handle
-await page.EvaluateAsync("arg => arg.myArray.add(arg.newElement)",
+await page.EvaluateAsync("arg => arg.myArray.push(arg.newElement)",
     new { myArray = myArrayHandle, newElement = 2 });
 
 // Release the object when it is no longer needed.

--- a/docs/src/input.md
+++ b/docs/src/input.md
@@ -75,7 +75,7 @@ await page.GetByRole(AriaRole.Textbox).FillAsync("Peter");
 await page.GetByLabel("Birth date").FillAsync("2020-02-02");
 
 // Time input
-await page.GetByLabel("Appointment time").FillAsync("13-15");
+await page.GetByLabel("Appointment time").FillAsync("13:15");
 
 // Local datetime input
 await page.GetByLabel("Local time").FillAsync("2020-03-02T05:15");

--- a/docs/src/service-workers-js-python.md
+++ b/docs/src/service-workers-js-python.md
@@ -32,7 +32,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   use: {
-    serviceWorkers: 'allow'
+    serviceWorkers: 'block'
   },
 });
 ```

--- a/docs/src/test-configuration-js.md
+++ b/docs/src/test-configuration-js.md
@@ -87,7 +87,7 @@ export default defineConfig({
 | Option | Description |
 | :- | :- |
 | [`property: TestConfig.testIgnore`] | Glob patterns or regular expressions that should be ignored when looking for the test files. For example, `'*test-assets'` |
-| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs <code>.*(test&#124;spec)\.(js&#124;ts&#124;mjs)</code> files. |
+| [`property: TestConfig.testMatch`] | Glob patterns or regular expressions that match test files. For example, `'*todo-tests/*.spec.ts'`. By default, Playwright runs <code>**/*.@(spec&#124;test).?(c&#124;m)[jt]s?(x)</code> files. |
 
 ## Advanced Configuration
 

--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -243,7 +243,7 @@ export default defineConfig({
 
 ## Worker index and parallel index
 
-Each worker process is assigned two ids: a unique worker index that starts with 1, and a parallel index that is between `0` and `workers - 1`. When a worker is restarted, for example after a failure, the new worker process has the same `parallelIndex` and a new `workerIndex`.
+Each worker process is assigned two ids: a unique worker index that starts with 0, and a parallel index that is between `0` and `workers - 1`. When a worker is restarted, for example after a failure, the new worker process has the same `parallelIndex` and a new `workerIndex`.
 
 You can read an index from environment variables `process.env.TEST_WORKER_INDEX` and `process.env.TEST_PARALLEL_INDEX`, or access them through [`property: TestInfo.workerIndex`] and [`property: TestInfo.parallelIndex`].
 

--- a/docs/src/test-reporters-js.md
+++ b/docs/src/test-reporters-js.md
@@ -347,7 +347,7 @@ Blob report supports following configuration options and environment variables:
 | Environment Variable Name | Reporter Config Option| Description | Default
 |---|---|---|---|
 | `PLAYWRIGHT_BLOB_OUTPUT_DIR` | `outputDir` | Directory to save the output. Existing content is deleted before writing the new report. | `blob-report`
-| `PLAYWRIGHT_BLOB_OUTPUT_NAME` | `fileName` | Report file name. | `report-<project>-<hash>-<shard_number>.zip`
+| `PLAYWRIGHT_BLOB_OUTPUT_NAME` | `fileName` | Report file name. | `report-<hash>-<shard_number>.zip`
 | `PLAYWRIGHT_BLOB_OUTPUT_FILE` | `outputFile` | Full path to the output file. If defined, `outputDir` and `fileName` will be ignored. | `undefined`
 
 ### JSON reporter

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -17991,7 +17991,7 @@ export interface BrowserType<Unused = {}> {
     strictSelectors?: boolean;
 
     /**
-     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
      * to disable timeout.
      */
     timeout?: number;
@@ -18190,7 +18190,7 @@ export interface BrowserType<Unused = {}> {
     };
 
     /**
-     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
      * to disable timeout.
      */
     timeout?: number;
@@ -25498,7 +25498,7 @@ export interface LaunchOptions {
   slowMo?: number;
 
   /**
-   * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+   * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
    * to disable timeout.
    */
   timeout?: number;

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -17991,7 +17991,7 @@ export interface BrowserType<Unused = {}> {
     strictSelectors?: boolean;
 
     /**
-     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
      * to disable timeout.
      */
     timeout?: number;
@@ -18190,7 +18190,7 @@ export interface BrowserType<Unused = {}> {
     };
 
     /**
-     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+     * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
      * to disable timeout.
      */
     timeout?: number;
@@ -25498,7 +25498,7 @@ export interface LaunchOptions {
   slowMo?: number;
 
   /**
-   * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0`
+   * Maximum time in milliseconds to wait for the browser instance to start. Defaults to `180000` (3 minutes). Pass `0`
    * to disable timeout.
    */
   timeout?: number;


### PR DESCRIPTION
## Summary
- Correct the default browser launch timeout to `180000` (3 minutes), matching `DEFAULT_PLAYWRIGHT_LAUNCH_TIMEOUT` in `packages/isomorphic/time.ts`
- Fix misplaced parenthesis in the python dialog sample and zero-argument dialog handlers in the beforeunload samples
- Set the service workers config sample to `'block'` as the surrounding text instructs
- Use `Array.push` instead of `List.add` in the java/csharp `handles.md` samples (the code runs in the page)
- Worker index starts with `0`, not `1` (`workerHost.ts` assigns `lastWorkerIndex++` starting from 0)
- Blob report default file name is `report-<hash>-<shard_number>.zip`, no project segment (`reporters/blob.ts`)
- Show the real default `testMatch` glob instead of an outdated regex
- Use a valid `13:15` time value in the csharp input sample