### PR TITLE
chore(driver): initialize the tools, the MCP SDK and the in-process Playwright lazily

### DIFF
--- a/packages/playwright-core/index.js
+++ b/packages/playwright-core/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 require('./lib/bootstrap');
-module.exports = require('./lib/coreBundle').inprocess.playwright;
+module.exports = require('./lib/coreBundle').inprocess.inProcessPlaywright();

--- a/packages/playwright-core/package.json
+++ b/packages/playwright-core/package.json
@@ -25,6 +25,7 @@
     "./lib/bootstrap": "./lib/bootstrap.js",
     "./lib/coreBundle": "./lib/coreBundle.js",
     "./lib/utilsBundle": "./lib/utilsBundle.js",
+    "./lib/mcpBundle": "./lib/mcpBundle.js",
     "./lib/tools/cli-client/program": "./lib/tools/cli-client/program.js"
   },
   "bin": {

--- a/packages/playwright-core/src/DEPS.list
+++ b/packages/playwright-core/src/DEPS.list
@@ -23,6 +23,9 @@ client/
 @isomorphic/**
 @utils/**
 
+[mcpBundle.ts]
+
+
 [utilsBundle.ts]
 node_modules/chokidar
 node_modules/colors/safe

--- a/packages/playwright-core/src/cli/browserActions.ts
+++ b/packages/playwright-core/src/cli/browserActions.ts
@@ -25,7 +25,7 @@ import dotenv from 'dotenv';
 import { program } from 'commander';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { ManualPromise } from '@isomorphic/manualPromise';
-import { playwright } from '../inprocess';
+import { inProcessPlaywright } from '../inprocess';
 import type { Browser } from '../client/browser';
 import type { BrowserContext } from '../client/browserContext';
 import type { BrowserType } from '../client/browserType';
@@ -72,7 +72,7 @@ async function launchContext(options: Options, extraOptions: LaunchOptions): Pro
 
   const contextOptions: BrowserContextOptions =
     // Copy the device descriptor since we have to compare and modify the options.
-    options.device ? { ...playwright.devices[options.device] } : {};
+    options.device ? { ...inProcessPlaywright().devices[options.device] } : {};
 
   // In headful mode, use host device scale factor for things to look nice.
   // In headless, keep things the way it works in Playwright by default.
@@ -351,6 +351,7 @@ export async function pdf(options: Options, captureOptions: CaptureOptions, url:
 }
 
 function lookupBrowserType(options: Options): BrowserType {
+  const playwright = inProcessPlaywright();
   let name = options.browser;
   if (options.device) {
     const device = playwright.devices[options.device];
@@ -371,6 +372,7 @@ function lookupBrowserType(options: Options): BrowserType {
 }
 
 function validateOptions(options: Options) {
+  const playwright = inProcessPlaywright();
   if (options.device && !(options.device in playwright.devices)) {
     const lines = [`Device descriptor not found: '${options.device}', available devices are:`];
     for (const name in playwright.devices)

--- a/packages/playwright-core/src/cli/driver.ts
+++ b/packages/playwright-core/src/cli/driver.ts
@@ -20,7 +20,7 @@ import fs from 'fs';
 
 import { PipeTransport } from '@utils/pipeTransport';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
-import { playwright } from '../inprocess';
+import { inProcessPlaywright } from '../inprocess';
 import { PlaywrightServer } from '../remote/playwrightServer';
 import { DispatcherConnection, PlaywrightDispatcher, RootDispatcher, createPlaywright } from '../server';
 
@@ -89,7 +89,7 @@ export async function launchBrowserServer(browserName: string, configFile?: stri
   let options: LaunchServerOptions = {};
   if (configFile)
     options = JSON.parse(fs.readFileSync(configFile).toString());
-  const browserType = (playwright as any)[browserName] as BrowserType;
+  const browserType = (inProcessPlaywright() as any)[browserName] as BrowserType;
   const server = await browserType.launchServer(options);
   console.log(server.wsEndpoint());
 }

--- a/packages/playwright-core/src/cli/program.ts
+++ b/packages/playwright-core/src/cli/program.ts
@@ -28,7 +28,6 @@ import { open, codegen } from './browserActions';
 import { installBrowsers, uninstallBrowsers, installDeps } from './installActions';
 import { runTraceInBrowser, runTraceViewerApp } from '../server/trace/viewer/traceViewer';
 import { screenshot, pdf } from './browserActions';
-import { program as cliProgram } from '../tools/cli-client/program';
 import { decorateMCPCommand } from '../tools/mcp/program';
 
 import type { TraceViewerServerOptions } from '../server/trace/viewer/traceViewer';
@@ -245,6 +244,7 @@ export function decorateProgram(program: Command) {
       .helpOption(false)
       .action(async options => {
         process.argv.splice(process.argv.indexOf('cli'), 1);
+        const { program: cliProgram } = require('../tools/cli-client/program') as typeof import('../tools/cli-client/program');
         cliProgram().catch(logErrorAndExit);
       });
 

--- a/packages/playwright-core/src/coreBundle.ts
+++ b/packages/playwright-core/src/coreBundle.ts
@@ -24,5 +24,16 @@ export * as oop from './outofprocess';
 export * as remote from './remote/playwrightServer';
 export * as registry from './server/registry/index';
 export * as server from './server/index';
-export * as tools from './tools';
+import type * as toolsModule from './tools';
+
+// The tools (MCP server, cli client, cli daemon, dashboard) are only needed by their commands; loading them here
+// would initialise all of them for every command and for `run-driver`.
+let toolsInstance: typeof toolsModule | undefined;
+export const tools: typeof toolsModule = new Proxy({} as typeof toolsModule, {
+  get: (_, property) => {
+    if (!toolsInstance)
+      toolsInstance = require('./tools') as typeof toolsModule;
+    return toolsInstance[property as keyof typeof toolsModule];
+  },
+});
 export { getUserAgent, getPlaywrightVersion } from './server/userAgent';

--- a/packages/playwright-core/src/inprocess.ts
+++ b/packages/playwright-core/src/inprocess.ts
@@ -24,9 +24,10 @@ import { packageRoot } from './package';
 import type { Playwright as PlaywrightAPI } from './client/playwright';
 import type { Language } from '@isomorphic/locatorGenerators';
 
+setCoreDir(packageRoot);
+
 export function createInProcessPlaywright(): PlaywrightAPI {
   const playwright = createPlaywright({ sdkLanguage: (process.env.PW_LANG_NAME as Language | undefined) || 'javascript', isClientCollocatedWithServer: true });
-  setCoreDir(packageRoot);
   const clientConnection = new Connection();
   clientConnection.useRawBuffers();
   const dispatcherConnection = new DispatcherConnection(true /* in process */);
