### PR TITLE
fix(screencast): keep overlays above top layer elements

### DIFF
--- a/packages/injected/src/highlight.ts
+++ b/packages/injected/src/highlight.ts
@@ -60,6 +60,7 @@ export class Highlight {
   private _userOverlayContainer: HTMLElement;
   private _userOverlays = new Map<string, HTMLElement>();
   private _userOverlayHidden = false;
+  private _userOverlayTimer: number | undefined;
   private _isUnderTest: boolean;
   private _injectedScript: InjectedScript;
   private _rafRequest: number | undefined;
@@ -174,6 +175,7 @@ export class Highlight {
       this._rafRequest = undefined;
     }
     this._elementHighlights = [];
+    this._clearUserOverlayTimer();
     this._glassPaneElement.remove();
   }
 
@@ -293,6 +295,7 @@ export class Highlight {
     this._userOverlays.set(id, element);
     this._userOverlayContainer.appendChild(element);
     this._userOverlayContainer.hidden = this._userOverlayHidden;
+    this._ensureUserOverlayTimer();
     return id;
   }
 
@@ -306,8 +309,28 @@ export class Highlight {
       element.remove();
       this._userOverlays.delete(id);
     }
-    if (this._userOverlays.size === 0)
+    if (this._userOverlays.size === 0) {
       this._userOverlayContainer.hidden = true;
+      this._clearUserOverlayTimer();
+    }
+  }
+
+  // Elements that enter the top layer later paint above the glass pane, so keep re-promoting it while overlays are showing.
+  private _ensureUserOverlayTimer() {
+    if (this._userOverlayTimer !== undefined)
+      return;
+    const tick = () => {
+      this.install();
+      this._userOverlayTimer = this._injectedScript.utils.builtins.setTimeout(tick, 500);
+    };
+    this._userOverlayTimer = this._injectedScript.utils.builtins.setTimeout(tick, 500);
+  }
+
+  private _clearUserOverlayTimer() {
+    if (this._userOverlayTimer === undefined)
+      return;
+    this._injectedScript.utils.builtins.clearTimeout(this._userOverlayTimer);
+    this._userOverlayTimer = undefined;
   }
 
   setUserOverlaysVisible(visible: boolean) {

--- a/packages/injected/src/injectedScript.ts
+++ b/packages/injected/src/injectedScript.ts
@@ -1337,10 +1337,10 @@ export class InjectedScript {
   }
 
   private _ensureHighlight() {
-    if (!this._highlight) {
+    if (!this._highlight)
       this._highlight = new Highlight(this);
-      this._highlight.install();
-    }
+
+    this._highlight.install();
     return this._highlight;
   }
 

--- a/tests/library/screencast-overlay.spec.ts
+++ b/tests/library/screencast-overlay.spec.ts
@@ -15,8 +15,15 @@
  */
 
 import { expect, browserTest as test } from '../config/browserTest';
+import { PNG } from 'playwright-core/lib/utilsBundle';
 
 test.skip(({ mode }) => mode !== 'default', 'Overlay uses an open shadow root only in default mode');
+
+function pixel(screenshot: Buffer, x: number, y: number) {
+  const png = PNG.sync.read(screenshot);
+  const offset = (y * png.width + x) * 4;
+  return [png.data[offset], png.data[offset + 1], png.data[offset + 2]];
+}
 
 test('should add and remove overlay', async ({ browser, server }) => {
   const context = await browser.newContext();
@@ -155,3 +162,46 @@ test('should allow styles in overlay html', async ({ browser, server }) => {
 
   await context.close();
 });
+
+const topLayerPages = {
+  dialog: `
+    <dialog id="target" style="position: fixed; inset: 0; margin: 0; width: 100vw; height: 100vh; padding: 0; border: 0; background: rgb(200, 200, 200);"></dialog>
+    <button onclick="target.showModal()">Open</button>
+  `,
+  popover: `
+    <div id="target" popover="manual" style="inset: 0; margin: 0; width: 100%; height: 100%; max-width: none; max-height: none; padding: 0; border: 0; background: rgb(200, 200, 200);"></div>
+    <button onclick="target.showPopover()">Open</button>
+  `,
+};
+const redOverlay = '<div style="position: absolute; top: 50px; left: 50px; width: 200px; height: 100px; background: rgb(255, 0, 0);"></div>';
+
+for (const [kind, content] of Object.entries(topLayerPages)) {
+  test(`should show overlay above ${kind} opened before it`, { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42629' } }, async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.setContent(content);
+    const disposable = await page.screencast.showOverlay('<div></div>');
+    await disposable.dispose();
+
+    await page.getByRole('button', { name: 'Open' }).click();
+    expect(pixel(await page.screenshot(), 100, 100)).toEqual([200, 200, 200]);
+
+    await page.screencast.showOverlay(redOverlay);
+    expect(pixel(await page.screenshot(), 100, 100)).toEqual([255, 0, 0]);
+
+    await context.close();
+  });
+
+  test(`should keep overlay above ${kind} opened after it`, { annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/42629' } }, async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.setContent(content);
+    await page.screencast.showOverlay(redOverlay);
+    expect(pixel(await page.screenshot(), 100, 100)).toEqual([255, 0, 0]);
+
+    await page.getByRole('button', { name: 'Open' }).click();
+    await expect.poll(async () => pixel(await page.screenshot(), 100, 100)).toEqual([255, 0, 0]);
+
+    await context.close();
+  });
+}


### PR DESCRIPTION
## Summary
- Re-promote the glass pane into the top layer on every highlight use, so overlays shown after a dialog or popover opened paint above it.
- While user overlays are showing, keep re-promoting the pane on a timer, so dialogs and popovers opened later do not cover it.

Fixes https://github.com/microsoft/playwright/issues/42629