### PR TITLE
docs: explain that offline emulation does not affect WebRTC

### DIFF
--- a/docs/src/api/class-browsercontext.md
+++ b/docs/src/api/class-browsercontext.md
@@ -1547,6 +1547,9 @@ Pass an array to use different credentials for different origins. The first entr
 
 Whether to emulate network being offline for the browser context.
 
+:::note
+Offline emulation only affects requests that go through the browser's regular network stack, such as page navigations, `fetch()`, `XMLHttpRequest` and WebSockets. It does not affect WebRTC traffic: established `RTCPeerConnection`s keep sending and receiving media over UDP. To test WebRTC connection loss, interrupt the connection outside the browser, for example by stopping the TURN server or using an OS-level firewall.
+:::
 
 ## async method: BrowserContext.storageState
 * since: v1.8

--- a/docs/src/emulation.md
+++ b/docs/src/emulation.md
@@ -782,6 +782,11 @@ context = browser.new_context(
 ```csharp
 var context = await browser.NewContextAsync(new() { Offline = true });
 ```
+
+:::note
+Offline emulation only affects requests that go through the browser's regular network stack, such as page navigations, `fetch()`, `XMLHttpRequest` and WebSockets. It does not affect WebRTC traffic: established `RTCPeerConnection`s keep sending and receiving media over UDP. To test WebRTC connection loss, interrupt the connection outside the browser, for example by stopping the TURN server or using an OS-level firewall.
+:::
+
 ## JavaScript Enabled
 
 Emulate a user scenario where JavaScript is disabled.

--- a/packages/playwright-client/types/types.d.ts
+++ b/packages/playwright-client/types/types.d.ts
@@ -10601,6 +10601,12 @@ export interface BrowserContext {
 
   /**
    * @param offline Whether to emulate network being offline for the browser context.
+   *
+   * **NOTE** Offline emulation only affects requests that go through the browser's regular network stack, such as page
+   * navigations, `fetch()`, `XMLHttpRequest` and WebSockets. It does not affect WebRTC traffic: established
+   * `RTCPeerConnection`s keep sending and receiving media over UDP. To test WebRTC connection loss, interrupt the
+   * connection outside the browser, for example by stopping the TURN server or using an OS-level firewall.
+   *
    */
   setOffline(offline: boolean): Promise<void>;
 

--- a/packages/playwright-core/types/types.d.ts
+++ b/packages/playwright-core/types/types.d.ts
@@ -10601,6 +10601,12 @@ export interface BrowserContext {
 
   /**
    * @param offline Whether to emulate network being offline for the browser context.
+   *
+   * **NOTE** Offline emulation only affects requests that go through the browser's regular network stack, such as page
+   * navigations, `fetch()`, `XMLHttpRequest` and WebSockets. It does not affect WebRTC traffic: established
+   * `RTCPeerConnection`s keep sending and receiving media over UDP. To test WebRTC connection loss, interrupt the
+   * connection outside the browser, for example by stopping the TURN server or using an OS-level firewall.
+   *
    */
   setOffline(offline: boolean): Promise<void>;
 


### PR DESCRIPTION
## Summary
- Document that `setOffline` / the `offline` option only affect the browser's regular network stack and do not interrupt WebRTC traffic.
- Suggest interrupting the connection outside the browser for WebRTC failure testing.

Fixes https://github.com/microsoft/playwright/issues/42623