### PR TITLE
chore: mark v1.64.0-next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-internal",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-internal",
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -9666,10 +9666,10 @@
       "version": "0.0.0"
     },
     "packages/playwright": {
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9680,11 +9680,11 @@
     },
     "packages/playwright-browser-chromium": {
       "name": "@playwright/browser-chromium",
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "engines": {
         "node": ">=20"
@@ -9692,11 +9692,11 @@
     },
     "packages/playwright-browser-firefox": {
       "name": "@playwright/browser-firefox",
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "engines": {
         "node": ">=20"
@@ -9704,22 +9704,22 @@
     },
     "packages/playwright-browser-webkit": {
       "name": "@playwright/browser-webkit",
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/playwright-chromium": {
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9733,14 +9733,14 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "packages/playwright-core": {
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -9750,11 +9750,11 @@
       }
     },
     "packages/playwright-firefox": {
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9765,10 +9765,10 @@
     },
     "packages/playwright-test": {
       "name": "@playwright/test",
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.63.0-next"
+        "playwright": "1.64.0-next"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9778,11 +9778,11 @@
       }
     },
     "packages/playwright-webkit": {
-      "version": "1.63.0-next",
+      "version": "1.64.0-next",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.63.0-next"
+        "playwright-core": "1.64.0-next"
       },
       "bin": {
         "playwright": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-internal",
   "private": true,
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",

--- a/packages/playwright-browser-chromium/package.json
+++ b/packages/playwright-browser-chromium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-chromium",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "Playwright package that automatically installs Chromium",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-browser-firefox/package.json
+++ b/packages/playwright-browser-firefox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-firefox",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "Playwright package that automatically installs Firefox",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-browser-webkit/package.json
+++ b/packages/playwright-browser-webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/browser-webkit",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "Playwright package that automatically installs WebKit",
   "repository": {
     "type": "git",
@@ -27,6 +27,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-chromium/package.json
+++ b/packages/playwright-chromium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-chromium",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate Chromium",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-client/package.json
+++ b/packages/playwright-client/package.json
@@ -24,6 +24,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-core",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",

--- a/packages/playwright-firefox/package.json
+++ b/packages/playwright-firefox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-firefox",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate Firefox",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright-test/package.json
+++ b/packages/playwright-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright/test",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
   },
   "scripts": {},
   "dependencies": {
-    "playwright": "1.63.0-next"
+    "playwright": "1.64.0-next"
   }
 }

--- a/packages/playwright-webkit/package.json
+++ b/packages/playwright-webkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-webkit",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate WebKit",
   "repository": {
     "type": "git",
@@ -30,6 +30,6 @@
     "install": "node install.js"
   },
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright",
-  "version": "1.63.0-next",
+  "version": "1.64.0-next",
   "description": "A high-level API to automate web browsers",
   "repository": {
     "type": "git",
@@ -50,6 +50,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "playwright-core": "1.63.0-next"
+    "playwright-core": "1.64.0-next"
   }
 }


### PR DESCRIPTION
## Summary
- Mark tip-of-tree as v1.64.0-next ahead of cutting the release-1.63 branch.