### PR TITLE
fix(dom): scroll instantly on pointer action retry with smooth scroll-behavior

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -413,7 +413,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       if (forceScrollOptions) {
         return await progress.race(this.evaluateInUtility(([injected, node, options]) => {
           if (node.nodeType === 1 /* Node.ELEMENT_NODE */)
-            (node as Node as Element).scrollIntoView(options);
+            (node as Node as Element).scrollIntoView({ ...options, behavior: 'instant' });
           return 'done' as const;
         }, forceScrollOptions));
       }

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -881,7 +881,7 @@ export class WVPage implements PageDelegate {
         : { left: box.left, top: box.top, right: box.right, bottom: box.bottom };
       const fullyVisible = target.left >= 0 && target.top >= 0 && target.right <= innerW && target.bottom <= innerH;
       if (!fullyVisible)
-        node.scrollIntoView({ block: 'center', inline: 'center' });
+        node.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
       return 'done';
     }, rect ?? null);
     if (result === 'error:notvisible' || result === 'error:notconnected' || result === 'done')

--- a/tests/page/page-click-scroll.spec.ts
+++ b/tests/page/page-click-scroll.spec.ts
@@ -156,3 +156,33 @@ it('should not scroll on hover when scroll is "none"', async ({ page }) => {
   expect(await page.evaluate('window._hovered')).toBeFalsy();
   expect(await page.evaluate(() => window.scrollY)).toBe(0);
 });
+
+it('should scroll instantly on retry when scroll-behavior is smooth', async ({ page }) => {
+  it.info().annotations.push({ type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42625' });
+  // The fixed header covers everything but the bottom strip of the viewport.
+  // The first attempt centers the button under the header, so the click is
+  // retried with a different scroll alignment using the native scrollIntoView().
+  await page.setContent(`
+    <style>
+      html { scroll-behavior: smooth; }
+      body { margin: 0; }
+      .spacer { height: 2000px; }
+      #header { position: fixed; top: 0; left: 0; right: 0; height: calc(100vh - 50px); background: rgba(0, 0, 0, 0.1); }
+      button { height: 30px; }
+    </style>
+    <div id="header"></div>
+    <div class="spacer"></div>
+    <button onclick="window.clicked = true">Target</button>
+    <div class="spacer"></div>
+    <script>
+      window.scrolls = [];
+      addEventListener('scroll', () => window.scrolls.push(window.scrollY));
+    </script>
+  `);
+  await page.click('button');
+  expect(await page.evaluate('window.clicked')).toBe(true);
+  // Every scroll performed by Playwright should be a single instant jump,
+  // and never a smooth animation that fires a scroll event per frame.
+  const scrolls = await page.evaluate(() => window['scrolls']);
+  expect(scrolls.length).toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary
- Pass `behavior: 'instant'` to the native `scrollIntoView()` used on pointer action retries, so `scroll-behavior: smooth` pages do not animate the scroll and the click lands on a stable element.
- Apply the same to the webview delegate's first-attempt scroll.

Fixes https://github.com/microsoft/playwright/issues/42625