### PR TITLE
fix(mcp): reject Windows reserved names in output files

### DIFF
--- a/packages/playwright-core/src/tools/backend/context.ts
+++ b/packages/playwright-core/src/tools/backend/context.ts
@@ -22,7 +22,7 @@ import debug from 'debug';
 import { escapeWithQuotes } from '@isomorphic/stringUtils';
 import { disposeAll } from '@isomorphic/disposable';
 import { eventsHelper } from '@utils/eventsHelper';
-import { isPathInside, isSystemDirectory, isWritable } from '@utils/fileUtils';
+import { isPathInside, isSystemDirectory, isWritable, outputFilenameError } from '@utils/fileUtils';
 import { playwright } from '../../inprocess';
 
 import { dedent, languageGeneratorId, secretCode } from './codegen';
@@ -437,6 +437,9 @@ function originOrHostGlob(originOrHost: string) {
 
 export async function workspaceFile(options: ContextOptions, fileName: string, perCallWorkspaceDir?: string): Promise<string> {
   const workspace = perCallWorkspaceDir ?? options.cwd;
+  const invalid = outputFilenameError(fileName);
+  if (invalid)
+    throw new Error(invalid);
   const resolvedName = path.resolve(workspace, fileName);
   await checkFile(options, resolvedName, { origin: 'llm' });
   return resolvedName;
@@ -452,6 +455,11 @@ export function outputDir(options: ContextOptions): string {
 }
 
 export async function outputFile(options: ContextOptions, fileName: string, flags: { origin: 'code' | 'llm' }): Promise<string> {
+  if (flags.origin === 'llm') {
+    const invalid = outputFilenameError(fileName);
+    if (invalid)
+      throw new Error(invalid);
+  }
   const resolvedFile = path.resolve(outputDir(options), fileName);
   await checkFile(options, resolvedFile, flags);
   await fs.promises.mkdir(path.dirname(resolvedFile), { recursive: true });
@@ -464,7 +472,6 @@ async function checkFile(options: ContextOptions, resolvedFilename: string, flag
   if (flags.origin === 'code' || options.config.allowUnrestrictedFileAccess || options.config.skillMode)
     return;
 
-  // Trust llm to use valid characters in file names.
   const output = outputDir(options);
   const workspace = options.cwd;
   if (!isPathInside(output, resolvedFilename) && !isPathInside(workspace, resolvedFilename))

--- a/packages/utils/fileUtils.ts
+++ b/packages/utils/fileUtils.ts
@@ -78,6 +78,22 @@ export function sanitizeForFilePath(s: string) {
   return s.replace(/[\x00-\x2C\x2E-\x2F\x3A-\x40\x5B-\x60\x7B-\x7F]+/g, '-');
 }
 
+// DOS device names, with or without an extension. Windows maps these to devices
+// (NUL.png writes to the NUL device) instead of keeping the path the caller asked for.
+const WINDOWS_RESERVED_DEVICE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i;
+
+export function outputFilenameError(fileName: string): string | undefined {
+  for (const part of fileName.split(/[\\/]/)) {
+    if (!part || part === '.' || part === '..')
+      continue;
+    if (WINDOWS_RESERVED_DEVICE.test(part))
+      return `Invalid output file name: '${fileName}' uses reserved device name '${part}'`;
+    if (/[. ]$/.test(part))
+      return `Invalid output file name: '${fileName}' would not be stored verbatim on Windows`;
+  }
+  return undefined;
+}
+
 export function trimLongString(s: string, length = 100) {
   if (s.length <= length)
     return s;

--- a/tests/mcp/screenshot.spec.ts
+++ b/tests/mcp/screenshot.spec.ts
@@ -246,6 +246,39 @@ test('browser_take_screenshot (filename: "output.png")', async ({ client, server
   expect(files[0]).toMatch(/^output\.png$/);
 });
 
+test('browser_take_screenshot rejects Windows reserved filenames', async ({ client, server }) => {
+  expect(await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  })).toHaveResponse({
+    code: expect.stringContaining(`page.goto('http://localhost`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: { filename: 'NUL.png' },
+  })).toHaveResponse({
+    isError: true,
+    error: expect.stringContaining(`reserved device name`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: { filename: 'sub/CON.txt' },
+  })).toHaveResponse({
+    isError: true,
+    error: expect.stringContaining(`reserved device name`),
+  });
+
+  expect(await client.callTool({
+    name: 'browser_take_screenshot',
+    arguments: { filename: 'output.png ' },
+  })).toHaveResponse({
+    isError: true,
+    error: expect.stringContaining(`would not be stored verbatim on Windows`),
+  });
+});
+
 test('browser_take_screenshot (filename: "sub/dir/output.png")', async ({ client, server }, testInfo) => {
   expect(await client.callTool({
     name: 'browser_navigate',


### PR DESCRIPTION
Related to #42496 (the reserved-name half; the no-clobber option is a separate design choice).

## problem

A named MCP output file is written with the caller’s string as-is. On Windows, `NUL.png` is the NUL device, and a trailing dot or space is stripped by the filesystem, so the bytes land under a different name than the tool reported.

`checkFile` already keeps LLM paths inside the workspace / output roots. It did not check whether the name would be stored verbatim.

## fix

Reject those names before `path.resolve`, for LLM-origin output (`workspaceFile`, and `outputFile` when `origin === 'llm'`):

- DOS device names as any path component (`NUL.png`, `sub/CON.txt`, `COM1`, `LPT9.log`, …)
- a trailing space or dot on any component (`output.png `)

Code-origin auto names are unchanged. The no-clobber option from #42496 is not in this patch.

## test

`browser_take_screenshot rejects Windows reserved filenames` in `tests/mcp/screenshot.spec.ts`.

```
npx playwright install chromium
npm run test-mcp -- --project=chromium screenshot.spec.ts -g reserved
```

1 passed on Windows.

Existing `filename: "output.png"` / `"sub/dir/output.png"` cases still pass.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i reproduced the windows reserved-name behaviour against the MCP write path, matched `Path` component checks to what `checkFile` already does for roots, and ran the mcp screenshot tests locally before opening this.
