### PR TITLE
chore(build): set esbuild target to node20

### DIFF
--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -1145,7 +1145,7 @@ class FrameSession {
       return null;
     if (frame === this._page.mainFrame())
       return { x: 0, y: 0 };
-    const element = await frame.frameElement(nullProgress);
+    using element = await frame.frameElement(nullProgress);
     const box = await element.boundingBox(nullProgress);
     return box;
   }

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -223,6 +223,10 @@ export class JSHandle<T = any> extends SdkObject {
     }
   }
 
+  [Symbol.dispose]() {
+    this.dispose();
+  }
+
   override toString(): string {
     return this._preview;
   }

--- a/utils/build/build.js
+++ b/utils/build/build.js
@@ -331,6 +331,7 @@ class EsbuildStep extends Step {
       sourcemap: withSourceMaps ? 'linked' : false,
       platform: 'node',
       format: 'cjs',
+      target: 'node20',
       ...options,
     };
     this._watchPaths = watchPaths;


### PR DESCRIPTION
## Summary
- esbuild had no explicit target and defaulted to `esnext`, so `using` declarations reached `lib/` verbatim and failed to parse on the minimum supported node.
- Adds `Symbol.dispose` to `JSHandle` and uses it for the frame element handle in `crPage`.