### PR TITLE
fix(test runner): forward the screen option from device descriptors

### DIFF
--- a/docs/src/test-api/class-testoptions.md
+++ b/docs/src/test-api/class-testoptions.md
@@ -561,6 +561,27 @@ export default defineConfig({
 });
 ```
 
+## property: TestOptions.screen
+* since: v1.64
+- type: ?<[Object]>
+  - `width` <[int]> page width in pixels.
+  - `height` <[int]> page height in pixels.
+
+Emulates consistent window screen size available inside web page via `window.screen`. Is only used when the [`property: TestOptions.viewport`] is set.
+
+**Usage**
+
+```js title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  use: {
+    viewport: { width: 390, height: 664 },
+    screen: { width: 390, height: 844 },
+  },
+});
+```
+
 ## property: TestOptions.screenshot
 * since: v1.10
 - type: <[Object]|[ScreenshotMode]<"off"|"on"|"only-on-failure"|"on-first-failure">>

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -279,6 +279,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
   permissions: [({ contextOptions }, use) => use(contextOptions.permissions), { option: true, box: true }],
   proxy: [({ contextOptions }, use) => use(contextOptions.proxy), { option: true, box: true }],
   reducedMotion: [({ contextOptions }, use) => use(contextOptions.reducedMotion === undefined ? 'no-preference' : contextOptions.reducedMotion), { option: true, box: true }],
+  screen: [({ contextOptions }, use) => use(contextOptions.screen), { option: true, box: true }],
   storageState: [({ contextOptions }, use) => use(contextOptions.storageState), { option: true, box: true }],
   clientCertificates: [({ contextOptions }, use) => use(contextOptions.clientCertificates), { option: true, box: true }],
   timezoneId: [({ contextOptions }, use) => use(contextOptions.timezoneId), { option: true, box: true }],
@@ -311,6 +312,7 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
     permissions,
     proxy,
     reducedMotion,
+    screen,
     storageState,
     viewport,
     timezoneId,
@@ -356,6 +358,8 @@ const playwrightFixtures: Fixtures<TestFixtures, WorkerFixtures, UtilityTestFixt
       options.proxy = proxy;
     if (reducedMotion !== undefined)
       options.reducedMotion = reducedMotion;
+    if (screen !== undefined)
+      options.screen = screen;
     if (storageState !== undefined)
       options.storageState = storageState;
     if (clientCertificates?.length)

--- a/packages/playwright/types/test.d.ts
+++ b/packages/playwright/types/test.d.ts
@@ -7684,6 +7684,26 @@ export interface PlaywrightTestOptions {
    */
   reducedMotion: ReducedMotion;
   /**
+   * Emulates consistent window screen size available inside web page via `window.screen`. Is only used when the
+   * [testOptions.viewport](https://playwright.dev/docs/api/class-testoptions#test-options-viewport) is set.
+   *
+   * **Usage**
+   *
+   * ```js
+   * // playwright.config.ts
+   * import { defineConfig } from '@playwright/test';
+   *
+   * export default defineConfig({
+   *   use: {
+   *     viewport: { width: 390, height: 664 },
+   *     screen: { width: 390, height: 844 },
+   *   },
+   * });
+   * ```
+   *
+   */
+  screen: ViewportSize | undefined;
+  /**
    * Learn more about [storage state and auth](https://playwright.dev/docs/auth).
    *
    * Populates context with given storage state. This option can be used to initialize context with logged-in

--- a/tests/playwright-test/playwright.spec.ts
+++ b/tests/playwright-test/playwright.spec.ts
@@ -36,6 +36,32 @@ export class VideoPlayer {
   }
 }
 
+test('should respect screen option', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'playwright.config.ts': `
+      module.exports = { use: { viewport: { width: 500, height: 500 }, screen: { width: 1000, height: 1000 } } };
+    `,
+    'a.test.ts': `
+      import { test, expect } from '@playwright/test';
+      test('pass', async ({ page, screen }) => {
+        expect(screen).toEqual({ width: 1000, height: 1000 });
+        expect(await page.evaluate(() => [window.screen.width, window.screen.height])).toEqual([1000, 1000]);
+      });
+    `,
+    'b.test.ts': `
+      import { test, expect, devices } from '@playwright/test';
+      test.use({ ...devices['iPhone 13'] });
+      test('pass', async ({ page, screen }) => {
+        expect(screen).toEqual({ width: 390, height: 844 });
+        expect(await page.evaluate(() => [window.screen.width, window.screen.height])).toEqual([390, 844]);
+      });
+    `,
+  }, { workers: 1 });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
 test('should respect viewport option', async ({ runInlineTest }) => {
   const result = await runInlineTest({
     'playwright.config.ts': `

--- a/utils/generate_types/overrides-test.d.ts
+++ b/utils/generate_types/overrides-test.d.ts
@@ -299,6 +299,7 @@ export interface PlaywrightTestOptions {
   permissions: string[] | undefined;
   proxy: Proxy | undefined;
   reducedMotion: ReducedMotion;
+  screen: ViewportSize | undefined;
   storageState: StorageState | undefined;
   timezoneId: string | undefined;
   userAgent: string | undefined;


### PR DESCRIPTION
## Summary
- Register `screen` as a test option so `test.use({ ...devices[...] })` and `use: { ...devices[...] }` in config forward the descriptor's `screen` key, matching library mode.
- Add the `TestOptions.screen` type and docs entry, plus a regression test.

Fixes https://github.com/microsoft/playwright/issues/42679

## Breaking change, not for landing
Every config that spreads a device descriptor into `use` starts emulating `screen` on upgrade. That includes all desktop descriptors, so the default scaffolded project changes `window.screen` from 1280x720 to 1920x1080 and `device-width` media queries follow. A user-defined fixture named `screen` that depends on `page` now fails with a fixture dependency cycle, which affects `@playwright-testing-library/test`.