### PR TITLE
docs(mcp): clarify artifact filename resolution

### DIFF
--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -28,7 +28,7 @@ type ImageFormat = 'png' | 'jpeg' | 'webp';
 
 const screenshotSchema = optionalElementSchema.extend({
   type: z.enum(['png', 'jpeg', 'webp']).optional().describe('Image format for the screenshot. If unset, inferred from the filename extension, otherwise png.'),
-  filename: z.string().optional().describe('File name to save the screenshot to. Defaults to `page-{timestamp}.{png|jpeg|webp}` if not specified. Prefer relative file names to stay within the output directory.'),
+  filename: z.string().optional().describe('File name to save the screenshot to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
   scale: z.enum(['css', 'device']).default('css').describe('Image resolution scale. "css" produces a screenshot sized in CSS pixels (smaller, consistent across devices). "device" produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.'),
 });

--- a/packages/playwright-core/src/tools/backend/screenshot.ts
+++ b/packages/playwright-core/src/tools/backend/screenshot.ts
@@ -28,7 +28,8 @@ type ImageFormat = 'png' | 'jpeg' | 'webp';
 
 const screenshotSchema = optionalElementSchema.extend({
   type: z.enum(['png', 'jpeg', 'webp']).optional().describe('Image format for the screenshot. If unset, inferred from the filename extension, otherwise png.'),
-  filename: z.string().optional().describe('File name to save the screenshot to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.'),
+  // "Directory provided by the MCP client" covers request cwd and workspace-root resolution; explicit filenames do not use outputDir.
+  filename: z.string().optional().describe('File name to save the screenshot to. Relative paths are resolved against the directory provided by the MCP client, or the server working directory if none is provided; they are not resolved against the configured output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.'),
   fullPage: z.boolean().optional().describe('When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.'),
   scale: z.enum(['css', 'device']).default('css').describe('Image resolution scale. "css" produces a screenshot sized in CSS pixels (smaller, consistent across devices). "device" produces a high-resolution screenshot using device pixels (larger, accounts for the device pixel ratio). Default is css.'),
 });

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -25,7 +25,7 @@ const videoStart = defineTool({
     title: 'Start video',
     description: 'Start video recording',
     inputSchema: z.object({
-      filename: z.string().optional().describe('Filename to save the video.'),
+      filename: z.string().optional().describe('File name to save the video to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.'),
       size: z.object({
         width: z.number().describe('Video width'),
         height: z.number().describe('Video height'),

--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -25,7 +25,8 @@ const videoStart = defineTool({
     title: 'Start video',
     description: 'Start video recording',
     inputSchema: z.object({
-      filename: z.string().optional().describe('File name to save the video to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.'),
+      // "Directory provided by the MCP client" covers request cwd and workspace-root resolution; explicit filenames do not use outputDir.
+      filename: z.string().optional().describe('File name to save the video to. Relative paths are resolved against the directory provided by the MCP client, or the server working directory if none is provided; they are not resolved against the configured output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.'),
       size: z.object({
         width: z.number().describe('Video width'),
         height: z.number().describe('Video height'),

--- a/tests/mcp/capabilities.spec.ts
+++ b/tests/mcp/capabilities.spec.ts
@@ -66,6 +66,23 @@ test('test capabilities (vision)', async ({ startClient }) => {
   expect(toolNames).toContain('browser_mouse_drag_xy');
 });
 
+test('filename descriptions explain output directory behavior', async ({ startClient }) => {
+  const { client } = await startClient({
+    args: ['--caps=devtools'],
+  });
+  const { tools } = await client.listTools();
+
+  const screenshot = tools.find(tool => tool.name === 'browser_take_screenshot');
+  expect(screenshot?.inputSchema.properties?.filename).toEqual(expect.objectContaining({
+    description: 'File name to save the screenshot to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.',
+  }));
+
+  const video = tools.find(tool => tool.name === 'browser_start_video');
+  expect(video?.inputSchema.properties?.filename).toEqual(expect.objectContaining({
+    description: 'File name to save the video to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.',
+  }));
+});
+
 test('support for legacy --vision option', async ({ startClient }) => {
   const { client } = await startClient({
     args: ['--vision'],

--- a/tests/mcp/capabilities.spec.ts
+++ b/tests/mcp/capabilities.spec.ts
@@ -74,12 +74,12 @@ test('filename descriptions explain output directory behavior', async ({ startCl
 
   const screenshot = tools.find(tool => tool.name === 'browser_take_screenshot');
   expect(screenshot?.inputSchema.properties?.filename).toEqual(expect.objectContaining({
-    description: 'File name to save the screenshot to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.',
+    description: 'File name to save the screenshot to. Relative paths are resolved against the directory provided by the MCP client, or the server working directory if none is provided; they are not resolved against the configured output directory. If omitted, the screenshot is saved as `page-{timestamp}.{png|jpeg|webp}` in the output directory.',
   }));
 
   const video = tools.find(tool => tool.name === 'browser_start_video');
   expect(video?.inputSchema.properties?.filename).toEqual(expect.objectContaining({
-    description: 'File name to save the video to. Relative paths are resolved against the MCP client workspace, not the server output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.',
+    description: 'File name to save the video to. Relative paths are resolved against the directory provided by the MCP client, or the server working directory if none is provided; they are not resolved against the configured output directory. If omitted, the video is saved as `video-{timestamp}.webm` in the output directory.',
   }));
 });
 


### PR DESCRIPTION
## Summary
- Clarify that explicit relative `filename` values for screenshots and videos are resolved against the directory provided by the MCP client (or the server working directory as a fallback), not the configured output directory.
- Document that omitting `filename` generates the default artifact name inside the configured output directory.
- Add a tool-list contract test for both filename descriptions.

## Background

This distinction is surprising when the server is started with an output directory such as:

```text
--output-dir /tmp/playwright-mcp
```

With that configuration, `browser_start_video({ "filename": "site-interaction.webm" })` can write `/tmp/site-interaction.webm` when the directory provided by the MCP client is `/tmp`, rather than `/tmp/playwright-mcp/site-interaction.webm`.

Screenshots follow the same shared resolution behavior:

- `browser_take_screenshot({ "filename": "named.png" })` writes the explicit relative filename under the directory provided by the client.
- `browser_take_screenshot({})` writes an auto-generated `page-{timestamp}.png` under the configured output directory.

The existing screenshot description was particularly misleading because it recommended relative filenames "to stay within the output directory."

## Validation

- Reproduced video and screenshot behavior with real MCP invocations using separate client workspace and output directories.
- Confirmed explicit relative filenames were written under the client-provided directory and omitted filenames were generated under `--output-dir`.
- Added and ran the focused MCP capability test that asserts both published tool descriptions.
- Ran ESLint on the modified source and test files.

Fixes https://github.com/microsoft/playwright/issues/42528
