### PR TITLE
fix(client): name target closed errors

### DIFF
--- a/packages/playwright-core/src/client/errors.ts
+++ b/packages/playwright-core/src/client/errors.ts
@@ -34,6 +34,7 @@ export class TimeoutError extends PlaywrightError {
 export class TargetClosedError extends PlaywrightError {
   constructor(cause?: string) {
     super(cause || 'Target page, context or browser has been closed');
+    this.name = 'TargetClosedError';
   }
 }
 

--- a/tests/library/page-close.spec.ts
+++ b/tests/library/page-close.spec.ts
@@ -59,6 +59,7 @@ test('should reject all promises when page is closed', async ({ page }) => {
     page.evaluate(() => new Promise(r => {})).catch(e => error = e),
     page.close(),
   ]);
+  expect(error.name).toBe('TargetClosedError');
   expect(error.message).toContain(kTargetClosedErrorMessage);
 });
 

--- a/tests/playwright-test/test-step.spec.ts
+++ b/tests/playwright-test/test-step.spec.ts
@@ -631,14 +631,14 @@ pw:api    |      Launch browser
 pw:api    |    Create page @ a.test.ts:6
 pw:api    |Set content @ a.test.ts:15
 pw:api    |Click locator('div') @ a.test.ts:16
-pw:api    |↪ error: Error: page.click: Target page, context or browser has been closed
+pw:api    |↪ error: TargetClosedError: page.click: Target page, context or browser has been closed
 hook      |After Hooks
 hook      |  afterAll hook @ a.test.ts:9
 pw:api    |    Close context @ a.test.ts:10
 hook      |Worker Cleanup
 fixture   |  Fixture "browser"
           |Test timeout of 2000ms exceeded.
-          |Error: page.click: Target page, context or browser has been closed
+          |TargetClosedError: page.click: Target page, context or browser has been closed
 `);
 });
 


### PR DESCRIPTION
## Summary
- Set `TargetClosedError.name` to `TargetClosedError`
- Update test to assert the name on page-close rejections

Fixes https://github.com/microsoft/playwright/issues/42522