### PR TITLE
docs: complete reporter unions and mode lists, fix version annotations

### DIFF
--- a/docs/src/api/class-apirequest.md
+++ b/docs/src/api/class-apirequest.md
@@ -13,7 +13,7 @@ see [APIRequestContext].
 Creates new instances of [APIRequestContext].
 
 ### option: APIRequest.newContext.clientCertificates = %%-context-option-clientCertificates-%%
-* since: 1.46
+* since: v1.46
 
 ### option: APIRequest.newContext.useragent = %%-context-option-useragent-%%
 * since: v1.16

--- a/docs/src/api/class-browser.md
+++ b/docs/src/api/class-browser.md
@@ -262,7 +262,7 @@ await browser.CloseAsync();
 * since: v1.8
 
 ### option: Browser.newContext.clientCertificates = %%-context-option-clientCertificates-%%
-* since: 1.46
+* since: v1.46
 
 ### option: Browser.newContext.storageState = %%-js-python-context-option-storage-state-%%
 * since: v1.8
@@ -290,7 +290,7 @@ testing frameworks should explicitly create [`method: Browser.newContext`] follo
 * since: v1.8
 
 ### option: Browser.newPage.clientCertificates = %%-context-option-clientCertificates-%%
-* since: 1.46
+* since: v1.46
 
 ### option: Browser.newPage.storageState = %%-js-python-context-option-storage-state-%%
 * since: v1.8

--- a/docs/src/api/class-browsertype.md
+++ b/docs/src/api/class-browsertype.md
@@ -373,7 +373,7 @@ Chromium/Chrome: Due to recent Chrome policy changes, automating the default Chr
 * since: v1.40
 
 ### option: BrowserType.launchPersistentContext.clientCertificates = %%-context-option-clientCertificates-%%
-* since: 1.46
+* since: v1.46
 
 ## async method: BrowserType.launchServer
 * since: v1.8

--- a/docs/src/api/class-cdpsession.md
+++ b/docs/src/api/class-cdpsession.md
@@ -141,7 +141,7 @@ Optional method parameters.
 Optional method parameters.
 
 ## method: CDPSession.event
-* since: v.1.30
+* since: v1.30
 * langs: csharp
 - returns: <[CDPSessionEvent]>
 

--- a/docs/src/api/class-cdpsessionevent.md
+++ b/docs/src/api/class-cdpsessionevent.md
@@ -12,6 +12,6 @@ Each object represents a named event and allows handling of the event when it is
 - argument: <[JsonElement?]>
 
 ## property: CDPSessionEvent.eventName
-* since: 1.30
+* since: v1.30
 * langs: csharp
 - returns: <[string]>

--- a/docs/src/api/class-elementhandle.md
+++ b/docs/src/api/class-elementhandle.md
@@ -802,7 +802,6 @@ Returns the buffer with the captured screenshot.
 ### option: ElementHandle.screenshot.signal = %%-input-signal-%%
 
 ### option: ElementHandle.screenshot.maskColor = %%-screenshot-option-mask-color-%%
-* since: v1.34
 
 ### option: ElementHandle.screenshot.style = %%-screenshot-option-style-%%
 * since: v1.41

--- a/docs/src/api/class-locator.md
+++ b/docs/src/api/class-locator.md
@@ -2390,7 +2390,6 @@ Returns the buffer with the captured screenshot.
 ### option: Locator.screenshot.signal = %%-input-signal-%%
 
 ### option: Locator.screenshot.maskColor = %%-screenshot-option-mask-color-%%
-* since: v1.34
 
 ### option: Locator.screenshot.style = %%-screenshot-option-style-%%
 * since: v1.41

--- a/docs/src/api/class-page.md
+++ b/docs/src/api/class-page.md
@@ -4056,7 +4056,6 @@ Returns the buffer with the captured screenshot.
 * since: v1.8
 
 ### option: Page.screenshot.maskColor = %%-screenshot-option-mask-color-%%
