### PR TITLE
docs(network): use lower-cased header name in delete header samples

### DIFF
--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -484,7 +484,7 @@ await page.GotoAsync("https://example.com");
 // Delete header
 await page.route('**/*', async route => {
   const headers = route.request().headers();
-  delete headers['X-Secret'];
+  delete headers['x-secret'];
   await route.continue({ headers });
 });
 
@@ -496,7 +496,7 @@ await page.route('**/*', route => route.continue({ method: 'POST' }));
 // Delete header
 page.route("**/*", route -> {
   Map<String, String> headers = new HashMap<>(route.request().headers());
-  headers.remove("X-Secret");
+  headers.remove("x-secret");
     route.resume(new Route.ResumeOptions().setHeaders(headers));
 });
 
@@ -532,7 +532,7 @@ page.route("**/*", lambda route: route.continue_(method="POST"))
 // Delete header
 await page.RouteAsync("**/*", async route => {
     var headers = new Dictionary<string, string>(route.Request.Headers.ToDictionary(x => x.Key, x => x.Value));
-    headers.Remove("X-Secret");
+    headers.Remove("x-secret");
     await route.ContinueAsync(new() { Headers = headers });
 });
 


### PR DESCRIPTION
## Summary
- `request.headers()` returns lower-cased header names, so `X-Secret` never matches and the "Delete header" samples for JavaScript, Java and C# silently leave the header in place instead of removing it.
- Lowercased the key in those three samples so they do what the surrounding text says. The Python samples already used the lower-cased name.