### PR TITLE
feat(trace): record full stack for test steps

### DIFF
--- a/packages/playwright/src/common/testType.ts
+++ b/packages/playwright/src/common/testType.ts
@@ -279,13 +279,13 @@ export class TestTypeImpl {
     if (!testInfo)
       throw new Error(`test.step() can only be called from a test`);
     await testInfo._onUserStepBegin?.(title);
-    const step = testInfo._addStep({ category: 'test.step', title, subtitle: options.subtitle, location: options.location, box: options.box, params: options.params });
+    const step = testInfo._addStep({ category: 'test.step', title, subtitle: options.subtitle, stack: options.location ? [options.location] : undefined, box: options.box, params: options.params });
     return await currentZone().with('stepZone', step).run(async () => {
       try {
         let result: Awaited<ReturnType<typeof raceAgainstDeadline<T>>> | undefined = undefined;
         result = await raceAgainstDeadline(async () => {
           try {
-            return await step.info._runStepBody(expectation === 'skip', body, step.location);
+            return await step.info._runStepBody(expectation === 'skip', body, step.stack[0]);
           } catch (e) {
             // If the step timed out, the test fixtures will tear down, which in turn
             // will abort unfinished actions in the step body. Record such errors here.

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -113,7 +113,7 @@ const utilityFixtures: Fixtures<UtilityTestFixtures, UtilityWorkerFixtures> = {
         // In the general case, create a step for each api call and connect them through the stepId.
         const params = renderParamsForCall({ type: channel.type, method: channel.method, params: channel.params });
         const step = testInfo._addStep({
-          location: data.frames[0],
+          stack: data.frames,
           category: 'pw:api',
           title: renderTitle(channel.type, channel.method, channel.params, data.title),
           subtitle: renderSubtitle(channel.type, channel.method, channel.params),

--- a/packages/playwright/src/matchers/expect.ts
+++ b/packages/playwright/src/matchers/expect.ts
@@ -342,7 +342,7 @@ function callMatcherAsStep(matcherName: string, info: ExpectMetaInfo, actual: un
     category: 'expect' as const,
     title,
     subtitle: suffixes.subtitle,
-    location: stackFrames[0],
+    stack: stackFrames,
     params: Object.keys(params).length ? params : undefined,
   };
   const step = testInfo?._addStep(stepData);

--- a/packages/playwright/src/worker/fixtureRunner.ts
+++ b/packages/playwright/src/worker/fixtureRunner.ts
@@ -25,6 +25,7 @@ import type { TestInfoImpl } from './testInfo';
 import type { FixtureDescription, RunnableDescription } from './timeoutManager';
 import type { WorkerInfo } from '../../types/test';
 import type { Location } from '../../types/testReporter';
+import type { StackFrame } from '@utils/stackTrace';
 
 class Fixture {
   runner: FixtureRunner;
@@ -36,7 +37,7 @@ class Fixture {
   private _selfTeardownComplete: Promise<void> | undefined;
   private _setupDescription: FixtureDescription;
   private _teardownDescription: FixtureDescription;
-  private _stepInfo: { title: string, category: 'fixture', location?: Location, group?: string } | undefined;
+  private _stepInfo: { title: string, category: 'fixture', stack?: StackFrame[], group?: string } | undefined;
   _deps = new Set<Fixture>();
   _usages = new Set<Fixture>();
 
@@ -47,7 +48,7 @@ class Fixture {
     const isUserFixture = this.registration.location && filterStackFile(this.registration.location.file);
     const title = this.registration.customTitle || this.registration.name;
     const location = isUserFixture ? this.registration.location : undefined;
-    this._stepInfo = { title: `Fixture ${escapeWithQuotes(title, '"')}`, category: 'fixture', location };
+    this._stepInfo = { title: `Fixture ${escapeWithQuotes(title, '"')}`, category: 'fixture', stack: location ? [location] : undefined };
     if (this.registration.box === 'self')
       this._stepInfo = undefined;
     else if (this.registration.box)

--- a/packages/playwright/src/worker/testInfo.ts
+++ b/packages/playwright/src/worker/testInfo.ts
@@ -43,7 +43,7 @@ interface TestStepData {
   title: string;
   subtitle?: string;
   category: TestStepCategory;
-  location?: Location;
+  stack?: StackFrame[];
   params?: Record<string, any>;
   box?: boolean;
   // steps with any defined group are hidden from the report
@@ -52,6 +52,7 @@ interface TestStepData {
 }
 
 export interface TestStepInternal extends TestStepData {
+  stack: StackFrame[];
   complete(result: { error?: Error | unknown, softError?: Error | unknown, shouldNotRetryTest?: boolean, suggestedRebaseline?: string, attachments?: TestInfo['attachments'] }): void;
   info: TestStepInfoImpl;
   attachmentIndices: number[];
@@ -295,19 +296,19 @@ export class TestInfoImpl implements TestInfo {
     }
 
     let boxedStack = parentStep?.boxedStack;
-    let location = data.location;
+    let stack = data.stack;
     if (!boxedStack && data.box) {
       boxedStack = filteredStackTrace(captureRawStack()).slice(1);
-      location ??= boxedStack[0];
+      stack ??= boxedStack;
     }
-    location ??= filteredStackTrace(captureRawStack())[0];
+    stack ??= filteredStackTrace(captureRawStack());
 
     const step: TestStepInternal = {
       ...data,
       stepId,
       group: parentStep?.group ?? data.group,
       boxedStack,
-      location,
+      stack,
       steps: [],
       attachmentIndices: [],
       info: new TestStepInfoImpl(this, stepId, data.title, parentStep?.info),
@@ -380,7 +381,7 @@ export class TestInfoImpl implements TestInfo {
         category: step.category,
         params: toReportedParams(step.params),
         wallTime: Date.now(),
-        location: step.location,
+        location: step.stack[0],
       };
       this._callbacks.onStepBegin(payload);
     }
@@ -392,7 +393,7 @@ export class TestInfoImpl implements TestInfo {
         subtitle: step.subtitle,
         category: step.category,
         params: step.params,
-        stack: step.location ? [step.location] : [],
+        stack: step.stack,
         group: step.group,
       });
     }
@@ -433,7 +434,7 @@ export class TestInfoImpl implements TestInfo {
     visit(root);
   }
 
-  async _runAsStep(stepInfo: { title: string, category: 'hook' | 'fixture', location?: Location, group?: string }, cb: () => Promise<any>) {
+  async _runAsStep(stepInfo: { title: string, category: 'hook' | 'fixture', stack?: StackFrame[], group?: string }, cb: () => Promise<any>) {
     const step = this._addStep(stepInfo);
     try {
       await cb();

--- a/packages/playwright/src/worker/workerMain.ts
+++ b/packages/playwright/src/worker/workerMain.ts
@@ -572,7 +572,7 @@ export class WorkerMain extends ProcessRunner {
     let firstError: Error | undefined;
     for (const hook of this._collectHooksAndModifiers(suite, type, testInfo)) {
       try {
-        await testInfo._runAsStep({ title: hook.title, category: 'hook', location: hook.location }, async () => {
+        await testInfo._runAsStep({ title: hook.title, category: 'hook', stack: [hook.location] }, async () => {
           // Separate time slot for each beforeAll/afterAll hook.
           const timeSlot = { timeout: this._project.project.timeout, elapsed: 0 };
           const runnable = { type: hook.type, slot: timeSlot, location: hook.location };
@@ -625,7 +625,7 @@ export class WorkerMain extends ProcessRunner {
         continue;
       }
       try {
-        await testInfo._runAsStep({ title: hook.title, category: 'hook', location: hook.location }, async () => {
+        await testInfo._runAsStep({ title: hook.title, category: 'hook', stack: [hook.location] }, async () => {
           await this._fixtureRunner.resolveParametersAndRunFunction(hook.fn, testInfo, 'test', runnable);
         });
       } catch (error) {

--- a/tests/playwright-test/playwright.trace.spec.ts
+++ b/tests/playwright-test/playwright.trace.spec.ts
@@ -16,7 +16,9 @@
 
 import { test, expect } from './playwright-test-fixtures';
 import { parseTrace, parseTraceRaw } from '../config/utils';
+
 import fs from 'fs';
+import path from 'path';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -1552,6 +1554,36 @@ test('should record step params in trace', async ({ runInlineTest }, testInfo) =
   const actionByTitle = (title: string) => trace.model.actions.find(a => a.title === title)!;
   expect(actionByTitle('my step').params).toEqual({ foo: 'bar' });
   expect(actionByTitle('Expect "toBe"').params).toEqual({ expected: '1' });
+});
+
+test('should record step stack in trace', async ({ runInlineTest }, testInfo) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      import { test, expect } from '@playwright/test';
+      async function helper(page) {
+        await test.step('my step', async () => {
+          await page.setContent('<title>hello</title>');
+          await expect(page).toHaveTitle('hello');
+        });
+      }
+      test('pass', async ({ page }) => {
+        await helper(page);
+      });
+    `,
+  }, { trace: 'on' });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(1);
+  const trace = await parseTrace(testInfo.outputPath('test-results', 'a-pass', 'trace.zip'));
+  const stacks = trace.model.actions.filter(a => a.stack?.length).map(a => a.stack!.map(f => `${path.basename(f.file)}:${f.line}:${f.column}`));
+  expect(stacks).toEqual([
+    // test.step
+    ['a.spec.ts:4:9', 'a.spec.ts:10:9'],
+    // page.setContent
+    ['a.spec.ts:5:22', 'a.spec.ts:4:9', 'a.spec.ts:10:9'],
+    // expect
+    ['a.spec.ts:6:30', 'a.spec.ts:4:9', 'a.spec.ts:10:9'],
+  ]);
 });
 
 test('should record step subtitle in trace', async ({ runInlineTest }, testInfo) => {


### PR DESCRIPTION
## Summary
- Test steps are written into the test trace with their full stack instead of just the top frame.
- `TestStepData.location` is replaced by `stack`; the step location is now `stack[0]`.