### PR TITLE
devops(triage): bump Copilot CLI model to claude-opus-5

### DIFF
--- a/.github/workflows/pr-ci-triage.yml
+++ b/.github/workflows/pr-ci-triage.yml
@@ -63,7 +63,7 @@ jobs:
             --no-ask-user \
             --enable-all-github-mcp-tools \
             --share=output/copilot-session.md \
-            --model claude-opus-4.8 \
+            --model claude-opus-5 \
             --max-ai-credits 500 \
             -p "$PROMPT"
 

--- a/.github/workflows/triage_linux.yml
+++ b/.github/workflows/triage_linux.yml
@@ -58,7 +58,7 @@ jobs:
             --no-ask-user \
             --enable-all-github-mcp-tools \
             --share=output/copilot-session.md \
-            --model claude-opus-4.8 \
+            --model claude-opus-5 \
             --max-ai-credits 500 \
             -p "$PROMPT"
 

--- a/.github/workflows/triage_mac.yml
+++ b/.github/workflows/triage_mac.yml
@@ -62,7 +62,7 @@ jobs:
             --no-ask-user \
             --enable-all-github-mcp-tools \
             --share=output/copilot-session.md \
-            --model claude-opus-4.8 \
+            --model claude-opus-5 \
             --max-ai-credits 500 \
             -p "$PROMPT"
 

--- a/.github/workflows/triage_win.yml
+++ b/.github/workflows/triage_win.yml
@@ -66,7 +66,7 @@ jobs:
             --no-ask-user \
             --enable-all-github-mcp-tools \
             --share=output/copilot-session.md \
-            --model claude-opus-4.8 \
+            --model claude-opus-5 \
             --max-ai-credits 500 \
             -p "$PROMPT"
 


### PR DESCRIPTION
## Summary
- Switch the triage and PR CI triage workflows from `claude-opus-4.8` to `claude-opus-5`.