### PR TITLE
feat(test-runner): support read and read-write lock modes

### DIFF
--- a/docs/src/test-api/class-test.md
+++ b/docs/src/test-api/class-test.md
@@ -100,6 +100,19 @@ test('update user settings', {
 });
 ```
 
+Tests that only read the shared resource can hold the lock in `'read'` mode. Any number of such tests run at the same time, but never together with a test holding the same lock in the default `'read-write'` mode.
+
+```js
+import { test, expect } from '@playwright/test';
+
+test('show user settings', {
+  lock: { name: 'user-settings', mode: 'read' },
+}, async ({ page }) => {
+  // This test runs concurrently with other 'read' holders,
+  // but never with 'update user settings' above.
+});
+```
+
 Learn more about [test locks](../test-parallel.md#test-locks).
 
 ### param: Test.(call).title
@@ -115,7 +128,9 @@ Test title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]> Annotation type, for example `'issue'`.
     - `description` ?<[string]> Optional annotation description, for example an issue url.
-  - `lock` ?<[string]|[Array]<[string]>>
+  - `lock` ?<[string]|[Object]|[Array]<[string]|[Object]>>
+    - `name` <[string]> Lock name.
+    - `mode` ?<[LockMode]<"read"|"read-write">> Lock mode. Any number of tests can hold the lock in `'read'` mode at the same time, while a test holding it in `'read-write'` mode runs alone. Defaults to `'read-write'`. A lock given as a string is equivalent to `{ name, mode: 'read-write' }`.
 
 Additional test details.
 
@@ -478,7 +493,9 @@ Group title.
   - `annotation` ?<[Object]|[Array]<[Object]>>
     - `type` <[string]>
     - `description` ?<[string]>
-  - `lock` ?<[string]|[Array]<[string]>>
+  - `lock` ?<[string]|[Object]|[Array]<[string]|[Object]>>
+    - `name` <[string]> Lock name.
+    - `mode` ?<[LockMode]<"read"|"read-write">> Lock mode. Any number of tests can hold the lock in `'read'` mode at the same time, while a test holding it in `'read-write'` mode runs alone. Defaults to `'read-write'`. A lock given as a string is equivalent to `{ name, mode: 'read-write' }`.
 
 Additional details for all tests in the group.
 

--- a/docs/src/test-parallel-js.md
+++ b/docs/src/test-parallel-js.md
@@ -157,6 +157,37 @@ test('reset the database', { lock: ['database', 'external-api'] }, async () => {
 
 Playwright acquires all the locks of a test before the test starts and releases them when it finishes.
 
+### Lock modes
+
+By default, a lock is held in `'read-write'` mode, which means that the test runs alone. When a test only reads the shared resource, declare the lock with `mode: 'read'`. Any number of tests can hold a lock in `'read'` mode at the same time, but none of them runs while a test holds the same lock in `'read-write'` mode.
+
+```js
+// Runs alone, since the default mode is 'read-write'.
+test('change color scheme', { lock: 'application-settings' }, async ({ page }) => {
+  // ...
+});
+
+// Runs at the same time as other 'read' holders,
+// but never with 'change color scheme' above.
+test('show color scheme', {
+  lock: { name: 'application-settings', mode: 'read' },
+}, async ({ page }) => {
+  // ...
+});
+
+// Modes can be mixed across multiple locks.
+test('sync settings', {
+  lock: [
+    { name: 'application-settings', mode: 'read-write' },
+    { name: 'vendor-api', mode: 'read' },
+  ],
+}, async ({ page }) => {
+  // ...
+});
+```
+
+Once a test is waiting to acquire a lock in `'read-write'` mode, tests declared after it do not acquire the same lock in `'read'` mode, so that a steady stream of readers does not delay the writer indefinitely.
+
 :::note
 In the default and [serial](#serial-mode) modes, all tests in a file run together in order, so a lock declared on any test is held for the duration of the whole file.
 :::

--- a/packages/isomorphic/jsonSchema.ts
+++ b/packages/isomorphic/jsonSchema.ts
@@ -30,17 +30,22 @@ export function validate(value: unknown, schema: JsonSchema, path: string): stri
   const errors: string[] = [];
 
   if (schema.oneOf) {
+    const isTypeMismatch = (errors: string[]) => errors.length === 1 && errors[0].startsWith(`${path}: expected `);
     let bestErrors: string[] | undefined;
+    let bestScore = Infinity;
     for (const variant of schema.oneOf) {
       const variantErrors = validate(value, variant, path);
       if (variantErrors.length === 0)
         return [];
-      // Prefer the variant with fewest errors (closest match).
-      if (!bestErrors || variantErrors.length < bestErrors.length)
+      // Prefer the variant with fewest errors (closest match), a top-level type mismatch is the farthest.
+      const score = isTypeMismatch(variantErrors) ? Infinity : variantErrors.length;
+      if (!bestErrors || score < bestScore) {
         bestErrors = variantErrors;
+        bestScore = score;
+      }
     }
     // If the best match has only top-level type mismatches, use a generic message.
-    if (bestErrors!.length === 1 && bestErrors![0].startsWith(`${path}: expected `))
+    if (isTypeMismatch(bestErrors!))
       return [`${path}: does not match any of the expected types`];
     return bestErrors!;
   }

--- a/packages/playwright/src/common/test.ts
+++ b/packages/playwright/src/common/test.ts
@@ -41,6 +41,11 @@ export type Modifier = {
   description: string | undefined
 };
 
+export type TestLock = {
+  name: string;
+  mode: 'read' | 'read-write';
+};
+
 export class Suite extends Base {
   location?: Location;
   parent?: Suite;
@@ -53,7 +58,7 @@ export class Suite extends Base {
   _staticAnnotations: TestAnnotation[] = [];
   // Explicitly declared tags that are not a part of the title.
   _tags: string[] = [];
-  _locks: string[] = [];
+  _locks: TestLock[] = [];
   _modifiers: Modifier[] = [];
   _parallelMode: 'none' | 'default' | 'serial' | 'parallel' = 'none';
   _fullProject: FullProjectInternal | undefined;
@@ -286,7 +291,7 @@ export class TestCase extends Base implements reporterTypes.TestCase {
   _projectId = '';
   // Explicitly declared tags that are not a part of the title.
   _tags: string[] = [];
-  _locks: string[] = [];
+  _locks: TestLock[] = [];
   _planAnnotations: TestAnnotation[] = [];
 
   constructor(title: string, fn: Function, testType: TestTypeImpl, location: Location) {

--- a/packages/playwright/src/common/validators.ts
+++ b/packages/playwright/src/common/validators.ts
@@ -17,7 +17,8 @@
 import { validate } from '@isomorphic/jsonSchema';
 
 import type { JsonSchema } from '@isomorphic/jsonSchema';
-import type { TestDetailsAnnotation } from '../../types/test';
+import type { TestLock } from './test';
+import type { TestDetailsAnnotation, TestDetailsLock } from '../../types/test';
 import type { Location } from '../../types/testReporter';
 
 const testAnnotationSchema: JsonSchema = {
@@ -27,6 +28,15 @@ const testAnnotationSchema: JsonSchema = {
     description: { type: 'string' },
   },
   required: ['type'],
+};
+
+const testLockSchema: JsonSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    mode: { type: 'string', pattern: '^(read|read-write)$', patternError: "Lock mode must be 'read' or 'read-write'" },
+  },
+  required: ['name'],
 };
 
 const testDetailsSchema: JsonSchema = {
@@ -46,8 +56,9 @@ const testDetailsSchema: JsonSchema = {
     },
     lock: {
       oneOf: [
+        testLockSchema,
         { type: 'string' },
-        { type: 'array', items: { type: 'string' } },
+        { type: 'array', items: { oneOf: [testLockSchema, { type: 'string' }] } },
       ]
     },
   },
@@ -56,7 +67,7 @@ const testDetailsSchema: JsonSchema = {
 type ValidTestDetails = {
   tags: string[];
   annotations: (TestDetailsAnnotation & { location: Location })[];
-  locks: string[];
+  locks: TestLock[];
   location: Location;
 };
 
@@ -72,8 +83,12 @@ export function validateTestDetails(details: unknown, location: Location): Valid
   const annotation = obj.annotation;
   const annotations: TestDetailsAnnotation[] = annotation === undefined ? [] : Array.isArray(annotation) ? annotation : [annotation as TestDetailsAnnotation];
 
-  const lock = obj.lock;
-  const locks: string[] = lock === undefined ? [] : typeof lock === 'string' ? [lock] : lock as string[];
+  const lock = obj.lock as string | TestDetailsLock | (string | TestDetailsLock)[] | undefined;
+  const locks: TestLock[] = (lock === undefined ? [] : Array.isArray(lock) ? lock : [lock]).map(lock => {
+    if (typeof lock === 'string')
+      return { name: lock, mode: 'read-write' };
+    return { name: lock.name, mode: lock.mode ?? 'read-write' };
+  });
 
   return {
     annotations: annotations.map(a => ({ ...a, location })),

--- a/packages/playwright/src/runner/dispatcher.ts
+++ b/packages/playwright/src/runner/dispatcher.ts
@@ -58,25 +58,41 @@ export class Dispatcher {
     }
   }
 
-  private _heldLocks(): Set<string> {
-    const heldLocks = new Set<string>();
+  private _heldLocks(): Map<string, testNs.TestLock['mode']> {
+    const heldLocks = new Map<string, testNs.TestLock['mode']>();
     for (const slot of this._workerSlots) {
-      for (const lock of slot.jobDispatcher?.job.locks || [])
-        heldLocks.add(lock);
+      for (const lock of slot.jobDispatcher?.job.locks || []) {
+        if (lock.mode === 'read-write' || !heldLocks.has(lock.name))
+          heldLocks.set(lock.name, lock.mode);
+      }
     }
     return heldLocks;
   }
 
   private _findFirstJobToRun() {
     const heldLocks = this._heldLocks();
+    // Read locks are not granted ahead of an earlier queued job waiting for the same lock in read-write mode.
+    const reservedLocks = new Set<string>();
+    const isLockAvailable = (lock: testNs.TestLock) => {
+      const heldMode = heldLocks.get(lock.name);
+      if (lock.mode === 'read-write')
+        return !heldMode;
+      return heldMode !== 'read-write' && !reservedLocks.has(lock.name);
+    };
     // Always pick the first job that can be run while respecting the project worker limit.
     for (let index = 0; index < this._queue.length; index++) {
       const job = this._queue[index];
       // Isolated retries only run one at a time, after all other jobs have finished.
       if (this._isolatedJobs.has(job) && this._workerSlots.some(w => !!w.jobDispatcher))
         continue;
-      if (job.locks.some(lock => heldLocks.has(lock)))
+      const unavailableLocks = job.locks.filter(lock => !isLockAvailable(lock));
+      if (unavailableLocks.length) {
+        for (const lock of unavailableLocks) {
+          if (lock.mode === 'read-write')
+            reservedLocks.add(lock.name);
+        }
         continue;
+      }
       const projectIdWorkerLimit = this._workerLimitPerProjectId.get(job.projectId);
       if (!projectIdWorkerLimit)
         return index;

--- a/packages/playwright/src/runner/testGroups.ts
+++ b/packages/playwright/src/runner/testGroups.ts
@@ -22,7 +22,7 @@ export type TestGroup = {
   repeatEachIndex: number;
   projectId: string;
   tests: test.TestCase[];
-  locks: string[];
+  locks: test.TestLock[];
 };
 
 export function createTestGroups(projectSuite: test.Suite, expectedParallelism: number): TestGroup[] {
@@ -131,12 +131,14 @@ export function createTestGroups(projectSuite: test.Suite, expectedParallelism: 
   }
 
   for (const group of result) {
-    const locks = new Set<string>();
+    const locks = new Map<string, test.TestLock>();
     for (const test of group.tests) {
-      for (const lock of test._locks)
-        locks.add(lock);
+      for (const lock of test._locks) {
+        if (lock.mode === 'read-write' || !locks.has(lock.name))
+          locks.set(lock.name, lock);
+      }
     }
-    group.locks = [...locks];
+    group.locks = [...locks.values()];
   }
   return result;
 }

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -2721,10 +2721,15 @@ export type TestAnnotation = TestDetailsAnnotation & {
   location?: Location;
 };
 
+export type TestDetailsLock = {
+  name: string;
+  mode?: 'read' | 'read-write';
+};
+
 export type TestDetails = {
   tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
-  lock?: string | string[];
+  lock?: string | TestDetailsLock | (string | TestDetailsLock)[];
 }
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<unknown> | unknown;
@@ -2835,6 +2840,20 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    * });
    * ```
    *
