### PR TITLE
fix(docs): add globalTimeout note to CI documentation

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -100,6 +100,10 @@ jobs:
         retention-days: 30
 ```
 
+:::note
+The `timeout-minutes` above is a hard kill, not a test failure. If your suite outgrows it, the runner stops the process mid-run, the job's conclusion is `cancelled`, and no report is written. Setting [`globalTimeout`](./test-timeouts-js.md) below it lets Playwright stop itself first, so an over-running suite fails with a full report instead.
+:::
+
 #### On push/pull_request
 * langs: python, java, csharp
 


### PR DESCRIPTION
## Summary

Fixes #42533

Add a note to the CI documentation explaining the relationship between GitHub Actions' `timeout-minutes` and Playwright's `globalTimeout` configuration option.

## Problem

The recommended GitHub Actions workflow sets a job-level `timeout-minutes` but doesn't mention `globalTimeout`. When a test suite exceeds the job timeout:
- The run's conclusion is `cancelled` rather than `failure`
- The report upload step is skipped due to the `!cancelled()` guard
- Users get no report on precisely the runs where they need it most

## Solution

Add a note explaining that setting `globalTimeout` below the job's `timeout-minutes` lets Playwright stop itself first, producing a proper failure with a full report instead of a cancelled run.