### PR TITLE
fix(mcp): return absolute video paths

### DIFF
--- a/packages/playwright-core/src/tools/backend/video.ts
+++ b/packages/playwright-core/src/tools/backend/video.ts
@@ -64,7 +64,10 @@ const videoStop = defineTool({
         ext: 'webm',
         suggestedFilename: fileName
       }, 'Video');
-      await response.addFileResult(resolvedFile, null);
+      await response.addFileResult({
+        ...resolvedFile,
+        printableLink: `- [Video](${resolvedFile.fileName})`,
+      }, null);
     }
   },
 });

--- a/tests/mcp/cli-devtools.spec.ts
+++ b/tests/mcp/cli-devtools.spec.ts
@@ -233,7 +233,7 @@ test('tracing-start-stop', async ({ cli, server }, testInfo) => {
   expect(fs.existsSync(testInfo.outputPath('.playwright-cli', 'traces', `trace-${timestamp}.network`))).toBeTruthy();
 });
 
-test('video-start-stop', async ({ cli, server }) => {
+test('video-start-stop', async ({ cli, server }, testInfo) => {
   await cli('open', server.HELLO_WORLD);
   const { output: videoStartOutput } = await cli('video-start', 'recordings/video.webm', '--size=400x300');
   expect(videoStartOutput).toContain('Video recording started.');
@@ -244,7 +244,7 @@ test('video-start-stop', async ({ cli, server }) => {
   const { output: tabCloseOutput } = await cli('tab-close');
   expect(tabCloseOutput).toContain(`0: (current) [](${server.EMPTY_PAGE})`);
   const { output: videoStopOutput } = await cli('video-stop');
-  expect(videoStopOutput).toContain(`### Result\n- [Video](recordings${path.sep}video.webm)\n- [Video](recordings${path.sep}video-1.webm)`);
+  expect(videoStopOutput).toContain(`### Result\n- [Video](${testInfo.outputPath('recordings', 'video.webm')})\n- [Video](${testInfo.outputPath('recordings', 'video-1.webm')})`);
 });
 
 test('video-chapter', async ({ cli, server }) => {

--- a/tests/mcp/video.spec.ts
+++ b/tests/mcp/video.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs';
+import path from 'path';
 
 import { test, expect } from './fixtures';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -92,6 +93,28 @@ test('reports missing ffmpeg, not missing browser, when recordVideo is enabled',
   expect.soft(response).toHaveResponse({
     isError: true,
     error: expect.not.stringContaining(`Browser "${mcpBrowser}" is not installed`),
+  });
+});
+
+test.describe('video tools', () => {
+  test.use({ mcpArgs: ['--caps=devtools'] });
+
+  test('browser_stop_video returns the absolute video path', async ({ client, server }, testInfo) => {
+    await navigateToTestPage(client, server);
+
+    expect(await client.callTool({
+      name: 'browser_start_video',
+      arguments: { filename: path.join('recordings', 'video.webm') },
+    })).toHaveResponse({
+      result: 'Video recording started.',
+    });
+
+    expect(await client.callTool({
+      name: 'browser_stop_video',
+      arguments: {},
+    })).toHaveResponse({
+      result: `- [Video](${testInfo.outputPath('recordings', 'video.webm')})`,
+    });
   });
 });
 


### PR DESCRIPTION
The browser_stop_video tool currently returns video links using paths relative to the MCP client's workspace. 

Agents often cannot determine which directory those paths are relative to, especially when the server working directory, client roots, and configured output directory differ. As a result, agents get confused and cannot reliably find the recorded video on disk.

## Summary
- return absolute filesystem paths from `browser_stop_video`
- cover absolute paths for MCP and CLI video results

Fixes https://github.com/microsoft/playwright/issues/42530