+   * Tests that only read the shared resource can hold the lock in `'read'` mode. Any number of such tests run at the
+   * same time, but never together with a test holding the same lock in the default `'read-write'` mode.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('show user settings', {
+   *   lock: { name: 'user-settings', mode: 'read' },
+   * }, async ({ page }) => {
+   *   // This test runs concurrently with other 'read' holders,
+   *   // but never with 'update user settings' above.
+   * });
+   * ```
+   *
    * Learn more about [test locks](https://playwright.dev/docs/test-parallel#test-locks).
    * @param title Test title.
    * @param details Additional test details.
@@ -2929,6 +2948,20 @@ export interface TestType<TestArgs extends {}, WorkerArgs extends {}> {
    * }, async ({ page }) => {
    *   // This test never runs concurrently with other tests
    *   // that declare the 'user-settings' lock.
+   * });
+   * ```
+   *
+   * Tests that only read the shared resource can hold the lock in `'read'` mode. Any number of such tests run at the
+   * same time, but never together with a test holding the same lock in the default `'read-write'` mode.
+   *
+   * ```js
+   * import { test, expect } from '@playwright/test';
+   *
+   * test('show user settings', {
+   *   lock: { name: 'user-settings', mode: 'read' },
+   * }, async ({ page }) => {
+   *   // This test runs concurrently with other 'read' holders,
+   *   // but never with 'update user settings' above.
    * });
    * ```
    *

