### PR TITLE
fix(chromium): re-apply touch emulation after screenshot beyond viewport

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -296,7 +296,7 @@ export class CRPage implements PageDelegate {
     const result = await progress.race(this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip, captureBeyondViewport: !fitsViewport }));
     if (!fitsViewport && this._browserContext._options.hasTouch) {
       // Capturing beyond viewport resets touch emulation in Chromium, so we re-apply it.
-      // See https://github.com/microsoft/playwright/issues/42607.
+      // See https://issues.chromium.org/issues/558509412 and https://github.com/microsoft/playwright/issues/42607.
       await progress.race(this._mainFrameSession._client.send('Emulation.setTouchEmulationEnabled', { enabled: true }));
     }
     return Buffer.from(result.data, 'base64');

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -294,6 +294,11 @@ export class CRPage implements PageDelegate {
       clip.scale /= deviceScaleFactor;
     }
     const result = await progress.race(this._mainFrameSession._client.send('Page.captureScreenshot', { format, quality, clip, captureBeyondViewport: !fitsViewport }));
+    if (!fitsViewport && this._browserContext._options.hasTouch) {
+      // Capturing beyond viewport resets touch emulation in Chromium, so we re-apply it.
+      // See https://github.com/microsoft/playwright/issues/42607.
+      await progress.race(this._mainFrameSession._client.send('Emulation.setTouchEmulationEnabled', { enabled: true }));
+    }
     return Buffer.from(result.data, 'base64');
   }
 

--- a/tests/library/browsercontext-viewport.spec.ts
+++ b/tests/library/browsercontext-viewport.spec.ts
@@ -129,6 +129,28 @@ browserTest('should support touch with null viewport', async ({ browser, server 
   await context.close();
 });
 
+browserTest('should keep touch emulation after screenshot beyond viewport', async ({ browser, server }) => {
+  browserTest.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42607' });
+  const context = await browser.newContext({ viewport: { width: 393, height: 727 }, hasTouch: true });
+  const page = await context.newPage();
+  await page.goto(server.EMPTY_PAGE);
+  await page.setContent(`<div id="tall" style="height:3000px">tall</div>`);
+  const probe = () => page.evaluate(() => ({
+    ontouchstart: 'ontouchstart' in window,
+    maxTouchPoints: navigator.maxTouchPoints,
+    coarse: matchMedia('(pointer: coarse)').matches,
+  }));
+  const expected = await probe();
+  expect(expected.ontouchstart).toBe(true);
+  await page.screenshot({ fullPage: true });
+  expect(await probe()).toEqual(expected);
+  await page.locator('#tall').screenshot();
+  expect(await probe()).toEqual(expected);
+  await page.goto(server.EMPTY_PAGE);
+  expect(await probe()).toEqual(expected);
+  await context.close();
+});
+
 it('should set both screen and viewport options', async ({ contextFactory, browserName, isBidi }) => {
   const context = await contextFactory({
     screen: { 'width': 1280, 'height': 720 },


### PR DESCRIPTION
## Summary
- Chromium's `Page.captureScreenshot` with `captureBeyondViewport: true` pushes WebPreferences, and Blink's `ApplyWebPreferences` overwrites the emulated `max_touch_points`, so `navigator.maxTouchPoints` drops to 0 after any full-page or beyond-viewport element screenshot.
- Re-send `Emulation.setTouchEmulationEnabled` after such a capture when the context has `hasTouch`.
- Workaround until https://issues.chromium.org/issues/558509412 is fixed upstream.

Fixes https://github.com/microsoft/playwright/issues/42607