### PR TITLE
chore(ci): remove flakiness dashboard upload and json reporter

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -26,15 +26,6 @@ inputs:
     description: 'Shell to use'
     required: false
     default: 'bash'
-  flakiness-client-id:
-    description: 'Azure Flakiness Dashboard Client ID'
-    required: false
-  flakiness-tenant-id:
-    description: 'Azure Flakiness Dashboard Tenant ID'
-    required: false
-  flakiness-subscription-id:
-    description: 'Azure Flakiness Dashboard Subscription ID'
-    required: false
 
 runs:
   using: composite
@@ -80,19 +71,6 @@ runs:
       shell: ${{ inputs.shell }}
       env:
         PW_TAG: "@${{ inputs.bot-name }}"
-    - name: Azure Login
-      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
-      if: ${{ !cancelled() && env.PLAYWRIGHT_SETUP_COMPLETE == 'true' && github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
-      with:
-        client-id: ${{ inputs.flakiness-client-id }}
-        tenant-id: ${{ inputs.flakiness-tenant-id }}
-        subscription-id: ${{ inputs.flakiness-subscription-id }}
-    - run: |
-        echo "::group::./utils/upload_flakiness_dashboard.sh"
-        ./utils/upload_flakiness_dashboard.sh ./test-results/report.json
-        echo "::endgroup::"
-      if: ${{ !cancelled() && env.PLAYWRIGHT_SETUP_COMPLETE == 'true' }}
-      shell: bash
     - name: Upload blob report
       if: ${{ !cancelled() && env.PLAYWRIGHT_SETUP_COMPLETE == 'true' && (github.event_name == 'pull_request' || failure()) }}
       uses: ./.github/actions/upload-blob-report

--- a/.github/workflows/tests_bidi.yml
+++ b/.github/workflows/tests_bidi.yml
@@ -70,14 +70,6 @@ jobs:
         path: test-results/report.csv
         retention-days: 7
 
-    - name: Upload json report to GitHub
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: json-report-${{ matrix.channel }}
-        path: test-results/report.json
-        retention-days: 7
-
     - name: Upload parquet report
       if: ${{ !cancelled() }}
       uses: ./.github/actions/upload-parquet-report

--- a/.github/workflows/tests_docker.yml
+++ b/.github/workflows/tests_docker.yml
@@ -37,8 +37,6 @@ jobs:
       id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     steps:
-    - name: Create ~/.azure directory
-      run: mkdir -p ~/.azure
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
@@ -74,7 +72,6 @@ jobs:
           --workdir /home/pwuser \
           --env CI \
           --env INSIDE_DOCKER=1 \
-          -v ~/.azure:/root/.azure \
           -d \
           -t \
           playwright:localbuild /bin/bash
@@ -112,29 +109,6 @@ jobs:
           --env GITHUB_SHA \
           --workdir /home/pwuser/playwright docker-tests xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test -- --grep "@smoke"
 
-    - name: Azure Login
-      if: ${{ !cancelled() && github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
-      uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
-      with:
-        client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
-    - name: Upload Flakiness dashboard
-      if: ${{ !cancelled() && github.event_name == 'push' && github.repository == 'microsoft/playwright' }}
-      run: |
-        # Flakiness dashboard has to be uploaded from-inside docker container so that it can collect meta information, e.g. arch
-        # See https://github.com/microsoft/playwright/blob/13b1e52d95df416fdfa7846c8a840aad8df263af/utils/upload_flakiness_dashboard.sh#L71-L86
-        docker exec \
-          --env GITHUB_REPOSITORY \
-          --env GITHUB_REF \
-          --env GITHUB_RUN_ID \
-          --user root \
-          --workdir /home/pwuser/playwright docker-tests /bin/bash -c '
-            set -e
-            # Azure-CLI is needed for upload_flakiness_dashboard.sh script.
-            curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-            ./utils/upload_flakiness_dashboard.sh "./test-results/report.json"
-          '
     - name: Copy blob report from container
       if: ${{ !cancelled() && (github.event_name == 'pull_request' || failure()) }}
       run: docker cp "docker-tests:/home/pwuser/playwright/blob-report" "./blob-report"

--- a/.github/workflows/tests_mcp.yml
+++ b/.github/workflows/tests_mcp.yml
@@ -31,8 +31,6 @@ env:
 jobs:
   test_mcp:
     name: ${{ matrix.os }} - ${{ matrix.project }}
-    # Used for authentication of flakiness upload
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +49,6 @@ jobs:
             project: msedge
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,6 +57,3 @@ jobs:
         node-version: "22"
         command: npm run test-mcp -- --project=${{ matrix.project }}
         bot-name: "mcp-${{ matrix.os }}-${{ matrix.project }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}

--- a/.github/workflows/tests_primary.yml
+++ b/.github/workflows/tests_primary.yml
@@ -32,7 +32,6 @@ env:
 jobs:
   test_linux:
     name: ${{ matrix.os }} (${{ matrix.browser }} - Node.js ${{ matrix.node-version }})
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +50,6 @@ jobs:
             browser: chromium
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -61,13 +59,9 @@ jobs:
         browsers-to-install: ${{ matrix.browser }} chromium
         command: npm run test -- --project=${{ matrix.browser }}-*
         bot-name: "${{ matrix.browser }}-${{ matrix.os }}-node${{ matrix.node-version }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test_test_runner:
     name: Test Runner
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -124,7 +118,6 @@ jobs:
             shardWeights: '58:42'
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -134,17 +127,12 @@ jobs:
         command: npm run ttest -- --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         bot-name: "${{ matrix.os }}-node${{ matrix.node-version }}"
         shard-index: ${{ matrix.shardIndex }}
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PWTEST_SHARD_WEIGHTS: ${{ matrix.shardWeights }}
 
   test_web_components:
     name: Web Components - ${{ matrix.package }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     strategy:
       fail-fast: false
@@ -159,9 +147,6 @@ jobs:
         browsers-to-install: chromium
         command: npm run test-${{ matrix.package }}
         bot-name: "web-components-${{ matrix.package }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test_vscode_extension:
     name: VSCode Extension
@@ -201,7 +186,6 @@ jobs:
 
   test_package_installations:
     name: "Installation Test ${{ matrix.os }}"
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -212,7 +196,6 @@ jobs:
     runs-on: ${{ matrix.os  }}
     timeout-minutes: 45
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -231,15 +214,10 @@ jobs:
         node-version: 22
         bot-name: "package-installations-${{ matrix.os }}"
         shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test_clock_frozen_time_linux:
     name: time library - ${{ matrix.clock }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     strategy:
       fail-fast: false
@@ -254,8 +232,5 @@ jobs:
         browsers-to-install: chromium
         command: npm run test -- --project=chromium-*
         bot-name: "${{ matrix.clock }}-time-library-chromium-linux"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PW_CLOCK: ${{ matrix.clock }}

--- a/.github/workflows/tests_secondary.yml
+++ b/.github/workflows/tests_secondary.yml
@@ -16,14 +16,12 @@ env:
   FORCE_COLOR: 1
 
 permissions:
-  id-token: write   # This is required for OIDC login (azure/login) to succeed
   contents: read    # This is required for actions/checkout to succeed
 
 jobs:
   test_mac:
     name: ${{ matrix.os }} (${{ matrix.browser }})
     if: ${{ github.event_name == 'push' || github.event.label.name == 'CQ1' }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,14 +40,10 @@ jobs:
         browsers-to-install: ${{ matrix.browser }} chromium
         command: npm run test -- --project=${{ matrix.browser }}-*
         bot-name: "${{ matrix.browser }}-${{ matrix.os }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test_win:
     name: "Windows"
     if: ${{ github.event_name == 'push' || github.event.label.name == 'CQ1' }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,14 +56,10 @@ jobs:
         browsers-to-install: ${{ matrix.browser }} chromium
         command: npm run test -- --project=${{ matrix.browser }}-* ${{ matrix.browser == 'firefox' && '--workers 1' || '' }}
         bot-name: "${{ matrix.browser }}-windows-latest"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test-package-installations-other-node-versions:
     name: "Installation Test ${{ matrix.os }} (${{ matrix.node_version }})"
     if: ${{ github.event_name == 'push' || github.event.label.name == 'CQ1' }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.os  }}
     strategy:
       fail-fast: false
@@ -98,13 +88,9 @@ jobs:
         node-version: ${{ matrix.node_version }}
         command: npm run itest
         bot-name: "package-installations-${{ matrix.os }}-node${{ matrix.node_version }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   driver_linux:
     name: "Driver"
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
     runs-on: ubuntu-22.04
@@ -115,15 +101,11 @@ jobs:
         browsers-to-install: chromium
         command: npm run ctest
         bot-name: "driver"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PWTEST_MODE: driver
 
   tracing_linux:
     name: Tracing ${{ matrix.browser }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -143,15 +125,11 @@ jobs:
         browsers-to-install: ${{ matrix.browser }} chromium
         command: npm run test -- --project=${{ matrix.browser }}-*
         bot-name: "tracing-${{ matrix.browser }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PWTEST_TRACE: 1
 
   test_chromium_channels:
     name: Test ${{ matrix.channel }} on ${{ matrix.runs-on }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -176,15 +154,11 @@ jobs:
         browsers-to-install: ${{ matrix.channel }}
         command: npm run ctest
         bot-name: ${{ matrix.channel }}-${{ matrix.runs-on }}
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PWTEST_CHANNEL: ${{ matrix.channel }}
 
   test_android:
     name: Android
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: playwright-x64-ubuntu24-64-core
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -209,16 +183,11 @@ jobs:
         browsers-to-install: android
         command: npm run atest
         bot-name: "android"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
 
   test_clock_frozen_time_test_runner:
     name: time test runner - ${{ matrix.clock }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     runs-on: ubuntu-22.04
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     strategy:
       fail-fast: false
@@ -231,21 +200,16 @@ jobs:
         node-version: 22
         command: npm run ttest
         bot-name: "${{ matrix.clock }}-time-runner-chromium-linux"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}
       env:
         PW_CLOCK: ${{ matrix.clock }}
 
   test_electron:
     name: Electron - ${{ matrix.os }}
-    environment: ${{ github.event_name == 'push' && 'allow-uploading-flakiness-results' || null }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     permissions:
-      id-token: write   # This is required for OIDC login (azure/login) to succeed
       contents: read    # This is required for actions/checkout to succeed
     runs-on: ${{ matrix.os }}
     steps:
@@ -269,6 +233,3 @@ jobs:
         setup-command: npx install-electron --no
         command: npm run etest
         bot-name: "electron-${{ matrix.os }}"
-        flakiness-client-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_CLIENT_ID }}
-        flakiness-tenant-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_TENANT_ID }}
-        flakiness-subscription-id: ${{ secrets.AZURE_FLAKINESS_DASHBOARD_SUBSCRIPTION_ID }}

--- a/tests/android/playwright.config.ts
+++ b/tests/android/playwright.config.ts
@@ -39,7 +39,6 @@ const config: Config<ServerWorkerOptions & PlaywrightWorkerOptions & PlaywrightT
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob'],
     ['../config/parquetReporter.ts'],
   ] : 'line',

--- a/tests/bidi/playwright.config.ts
+++ b/tests/bidi/playwright.config.ts
@@ -44,7 +44,6 @@ const testDir = path.join(__dirname, '..');
 const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     hasDebugOutput ? ['list'] : ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob'],
     ['../config/parquetReporter.ts'],
     ['./csvReporter', { outputFile: path.join(outputDir, 'report.csv') }],

--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -38,7 +38,6 @@ const config: Config<PlaywrightWorkerOptions & PlaywrightTestOptions> = {
   retries: process.env.CI ? 3 : 0,
   reporter: process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     // Needed since tests/electron/package.json exists which would otherwise be picked up as tests/electron/ (outputDir)
     ['blob', { outputDir: path.resolve(__dirname, '../../blob-report') }],
     ['../config/parquetReporter.ts'],

--- a/tests/installation/playwright.config.ts
+++ b/tests/installation/playwright.config.ts
@@ -23,7 +23,6 @@ loadEnv({ path: path.join(__dirname, '..', '..', '.env'), quiet: true });
 const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob'],
     ['../config/parquetReporter.ts'],
   ] : [

--- a/tests/library/playwright.config.ts
+++ b/tests/library/playwright.config.ts
@@ -45,7 +45,6 @@ const testDir = path.join(__dirname, '..');
 const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob'],
     ['../config/parquetReporter.ts'],
   ] : [

--- a/tests/mcp/playwright.config.ts
+++ b/tests/mcp/playwright.config.ts
@@ -27,12 +27,10 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env'), quiet: true });
 
 const rootTestDir = path.join(__dirname, '..');
 const testDir = path.join(rootTestDir, 'mcp');
-const outputDir = path.join(__dirname, '..', '..', 'test-results');
 
 const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob', { outputDir: path.join(__dirname, '..', '..', 'blob-report') }],
     ['../config/parquetReporter.ts'],
   ] : [

--- a/tests/playwright-test/playwright.config.ts
+++ b/tests/playwright-test/playwright.config.ts
@@ -21,11 +21,9 @@ process.env.PWTEST_UNDER_TEST = '1';
 import { defineConfig, type ReporterDescription } from './stable-test-runner';
 import * as path from 'path';
 
-const outputDir = path.join(__dirname, '..', '..', 'test-results');
 const reporters = () => {
   const result: ReporterDescription[] = process.env.CI ? [
     ['dot'],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['blob', { outputDir: path.join(__dirname, '..', '..', 'blob-report') }],
     ['../config/parquetReporter.ts'],
   ] : [

--- a/tests/webview/playwright.config.ts
+++ b/tests/webview/playwright.config.ts
@@ -39,7 +39,6 @@ const config: Config<ServerWorkerOptions & PlaywrightWorkerOptions & PlaywrightT
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [
     ['list', { printFailuresInline: true }],
-    ['json', { outputFile: path.join(outputDir, 'report.json') }],
     ['../config/parquetReporter.ts'],
   ] : 'line',
   projects: [],


### PR DESCRIPTION
## Summary
- Remove the flakiness dashboard upload (Azure login + `upload_flakiness_dashboard.sh`) from `run-test` action and workflows.
- Drop the `json` reporter from test configs since nothing consumes `report.json` anymore.
- Remove the corresponding `environment` / `id-token` permissions where no Azure login remains.