@@ -59,4 +60,10 @@ export function createInProcessPlaywright(): PlaywrightAPI {
   return playwrightAPI;
 }
 
-export const playwright = createInProcessPlaywright();
+let playwrightInstance: PlaywrightAPI | undefined;
+
+export function inProcessPlaywright(): PlaywrightAPI {
+  if (!playwrightInstance)
+    playwrightInstance = createInProcessPlaywright();
+  return playwrightInstance;
+}

--- a/packages/playwright-core/src/mcpBundle.ts
+++ b/packages/playwright-core/src/mcpBundle.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// zod and the MCP SDK are only needed by the MCP server and the tools built on
+// it, so they live in their own bundle that is loaded on demand.
+
+export * as z from 'zod';
+
+export { Client } from '@modelcontextprotocol/sdk/client/index.js';
+export { Server } from '@modelcontextprotocol/sdk/server/index.js';
+export { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+export { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+export { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+export { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+export { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+export { CallToolRequestSchema, ListRootsRequestSchema, ListToolsRequestSchema, PingRequestSchema, ProgressNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+export { zodToJsonSchema } from 'zod-to-json-schema';

--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -23,7 +23,7 @@ import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { disposeAll } from '@isomorphic/disposable';
 import { eventsHelper } from '@utils/eventsHelper';
 import { isPathInside, isSystemDirectory, isWritable } from '@utils/fileUtils';
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 
 import { dedent, languageGeneratorId, secretCode } from './codegen';
 import { Tab } from './tab';
@@ -375,7 +375,7 @@ export class Context {
 
   private async _initializeBrowserContext() {
     if (this.config.testIdAttribute)
-      playwright.selectors.setTestIdAttribute(this.config.testIdAttribute);
+      inProcessPlaywright().selectors.setTestIdAttribute(this.config.testIdAttribute);
     const browserContext = this._rawBrowserContext;
     await this._setupRequestInterception(browserContext);
 

--- a/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
+++ b/packages/playwright-core/src/tools/dashboard/dashboardApp.ts
@@ -24,7 +24,7 @@ import { makeSocketPath } from '@utils/fileUtils';
 import { gracefullyProcessExitDoNotHang } from '@utils/processLauncher';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { libPath } from '../../package';
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 import { findChromiumChannelBestEffort, registryDirectory } from '../../server/registry/index';
 import { minimist } from '../cli-client/minimist';
 import { DashboardConnection } from './dashboardController';
@@ -140,7 +140,7 @@ type AppState = { page?: api.Page; server: DashboardServer };
 
 async function launchApp(appName: string, options?: { onClose?: () => void }) {
   const channel = findChromiumChannelBestEffort('javascript');
-  const context = await playwright.chromium.launchPersistentContext('', {
+  const context = await inProcessPlaywright().chromium.launchPersistentContext('', {
     ignoreDefaultArgs: ['--enable-automation'],
     channel,
     headless: !!process.env.PWTEST_DASHBOARD_APP_BIND_TITLE,

--- a/packages/playwright-core/src/tools/mcp/browserFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/browserFactory.ts
@@ -18,7 +18,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 import { defaultCacheDirectory } from '../../server/registry/index';
 import { testDebug } from './log';
 import { outputDir } from '../backend/context';
@@ -88,7 +88,7 @@ function browserInfo(browser: playwrightTypes.Browser, config: FullConfig): Brow
 
 async function createIsolatedBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {
   testDebug('create browser (isolated)');
-  const browserType = playwright[config.browser.browserName];
+  const browserType = inProcessPlaywright()[config.browser.browserName];
   const tracesDir = await computeTracesDir(config, clientInfo);
   const browser = await browserType.launch({
     tracesDir,
@@ -105,7 +105,7 @@ async function createIsolatedBrowser(config: FullConfig, clientInfo: ClientInfo)
 async function createCDPBrowser(config: FullConfig, clientInfo: ClientInfo): Promise<playwrightTypes.Browser> {
   testDebug('create browser (cdp)');
   const artifactsDir = await computeTracesDir(config, clientInfo);
-  const browser = await playwright.chromium.connectOverCDP(config.browser.cdpEndpoint!, {
+  const browser = await inProcessPlaywright().chromium.connectOverCDP(config.browser.cdpEndpoint!, {
     headers: config.browser.cdpHeaders,
     timeout: config.browser.cdpTimeout,
     noDefaults: true,
@@ -144,7 +144,7 @@ async function createRemoteBrowser(config: FullConfig): Promise<BrowserWithInfo>
     };
   }
 
-  const playwrightObject = playwright as Playwright;
+  const playwrightObject = inProcessPlaywright() as Playwright;
   // Use connectToBrowser instead of playwright[browserName].connect because we don't have browserName.
   const browser = await connectToBrowser(playwrightObject, remoteOptions);
   browser._connectToBrowserType(playwrightObject[browser._browserName], {}, undefined);
@@ -163,7 +163,7 @@ async function createPersistentBrowser(config: FullConfig, clientInfo: ClientInf
   if (await isProfileLocked5Times(userDataDir))
     throw new Error(`Browser is already in use for ${userDataDir}, use --isolated to run multiple instances of the same browser`);
 
-  const browserType = playwright[config.browser.browserName];
+  const browserType = inProcessPlaywright()[config.browser.browserName];
   const configIgnoreDefaultArgs = config.browser.launchOptions?.ignoreDefaultArgs;
   const launchOptions: playwrightTypes.LaunchOptions & playwrightTypes.BrowserContextOptions = {
     tracesDir,

--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -20,7 +20,7 @@ import os from 'os';
 
 import dotenv from 'dotenv';
 import { isSystemDirectory } from '@utils/fileUtils';
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 import { configFromIniFile } from './configIni';
 
 import type * as playwrightTypes from '../../..';
@@ -321,7 +321,7 @@ function configFromCLIOptions(cliOptions: CLIOptions): Config & { configFile?: s
     throw new Error('Device emulation is not supported with cdpEndpoint.');
 
   // Context options
-  const contextOptions: playwrightTypes.BrowserContextOptions = device ? playwright.devices[device] : {};
+  const contextOptions: playwrightTypes.BrowserContextOptions = device ? inProcessPlaywright().devices[device] : {};
 
   if (cliOptions.proxyServer) {
     const proxy: playwrightTypes.LaunchOptions['proxy'] = { server: cliOptions.proxyServer };

--- a/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
+++ b/packages/playwright-core/src/tools/mcp/extensionContextFactory.ts
@@ -18,7 +18,7 @@ import path from 'path';
 
 import debug from 'debug';
 import { defaultUserDataDirForChannel } from '@utils/chromiumChannels';
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 import { findPlaywrightExtensionProfile, isExtensionInstalledInProfile, playwrightExtensionInstallUrl } from '../utils/extension';
 import { CDPRelayServer } from './cdpRelay';
 
@@ -40,7 +40,7 @@ export async function createExtensionBrowser(channel: string, executablePath: st
 
   try {
     await relay.establishExtensionConnection(clientName);
-    const browser = await playwright.chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0, noDefaults: true });
+    const browser = await inProcessPlaywright().chromium.connectOverCDP(relay.cdpEndpoint(), { isLocal: true, timeout: 0, noDefaults: true });
     browser.on('disconnected', () => relay.stop());
     return browser;
   } catch (error) {

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -15,14 +15,11 @@
  */
 
 import { Option as ProgramOption } from 'commander';
-import * as mcpServer from '../utils/mcp/server';
 import { commaSeparatedList, defaultCodegenLanguage, dotenvFileLoader, enumParser, headerParser, numberParser, resolutionParser, resolveCLIConfigForMCP, semicolonSeparatedList } from './config';
 import { setupExitWatchdog } from './watchdog';
-import { createBrowserWithInfo } from './browserFactory';
-import { BrowserBackend } from '../backend/browserBackend';
-import { filteredTools } from '../backend/tools';
 import { testDebug } from './log';
 import { packageJSON } from '../../package';
+import type * as mcpServer from '../utils/mcp/server';
 
 import type { Command } from 'commander';
 import type { ClientInfo } from '../utils/mcp/server';
@@ -95,6 +92,10 @@ export function decorateMCPCommand(command: Command) {
           options.caps.push('devtools');
 
         const config = await resolveCLIConfigForMCP(options);
+        const { start } = require('../utils/mcp/server') as typeof import('../utils/mcp/server');
+        const { createBrowserWithInfo } = require('./browserFactory') as typeof import('./browserFactory');
+        const { BrowserBackend } = require('../backend/browserBackend') as typeof import('../backend/browserBackend');
+        const { filteredTools } = require('../backend/tools') as typeof import('../backend/tools');
         const tools = filteredTools(config);
         const useSharedBrowser = config.sharedBrowserContext || config.browser.isolated;
         let sharedBrowserPromise: Promise<playwright.Browser> | undefined;
@@ -159,6 +160,6 @@ export function decorateMCPCommand(command: Command) {
             }
           },
         };
-        await mcpServer.start(factory, config.server);
+        await start(factory, config.server);
       });
 }

--- a/packages/playwright-core/src/tools/trace/traceCli.ts
+++ b/packages/playwright-core/src/tools/trace/traceCli.ts
@@ -22,7 +22,6 @@ import { traceRequests } from './traceRequests';
 import { traceRequest } from './traceRequests';
 import { traceConsole } from './traceConsole';
 import { traceErrors } from './traceErrors';
-import { traceSnapshot } from './traceSnapshot';
 import { traceScreenshot } from './traceScreenshot';
 import { traceAttachments } from './traceAttachments';
 import { traceAttachment } from './traceAttachments';
@@ -113,6 +112,7 @@ export function addTraceCommands(program: Command, logErrorAndExit: (e: Error) =
         try {
           // Collect everything after '--' as the browser command.
           const browserArgs = cmd.args.slice(1);
+          const { traceSnapshot } = require('./traceSnapshot') as typeof import('./traceSnapshot');
           await traceSnapshot(actionId, { ...options, browserArgs });
         } catch (e) {
           logErrorAndExit(e as Error);

--- a/packages/playwright-core/src/tools/trace/traceSnapshot.ts
+++ b/packages/playwright-core/src/tools/trace/traceSnapshot.ts
@@ -22,7 +22,7 @@ import { HttpServer } from '@utils/httpServer';
 import { SnapshotServer } from '@isomorphic/trace/snapshotServer';
 import { BrowserBackend } from '../backend/browserBackend';
 import { browserTools } from '../backend/tools';
-import { playwright } from '../../inprocess';
+import { inProcessPlaywright } from '../../inprocess';
 import { parseCommand } from '../cli-daemon/command';
 import { minimist } from '../cli-client/minimist';
 import { commands } from '../cli-daemon/commands';
@@ -170,7 +170,7 @@ async function bootstrapSnapshotPage(swUrl: string, snapshotUrl: string) {
 }
 
 async function runCommandOnSnapshot(server: { url: string, stop: () => Promise<void> }, browserArgs: string[]) {
-  const browser = await playwright.chromium.launch({ headless: true });
+  const browser = await inProcessPlaywright().chromium.launch({ headless: true });
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto(server.url);

--- a/packages/playwright-core/src/utilsBundle.ts
+++ b/packages/playwright-core/src/utilsBundle.ts
@@ -101,16 +101,3 @@ export const httpProxyAgent = httpProxyAgentLibrary;
 
 import { SocksProxyAgent as socksProxyAgentLibrary } from 'socks-proxy-agent';
 export const socksProxyAgent = socksProxyAgentLibrary;
-
-export * as z from 'zod';
-
-export { Client } from '@modelcontextprotocol/sdk/client/index.js';
-export { Server } from '@modelcontextprotocol/sdk/server/index.js';
-export { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-export { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-export { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-export { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-export { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-export { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-export { CallToolRequestSchema, ListRootsRequestSchema, ListToolsRequestSchema, PingRequestSchema, ProgressNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
-export { zodToJsonSchema } from 'zod-to-json-schema';

--- a/packages/playwright/src/mcp/test/browserBackend.ts
+++ b/packages/playwright/src/mcp/test/browserBackend.ts
@@ -18,7 +18,7 @@ import crypto from 'crypto';
 
 import { stripAnsiEscapes } from '@isomorphic/stringUtils';
 
-import type { tools } from 'playwright-core/lib/coreBundle';
+import type * as tools from 'playwright-core/lib/tools';
 import type * as playwright from '../../../index';
 import type { TestInfoImpl } from '../../worker/testInfo';
 

--- a/packages/playwright/src/mcp/test/testBackend.ts
+++ b/packages/playwright/src/mcp/test/testBackend.ts
@@ -23,6 +23,7 @@ import { TestContext } from './testContext';
 import * as testTools from './testTools.js';
 import * as generatorTools from './generatorTools.js';
 import * as plannerTools from './plannerTools.js';
+import type * as toolsTypes from 'playwright-core/lib/tools';
 
 import type { TestTool } from './testTool';
 
@@ -41,7 +42,7 @@ export const testServerBackendTools: TestTool<any>[] = [
   ...tools.browserTools.map(tool => wrapBrowserTool(tool)),
 ];
 
-export class TestServerBackend extends EventEmitter implements tools.ServerBackend {
+export class TestServerBackend extends EventEmitter implements toolsTypes.ServerBackend {
   readonly name = 'Playwright';
   readonly version = '0.0.1';
   private _options: { muteConsole?: boolean, headless?: boolean };
@@ -54,11 +55,11 @@ export class TestServerBackend extends EventEmitter implements tools.ServerBacke
     this._configPath = configPath;
   }
 
-  async initialize(clientInfo: tools.ClientInfo): Promise<void> {
+  async initialize(clientInfo: toolsTypes.ClientInfo): Promise<void> {
     this._context = new TestContext(clientInfo, this._configPath, this._options);
   }
 
-  async callTool(name: string, args: tools.CallToolRequest['params']['arguments'], signal: AbortSignal): Promise<tools.CallToolResult> {
+  async callTool(name: string, args: toolsTypes.CallToolRequest['params']['arguments'], signal: AbortSignal): Promise<toolsTypes.CallToolResult> {
     const tool = testServerBackendTools.find(tool => tool.schema.name === name);
     if (!tool)
       throw new Error(`Tool not found: ${name}. Available tools: ${testServerBackendTools.map(tool => tool.schema.name).join(', ')}`);
@@ -74,7 +75,7 @@ export class TestServerBackend extends EventEmitter implements tools.ServerBacke
   }
 }
 
-function wrapBrowserTool(tool: tools.Tool): TestTool {
+function wrapBrowserTool(tool: toolsTypes.Tool): TestTool {
   const inputSchema = typesWithIntent.includes(tool.schema.type) ? (tool.schema.inputSchema as any).extend({
     intent: zod.string().describe('The intent of the call, for example the test step description plan idea')
   }) : tool.schema.inputSchema;

--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -30,6 +30,7 @@ import { StringWriteStream } from './streams';
 import { fileExistsAsync } from '../../util';
 import { ensureSeedFile, seedProject } from './seed';
 import { configLoader } from '../../common';
+import type * as toolsTypes from 'playwright-core/lib/tools';
 
 import type { ConfigLocation } from '../../common';
 import type { BrowserMCPRequest, BrowserMCPResponse } from './browserBackend';
@@ -86,7 +87,7 @@ type TestRunnerAndScreen = {
 };
 
 export class TestContext {
-  private _clientInfo: tools.ClientInfo;
+  private _clientInfo: toolsTypes.ClientInfo;
   private _testRunnerAndScreen: TestRunnerAndScreen | undefined;
   private _testOpQueue: Promise<void> = Promise.resolve();
   readonly computedHeaded: boolean;
@@ -94,7 +95,7 @@ export class TestContext {
   readonly rootPath: string;
   generatorJournal: GeneratorJournal | undefined;
 
-  constructor(clientInfo: tools.ClientInfo, configPath: string | undefined, options?: { muteConsole?: boolean, headless?: boolean }) {
+  constructor(clientInfo: toolsTypes.ClientInfo, configPath: string | undefined, options?: { muteConsole?: boolean, headless?: boolean }) {
     this._clientInfo = clientInfo;
 
     this._configLocation = configLoader.resolveConfigLocation(configPath || clientInfo.cwd);

--- a/packages/playwright/src/mcp/test/testTool.ts
+++ b/packages/playwright/src/mcp/test/testTool.ts
@@ -17,7 +17,7 @@
 import type { z } from 'zod';
 import type { TestContext } from './testContext.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import type { tools } from 'playwright-core/lib/coreBundle';
+import type * as tools from 'playwright-core/lib/tools';
 
 export type TestTool<Input extends z.Schema = z.Schema> = {
   schema: tools.ToolSchema<Input>;

--- a/packages/playwright/src/program.ts
+++ b/packages/playwright/src/program.ts
@@ -28,6 +28,7 @@ import { showReport, mergeReports } from './cli/reportActions';
 import { TestServerBackend, testServerBackendTools } from './mcp/test/testBackend';
 import { ClaudeGenerator, CodexGenerator, OpencodeGenerator, VSCodeGenerator, CopilotGenerator } from './agents/generateAgents';
 import { packageRoot, packageJSON } from './package';
+import type * as toolsTypes from 'playwright-core/lib/tools';
 
 export { program };
 
@@ -146,7 +147,7 @@ function addTestMCPServerCommand(program: Command) {
   command.option('--port <port>', 'port to listen on for SSE transport.');
   command.action(async options => {
     tools.setupExitWatchdog();
-    const factory: tools.ServerBackendFactory = {
+    const factory: toolsTypes.ServerBackendFactory = {
       name: 'Playwright Test Runner',
       nameInConfig: 'playwright-test-runner',
       version: packageJSON.version,

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -447,8 +447,8 @@ class CustomCallbackStep extends Step {
 // 3. `import …  from '<vendored-pkg>'` (debug, mime, ws, …) →
 //    `const … = require('playwright-core/lib/utilsBundle').<key>` so that
 //    consumers can write idiomatic npm imports while the runtime still goes
-//    through the vendored utilsBundle. The mapping lives in
-//    utils/build/utilsBundleMapping.js.
+//    through the vendored utilsBundle (or mcpBundle for zod and the MCP SDK).
+//    The mapping lives in utils/build/utilsBundleMapping.js.
 const { MAPPING: VENDORED_MAPPING, VENDORED_PACKAGES } = require('./utilsBundleMapping');
 
 const VENDORED_INVERSE_NAMED = {};
@@ -471,13 +471,13 @@ const VENDORED_PKG_RE = new RegExp(
     'gm'
 );
 
-function _utilsBundleSpecifier(filePath) {
+function _bundleSpecifier(filePath, bundle) {
   const coreSrcMarker = `${path.sep}playwright-core${path.sep}src${path.sep}`;
   const idx = filePath.indexOf(coreSrcMarker);
   if (idx === -1)
-    return "'playwright-core/lib/utilsBundle'";
+    return `'playwright-core/lib/${bundle}'`;
   const coreSrcRoot = filePath.slice(0, idx + coreSrcMarker.length - 1);
-  let rel = path.relative(path.dirname(filePath), path.join(coreSrcRoot, 'utilsBundle'));
+  let rel = path.relative(path.dirname(filePath), path.join(coreSrcRoot, bundle));
   rel = rel.split(path.sep).join('/');
   if (!rel.startsWith('.'))
     rel = './' + rel;
@@ -527,12 +527,12 @@ function _parseNamedList(braced) {
 }
 
 function _rewriteVendoredImports(filePath, contents) {
-  const bundleSpec = _utilsBundleSpecifier(filePath);
   return contents.replace(VENDORED_PKG_RE, (full, clause, pkg) => {
     const def = VENDORED_MAPPING[pkg];
     const parsed = _parseClause(clause);
     if (!parsed)
       return full;
+    const bundleSpec = _bundleSpecifier(filePath, def.bundle || 'utilsBundle');
     /** @type {string[]} */
     const lines = [];
     if (parsed.default && def.default)
@@ -677,11 +677,19 @@ steps.push(new EsbuildStep({
   bundle: true,
   entryPoints: [filePath('packages/playwright-core/src/utilsBundle.ts')],
   outfile: filePath('packages/playwright-core/lib/utilsBundle.js'),
+}, [filePath('packages/playwright-core/src/utilsBundle.ts')]));
+
+// playwright-core/lib/mcpBundle.js — zod and the MCP SDK, loaded on demand by
+// the MCP server and the tools so that everything else does not pay for them.
+steps.push(new EsbuildStep({
+  bundle: true,
+  entryPoints: [filePath('packages/playwright-core/src/mcpBundle.ts')],
+  outfile: filePath('packages/playwright-core/lib/mcpBundle.js'),
   external: ['express', '@anthropic-ai/sdk'],
   alias: {
     'raw-body': filePath('utils/build/raw-body.ts'),
   },
-}, [filePath('packages/playwright-core/src/utilsBundle.ts'), filePath('utils/build/raw-body.ts')]));
+}, [filePath('packages/playwright-core/src/mcpBundle.ts'), filePath('utils/build/raw-body.ts')]));
 
 // Build playwright-core as a single bundle.
 steps.push(new EsbuildStep({
@@ -706,9 +714,9 @@ steps.push(new EsbuildStep({
     __PW_HMR__: String(!!watchMode),
   },
   plugins: [{
-    name: 'externalize-utilsBundle',
-    setup: build => build.onResolve({ filter: /utilsBundle/ },
-        () => ({ path: './utilsBundle', external: true })),
+    name: 'externalize-bundles',
+    setup: build => build.onResolve({ filter: /utilsBundle|mcpBundle/ },
+        args => ({ path: './' + path.basename(args.path, '.js'), external: true })),
   }, dynamicImportToRequirePlugin],
 }, [playwrightCoreSrc, ...commonUtilsSrc, filePath('packages/injected')]));
 

--- a/utils/build/utilsBundleMapping.js
+++ b/utils/build/utilsBundleMapping.js
@@ -1,11 +1,13 @@
 // Single source of truth for the mapping between idiomatic npm imports and
-// the keys exported from `playwright-core/lib/utilsBundle`.
+// the keys exported from `playwright-core/lib/utilsBundle` (or, for packages
+// that only the MCP server and tools need, `playwright-core/lib/mcpBundle`).
 //
-// Each entry: package specifier → { default?, named?: {srcName: bundleKey}, namespace? }
+// Each entry: package specifier → { default?, named?: {srcName: bundleKey}, namespace?, bundle? }
+// `bundle` defaults to 'utilsBundle'.
 // `lockfile` and `extract` have no clean npm equivalent (they wrap in-tree
 // third_party files) and intentionally remain as direct utilsBundle imports.
 
-/** @type {Record<string, { default?: string, named?: Record<string,string>, namespace?: string }>} */
+/** @type {Record<string, { default?: string, named?: Record<string,string>, namespace?: string, bundle?: 'utilsBundle' | 'mcpBundle' }>} */
 const MAPPING = {
   'colors/safe': { default: 'colors' },
   'debug': { default: 'debug' },
@@ -34,16 +36,16 @@ const MAPPING = {
   'get-east-asian-width': { namespace: 'getEastAsianWidth' },
   'yazl': { namespace: 'yazl' },
   'yauzl': { default: 'yauzl', namespace: 'yauzl' },
-  'zod': { namespace: 'z' },
-  'zod-to-json-schema': { named: { zodToJsonSchema: 'zodToJsonSchema' } },
-  '@modelcontextprotocol/sdk/client/index.js': { named: { Client: 'Client' } },
-  '@modelcontextprotocol/sdk/server/index.js': { named: { Server: 'Server' } },
-  '@modelcontextprotocol/sdk/client/sse.js': { named: { SSEClientTransport: 'SSEClientTransport' } },
-  '@modelcontextprotocol/sdk/server/sse.js': { named: { SSEServerTransport: 'SSEServerTransport' } },
-  '@modelcontextprotocol/sdk/client/stdio.js': { named: { StdioClientTransport: 'StdioClientTransport' } },
-  '@modelcontextprotocol/sdk/server/stdio.js': { named: { StdioServerTransport: 'StdioServerTransport' } },
-  '@modelcontextprotocol/sdk/server/streamableHttp.js': { named: { StreamableHTTPServerTransport: 'StreamableHTTPServerTransport' } },
-  '@modelcontextprotocol/sdk/client/streamableHttp.js': { named: { StreamableHTTPClientTransport: 'StreamableHTTPClientTransport' } },
+  'zod': { namespace: 'z', bundle: 'mcpBundle' },
+  'zod-to-json-schema': { named: { zodToJsonSchema: 'zodToJsonSchema' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/client/index.js': { named: { Client: 'Client' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/server/index.js': { named: { Server: 'Server' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/client/sse.js': { named: { SSEClientTransport: 'SSEClientTransport' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/server/sse.js': { named: { SSEServerTransport: 'SSEServerTransport' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/client/stdio.js': { named: { StdioClientTransport: 'StdioClientTransport' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/server/stdio.js': { named: { StdioServerTransport: 'StdioServerTransport' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/server/streamableHttp.js': { named: { StreamableHTTPServerTransport: 'StreamableHTTPServerTransport' }, bundle: 'mcpBundle' },
+  '@modelcontextprotocol/sdk/client/streamableHttp.js': { named: { StreamableHTTPClientTransport: 'StreamableHTTPClientTransport' }, bundle: 'mcpBundle' },
   '@modelcontextprotocol/sdk/types.js': {
     named: {
       CallToolRequestSchema: 'CallToolRequestSchema',
@@ -52,6 +54,7 @@ const MAPPING = {
       PingRequestSchema: 'PingRequestSchema',
       ProgressNotificationSchema: 'ProgressNotificationSchema',
     },
+    bundle: 'mcpBundle',
   },
   // Transitive deps of in-tree third_party extractZip.ts / lockfile.ts.
   // Callers use `@utils/third_party/*` which routes through coreBundle.utils;


### PR DESCRIPTION
`cli.js run-driver` is what every language binding (Python, Java, .NET) spawns per `Playwright.create()`, and at the moment `require('./lib/coreBundle')` does a fair bit of work that `run-driver` never uses:

- `inprocess.ts` creates the in-process Playwright (client `Connection`, `DispatcherConnection`, `RootDispatcher`/`PlaywrightDispatcher`, server `createPlaywright()`) at module scope, although only `index.js` and a handful of CLI commands need it.
- `coreBundle.ts` re-exports `tools`, which (with esbuild's lazy `__esm` wrappers) initializes the whole MCP server / cli client / cli daemon / dashboard module graph, including the module-scope zod schemas, for every command.
- `utilsBundle` executes zod, `@modelcontextprotocol/sdk` and `zod-to-json-schema` (and their dependencies) for every command too, although only the MCP server and the tools use them.

This PR makes all three lazy, in three commits:

- `inprocess.ts`: `createInProcessPlaywright()` is unchanged, and a cached `inProcessPlaywright()` replaces the eagerly created `playwright` export. `index.js` still creates it at require time, so library users see no difference; the CLI consumers call `inProcessPlaywright()` where they use it.
- `coreBundle.ts`: `tools` is a getter proxy that requires `./tools` on first access. `cli/program.ts`, `tools/mcp/program.ts` and `tools/trace/traceCli.ts` require the cli client, the MCP server/backend and the trace snapshot runner inside their command actions, so registration (names, options, help) stays exactly as it was.
- `packages/playwright` takes the `tools` _types_ from `playwright-core/lib/tools` (type-only, erased at build) since a proxied const can't be used as a type namespace.
- zod and the MCP SDK move from `utilsBundle` to a new `lib/mcpBundle.js`. `utilsBundleMapping.js` gets a `bundle` field so the existing import rewrite sends `import ... from 'zod'` to the right bundle, nothing in the consumers changes, and `mcpBundle` only loads when something touches it.

Measured with the bundled Node 24 on macOS arm64, 7 runs, medians:

| | before | after |
|---|---|---|
| `run-driver` initialize round trip | 162 ms | 114 ms |
| `npx playwright --version` | 162 ms | 111 ms |
| driver RSS after initialize | 133 MB | 94 MB |
| `utilsBundle.js` | 2,977 KB | 1,506 KB (+ 1,468 KB `mcpBundle.js`, not loaded by `run-driver`) |

`--help` for `--help`, `mcp`, `trace snapshot`, `cli`, `codegen`, `open` and `install` is byte-identical before and after. `npm run eslint`, `tsc` and `check-deps` pass. `npm run test-mcp` (`core`, `cli-core`, `capabilities`, `cli-config`, `sse` specs, chromium): 72 passed, 2 skipped; the MCP stdio handshake and `tools/list` return the same 24 tools; `tests/library` `browsertype-basic`, `browsertype-connect` and `global-fetch` (chromium): 183 passed, 12 skipped.

A couple of things I'd like your view on:

- Is the getter proxy for `tools` ok, or would you rather an explicit `loadTools()`? The proxy keeps the `packages/playwright` call sites untouched, but `Object.keys(tools)` is now empty (nothing in the repo enumerates it).
- The split is done via the mapping's new `bundle` field rather than a second mapping file, which felt like the smallest change to the build; happy to reshape it if you'd rather the MCP bits lived elsewhere.
- What still initializes eagerly on `run-driver` is commander registration itself and the yaml/pngjs/ws/colors CJS deps that a few core modules read at init; lazy getters in `utilsBundle.ts` would cover those, so that could be a follow-up if this direction is welcome.

Disclosure: this change was made with AI assistance (Claude), I've reviewed the diff and the measurements and testing above are mine.
