### PR TITLE
docs: fix broken hydration wikipedia link

### DIFF
--- a/docs/src/navigations.md
+++ b/docs/src/navigations.md
@@ -105,7 +105,7 @@ resources loaded, etc.
 At some point in time, you'll stumble upon a use case where Playwright performs
 an action, but nothing seemingly happens. Or you enter some text into the input
 field and it will disappear. The most probable reason behind that is a poor page
-[hydration](https://en.wikipedia.org/wiki/Hydration_(web_development)).
+[hydration](https://en.wikipedia.org/wiki/Hydration_%28web_development%29).
 
 When page is hydrated, first, a static version of the page is sent to the browser.
 Then the dynamic part is sent and the page becomes "live". As a very fast user,


### PR DESCRIPTION
## Summary
- The Wikipedia link in the Hydration section of `docs/src/navigations.md` has an unescaped closing parenthesis, which breaks Markdown link parsing — the rendered page shows a stray `).` right after the link instead of it being part of the URL.
- Fixed by percent-encoding the parentheses in the URL (`%28`/`%29`), which is the standard workaround for parens inside Markdown link targets.

This is a minor documentation fix, exempt from the linked-issue requirement per CONTRIBUTING.md.

## Test plan
- [x] Verified the broken rendering on the live page at https://playwright.dev/docs/navigations (Hydration section)
- [x] Confirmed the new URL resolves correctly