### PR TITLE
docs: clarify PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT is an idle timeout

### DIFF
--- a/docs/src/browsers.md
+++ b/docs/src/browsers.md
@@ -671,7 +671,7 @@ set NODE_EXTRA_CA_CERTS="C:\certs\root.crt"
 $Env:NODE_EXTRA_CA_CERTS="C:\certs\root.crt"
 ```
 
-If your network is slow to connect to Playwright browser archive, you can increase the connection timeout in milliseconds with `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` environment variable:
+If the browser archive download is slow or stalls, you can increase the download socket timeout in milliseconds with the `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` environment variable. Despite its name this is an idle timeout rather than a connection timeout; it limits how long the download may go without receiving data, and defaults to 30 seconds:
 
 ```bash tab=bash-bash lang=js
 PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000 npx playwright install


### PR DESCRIPTION
`docs/src/browsers.md` calls this variable a connection timeout. The codebase stopped calling it that in #35583, "chore: rename \*ConnectionTimeout to \*SocketTimeout", whose body is "This is to avoid confusion in our codebase." That rename touched three files under `registry/` and left the docs sentence behind, so the confusion it removed from the codebase is still in the documentation.

`packages/playwright-core/src/server/registry/index.ts`:

```ts
// PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT is a misnomer, it actually controls the socket's
// max idle timeout. Unfortunately, we cannot rename it without breaking existing user workflows.
```

It reaches the transfer as `request.setTimeout(...)` in `packages/utils/network.ts` and falls back to `NET_DEFAULT_TIMEOUT = 30_000` when unset. `tests/installation/playwright-cdn.spec.ts` exercises it in exactly that shape: `playwright cdn should race with a timeout` points the download at an `http.createServer(() => {})` that accepts and never answers, and `npx playwright install should not hang when CDN TCP connection stalls` at a server that writes the headers plus one byte and then stops. Both are established connections going idle, and neither is a connect that fails.

The review on #28698 suggested "the connection and idle timeout". This says idle only, because the connect phase is not covered: `request.setTimeout` is handed to the socket once it is connected, so while an agent has not yet produced a connected socket there is nothing for the timer to be armed on.

### why this sentence is worth a PR

It was reported as #28619 and closed with "we consider this a documentation problem. If you would like to issue a PR which clarifies the environment variable, feel free to do so." #28698 followed, picked up a suggested wording in review, and was closed; the sentence was never changed and reads the same on `main` today.

It is still costing triage. #42597, opened this week, sets the variable to 120000, watches every download attempt fail at 21 s, and reports it as a 1.63.0 regression. The failure there is an unroutable proxy address, but the reason the variable looked like the fix is this sentence.

The change keeps the variable name and every example untouched and only says what the variable does, with the 30 s default named so the number is not a mystery.

Per CONTRIBUTING this is a minor documentation fix, which is the stated exception to the linked-issue requirement, and #28619 carries an explicit invitation to send it.