--- a/tests/library/unit/json-schema.spec.ts
+++ b/tests/library/unit/json-schema.spec.ts
@@ -69,6 +69,13 @@ it('should validate oneOf', () => {
   expect(validate(123, schema, '$')).toEqual(['$: does not match any of the expected types']);
 });
 
+it('should prefer oneOf variant with matching type when reporting errors', () => {
+  const item: JsonSchema = { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] };
+  const schema: JsonSchema = { oneOf: [{ type: 'string' }, item, { type: 'array', items: { oneOf: [{ type: 'string' }, item] } }] };
+  expect(validate({}, schema, '$')).toEqual(['$.name: required']);
+  expect(validate(['a', {}], schema, '$')).toEqual(['$[1].name: required']);
+});
+
 it('should validate nested objects', () => {
   const schema: JsonSchema = {
     type: 'object',

--- a/tests/playwright-test/test-locks.spec.ts
+++ b/tests/playwright-test/test-locks.spec.ts
@@ -36,7 +36,7 @@ function conflictingOverlaps(lines: string[], conflicts: [string, string][]): [s
   return overlaps;
 }
 
-const lockedTest = (name: string, delay: number, lock?: string | string[]) => `
+const lockedTest = (name: string, delay: number, lock?: unknown) => `
   test('${name}'${lock !== undefined ? `, { lock: ${JSON.stringify(lock)} }` : ''}, async () => {
     console.log('\\n%%begin:${name}');
     await new Promise(f => setTimeout(f, ${delay}));
@@ -235,4 +235,150 @@ test('should validate lock in test details', async ({ runInlineTest }) => {
   });
   expect(result.exitCode).toBe(1);
   expect(result.output).toContain('details.lock');
+});
+
+test('should run tests with read locks at the same time', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'helper.ts': `
+      import fs from 'fs';
+      import path from 'path';
+      export async function signalAndWait(signal: string, waitFor: string) {
+        fs.mkdirSync(process.env.SIGNAL_DIR, { recursive: true });
+        fs.writeFileSync(path.join(process.env.SIGNAL_DIR, signal), '');
+        while (!fs.existsSync(path.join(process.env.SIGNAL_DIR, waitFor)))
+          await new Promise(f => setTimeout(f, 100));
+      }
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      import { signalAndWait } from './helper';
+      test('test1', { lock: { name: 'shared', mode: 'read' } }, async () => {
+        await signalAndWait('a.txt', 'b.txt');
+      });
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      import { signalAndWait } from './helper';
+      test('test2', { lock: { name: 'shared', mode: 'read' } }, async () => {
+        await signalAndWait('b.txt', 'a.txt');
+      });
+    `,
+  }, { workers: 2 }, { SIGNAL_DIR: test.info().outputDir });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
+test('should not run read and read-write locks at the same time', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test1', 1000, { name: 'shared', mode: 'read' })}
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test2', 1000, 'shared')}
+    `,
+    'c.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test3', 1000, { name: 'shared', mode: 'read-write' })}
+    `,
+  }, { workers: 3 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(conflictingOverlaps(result.outputLines, [['test1', 'test2'], ['test1', 'test3'], ['test2', 'test3']])).toEqual([]);
+});
+
+test('should support mixed string and object locks', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test1', 1000, ['lock-a', { name: 'lock-b', mode: 'read' }])}
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test2', 1000, { name: 'lock-a', mode: 'read' })}
+    `,
+    'c.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('test3', 1000, { name: 'lock-b', mode: 'read' })}
+    `,
+  }, { workers: 3 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(conflictingOverlaps(result.outputLines, [['test1', 'test2']])).toEqual([]);
+  // Both read 'lock-b', so they run together.
+  expect(conflictingOverlaps(result.outputLines, [['test1', 'test3']])).toEqual([['test1', 'test3']]);
+});
+
+test('should not starve a read-write lock behind read locks', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { fullyParallel: true };
+    `,
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('reader1', 500, { name: 'shared', mode: 'read' })}
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('writer', 500, 'shared')}
+    `,
+    'c.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('reader2', 500, { name: 'shared', mode: 'read' })}
+    `,
+    'd.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('other', 100, { name: 'other', mode: 'read' })}
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(4);
+  // reader2 waits for the writer that was queued before it, instead of joining reader1.
+  const lines = result.outputLines.filter(line => !line.endsWith(':other'));
+  expect(lines).toEqual(['begin:reader1', 'end:reader1', 'begin:writer', 'end:writer', 'begin:reader2', 'end:reader2']);
+  // Unrelated locks are not affected by the waiting writer.
+  expect(conflictingOverlaps(result.outputLines, [['reader1', 'other']])).toEqual([['reader1', 'other']]);
+});
+
+test('should hold the lock in read-write mode for the whole file group when any test needs it', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('a1', 500, { name: 'shared', mode: 'read' })}
+      ${lockedTest('a2', 500, 'shared')}
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      ${lockedTest('b1', 1000, { name: 'shared', mode: 'read' })}
+    `,
+  }, { workers: 2 });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(3);
+  expect(conflictingOverlaps(result.outputLines, [['a1', 'b1'], ['a2', 'b1']])).toEqual([]);
+});
+
+test('should validate lock mode in test details', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.test.ts': `
+      import { test } from '@playwright/test';
+      test('test1', { lock: [{ name: 'shared', mode: 'exclusive' }] }, async () => {});
+    `,
+    'b.test.ts': `
+      import { test } from '@playwright/test';
+      test('test2', { lock: { mode: 'read' } }, async () => {});
+    `,
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain(`Lock mode must be 'read' or 'read-write'`);
+  expect(result.output).toContain('details.lock.name: required');
 });

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -101,10 +101,15 @@ export type TestAnnotation = TestDetailsAnnotation & {
   location?: Location;
 };
 
+export type TestDetailsLock = {
+  name: string;
+  mode?: 'read' | 'read-write';
+};
+
 export type TestDetails = {
   tag?: string | string[];
   annotation?: TestDetailsAnnotation | TestDetailsAnnotation[];
-  lock?: string | string[];
+  lock?: string | TestDetailsLock | (string | TestDetailsLock)[];
 }
 
 type TestBody<TestArgs> = (args: TestArgs, testInfo: TestInfo) => Promise<unknown> | unknown;


### PR DESCRIPTION
## Summary
- `lock` accepts `{ name, mode }` where `mode` is `'read'` or `'read-write'` (default); plain strings stay `'read-write'`.
- Any number of `'read'` holders run together, a `'read-write'` holder runs alone. Read locks are not granted ahead of a queued `'read-write'` job waiting for the same lock, so writers are not starved.
- A file group holds a lock in `'read-write'` mode when any of its tests needs it.
- `oneOf` schema errors prefer the variant whose type matched, so a bad `mode` is reported instead of a generic type mismatch.

Fixes https://github.com/microsoft/playwright/issues/42594