### PR TITLE
fix(net): apply socketTimeout from socket creation in httpRequest

### DIFF
--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -52,6 +52,12 @@ export function httpRequest(params: HTTPRequestParams, onResponse: (r: http.Inco
     headers: params.headers,
     ...happyEyeballsOptions,
   };
+  // Pass the timeout via request options, so that it is applied to the socket
+  // at creation time. `request.setTimeout()` alone only takes effect once the
+  // socket connects, so without this the default agent's 5s timeout would kill
+  // sockets that take longer to connect, ignoring the requested timeout.
+  if (params.socketTimeout !== undefined)
+    options.timeout = params.socketTimeout;
   if (params.rejectUnauthorized !== undefined)
     options.rejectUnauthorized = params.rejectUnauthorized;
 

--- a/tests/library/network-timeout.spec.ts
+++ b/tests/library/network-timeout.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import http from 'http';
+import { browserTest as test, expect } from '../config/browserTest';
+import { utils } from '../../packages/playwright-core/lib/coreBundle.js';
+
+test.skip(({ mode }) => mode !== 'default');
+
+test('httpRequest should honor socketTimeout while connecting', async () => {
+  // 203.0.113.1 is TEST-NET-3 (RFC 5737), guaranteed to be unroutable, so the
+  // TCP connection stalls instead of failing. Node's default agents come with
+  // a 5s socket timeout, while `request.setTimeout()` only takes effect after
+  // the socket connects - make sure the requested timeout governs from the start.
+  const socketTimeout = 8000;
+  const start = Date.now();
+  const error: Error = await new Promise(resolve => {
+    utils.httpRequest({
+      url: 'http://203.0.113.1/index.html',
+      socketTimeout,
+    }, () => resolve(new Error('unexpected response')), resolve);
+  });
+  const elapsed = Date.now() - start;
+  if (!error.message.includes('timed out after')) {
+    // Some networks actively refuse TEST-NET addresses instead of blackholing them.
+    test.skip(true, `environment does not stall connections to TEST-NET: ${error.message}`);
+    return;
+  }
+  expect(error.message).toContain(`timed out after ${socketTimeout}ms`);
+  expect(elapsed).toBeGreaterThanOrEqual(socketTimeout - 1000);
+});
+
+test('httpRequest should honor socketTimeout for stalled responses', async () => {
+  const server = http.createServer(() => {});
+  await new Promise<void>(f => server.listen(0, '127.0.0.1', () => f()));
+  const port = (server.address() as import('node:net').AddressInfo).port;
+  const socketTimeout = 1500;
+  const start = Date.now();
+  try {
+    const error: Error = await new Promise(resolve => {
+      utils.httpRequest({
+        url: `http://127.0.0.1:${port}/index.html`,
+        socketTimeout,
+      }, () => resolve(new Error('unexpected response')), resolve);
+    });
+    const elapsed = Date.now() - start;
+    expect(error.message).toContain(`timed out after ${socketTimeout}ms`);
+    expect(elapsed).toBeGreaterThanOrEqual(socketTimeout - 500);
+    expect(elapsed).toBeLessThan(socketTimeout * 3);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
- `request.setTimeout()` only takes effect after the socket connects, so on a stalled TCP connect the default agent's built-in 5s timeout killed the request while the error still reported the configured value — e.g. debug logs showed `timed out after 120000ms` firing at `+5s`, and `PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` had no effect (see #42597)
- Pass `socketTimeout` via request options so it governs the socket from creation; regression-tested with a stalled-connect case (fails at ~5s before the fix) and a stalled-response case

Fixes #42578
Fixes #42597