### PR TITLE
fix(frames): restore networkidle after a request completes before domcontentloaded

### DIFF
--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -1820,7 +1820,11 @@ export class Frame extends SdkObject<FrameEventMap> {
     // We should not start a timer and report networkidle in detached frames.
     // This happens at least in Firefox for child frames, where we may get requestFinished
     // after the frame was detached - probably a race in the Firefox itself.
-    if (this._firedLifecycleEvents.has('networkidle') || this._detachedScope.isClosed())
+    //
+    // Note that we check _firedNetworkIdleSelf and not the 'networkidle' lifecycle event:
+    // the latter is sticky and outlives the idle state it was derived from, so relying on it
+    // would leave the frame without a timer once _recalculateNetworkIdle removes it again.
+    if (this._firedNetworkIdleSelf || this._detachedScope.isClosed())
       return;
     this._networkIdleTimer = setTimeout(() => {
       this._firedNetworkIdleSelf = true;

--- a/tests/page/page-network-idle.spec.ts
+++ b/tests/page/page-network-idle.spec.ts
@@ -228,6 +228,36 @@ it('should not wait for an open EventSource connection', async ({ page, server }
   expect(response.status()).toBe(200);
 });
 
+it('should reach networkidle again when the last request finishes before domcontentloaded', async ({ page, server }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42598' });
+
+  // The whole document body is consumed before this script runs, so both the document
+  // and the script are reported as finished and the first networkidle timer starts.
+  // Blocking the parser here lets that networkidle fire while parsing is still in progress.
+  server.setRoute('/blocker.js', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    res.end(`
+      const deadline = Date.now() + 900;
+      while (Date.now() < deadline) {}
+      document.write('<script src="/late.js"><\\/script>');
+    `);
+  });
+  // This request starts and finishes before domcontentloaded, which used to leave the
+  // frame with no inflight requests, no networkidle and no timer to ever report it again.
+  server.setRoute('/late.js', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    res.end(`window.__late = true;`);
+  });
+  server.setRoute('/idle-before-dcl.html', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<script src="/blocker.js"></script>`);
+  });
+
+  await page.goto(server.PREFIX + '/idle-before-dcl.html', { waitUntil: 'domcontentloaded' });
+  expect(await page.evaluate(() => window['__late'])).toBe(true);
+  await page.waitForLoadState('networkidle');
+});
+
 it('should not wait for an open EventSource connection in setContent', async ({ page, server }) => {
   it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/37226' });
 


### PR DESCRIPTION
## Summary
- `_startNetworkIdleTimer()` skipped arming a timer whenever the `networkidle` lifecycle event was recorded. That event is sticky and `_recalculateNetworkIdle()` can remove it later, so its presence does not mean the frame is idle.
- A request that starts and finishes while `networkidle` is still recorded clears `_firedNetworkIdleSelf` on start and then gets no new timer on finish. A later `domcontentloaded` removes the lifecycle event, and the frame is left with no inflight requests, no `networkidle` and no timer, so `waitForLoadState('networkidle')` hangs.
- Keying off `_firedNetworkIdleSelf` fixes it, since that is the state the timer actually maintains. No new event is emitted when the frame is already idle.

Fixes https://github.com/microsoft/playwright/issues/42598