### PR TITLE
fix(har): do not report zero sizes for bodies that were never read

### DIFF
--- a/packages/playwright-core/src/server/har/harTracer.ts
+++ b/packages/playwright-core/src/server/har/harTracer.ts
@@ -265,9 +265,12 @@ export class HarTracer {
     const contentType = event.headers['content-type'];
     if (contentType)
       content.mimeType = contentType;
-    this._storeResponseContent(event.body, content, 'other');
-    if (!this._options.omitSizes)
-      harEntry.response.bodySize = event.body?.length ?? 0;
+    // Keep the size as -1 "not available" when we did not actually read the body.
+    if (event.body) {
+      this._storeResponseContent(event.body, content, 'other');
+      if (!this._options.omitSizes)
+        harEntry.response.bodySize = event.body.length;
+    }
 
     if (this._started)
       this._delegate.onEntryFinished(harEntry);
@@ -541,12 +544,7 @@ export class HarTracer {
       this._delegate.onEntryStarted(harEntry);
   }
 
-  private _storeResponseContent(buffer: Buffer | undefined, content: har.Content, resourceType: string) {
-    if (!buffer) {
-      content.size = 0;
-      return;
-    }
-
+  private _storeResponseContent(buffer: Buffer, content: har.Content, resourceType: string) {
     if (!this._options.omitSizes)
       content.size = buffer.length;
 

--- a/tests/library/har.spec.ts
+++ b/tests/library/har.spec.ts
@@ -880,7 +880,8 @@ it('should include redirects from API request', async ({ contextFactory, server 
   const [redirect, json] = log.entries;
   expect(redirect.request.url).toBe(server.PREFIX + '/redirect-me');
   expect(json.request.url).toBe(server.PREFIX + '/simple.json');
-
+  expect(redirect.response.bodySize).toBe(-1);
+  expect(redirect.response.content.size).toBe(-1);
   expect(redirect.timings).toBeDefined();
   expect(json.timings).toBeDefined();
 });


### PR DESCRIPTION
## Summary
- `APIRequestContext` destroys the request on a redirect and on the 401 basic-auth retry before reading the body, so the har tracer recorded `bodySize`/`content.size` as `0` for those hops, contradicting the `Content-Length` header in the same entry.
- Keep the `-1` "not available" sentinel instead, matching what the browser path already does.

Fixes https://github.com/microsoft/playwright/issues/42370