### PR TITLE
devops: restore npm publishing from GitHub Actions

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,25 +1,12 @@
-# Publishes all npm packages via ESRP:
-# - @next (alpha with today's date) from main, daily on schedule
-# - @next (alpha with commit timestamp) from main, on manual trigger
-# - @beta (beta with commit timestamp) from release-* branches, on push
-# - @latest from v* release tags (pushed when a GitHub release is published)
-trigger:
-  branches:
-    include:
-    - release-*
-  tags:
-    include:
-    - v*
+# Publishes npm packages via ESRP. Manual trigger only, regular publishing
+# is done from GitHub Actions, see .github/workflows/publish_release.yml.
+# Depending on the selected ref, a manual run publishes:
+# - @next (alpha with commit timestamp) from main
+# - @beta (beta with commit timestamp) from release-* branches
+# - @latest from v* release tags
+trigger: none
 
 pr: none
-
-schedules:
-- cron: '10 5 * * *'
-  displayName: "Daily @next publish"
-  branches:
-    include:
-    - main
-  always: true
 
 resources:
   repositories:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,6 +1,4 @@
-# npm publishing (@next, @beta and @latest) is done by the ESRP pipeline,
-# see .azure-pipelines/publish.yml
-name: "publish release - trace viewer"
+name: "publish release - npm, trace viewer"
 
 on:
   workflow_dispatch:
@@ -13,6 +11,41 @@ on:
     types: [published]
 
 jobs:
+  publish-npm:
+    name: "publish NPM"
+    runs-on: ubuntu-24.04
+    if: github.repository == 'microsoft/playwright'
+    permissions:
+      id-token: write  # This is required for OIDC login (NPM publish) to succeed
+      contents: read   # This is required for actions/checkout to succeed
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: lts/*
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - run: npm run build
+
+    - name: "@next: publish with commit timestamp (triggered manually)"
+      if: contains(github.ref, 'main') && github.event_name == 'workflow_dispatch'
+      run: |
+        node utils/build/update_canary_version.js --alpha --commit-timestamp
+        utils/publish_all_packages.sh --alpha
+    - name: "@next: publish with today's date (triggered automatically)"
+      if: contains(github.ref, 'main') && github.event.schedule
+      run: |
+        node utils/build/update_canary_version.js --alpha --today-date
+        utils/publish_all_packages.sh --alpha
+    - name: "@beta: publish with commit timestamp (triggered automatically)"
+      if: contains(github.ref, 'release') && github.event_name == 'push'
+      run: |
+        node utils/build/update_canary_version.js --beta --commit-timestamp
+        utils/publish_all_packages.sh --beta
+    - name: "publish release to NPM"
+      if: github.event_name == 'release' && github.event.action == 'published'
+      run: utils/publish_all_packages.sh --release
+
   publish-trace-viewer:
     name: "publish Trace Viewer to trace.playwright.dev"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Regular publishing (@next, @beta, @latest) goes back to the GitHub Actions workflow with OIDC trusted publishing and provenance.
- The ESRP pipeline stays available for manual on-demand runs only (no automatic triggers).