### PR TITLE
fix(evaluate): reject exposeFunctions in the utility world

### DIFF
--- a/docs/src/api/params.md
+++ b/docs/src/api/params.md
@@ -588,13 +588,13 @@ Function to be evaluated in the page context.
 * langs: js
 - `exposeFunctions` <[boolean]>
 
-When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the page function. Calling one returns a [Promise] of its result. Under the hood, each function is exposed via [`method: Page.exposeFunction`], so it is technically accessible from all frames and worlds of the page. Exposed functions are cleared upon the top-level navigation. Defaults to `false`, in which case functions are not serializable and passing one throws an error.
+When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the page function. Calling one returns a [Promise] of its result. Under the hood, each function is exposed via [`method: Page.exposeFunction`], so it is technically accessible from all frames of the page. Exposed functions are cleared upon the top-level navigation. Defaults to `false`, in which case functions are not serializable and passing one throws an error.
 
 ## js-init-script-expose-functions
 * langs: js
 - `exposeFunctions` <[boolean]>
 
-When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the init script. Calling one returns a [Promise] of its result. Under the hood, each function is exposed via [`method: Page.exposeFunction`], so it is technically accessible from all frames and worlds of the page. Unlike functions passed to [`method: Page.evaluate`], functions passed to an init script are exposed in every new document, so they survive navigations. Defaults to `false`, in which case functions are not serializable and are silently dropped.
+When set to `true`, functions passed inside [`param: arg`] are exposed in the page and can be called from the init script. Calling one returns a [Promise] of its result. Under the hood, each function is exposed via [`method: Page.exposeFunction`], so it is technically accessible from all frames of the page. Unlike functions passed to [`method: Page.evaluate`], functions passed to an init script are exposed in every new document, so they survive navigations. Defaults to `false`, in which case functions are not serializable and are silently dropped.
 
 ## js-evaluate-world
 * langs: js

--- a/packages/playwright-core/src/client/jsHandle.ts
+++ b/packages/playwright-core/src/client/jsHandle.ts
@@ -147,4 +147,8 @@ export function assertMaxArguments(count: number, max: number): asserts count {
 export function assertEvaluateOptions(options: any) {
   if (options !== undefined && (typeof options !== 'object' || options === null || Array.isArray(options)))
     throw new Error('Too many arguments. If you need to pass more than 1 argument to the function wrap them in an object.');
+  // Bindings are installed by an init script, which only runs in the main world, so the
+  // exposed callbacks are unreachable from the utility world.
+  if (options?.exposeFunctions && options?.world === 'utility')
+    throw new Error('Option "exposeFunctions" is not supported in the "utility" world.');
 }

--- a/tests/page/page-evaluate-world.spec.ts
+++ b/tests/page/page-evaluate-world.spec.ts
@@ -142,3 +142,9 @@ it('should isolate the utility world from main world tampering', async ({ page }
   expect(await locator.evaluate(e => e.getAttribute('data-value'))).toBe('tampered');
   expect(await locator.evaluate(e => e.getAttribute('data-value'), undefined, { world: 'utility' })).toBe('1');
 });
+
+it('should reject exposeFunctions in the utility world', async ({ page }) => {
+  const error = await page.evaluate(async ({ cb }) => await cb(17), { cb: (x: number) => x * 2 }, { exposeFunctions: true, world: 'utility' }).catch(e => e);
+  expect(error.message).toContain('Option "exposeFunctions" is not supported in the "utility" world.');
+  expect(await page.evaluate(async ({ cb }) => await cb(17), { cb: (x: number) => x * 2 }, { exposeFunctions: true })).toBe(34);
+});


### PR DESCRIPTION
## What is wrong today

`exposeFunctions` and the new `world` option cannot be combined, but passing both crashes inside the injected code instead of saying so. On `aeebee1d2`:

```js
await page.evaluate(async ({ cb }) => await cb(17), { cb: x => x * 2 },
    { exposeFunctions: true, world: 'utility' });
// page.evaluate: TypeError: Cannot read properties of undefined (reading 'callBinding')
```

Same error from `frame.evaluate` and `locator.evaluate`. Reproduced on chromium, firefox and webkit.

## Why

`PageBinding.createInitScript` installs the bindings controller as an init script, and init scripts only run in the main world, so `globalThis[kBindingsControllerProperty]` is undefined in the utility world. `Runtime.addBinding` is registered without a world, so the transport is there, but the controller that dispatches through it is not. That is also why the docs sentence saying an exposed function is "technically accessible from all frames and worlds of the page" does not hold:

```js
await page.exposeFunction('f', x => x * 2);
await page.evaluate(() => window.f?.(21) ?? 'NOT PRESENT');                        // 42
await page.evaluate(() => window.f?.(21) ?? 'NOT PRESENT', undefined, { world: 'utility' }); // 'NOT PRESENT'
```

## What this changes

Throws on the combination from `assertEvaluateOptions`, which every `evaluate` entry point already calls, and corrects the two doc sentences that promise all worlds. This matches the error `JSHandleDispatcher.evaluateExpression` already throws for a world it cannot serve.

If bindings are meant to work in the utility world, this guard is the wrong fix and I am happy to close it. The doc sentences would be the part worth keeping either way.

Verified with `npm run flint` green and `tests/page/page-evaluate-world.spec.ts` plus the seven adjacent evaluate/expose-function specs (173 tests) passing; the new test fails with the `callBinding` TypeError when the guard is reverted.

I am a freshman in college trying my best to contribute for the greater good, so please tell me if I have read the intent backwards here.