### PR TITLE
fix: preserve err.code in SerializedError cross-process serialization

### DIFF
--- a/packages/playwright-core/src/client/errors.ts
+++ b/packages/playwright-core/src/client/errors.ts
@@ -50,8 +50,12 @@ export function isTargetClosedError(error: Error) {
 }
 
 export function serializeError(e: any): SerializedError {
-  if (isError(e))
-    return { error: { message: e.message, stack: e.stack, name: e.name } };
+  if (isError(e)) {
+    const serialized: SerializedError = { error: { message: e.message, stack: e.stack, name: e.name } };
+    if (e.code)
+      serialized.error!.code = e.code;
+    return serialized;
+  }
   return { value: serializeValue(e, value => ({ fallThrough: value })) };
 }
 
@@ -71,5 +75,7 @@ export function parseError(error: SerializedError): PlaywrightError {
   else
     e = Object.assign(new PlaywrightError(error.error.message), { name: error.error.name });
   e.stack = error.error.stack || '';
+  if (error.error.code)
+    (e as any).code = error.error.code;
   return e;
 }

--- a/packages/playwright-core/src/server/errors.ts
+++ b/packages/playwright-core/src/server/errors.ts
@@ -49,8 +49,12 @@ export function isTargetClosedError(error: Error) {
 }
 
 export function serializeError(e: any): SerializedError {
-  if (isError(e))
-    return { error: { message: e.message, stack: e.stack, name: e.name } };
+  if (isError(e)) {
+    const serialized: SerializedError = { error: { message: e.message, stack: e.stack, name: e.name } };
+    if (e.code)
+      serialized.error!.code = e.code;
+    return serialized;
+  }
   return { value: serializeValue(e, value => ({ fallThrough: value })) };
 }
 
@@ -63,5 +67,7 @@ export function parseError(error: SerializedError): Error {
   const e = new Error(error.error.message);
   e.stack = error.error.stack || '';
   e.name = error.error.name;
+  if (error.error.code)
+    (e as any).code = error.error.code;
   return e;
 }

--- a/packages/protocol/src/structs.d.ts
+++ b/packages/protocol/src/structs.d.ts
@@ -314,6 +314,7 @@ export type SerializedError = {
     message: string,
     name: string,
     stack?: string,
+    code?: string,
   },
   value?: SerializedValue,
 };


### PR DESCRIPTION
## Summary

APIRequestContext errors were losing the `err.code` structured field after cross-process serialization.

## Root Cause

`serializeError` in both `client/errors.ts` and `server/errors.ts` only preserved `message`, `stack`, and `name` from error objects. The `code` field (common in Node.js network errors like `ECONNREFUSED`, `ECONNRESET`, etc.) was silently dropped.

## Fix

1. Added `code?: string` to the `SerializedError.error` type in `packages/protocol/src/structs.d.ts`
2. Updated `serializeError` in both client and server to include `e.code` when present
3. Updated `parseError` in both client and server to restore the `code` field on the deserialized error

## Testing

This fix can be verified with the reproduction script from issue #42532:

```javascript
import { request } from '@playwright/test'

const context = await request.newContext()
try {
  await context.post('http://127.0.0.1:1/', { data: {} })
} catch (err) {
  console.log('code:', err.code)  // Now properly shows 'ECONNREFUSED'
}
```

## Related Issue

Fixes #42532