-* since: v1.34
 
 ### option: Page.screenshot.style = %%-screenshot-option-style-%%
 * since: v1.41

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -586,7 +586,7 @@ await context.SetGeolocationAsync(new Geolocation() { Longitude = 48.858455, Lat
 **Note** you can only change geolocation for all pages in the context.
 ## Color Scheme and Media
 
-Emulate the users `"colorScheme"`. Supported values are 'light' and 'dark'. You can also emulate the media type with [`method: Page.emulateMedia`].
+Emulate the users `"colorScheme"`. Supported values are 'light', 'dark' and 'no-preference'. You can also emulate the media type with [`method: Page.emulateMedia`].
 
 ```js title="playwright.config.ts"
 import { defineConfig } from '@playwright/test';

--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -19,7 +19,7 @@ any argument-parsing library.
 * since: v1.20
 - type: ?<[string]>
 
-Path to the configuration file used to run the tests. The value is an empty string if no config file was used.
+Path to the configuration file used to run the tests. The value is `undefined` if no config file was used.
 
 ## property: FullConfig.failOnFlakyTests
 * since: v1.61
@@ -101,7 +101,7 @@ See [`property: TestConfig.quiet`].
 
 ## property: FullConfig.reporter
 * since: v1.10
-- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"perfetto">>
+- type: <[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"blob"|"perfetto">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-api/class-testconfig.md
+++ b/docs/src/test-api/class-testconfig.md
@@ -448,7 +448,7 @@ export default defineConfig({
 
 ## property: TestConfig.reporter
 * since: v1.10
-- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"perfetto">>
+- type: ?<[string]|[Array]<[Object]>|[BuiltInReporter]<"list"|"dot"|"line"|"github"|"json"|"junit"|"null"|"html"|"blob"|"perfetto">>
   - `0` <[string]> Reporter name or module or file path
   - `1` <[Object]> An object with reporter options if any
 

--- a/docs/src/test-cli-js.md
+++ b/docs/src/test-cli-js.md
@@ -317,7 +317,7 @@ npx playwright merge-reports ./reports
 | Option | Description |
 | :--- | :--- |
 | `-c, --config <file>` | Configuration file. Can be used to specify additional configuration for the output report |
-| `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob" (default: "list") |
+| `--reporter <reporter>` | Reporter to use, comma-separated, can be "list", "line", "dot", "json", "junit", "null", "github", "html", "blob", "perfetto" (default: "list") |
 
 ### Clear Cache
 

--- a/docs/src/trace-viewer.md
+++ b/docs/src/trace-viewer.md
@@ -123,6 +123,8 @@ Available options to record a trace:
 - `'off'` - Do not record a trace.
 - `'on'` - Record a trace for each test. (not recommended as it's performance heavy)
 - `'retain-on-failure'` - Record a trace for each test, but remove it from successful test runs.
+- `'retain-on-first-failure'` - Record a trace only for the first run of a test, not for retries. Keep it only if that run failed.
+- `'retain-on-failure-and-retries'` - Record a trace for every run, and keep it for any run that failed or that is a retry.
 
 
 You can also use `trace: 'retain-on-failure'` if you do not enable retries but still want traces for failed tests.

--- a/docs/src/videos.md
+++ b/docs/src/videos.md
@@ -16,6 +16,9 @@ Playwright Test can record videos for your tests, controlled by the `video` opti
 - `'on'` - Record video for each test.
 - `'retain-on-failure'` - Record video for each test, but remove all videos from successful test runs.
 - `'on-first-retry'` - Record video only when retrying a test for the first time.
+- `'on-all-retries'` - Record video for all test retries.
+- `'retain-on-first-failure'` - Record video only for the first run of a test, not for retries. Keep it only if that run failed.
+- `'retain-on-failure-and-retries'` - Record video for every run, and keep it for any run that failed or that is a retry.
 
 Video files will appear in the test output directory, typically `test-results`. See [`property: TestOptions.video`] for advanced video configuration.
 

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -919,7 +919,7 @@ interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
    * ```
    *
    */
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'perfetto', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'blob'|'perfetto', string> | ReporterDescription[];
   /**
    * Global options for all tests, for example
    * [testOptions.browserName](https://playwright.dev/docs/api/class-testoptions#test-options-browser-name). Learn more

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2058,7 +2058,7 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   argv: Array<string>;
 
   /**
-   * Path to the configuration file used to run the tests. The value is an empty string if no config file was used.
+   * Path to the configuration file used to run the tests. The value is `undefined` if no config file was used.
    */
   configFile?: string;
 

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -69,7 +69,7 @@ type LiteralUnion<T extends U, U = string> = T | (U & { zz_IGNORE_ME?: never });
 
 interface TestConfig<TestArgs = {}, WorkerArgs = {}> {
   projects?: Project<TestArgs, WorkerArgs>[];
-  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'perfetto', string> | ReporterDescription[];
+  reporter?: LiteralUnion<'list'|'dot'|'line'|'github'|'json'|'junit'|'null'|'html'|'blob'|'perfetto', string> | ReporterDescription[];
   use?: UseOptions<TestArgs, WorkerArgs>;
   webServer?: TestConfigWebServer | TestConfigWebServer[];
 }


### PR DESCRIPTION
## Summary
- Add `blob` to the `BuiltInReporter` unions in `TestConfig`/`FullConfig` docs and to the `FullConfig.reporter` type override (it is in `builtInReporters` and `ReporterDescription`, but missing from both unions)
- Add `perfetto` to the merge-reports `--reporter` list
- List the missing `retain-on-first-failure` and `retain-on-failure-and-retries` trace modes and `on-all-retries`, `retain-on-first-failure`, `retain-on-failure-and-retries` video modes (all shipped, announced in release notes)
- `FullConfig.configFile` is `undefined` without a config file, not an empty string
- `colorScheme` also supports `'no-preference'`
- `maskColor` was introduced in v1.35 (per release notes and the shared template), not v1.34
- Normalize malformed `since` version strings (`v.1.30`, `1.30`, `1.46`)