### PR TITLE
fix(mcp): use bundled Chromium for --browser chromium

### DIFF
--- a/packages/playwright-core/src/tools/mcp/config.ts
+++ b/packages/playwright-core/src/tools/mcp/config.ts
@@ -279,7 +279,7 @@ function resolveBrowserParam(browserOption: string | undefined): { browserName?:
     case 'msedge-dev':
       return { browserName: 'chromium', channel: browserOption };
     case 'chromium':
-      return { browserName: 'chromium', channel: 'chrome-for-testing' };
+      return { browserName: 'chromium' };
     case 'firefox':
       return { browserName: 'firefox' };
     case 'moz-firefox':

--- a/packages/playwright-core/src/tools/mcp/program.ts
+++ b/packages/playwright-core/src/tools/mcp/program.ts
@@ -37,7 +37,7 @@ export function decorateMCPCommand(command: Command) {
       .option('--allow-unrestricted-file-access', 'allow access to files outside of the workspace roots. Also allows unrestricted access to file:// URLs. By default access to file system is restricted to workspace root directories (or cwd if no roots are configured) only, and navigation to file:// URLs is blocked.')
       .option('--blocked-origins <origins>', 'semicolon-separated list of origins to block the browser from requesting. Blocklist is evaluated before allowlist. If used without the allowlist, requests not matching the blocklist are still allowed.\nImportant: *does not* serve as a security boundary and *does not* affect redirects.', semicolonSeparatedList)
       .option('--block-service-workers', 'block service workers')
-      .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, firefox, webkit, msedge.')
+      .option('--browser <browser>', 'browser or chrome channel to use, possible values: chrome, chromium, firefox, webkit, msedge.')
       .option('--caps <caps>', 'comma-separated list of additional capabilities to enable, possible values: vision, pdf, devtools.', commaSeparatedList)
       .option('--cdp-endpoint <endpoint>', 'CDP endpoint to connect to.')
       .option('--cdp-header <headers...>', 'CDP headers to send with the connect request, multiple can be specified.', headerParser)

--- a/tests/mcp/config-resolve.spec.ts
+++ b/tests/mcp/config-resolve.spec.ts
@@ -55,10 +55,10 @@ test.describe('browserName and channel', () => {
     expect(config.browser.launchOptions.channel).toBe('chrome');
   });
 
-  test('--browser=chromium sets chromium with chrome-for-testing channel', async () => {
+  test('--browser=chromium sets chromium without channel', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chromium' }, emptyEnv);
     expect(config.browser.browserName).toBe('chromium');
-    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
   });
 
   test('--browser=firefox sets firefox without channel', async () => {
@@ -148,9 +148,9 @@ test.describe('sandbox', () => {
     expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 
-  test('chromium sandbox for chrome-for-testing channel', async () => {
+  test('chromium sandbox for bundled chromium (no channel)', async () => {
     const config = await resolveCLIConfigForMCP({ browser: 'chromium' }, emptyEnv);
-    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
     if (process.platform === 'linux')
       expect(config.browser.launchOptions.chromiumSandbox).toBe(false);
     else
@@ -187,7 +187,7 @@ test.describe('sandbox', () => {
 
   test('--sandbox on the command line enables the sandbox', async () => {
     const config = await resolveCLIConfigForMCP(await parseCLIOptions(['--browser=chromium', '--sandbox']), emptyEnv);
-    expect(config.browser.launchOptions.channel).toBe('chrome-for-testing');
+    expect(config.browser.launchOptions.channel).toBeUndefined();
     expect(config.browser.launchOptions.chromiumSandbox).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- `--browser chromium` currently sets `channel: 'chrome-for-testing'`, but that channel is not registered as a launchable executable in the browser registry — it only exists as an alias for `playwright install`. This causes a runtime error: `Chromium distribution 'chrome' is not found at /opt/google/chrome/chrome`
- Fix: drop the channel entirely so Playwright uses the bundled Chromium binary directly (same pattern as `--browser firefox`)
- Add `chromium` to the `--browser` help text, which previously omitted it

## Changes

- `packages/playwright-core/src/tools/mcp/config.ts` — remove `channel: 'chrome-for-testing'` from the chromium case in `resolveBrowserParam()`
- `packages/playwright-core/src/tools/mcp/program.ts` — add `chromium` to valid values in help text
- `tests/mcp/config-resolve.spec.ts` — update 3 tests to expect no channel for chromium

## Test plan

- [x] Verified locally: `--browser chromium` launches bundled Chromium without error
- [x] Navigated to multiple sites (example.com, youtube.com, facebook.com) successfully
- [ ] Upstream test suite (`config-resolve.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)