### PR TITLE
feat(test runner): expose filteredProjects on FullConfig

### DIFF
--- a/docs/src/test-api/class-fullconfig.md
+++ b/docs/src/test-api/class-fullconfig.md
@@ -27,6 +27,12 @@ Path to the configuration file used to run the tests. The value is an empty stri
 
 See [`property: TestConfig.failOnFlakyTests`].
 
+## property: FullConfig.filteredProjects
+* since: v1.64
+- type: <[Array]<[FullProject]>>
+
+List of projects that were selected to run, after applying the `--project` command line filter. When no filter is specified, this is the same as [`property: FullConfig.projects`].
+
 ## property: FullConfig.forbidOnly
 * since: v1.10
 - type: <[boolean]>

--- a/packages/playwright/src/common/config.ts
+++ b/packages/playwright/src/common/config.ts
@@ -99,6 +99,7 @@ export class FullConfigInternal {
       metadata: metadata ?? userConfig.metadata,
       preserveOutput: takeFirst(userConfig.preserveOutput, 'always'),
       projects: [],
+      filteredProjects: [],
       quiet: takeFirst(configCLIOverrides.quiet, userConfig.quiet, false),
       reporter: [...takeFirst(configCLIOverrides.reporter, resolveReporters(userConfig.reporter, configDir), [[defaultReporter]]), ...(configCLIOverrides.additionalReporters ?? [])],
       reportSlowTests: takeFirst(userConfig.reportSlowTests, { max: 5, threshold: 300_000 /* 5 minutes */ }),
@@ -135,6 +136,7 @@ export class FullConfigInternal {
     resolveProjectDependencies(this.projects);
     this._assignUniqueProjectIds(this.projects);
     this.config.projects = this.projects.map(p => p.project);
+    this.config.filteredProjects = this.config.projects;
   }
 
   private _assignUniqueProjectIds(projects: FullProjectInternal[]) {

--- a/packages/playwright/src/isomorphic/teleReceiver.ts
+++ b/packages/playwright/src/isomorphic/teleReceiver.ts
@@ -825,6 +825,7 @@ export const baseFullConfig: reporterTypes.FullConfig = {
   metadata: {},
   preserveOutput: 'always',
   projects: [],
+  filteredProjects: [],
   reporter: [[process.env.CI ? 'dot' : 'list']],
   reportSlowTests: { max: 5, threshold: 300_000 /* 5 minutes */ },
   configFile: '',

--- a/packages/playwright/src/runner/tasks.ts
+++ b/packages/playwright/src/runner/tasks.ts
@@ -99,6 +99,7 @@ export class TestRun {
     this.options = options ?? {};
     this.reporter = reporter;
     this.filteredProjects = filterProjects(config.projects, this.options.projectFilter);
+    config.config.filteredProjects = this.filteredProjects.map(p => p.project);
   }
 
   onTestPaused(params: TestPausedParams) {

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2069,6 +2069,13 @@ export interface FullConfig<TestArgs = {}, WorkerArgs = {}> {
   failOnFlakyTests: boolean;
 
   /**
+   * List of projects that were selected to run, after applying the `--project` command line filter. When no filter is
+   * specified, this is the same as
+   * [fullConfig.projects](https://playwright.dev/docs/api/class-fullconfig#full-config-projects).
+   */
+  filteredProjects: Array<FullProject>;
+
+  /**
    * See [testConfig.forbidOnly](https://playwright.dev/docs/api/class-testconfig#test-config-forbid-only).
    */
   forbidOnly: boolean;

--- a/tests/playwright-test/global-setup.spec.ts
+++ b/tests/playwright-test/global-setup.spec.ts
@@ -489,3 +489,38 @@ test('globalSetup and globalTeardown should have PLAYWRIGHT_TEST=1', async ({ ru
     'teardown env=1',
   ]);
 });
+
+test('globalSetup should see filtered projects', async ({ runInlineTest }) => {
+  const files = {
+    'playwright.config.ts': `
+      module.exports = {
+        globalSetup: './globalSetup',
+        projects: [{ name: 'p1' }, { name: 'p2' }, { name: 'p3' }],
+      };
+    `,
+    'globalSetup.ts': `
+      module.exports = async (config) => {
+        console.log('\\n%%projects=' + config.projects.map(p => p.name).join(','));
+        console.log('\\n%%filteredProjects=' + config.filteredProjects.map(p => p.name).join(','));
+      };
+    `,
+    'a.test.js': `
+      import { test, expect } from '@playwright/test';
+      test('should work', async ({}) => {});
+    `,
+  };
+
+  const result = await runInlineTest(files, { project: ['p1', 'p3'] });
+  expect(result.exitCode).toBe(0);
+  expect(result.outputLines).toEqual([
+    'projects=p1,p2,p3',
+    'filteredProjects=p1,p3',
+  ]);
+
+  const result2 = await runInlineTest(files);
+  expect(result2.exitCode).toBe(0);
+  expect(result2.outputLines).toEqual([
+    'projects=p1,p2,p3',
+    'filteredProjects=p1,p2,p3',
+  ]);
+});


### PR DESCRIPTION
## Summary
- Adds `FullConfig.filteredProjects`, the list of projects that remain after applying the `--project` filter.
- Populated in `TestRun` right after filtering, so global setup and reporters can see which projects will actually run.

Fixes https://github.com/microsoft/playwright/issues/14031
Fixes https://github.com/microsoft/playwright/issues/13648
Fixes https://github.com/microsoft/playwright/issues/13643
Fixes https://github.com/microsoft/playwright/issues/16008
Fixes https://github.com/microsoft/playwright/issues/36847
Partially addresses https://github.com/microsoft/playwright/issues/38965