### PR TITLE
fix(server): dispose temporary iframe element handles after hit-target checks

### DIFF
--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -936,37 +936,44 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
   async _checkFrameIsHitTarget(progress: Progress, point: types.Point): Promise<{ framePoint: types.Point | undefined } | 'error:notconnected' | { hitTargetDescription: string }> {
     let frame = this._frame;
     const data: { frame: frames.Frame, frameElement: ElementHandle<Element> | null, pointInFrame: types.Point }[] = [];
-    while (frame.parentFrame()) {
-      const frameElement = await frame.frameElement(progress) as ElementHandle<Element>;
-      const box = await frameElement.boundingBox(progress);
-      const style = await progress.race(frameElement.evaluateInUtility(([injected, iframe]) => injected.describeIFrameStyle(iframe), {}).catch(e => 'error:notconnected' as const));
-      if (!box || style === 'error:notconnected')
-        return 'error:notconnected';
-      if (style === 'transformed') {
-        // We cannot translate coordinates when iframe has any transform applied.
-        // The best we can do right now is to skip the hitPoint check,
-        // and solely rely on the event interceptor.
-        return { framePoint: undefined };
+    const temporaryFrameElements: ElementHandle<Element>[] = [];
+    try {
+      while (frame.parentFrame()) {
+        const frameElement = await frame.frameElement(progress) as ElementHandle<Element>;
+        temporaryFrameElements.push(frameElement);
+        const box = await frameElement.boundingBox(progress);
+        const style = await progress.race(frameElement.evaluateInUtility(([injected, iframe]) => injected.describeIFrameStyle(iframe), {}).catch(e => 'error:notconnected' as const));
+        if (!box || style === 'error:notconnected')
+          return 'error:notconnected';
+        if (style === 'transformed') {
+          // We cannot translate coordinates when iframe has any transform applied.
+          // The best we can do right now is to skip the hitPoint check,
+          // and solely rely on the event interceptor.
+          return { framePoint: undefined };
+        }
+        // Translate from viewport coordinates to frame coordinates.
+        const pointInFrame = { x: point.x - box.x - style.left, y: point.y - box.y - style.top };
+        data.push({ frame, frameElement, pointInFrame });
+        frame = frame.parentFrame()!;
       }
-      // Translate from viewport coordinates to frame coordinates.
-      const pointInFrame = { x: point.x - box.x - style.left, y: point.y - box.y - style.top };
-      data.push({ frame, frameElement, pointInFrame });
-      frame = frame.parentFrame()!;
-    }
-    // Add main frame.
-    data.push({ frame, frameElement: null, pointInFrame: point });
+      // Add main frame.
+      data.push({ frame, frameElement: null, pointInFrame: point });
 
-    for (let i = data.length - 1; i > 0; i--) {
-      const element = data[i - 1].frameElement!;
-      const point = data[i].pointInFrame;
-      // Hit target in the parent frame should hit the child frame element.
-      const hitTargetResult = await progress.race(element.evaluateInUtility(([injected, element, hitPoint]) => {
-        return injected.expectHitTarget(hitPoint, element);
-      }, point));
-      if (hitTargetResult !== 'done')
-        return hitTargetResult;
+      for (let i = data.length - 1; i > 0; i--) {
+        const element = data[i - 1].frameElement!;
+        const point = data[i].pointInFrame;
+        // Hit target in the parent frame should hit the child frame element.
+        const hitTargetResult = await progress.race(element.evaluateInUtility(([injected, element, hitPoint]) => {
+          return injected.expectHitTarget(hitPoint, element);
+        }, point));
+        if (hitTargetResult !== 'done')
+          return hitTargetResult;
+      }
+      return { framePoint: data[0].pointInFrame };
+    } finally {
+      for (const frameElement of temporaryFrameElements)
+        frameElement.dispose();
     }
-    return { framePoint: data[0].pointInFrame };
   }
 }
 

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1027,8 +1027,7 @@ it('should click in an iframe with border 2', async ({ page }) => {
   expect(await page.evaluate('window._clicked')).toBe(true);
 });
 
-it('should not retain removed iframe after clicking inside it', async ({ page, browserName }) => {
-  it.skip(browserName !== 'chromium', 'CDP is Chromium only');
+it('should not retain removed iframe after clicking inside it', async ({ page }) => {
   await page.setContent('<iframe srcdoc="<button>Click</button>"></iframe>');
   const button = page.frameLocator('iframe').getByRole('button');
   await button.waitFor();
@@ -1039,18 +1038,9 @@ it('should not retain removed iframe after clicking inside it', async ({ page, b
   await page.evaluate(() => document.querySelector('iframe')!.remove());
   // Move the mouse away to release Chromium's own last-hovered-node retention.
   await page.mouse.move(500, 500);
-  const session = await page.context().newCDPSession(page);
-  try {
-    await session.send('HeapProfiler.collectGarbage');
-    await session.send('HeapProfiler.collectGarbage');
-    const { result } = await session.send('Runtime.evaluate', {
-      expression: 'Boolean(window.iframeRef.deref())',
-      returnByValue: true,
-    });
-    expect(result.value).toBe(false);
-  } finally {
-    await session.detach();
-  }
+  await page.requestGC();
+  const retained = await page.evaluate(() => Boolean((window as any).iframeRef.deref()));
+  expect(retained).toBe(false);
 });
 
 it('should click in a transformed iframe', async ({ page }) => {

--- a/tests/page/page-click.spec.ts
+++ b/tests/page/page-click.spec.ts
@@ -1027,6 +1027,32 @@ it('should click in an iframe with border 2', async ({ page }) => {
   expect(await page.evaluate('window._clicked')).toBe(true);
 });
 
+it('should not retain removed iframe after clicking inside it', async ({ page, browserName }) => {
+  it.skip(browserName !== 'chromium', 'CDP is Chromium only');
+  await page.setContent('<iframe srcdoc="<button>Click</button>"></iframe>');
+  const button = page.frameLocator('iframe').getByRole('button');
+  await button.waitFor();
+  await page.evaluate(() => {
+    (window as any).iframeRef = new WeakRef(document.querySelector('iframe')!);
+  });
+  await button.click();
+  await page.evaluate(() => document.querySelector('iframe')!.remove());
+  // Move the mouse away to release Chromium's own last-hovered-node retention.
+  await page.mouse.move(500, 500);
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('HeapProfiler.collectGarbage');
+    await session.send('HeapProfiler.collectGarbage');
+    const { result } = await session.send('Runtime.evaluate', {
+      expression: 'Boolean(window.iframeRef.deref())',
+      returnByValue: true,
+    });
+    expect(result.value).toBe(false);
+  } finally {
+    await session.detach();
+  }
+});
+
 it('should click in a transformed iframe', async ({ page }) => {
   await page.setContent(`
     <style>


### PR DESCRIPTION
- Dispose temporary iframe element handles in `ElementHandle._checkFrameIsHitTarget` (including early-return and exception paths) and in `FrameSession._framePosition`, so Chromium does not retain detached iframes after clicks inside frames
- Add a regression test that removes an iframe after clicking inside it and asserts collection via CDP-forced GC

Diagnosis and reproduction in the issue by @dolezel.

Fixes #42653