### PR TITLE
chore: replace manual `dispose` and similar things with `using`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,7 +69,7 @@ const ignores = [
 export const baseRules = {
   "@typescript-eslint/no-unused-vars": [
     2,
-    { args: "none", caughtErrors: "none" },
+    { args: "none", caughtErrors: "none", ignoreUsingDeclarations: true },
   ],
 
   /**

--- a/packages/isomorphic/manualPromise.ts
+++ b/packages/isomorphic/manualPromise.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
+
 export class ManualPromise<T = void> extends Promise<T> {
   private _resolve!: (t: T) => void;
   private _reject!: (e: Error) => void;
@@ -111,16 +113,18 @@ export class LongStandingScope {
   }
 }
 
-export function signalToPromise(signal: AbortSignal): { promise: Promise<void>, dispose: () => void } {
-  if (signal.aborted)
-    return { promise: Promise.resolve(), dispose: () => {} };
+export function signalToPromise(signal: AbortSignal): Disposable & { promise: Promise<void>, dispose: () => void } {
+  if (signal.aborted) {
+    function dispose() {}
+    return { promise: Promise.resolve(), dispose, [kDispose]: dispose };
+  }
   let dispose: (() => void) | undefined;
   const promise = new Promise<void>(resolve => {
     const onAbort = () => resolve();
     signal.addEventListener('abort', onAbort, { once: true });
     dispose = () => signal.removeEventListener('abort', onAbort);
   });
-  return { promise, dispose: dispose! };
+  return { promise, dispose: dispose!, [kDispose]: dispose! };
 }
 
 function cloneError(error: Error, frames: string[]) {

--- a/packages/isomorphic/timeoutRunner.ts
+++ b/packages/isomorphic/timeoutRunner.ts
@@ -21,22 +21,26 @@
 /* eslint-disable no-restricted-globals */
 
 import { monotonicTime } from './time';
+import { ManualPromise } from './manualPromise';
+
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
+
+// Timers do not implement Symbol.dispose on every supported Node.js version.
+export function createTimeout(callback: () => void, timeout: number): Disposable {
+  const timer = setTimeout(callback, timeout);
+  return {
+    [kDispose]() {
+      clearTimeout(timer);
+    },
+  };
+}
 
 export async function raceAgainstDeadline<T>(cb: () => Promise<T>, deadline: number): Promise<{ result: T, timedOut: false } | { timedOut: true }> {
-  let timer: NodeJS.Timeout | undefined;
+  const resultPromise: Promise<{ result: T, timedOut: false }> = cb().then(result => ({ result, timedOut: false }));
+  const timeoutPromise = new ManualPromise<{ timedOut: true }>();
+  using timer = deadline ? createTimeout(() => timeoutPromise.resolve({ timedOut: true }), Math.max(0, deadline - monotonicTime())) : undefined;
   // Note: not including "await" here truncates the async stack inside cb(), so always include it.
-  return await Promise.race([
-    cb().then(result => {
-      return { result, timedOut: false };
-    }),
-    new Promise<{ timedOut: true }>(resolve => {
-      if (!deadline)
-        return;
-      timer = setTimeout(() => resolve({ timedOut: true }), Math.max(0, deadline - monotonicTime()));
-    }),
-  ]).finally(() => {
-    clearTimeout(timer);
-  });
+  return await Promise.race([resultPromise, timeoutPromise]);
 }
 
 export async function pollAgainstDeadline<T>(callback: () => Promise<{ continuePolling: boolean, result: T }>, deadline: number, [...pollIntervals]: number[] = [100, 250, 500, 1000]): Promise<{ result?: T, timedOut: boolean }> {

--- a/packages/playwright-core/src/client/android.ts
+++ b/packages/playwright-core/src/client/android.ts
@@ -274,13 +274,11 @@ export class AndroidDevice extends ChannelOwner<channels.AndroidDeviceChannel> i
     return await this._wrapApiCall(async () => {
       const timeoutOptions = this._timeoutSettings.timeout(typeof optionsOrPredicate === 'function' ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function' ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
       if (event !== Events.AndroidDevice.Close)
         waiter.rejectOnEvent(this, Events.AndroidDevice.Close, () => new TargetClosedError());
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 }

--- a/packages/playwright-core/src/client/browserContext.ts
+++ b/packages/playwright-core/src/client/browserContext.ts
@@ -469,13 +469,11 @@ export class BrowserContext extends ChannelOwner<channels.BrowserContextChannel>
     return await this._wrapApiCall(async () => {
       const timeoutOptions = this._timeoutSettings.timeout(typeof optionsOrPredicate === 'function'  ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function'  ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
       if (event !== Events.BrowserContext.Close)
         waiter.rejectOnEvent(this, Events.BrowserContext.Close, () => new TargetClosedError(this._effectiveCloseReason()));
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 

--- a/packages/playwright-core/src/client/electron.ts
+++ b/packages/playwright-core/src/client/electron.ts
@@ -143,13 +143,11 @@ export class ElectronApplication extends ChannelOwner<channels.ElectronApplicati
     return await this._wrapApiCall(async () => {
       const timeoutOptions = this._timeoutSettings.timeout(typeof optionsOrPredicate === 'function' ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function' ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
       if (event !== Events.ElectronApplication.Close)
         waiter.rejectOnEvent(this, Events.ElectronApplication.Close, () => new TargetClosedError());
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 

--- a/packages/playwright-core/src/client/frame.ts
+++ b/packages/playwright-core/src/client/frame.ts
@@ -143,7 +143,7 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
   async waitForNavigation(options: WaitForNavigationOptions = {}): Promise<network.Response | null> {
     return await this._page!._wrapApiCall(async () => {
       const waitUntil = verifyLoadState('waitUntil', options.waitUntil === undefined ? 'load' : options.waitUntil);
-      const waiter = this._setupNavigationWaiter(options);
+      using waiter = this._setupNavigationWaiter(options);
 
       const toUrl = typeof options.url === 'string' ? ` to "${options.url}"` : '';
       waiter.log(`waiting for navigation${toUrl} until "${waitUntil}"`);
@@ -169,28 +169,22 @@ export class Frame extends ChannelOwner<channels.FrameChannel> implements api.Fr
       }
 
       const request = navigatedEvent.newDocument ? network.Request.fromNullable(navigatedEvent.newDocument.request) : null;
-      const response = request ? await waiter.waitForPromise(request._finalRequest()._internalResponse()) : null;
-      waiter.dispose();
-      return response;
+      return request ? await waiter.waitForPromise(request._finalRequest()._internalResponse()) : null;
     }, { title: 'Wait for navigation' });
   }
 
   async waitForLoadState(state: LifecycleEvent = 'load', options?: TimeoutOptions): Promise<void> {
     state = verifyLoadState('state', state);
     return await this._page!._wrapApiCall(async () => {
-      const waiter = this._setupNavigationWaiter(options ?? {});
-      try {
-        if (this._loadStates.has(state)) {
-          waiter.log(`  not waiting, "${state}" event already fired`);
-          waiter.throwIfImmediatelyRejected();
-        } else {
-          await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
-            waiter.log(`  "${s}" event fired`);
-            return s === state;
-          });
-        }
-      } finally {
-        waiter.dispose();
+      using waiter = this._setupNavigationWaiter(options ?? {});
+      if (this._loadStates.has(state)) {
+        waiter.log(`  not waiting, "${state}" event already fired`);
+        waiter.throwIfImmediatelyRejected();
+      } else {
+        await waiter.waitForEvent<LifecycleEvent>(this._eventEmitter, 'loadstate', s => {
+          waiter.log(`  "${s}" event fired`);
+          return s === state;
+        });
       }
     }, { title: `Wait for load state "${state}"` });
   }

--- a/packages/playwright-core/src/client/jsHandle.ts
+++ b/packages/playwright-core/src/client/jsHandle.ts
@@ -26,6 +26,8 @@ import type * as api from '../../types/types';
 import type * as channels from './channels';
 import type { Page } from './page';
 
+// Match esbuild's `await using` fallback in browsers without Symbol.asyncDispose.
+const kAsyncDispose: typeof Symbol.asyncDispose = (Symbol.asyncDispose || Symbol.for('Symbol.asyncDispose')) as typeof Symbol.asyncDispose;
 
 export class JSHandle<T = any> extends ChannelOwner<channels.JSHandleChannel> implements api.JSHandle {
   private _preview: string;
@@ -79,7 +81,7 @@ export class JSHandle<T = any> extends ChannelOwner<channels.JSHandleChannel> im
     return null as any;
   }
 
-  async [Symbol.asyncDispose]() {
+  async [kAsyncDispose]() {
     await this.dispose();
   }
 

--- a/packages/playwright-core/src/client/locator.ts
+++ b/packages/playwright-core/src/client/locator.ts
@@ -87,14 +87,10 @@ export class Locator implements api.Locator {
 
     return await this._frame._wrapApiCall<R>(async () => {
       const result = await this._frame._channel.waitForSelector({ selector: this._selector, strict: true, state: 'attached' }, { signal: options.signal, timeout });
-      const handle = ElementHandle.fromNullable(result.element) as ElementHandle<SVGElement | HTMLElement> | null;
+      await using handle = ElementHandle.fromNullable(result.element) as ElementHandle<SVGElement | HTMLElement> | null;
       if (!handle)
         throw new Error(`Could not resolve ${this._selector} to DOM Element`);
-      try {
-        return await task(handle, deadline ? deadline - monotonicTime() : 0);
-      } finally {
-        await handle.dispose();
-      }
+      return await task(handle, deadline ? deadline - monotonicTime() : 0);
     }, { title: options.title, internal: options.internal });
   }
 

--- a/packages/playwright-core/src/client/network.ts
+++ b/packages/playwright-core/src/client/network.ts
@@ -806,16 +806,14 @@ export class WebSocket extends ChannelOwner<channels.WebSocketChannel> implement
     return await this._wrapApiCall(async () => {
       const timeoutOptions = this._page._timeoutSettings.timeout(typeof optionsOrPredicate === 'function' ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function' ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
       if (event !== Events.WebSocket.Error)
         waiter.rejectOnEvent(this, Events.WebSocket.Error, new Error('Socket error'));
       if (event !== Events.WebSocket.Close)
         waiter.rejectOnEvent(this, Events.WebSocket.Close, new Error('Socket closed'));
       waiter.rejectOnEvent(this._page, Events.Page.Close, () => this._page._closeErrorWithReason());
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 }

--- a/packages/playwright-core/src/client/page.ts
+++ b/packages/playwright-core/src/client/page.ts
@@ -505,7 +505,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
     return await this._wrapApiCall(async () => {
       const timeoutOptions = this._timeoutSettings.timeout(typeof optionsOrPredicate === 'function' ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function' ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       if (logLine)
         waiter.log(logLine);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
@@ -513,9 +513,7 @@ export class Page extends ChannelOwner<channels.PageChannel> implements api.Page
         waiter.rejectOnEvent(this, Events.Page.Crash, new Error('Page crashed'));
       if (event !== Events.Page.Close)
         waiter.rejectOnEvent(this, Events.Page.Close, () => this._closeErrorWithReason());
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 

--- a/packages/playwright-core/src/client/waiter.ts
+++ b/packages/playwright-core/src/client/waiter.ts
@@ -24,6 +24,8 @@ import type * as channels from './channels';
 import type { EventEmitter } from 'events';
 import type { Zone } from '@utils/zones';
 
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
+
 export class Waiter {
   private _dispose: (() => void)[];
   private _failures: Promise<any>[] = [];
@@ -107,8 +109,12 @@ export class Waiter {
   }
 
   dispose() {
-    for (const dispose of this._dispose)
+    for (const dispose of this._dispose.splice(0))
       dispose();
+  }
+
+  [kDispose]() {
+    this.dispose();
   }
 
   async waitForPromise<T>(promise: Promise<T>, dispose?: () => void): Promise<T> {

--- a/packages/playwright-core/src/client/worker.ts
+++ b/packages/playwright-core/src/client/worker.ts
@@ -91,13 +91,11 @@ export class Worker extends ChannelOwner<channels.WorkerChannel> implements api.
       const timeoutSettings = this._page?._timeoutSettings ?? this._context?._timeoutSettings ?? new TimeoutSettings();
       const timeoutOptions = timeoutSettings.timeout(typeof optionsOrPredicate === 'function' ? {} : optionsOrPredicate);
       const predicate = typeof optionsOrPredicate === 'function' ? optionsOrPredicate : optionsOrPredicate.predicate;
-      const waiter = Waiter.createForEvent(this, event);
+      using waiter = Waiter.createForEvent(this, event);
       waiter.rejectOnTimeout(timeoutOptions, `Timeout ${timeoutOptions.timeout}ms exceeded while waiting for event "${event}"`);
       if (event !== Events.Worker.Close)
         waiter.rejectOnEvent(this, Events.Worker.Close, () => this._closeErrorWithReason());
-      const result = await waiter.waitForEvent(this, event, predicate as any);
-      waiter.dispose();
-      return result;
+      return await waiter.waitForEvent(this, event, predicate as any);
     });
   }
 

--- a/packages/playwright-core/src/server/android/backendAdb.ts
+++ b/packages/playwright-core/src/server/android/backendAdb.ts
@@ -72,27 +72,23 @@ class AdbDevice implements DeviceBackend {
 
 async function runCommand(command: string, host: string = '127.0.0.1', port: number = 5037, serial?: string): Promise<Buffer> {
   debug('pw:adb:runCommand')(command, serial);
-  const socket = new BufferedSocketWrapper(command, net.createConnection({ host, port }));
-  try {
-    if (serial) {
-      await socket.write(encodeMessage(`host:transport:${serial}`));
-      const status = await socket.read(4);
-      assert(status.toString() === 'OKAY', status.toString());
-    }
-    await socket.write(encodeMessage(command));
+  using socket = new BufferedSocketWrapper(command, net.createConnection({ host, port }));
+  if (serial) {
+    await socket.write(encodeMessage(`host:transport:${serial}`));
     const status = await socket.read(4);
     assert(status.toString() === 'OKAY', status.toString());
-    let commandOutput: Buffer;
-    if (!command.startsWith('shell:')) {
-      const remainingLength = parseInt((await socket.read(4)).toString(), 16);
-      commandOutput = await socket.read(remainingLength);
-    } else {
-      commandOutput = await socket.readAll();
-    }
-    return commandOutput;
-  } finally {
-    socket.close();
   }
+  await socket.write(encodeMessage(command));
+  const status = await socket.read(4);
+  assert(status.toString() === 'OKAY', status.toString());
+  let commandOutput: Buffer;
+  if (!command.startsWith('shell:')) {
+    const remainingLength = parseInt((await socket.read(4)).toString(), 16);
+    commandOutput = await socket.read(remainingLength);
+  } else {
+    commandOutput = await socket.readAll();
+  }
+  return commandOutput;
 }
 
 async function open(command: string, host: string = '127.0.0.1', port: number = 5037, serial?: string): Promise<BufferedSocketWrapper> {
@@ -159,6 +155,10 @@ class BufferedSocketWrapper extends EventEmitter implements SocketBackend {
       return;
     debug('pw:adb')('Close ' + this._command);
     this._socket.destroy();
+  }
+
+  [Symbol.dispose]() {
+    this.close();
   }
 
   async read(length: number): Promise<Buffer> {

--- a/packages/playwright-core/src/server/bidi/bidiInput.ts
+++ b/packages/playwright-core/src/server/bidi/bidiInput.ts
@@ -51,19 +51,13 @@ export class RawKeyboardImpl implements input.RawKeyboard {
     let frame: Frame | null = this._page._page.mainFrame();
     while (frame) {
       const context: FrameExecutionContext = await progress.race(frame.mainContext());
-      const handle = await progress.race(context.evaluateHandle((text: string) => (window as any).__pw_bidiInsertText(text), text));
+      using handle = await progress.race(context.evaluateHandle((text: string) => (window as any).__pw_bidiInsertText(text), text));
       // insertText returns the focused frame element when the focus lives inside a nested frame,
       // otherwise the text was inserted (if possible) and we are done.
       const element = handle.asElement();
-      if (!element) {
-        handle.dispose();
+      if (!element)
         return;
-      }
-      try {
-        frame = await element.contentFrame(progress);
-      } finally {
-        element.dispose();
-      }
+      frame = await element.contentFrame(progress);
     }
   }
 

--- a/packages/playwright-core/src/server/bidi/bidiPage.ts
+++ b/packages/playwright-core/src/server/bidi/bidiPage.ts
@@ -535,14 +535,14 @@ export class BidiPage implements PageDelegate {
 
   async getOwnerFrame(handle: dom.ElementHandle): Promise<string | null> {
     // TODO: switch to utility world?
-    const windowHandle = await handle.evaluateHandle(node => {
+    using windowHandle = await handle.evaluateHandle(node => {
       const doc = node.ownerDocument ?? node as Document;
       return doc.defaultView;
     });
     if (!windowHandle)
       return null;
     const executionContext = toBidiExecutionContext(handle._context);
-    return executionContext.frameIdForWindowHandle(windowHandle);
+    return await executionContext.frameIdForWindowHandle(windowHandle);
   }
 
   async getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null> {
@@ -566,7 +566,7 @@ export class BidiPage implements PageDelegate {
   private async _framePosition(frame: frames.Frame): Promise<types.Point | null> {
     if (frame === this._page.mainFrame())
       return { x: 0, y: 0 };
-    const element = await frame.frameElement(nullProgress);
+    using element = await frame.frameElement(nullProgress);
     const box = await element.boundingBox(nullProgress);
     if (!box)
       return null;

--- a/packages/playwright-core/src/server/browserType.ts
+++ b/packages/playwright-core/src/server/browserType.ts
@@ -21,6 +21,7 @@ import path from 'path';
 import { assert } from '@isomorphic/assert';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { DEFAULT_PLAYWRIGHT_TIMEOUT } from '@isomorphic/time';
+import { createTimeout } from '@isomorphic/timeoutRunner';
 import { debugMode } from '@utils/debug';
 import { existsAsync } from '@utils/fileUtils';
 import { envArrayToObject, launchProcess } from '@utils/processLauncher';
@@ -243,16 +244,15 @@ export abstract class BrowserType extends SdkObject {
     }));
 
     async function closeOrKill(timeout: number): Promise<void> {
-      let timer: NodeJS.Timeout;
+      const timeoutPromise = new ManualPromise<void>();
+      using timer = createTimeout(() => timeoutPromise.reject(new Error('Browser close timed out')), timeout);
       try {
         await Promise.race([
           gracefullyClose(),
-          new Promise((resolve, reject) => timer = setTimeout(reject, timeout)),
+          timeoutPromise,
         ]);
       } catch (ignored) {
         await kill().catch(ignored => {}); // Make sure to await actual process exit.
-      } finally {
-        clearTimeout(timer!);
       }
     }
     browserProcess = {

--- a/packages/playwright-core/src/server/chromium/crPage.ts
+++ b/packages/playwright-core/src/server/chromium/crPage.ts
@@ -1103,7 +1103,7 @@ class FrameSession {
 
   async _getOwnerFrame(handle: dom.ElementHandle): Promise<string | null> {
     // document.documentElement has frameId of the owner frame.
-    const documentElement = await handle.evaluateHandle(node => {
+    using documentElement = await handle.evaluateHandle(node => {
       const doc = node as Document;
       if (doc.documentElement && doc.documentElement.ownerDocument === doc)
         return doc.documentElement;
@@ -1116,10 +1116,8 @@ class FrameSession {
     const nodeInfo = await this._client.send('DOM.describeNode', {
       objectId: documentElement._objectId
     });
-    const frameId = nodeInfo && typeof nodeInfo.node.frameId === 'string' ?
+    return nodeInfo && typeof nodeInfo.node.frameId === 'string' ?
       nodeInfo.node.frameId : null;
-    documentElement.dispose();
-    return frameId;
   }
 
   async _getBoundingBox(handle: dom.ElementHandle): Promise<types.Rect | null> {

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -681,45 +681,40 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
       // boundary into the page's main world. Adopt the element to main context and
       // construct the DataTransfer + dispatch events there.
       const mainContext = await progress.race(this._frame.mainContext());
-      const handle = this._context === mainContext ? this : await progress.race(this._page.delegate.adoptElementHandle(this, mainContext));
-      const disposeHandle = handle !== this;
-      try {
-        const result = await progress.race(handle.evaluate((node: Node, { payloads, data, point }) => {
-          if (!node.isConnected || node.nodeType !== 1 /* ELEMENT_NODE */)
-            return 'error:notconnected' as const;
-          const element = node as Element;
-          const dt = new DataTransfer();
-          for (const p of payloads) {
-            const bytes = Uint8Array.from(atob(p.buffer), c => c.charCodeAt(0));
-            const file = new File([bytes], p.name, { type: p.mimeType, lastModified: p.lastModifiedMs });
-            dt.items.add(file);
-          }
-          for (const entry of data)
-            dt.setData(entry.mimeType, entry.value);
-          const makeEvent = (type: string) => new DragEvent(type, {
-            bubbles: true,
-            cancelable: true,
-            composed: true,
-            clientX: point.x,
-            clientY: point.y,
-            dataTransfer: dt,
-          });
-          element.dispatchEvent(makeEvent('dragenter'));
-          const over = makeEvent('dragover');
-          element.dispatchEvent(over);
-          if (!over.defaultPrevented) {
-            element.dispatchEvent(makeEvent('dragleave'));
-            return 'not-accepted' as const;
-          }
-          element.dispatchEvent(makeEvent('drop'));
-          return 'accepted' as const;
-        }, { payloads, data, point }));
-        if (result === 'not-accepted')
-          throw new NonRecoverableDOMError('Drop target did not accept the drop — its dragover handler did not call preventDefault()');
-      } finally {
-        if (disposeHandle)
-          handle.dispose();
-      }
+      using adoptedHandle = this._context === mainContext ? null : await progress.race(this._page.delegate.adoptElementHandle(this, mainContext));
+      const handle = adoptedHandle || this;
+      const result = await progress.race(handle.evaluate((node: Node, { payloads, data, point }) => {
+        if (!node.isConnected || node.nodeType !== 1 /* ELEMENT_NODE */)
+          return 'error:notconnected' as const;
+        const element = node as Element;
+        const dt = new DataTransfer();
+        for (const p of payloads) {
+          const bytes = Uint8Array.from(atob(p.buffer), c => c.charCodeAt(0));
+          const file = new File([bytes], p.name, { type: p.mimeType, lastModified: p.lastModifiedMs });
+          dt.items.add(file);
+        }
+        for (const entry of data)
+          dt.setData(entry.mimeType, entry.value);
+        const makeEvent = (type: string) => new DragEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          clientX: point.x,
+          clientY: point.y,
+          dataTransfer: dt,
+        });
+        element.dispatchEvent(makeEvent('dragenter'));
+        const over = makeEvent('dragover');
+        element.dispatchEvent(over);
+        if (!over.defaultPrevented) {
+          element.dispatchEvent(makeEvent('dragleave'));
+          return 'not-accepted' as const;
+        }
+        element.dispatchEvent(makeEvent('drop'));
+        return 'accepted' as const;
+      }, { payloads, data, point }));
+      if (result === 'not-accepted')
+        throw new NonRecoverableDOMError('Drop target did not accept the drop — its dragover handler did not call preventDefault()');
     }, { ...options, waitAfter: 'disabled' });
   }
 
@@ -926,9 +921,8 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
 
   async _adoptTo(context: FrameExecutionContext): Promise<ElementHandle<T>> {
     if (this._context !== context) {
-      const adopted = await this._page.delegate.adoptElementHandle(this, context);
-      this.dispose();
-      return adopted;
+      using handle = this;
+      return await this._page.delegate.adoptElementHandle(handle, context);
     }
     return this;
   }

--- a/packages/playwright-core/src/server/dom.ts
+++ b/packages/playwright-core/src/server/dom.ts
@@ -743,7 +743,7 @@ export class ElementHandle<T extends Node = Node> extends js.JSHandle<T> {
     }, { multiple, directoryUpload: !!localDirectory }));
     if (result === 'error:notconnected' || !result.asElement())
       return 'error:notconnected';
-    const retargeted = result.asElement() as ElementHandle<HTMLInputElement>;
+    using retargeted = result.asElement() as ElementHandle<HTMLInputElement>;
     await this.instrumentation.onBeforeInputAction(progress, this, undefined, box);
     if (localPaths || localDirectory) {
       const localPathsOrDirectory = localDirectory ? [localDirectory] : localPaths!;

--- a/packages/playwright-core/src/server/electron/electron.ts
+++ b/packages/playwright-core/src/server/electron/electron.ts
@@ -325,13 +325,11 @@ async function waitForLine(progress: Progress, process: childProcess.ChildProces
   // eslint-disable-next-line no-restricted-properties
   const rl = readline.createInterface({ input: process.stderr! });
   const failError = new Error('Process failed to launch!');
-  const listeners = [
-    eventsHelper.addEventListener(rl, 'line', onLine),
-    eventsHelper.addEventListener(rl, 'close', () => promise.reject(failError)),
-    eventsHelper.addEventListener(process, 'exit', () => promise.reject(failError)),
-    // It is Ok to remove error handler because we did not create process and there is another listener.
-    eventsHelper.addEventListener(process, 'error', () => promise.reject(failError)),
-  ];
+  using lineListener = eventsHelper.addEventListener(rl, 'line', onLine);
+  using closeListener = eventsHelper.addEventListener(rl, 'close', () => promise.reject(failError));
+  using exitListener = eventsHelper.addEventListener(process, 'exit', () => promise.reject(failError));
+  // It is Ok to remove error handler because we did not create process and there is another listener.
+  using errorListener = eventsHelper.addEventListener(process, 'error', () => promise.reject(failError));
 
   function onLine(line: string) {
     const match = line.match(regex);
@@ -339,11 +337,7 @@ async function waitForLine(progress: Progress, process: childProcess.ChildProces
       promise.resolve(match);
   }
 
-  try {
-    return await progress.race(promise);
-  } finally {
-    eventsHelper.removeEventListeners(listeners);
-  }
+  return await progress.race(promise);
 }
 
 function escapeDoubleQuotes(str: string): string {

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -78,8 +78,8 @@ export class FrameSelectors {
     const context = await resolved.frame.context(world);
     if (context === resolved.result._context)
       return resolved.result;
-    const properties = await resolved.result.internalGetProperties();
-    resolved.result.dispose();
+    using arrayHandle = resolved.result;
+    const properties = await arrayHandle.internalGetProperties();
     const elements = [...properties.values()];
     try {
       return await context.evaluateExpressionHandle('elements => elements', { isFunction: true }, elements);
@@ -313,7 +313,6 @@ export class FrameSelectors {
 async function adoptIfNeeded<T extends Node>(handle: ElementHandle<T>, context: FrameExecutionContext): Promise<ElementHandle<T>> {
   if (handle._context === context)
     return handle;
-  const adopted = await handle._page.delegate.adoptElementHandle(handle, context);
-  handle.dispose();
-  return adopted;
+  using originalHandle = handle;
+  return await handle._page.delegate.adoptElementHandle(originalHandle, context);
 }

--- a/packages/playwright-core/src/server/frameSelectors.ts
+++ b/packages/playwright-core/src/server/frameSelectors.ts
@@ -98,7 +98,7 @@ export class FrameSelectors {
     if (!resolved)
       return [];
 
-    const arrayHandle = resolved.result;
+    using arrayHandle = resolved.result;
     const properties = await arrayHandle.internalGetProperties();
     const elementHandles: ElementHandle<Element>[] = [];
     for (const property of properties.values()) {
@@ -108,7 +108,6 @@ export class FrameSelectors {
       else
         property.dispose();
     }
-    arrayHandle.dispose();
     if (!elementHandles.length)
       return [];
 
@@ -182,18 +181,16 @@ export class FrameSelectors {
     result.push(this.frame);
     await this.frame.raceAgainstEvaluationStallingEvents(async () => {
       const injected = await scope._context.injectedScript();
-      const frameElements = await injected.evaluateHandle((injected, scope) => {
+      using frameElements = await injected.evaluateHandle((injected, scope) => {
         return injected.querySelectorAll(injected.parseSelector('css=frame,iframe'), scope);
       }, scope);
       const count = await frameElements.evaluate(elements => elements.length);
       for (let i = 0; i < count; ++i) {
-        const frameElement = await frameElements.evaluateHandle((elements, i) => elements[i], i) as ElementHandle<Element>;
+        using frameElement = await frameElements.evaluateHandle((elements, i) => elements[i], i) as ElementHandle<Element>;
         const childFrame = await this.frame._page.delegate.getContentFrame(frameElement);
-        frameElement.dispose();
         if (childFrame)
           collectSubtree(childFrame);
       }
-      frameElements.dispose();
     }).catch(() => {});
     return result;
   }
@@ -215,7 +212,7 @@ export class FrameSelectors {
           return element;
         }, { info, scope: i === 0 ? scope : undefined, selectorString: stringifySelector(info.parsed) });
       };
-      const handle = noStall ? await frame.raceAgainstEvaluationStallingEvents(queryFrameElement).catch(e => {
+      using handle = noStall ? await frame.raceAgainstEvaluationStallingEvents(queryFrameElement).catch(e => {
         if (e instanceof EvaluationStalledError)
           return null;
         throw e;
@@ -224,7 +221,6 @@ export class FrameSelectors {
       if (!element)
         return null;
       const maybeFrame = await frame._page.delegate.getContentFrame(element);
-      element.dispose();
       if (!maybeFrame)
         return null;
       frame = maybeFrame;

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -865,21 +865,16 @@ export class Frame extends SdkObject<FrameEventMap> {
           return null;
         return continuePolling;
       }
-      const result = resolved.result;
+      using result = resolved.result;
       const { log, visible, attached } = await progress.race(result.evaluate(r => ({ log: r.log, visible: r.visible, attached: r.attached })));
       if (log)
         progress.log(log);
       const success = { attached, detached: !attached, visible, hidden: !visible }[state];
-      if (!success) {
-        result.dispose();
+      if (!success)
         return continuePolling;
-      }
-      if (options.omitReturnValue) {
-        result.dispose();
+      if (options.omitReturnValue)
         return null;
-      }
       const element = state === 'attached' || state === 'visible' ? await progress.race(result.evaluateHandle(r => r.element)) : null;
-      result.dispose();
       if (!element)
         return null;
       if ((options as any).__testHookBeforeAdoptNode)
@@ -906,12 +901,10 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   private async _evalOnSelector(selector: string, strict: boolean, expression: string, options: { isFunction?: boolean, world?: types.World }, arg: any, scope?: dom.ElementHandle): Promise<any> {
-    const handle = await this.selectors.query(selector, { strict }, scope);
+    using handle = await this.selectors.query(selector, { strict }, scope);
     if (!handle)
       throw new Error(`Failed to find element matching selector "${selector}"`);
-    const result = await handle.internalEvaluateExpression(expression, options, arg);
-    handle.dispose();
-    return result;
+    return await handle.internalEvaluateExpression(expression, options, arg);
   }
 
   async evalOnSelectorAll(progress: Progress, selector: string, expression: string, options: { isFunction?: boolean, world?: types.World }, arg: any, scope?: dom.ElementHandle): Promise<any> {
@@ -919,10 +912,8 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   private async _evalOnSelectorAll(selector: string, expression: string, options: { isFunction?: boolean, world?: types.World }, arg: any, scope?: dom.ElementHandle): Promise<any> {
-    const arrayHandle = await this.selectors.queryArrayInWorld(selector, options.world ?? 'main', scope);
-    const result = await arrayHandle.internalEvaluateExpression(expression, { isFunction: options.isFunction }, arg);
-    arrayHandle.dispose();
-    return result;
+    using arrayHandle = await this.selectors.queryArrayInWorld(selector, options.world ?? 'main', scope);
+    return await arrayHandle.internalEvaluateExpression(expression, { isFunction: options.isFunction }, arg);
   }
 
   async querySelectorAll(progress: Progress, selector: string): Promise<dom.ElementHandle<Element>[]> {
@@ -1223,30 +1214,24 @@ export class Frame extends SdkObject<FrameEventMap> {
           throw new dom.NonRecoverableDOMError('Element(s) not found');
         return continuePolling;
       }
-      const result = resolved.result;
+      using result = resolved.result;
       const { log, success, box } = await progress.race(result.evaluate(r => ({ log: r.log, success: r.success, box: r.box })));
       if (log)
         progress.log(log);
       if (!success) {
         if (noAutoWaiting)
           throw new dom.NonRecoverableDOMError('Element(s) not found');
-        result.dispose();
         return continuePolling;
       }
-      const element = await progress.race(result.evaluateHandle(r => r.element)) as dom.ElementHandle<Element>;
-      result.dispose();
-      try {
-        const result = await action(progress, element, box);
-        if (result === 'error:notconnected') {
-          if (noAutoWaiting)
-            throw new dom.NonRecoverableDOMError('Element is not attached to the DOM');
-          progress.log('element was detached from the DOM, retrying');
-          return continuePolling;
-        }
-        return result;
-      } finally {
-        element?.dispose();
+      using element = await progress.race(result.evaluateHandle(r => r.element)) as dom.ElementHandle<Element>;
+      const actionResult = await action(progress, element, box);
+      if (actionResult === 'error:notconnected') {
+        if (noAutoWaiting)
+          throw new dom.NonRecoverableDOMError('Element is not attached to the DOM');
+        progress.log('element was detached from the DOM, retrying');
+        return continuePolling;
       }
+      return actionResult;
     });
   }
 
@@ -1308,7 +1293,7 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async resolveSelector(progress: Progress, selector: string, options: { mainWorld?: boolean } = {}): Promise<{ resolvedSelector: string }> {
-    const element = await progress.race(this.selectors.query(selector, options));
+    using element = await progress.race(this.selectors.query(selector, options));
     if (!element)
       throw new Error(`No element matching ${selector}`);
 
@@ -1321,12 +1306,11 @@ export class Frame extends SdkObject<FrameEventMap> {
     let frame: Frame | null = element._frame;
     const result = [generated];
     while (frame?.parentFrame()) {
-      const frameElement = await frame.frameElement(progress);
+      using frameElement = await frame.frameElement(progress);
       if (frameElement) {
         const generated = await progress.race(frameElement.evaluateInUtility(async ([injected, node]) => {
           return injected.generateSelectorSimple(node as unknown as Element);
         }, {}));
-        frameElement.dispose();
         if (generated === 'error:notconnected' || !generated)
           throw new Error(`Unable to generate locator for ${selector}`);
         result.push(generated);
@@ -1613,7 +1597,7 @@ export class Frame extends SdkObject<FrameEventMap> {
     return this.retryWithProgressAndTimeouts(progress, [100], async () => {
       const context = world === 'main' ? await progress.race(this.mainContext()) : await progress.race(this.utilityContext());
       const injectedScript = await progress.race(context.injectedScript());
-      const handle = await raceUncancellableOperationWithCleanup(progress, () => injectedScript.evaluateHandle((injected, { expression, isFunction, polling, arg }) => {
+      using handle = await raceUncancellableOperationWithCleanup(progress, () => injectedScript.evaluateHandle((injected, { expression, isFunction, polling, arg }) => {
         let evaledExpression: any;
         const predicate = (): R => {
           // NOTE: make sure to use `globalThis.eval` instead of `self.eval` due to a bug with sandbox isolation
@@ -1671,8 +1655,6 @@ export class Frame extends SdkObject<FrameEventMap> {
         // after this method returns.
         await handle.evaluate(h => h.abort()).catch(() => {});
         throw error;
-      } finally {
-        handle.dispose();
       }
     });
   }

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -45,7 +45,6 @@ import type { ConsoleMessage } from './console';
 import type { ElementStateWithoutStable, FrameExpectParams, InjectedScript } from '@injected/injectedScript';
 import type { Progress } from './progress';
 import type { ScreenshotOptions } from './screenshotter';
-import type { RegisteredListener } from '@utils/eventsHelper';
 import type * as channels from './channels';
 import type { AriaSnapshotJSON } from '@isomorphic/ariaSnapshot';
 
@@ -1110,23 +1109,22 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   private async _raceWithCSPError(func: () => Promise<dom.ElementHandle>): Promise<dom.ElementHandle> {
-    const listeners: RegisteredListener[] = [];
     let result: dom.ElementHandle;
     let error: Error | undefined;
     let cspMessage: ConsoleMessage | undefined;
     const actionPromise = func().then(r => result = r).catch(e => error = e);
-    const errorPromise = new Promise<void>(resolve => {
-      listeners.push(eventsHelper.addEventListener(this._page.browserContext, BrowserContext.Events.Console, (message: ConsoleMessage) => {
+    const errorPromise = new ManualPromise<void>();
+    {
+      using listener = eventsHelper.addEventListener(this._page.browserContext, BrowserContext.Events.Console, (message: ConsoleMessage) => {
         if (message.page() !== this._page || message.type() !== 'error')
           return;
         if (message.text().includes('Content-Security-Policy') || message.text().includes('Content Security Policy')) {
           cspMessage = message;
-          resolve();
+          errorPromise.resolve();
         }
-      }));
-    });
-    await Promise.race([actionPromise, errorPromise]);
-    eventsHelper.removeEventListeners(listeners);
+      });
+      await Promise.race([actionPromise, errorPromise]);
+    }
     if (cspMessage)
       throw new Error(cspMessage.text());
     if (error)

--- a/packages/playwright-core/src/server/frames.ts
+++ b/packages/playwright-core/src/server/frames.ts
@@ -25,6 +25,7 @@ import { LongStandingScope } from '@isomorphic/manualPromise';
 import { asLocator } from '@isomorphic/locatorGenerators';
 import { assert } from '@isomorphic/assert';
 import { constructURLBasedOnBaseURL } from '@isomorphic/urlMatch';
+import { createTimeout } from '@isomorphic/timeoutRunner';
 import { createGuid } from '@utils/crypto';
 import { BrowserContext } from './browserContext';
 import * as dom from './dom';
@@ -1444,17 +1445,13 @@ export class Frame extends SdkObject<FrameEventMap> {
   }
 
   async waitForTimeout(progress: Progress, timeout: number) {
-    let timer: NodeJS.Timeout;
-    const promise = new Promise<void>(f => timer = setTimeout(f, timeout));
-    try {
-      // Make sure we react to page close or frame detach.
-      await progress.race(LongStandingScope.raceMultiple([
-        this._page.openScope,
-        this._detachedScope,
-      ], promise));
-    } finally {
-      clearTimeout(timer!);
-    }
+    const promise = new ManualPromise<void>();
+    using timer = createTimeout(() => promise.resolve(), timeout);
+    // Make sure we react to page close or frame detach.
+    await progress.race(LongStandingScope.raceMultiple([
+      this._page.openScope,
+      this._detachedScope,
+    ], promise));
   }
 
   async expect(progress: Progress, selector: string | undefined, options: FrameExpectParams): Promise<void> {

--- a/packages/playwright-core/src/server/javascript.ts
+++ b/packages/playwright-core/src/server/javascript.ts
@@ -180,15 +180,13 @@ export class JSHandle<T = any> extends SdkObject {
   }
 
   private async _getProperty(propertyName: string): Promise<JSHandle> {
-    const objectHandle = await this.evaluateHandle((object: any, propertyName) => {
+    using objectHandle = await this.evaluateHandle((object: any, propertyName) => {
       const result: any = { __proto__: null };
       result[propertyName] = object[propertyName];
       return result;
     }, propertyName);
     const properties = await objectHandle.internalGetProperties();
-    const result = properties.get(propertyName)!;
-    objectHandle.dispose();
-    return result;
+    return properties.get(propertyName)!;
   }
 
   async internalGetProperties(): Promise<Map<string, JSHandle>> {

--- a/packages/playwright-core/src/server/localUtils.ts
+++ b/packages/playwright-core/src/server/localUtils.ts
@@ -188,28 +188,24 @@ export function harClose(harBackends: Map<string, HarBackend>, params: channels.
 
 export async function harUnzip(progress: Progress, params: channels.LocalUtilsHarUnzipParams): Promise<void> {
   const resourcesDir = params.resourcesDir ?? path.dirname(params.zipFile);
-  const zipFile = new ZipFile(params.zipFile);
+  using zipFile = new ZipFile(params.zipFile);
   let resourcesDirCreated = false;
-  try {
-    for (const entry of await progress.race(zipFile.entries())) {
-      const buffer = await progress.race(zipFile.read(entry));
-      if (entry === 'har.har') {
-        await progress.race(fs.promises.writeFile(params.harFile, buffer));
-      } else {
-        if (!resourcesDirCreated) {
-          await progress.race(fs.promises.mkdir(resourcesDir, { recursive: true }));
-          resourcesDirCreated = true;
-        }
-        const outPath = resolveWithinRoot(resourcesDir, entry);
-        if (!outPath)
-          throw new Error(`HAR zip entry '${entry}' escapes output directory`);
-        await progress.race(fs.promises.writeFile(outPath, buffer));
+  for (const entry of await progress.race(zipFile.entries())) {
+    const buffer = await progress.race(zipFile.read(entry));
+    if (entry === 'har.har') {
+      await progress.race(fs.promises.writeFile(params.harFile, buffer));
+    } else {
+      if (!resourcesDirCreated) {
+        await progress.race(fs.promises.mkdir(resourcesDir, { recursive: true }));
+        resourcesDirCreated = true;
       }
+      const outPath = resolveWithinRoot(resourcesDir, entry);
+      if (!outPath)
+        throw new Error(`HAR zip entry '${entry}' escapes output directory`);
+      await progress.race(fs.promises.writeFile(outPath, buffer));
     }
-    await progress.race(fs.promises.unlink(params.zipFile));
-  } finally {
-    zipFile.close();
   }
+  await progress.race(fs.promises.unlink(params.zipFile));
 }
 
 export async function tracingStarted(progress: Progress, stackSessions: Map<string, StackSession>, params: channels.LocalUtilsTracingStartedParams): Promise<channels.LocalUtilsTracingStartedResult> {

--- a/packages/playwright-core/src/server/progress.ts
+++ b/packages/playwright-core/src/server/progress.ts
@@ -17,6 +17,7 @@
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { assert } from '@isomorphic/assert';
 import { monotonicTime } from '@isomorphic/time';
+import { createTimeout } from '@isomorphic/timeoutRunner';
 import { debugLogger } from '@utils/debugLogger';
 import { TimeoutError } from './errors';
 
@@ -125,9 +126,9 @@ export class ProgressController {
       },
       wait: async (timeout: number) => {
         // Timeout = 0 here means nowait. Counter to what it typically is (wait forever).
-        let timer: NodeJS.Timeout;
-        const promise = new Promise<void>(f => timer = setTimeout(f, timeout));
-        return progress.race(promise).finally(() => clearTimeout(timer));
+        const promise = new ManualPromise<void>();
+        using timer = createTimeout(() => promise.resolve(), timeout);
+        return await progress.race(promise);
       },
       signal: this._controller.signal,
     };

--- a/packages/playwright-core/src/server/recorder.ts
+++ b/packages/playwright-core/src/server/recorder.ts
@@ -281,11 +281,9 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       recorderChangedState = true;
       selectorPromise.reject(new Error('Locator picking was cancelled'));
     };
-    const listeners: RegisteredListener[] = [
-      eventsHelper.addEventListener(this, RecorderEvent.ElementPicked, onElementPicked),
-      eventsHelper.addEventListener(this, RecorderEvent.ModeChanged, onModeChanged),
-    ];
     try {
+      using elementPickedListener = eventsHelper.addEventListener(this, RecorderEvent.ElementPicked, onElementPicked);
+      using modeChangedListener = eventsHelper.addEventListener(this, RecorderEvent.ModeChanged, onModeChanged);
       const doPickLocator = async () => {
         // Prevent unhandled rejection in case of cancellation during setMode
         selectorPromise.catch(() => {});
@@ -295,7 +293,6 @@ export class Recorder extends EventEmitter<RecorderEventMap> implements Instrume
       };
       return await progress.race(page.openScope.race(doPickLocator()));
     } finally {
-      eventsHelper.removeEventListeners(listeners);
       this._pickLocatorPage = undefined;
       if (!recorderChangedState)
         await progress.race(this.setMode('none'));

--- a/packages/playwright-core/src/server/recorder/recorderUtils.ts
+++ b/packages/playwright-core/src/server/recorder/recorderUtils.ts
@@ -125,7 +125,7 @@ async function generateFrameSelector(progress: Progress, frame: Frame, timeout: 
 async function generateFrameSelectorInParent(prgoress: Progress, parent: Frame, frame: Frame, timeout: number): Promise<string> {
   const result = await raceAgainstDeadline(async () => {
     try {
-      const frameElement = await frame.frameElement(prgoress);
+      using frameElement = await frame.frameElement(prgoress);
       if (!frameElement || !parent)
         return;
       const utility = await parent.utilityContext();

--- a/packages/playwright-core/src/server/registry/index.ts
+++ b/packages/playwright-core/src/server/registry/index.ts
@@ -43,6 +43,7 @@ export { writeDockerVersion } from './dependencies';
 
 const PACKAGE_PATH = packageRoot;
 const BIN_PATH = binPath;
+const kAsyncDispose: typeof Symbol.asyncDispose = (Symbol.asyncDispose || Symbol.for('Symbol.asyncDispose')) as typeof Symbol.asyncDispose;
 
 const PLAYWRIGHT_CDN_MIRRORS = [
   'https://cdn.playwright.dev/dbazure/download/playwright', // ESRP CDN
@@ -937,21 +938,22 @@ export class Registry {
     const lockfilePath = path.join(registryDirectory, '__dirlock');
     const linksDir = path.join(registryDirectory, '.links');
 
-    let releaseLock;
     try {
-      releaseLock = await lock(registryDirectory, {
-        retries: {
-          // Retry 20 times during 10 minutes with
-          // exponential back-off.
-          // See documentation at: https://www.npmjs.com/package/retry#retrytimeoutsoptions
-          retries: 20,
-          factor: 1.27579,
-        },
-        onCompromised: (err: Error) => {
-          throw new Error(`${err.message} Path: ${lockfilePath}`);
-        },
-        lockfilePath,
-      });
+      await using installationLock = {
+        [kAsyncDispose]: await lock(registryDirectory, {
+          retries: {
+            // Retry 20 times during 10 minutes with
+            // exponential back-off.
+            // See documentation at: https://www.npmjs.com/package/retry#retrytimeoutsoptions
+            retries: 20,
+            factor: 1.27579,
+          },
+          onCompromised: (err: Error) => {
+            throw new Error(`${err.message} Path: ${lockfilePath}`);
+          },
+          lockfilePath,
+        }),
+      };
       // Create a link first, so that cache validation does not remove our own browsers.
       await fs.promises.mkdir(linksDir, { recursive: true });
       await fs.promises.writeFile(path.join(linksDir, calculateSha1(PACKAGE_PATH)), PACKAGE_PATH);
@@ -1007,9 +1009,6 @@ export class Registry {
       } else {
         throw e;
       }
-    } finally {
-      if (releaseLock)
-        await releaseLock();
     }
   }
 

--- a/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
+++ b/packages/playwright-core/src/server/trace/recorder/snapshotter.ts
@@ -166,7 +166,7 @@ export class Snapshotter {
 
   private _annotateFrameHierarchy(frame: Frame) {
     (async () => {
-      const frameElement = await frame.frameElement(nullProgress);
+      using frameElement = await frame.frameElement(nullProgress);
       const parent = frame.parentFrame();
       if (!parent)
         return;
@@ -174,7 +174,6 @@ export class Snapshotter {
       await context?.evaluate(({ snapshotStreamer, frameElement, frameId }) => {
         (window as any)[snapshotStreamer].markIframe(frameElement, frameId);
       }, { snapshotStreamer: this._snapshotStreamer, frameElement, frameId: frame.guid });
-      frameElement.dispose();
     })().catch(() => {});
   }
 }

--- a/packages/playwright-core/src/server/webkit/webview/wvPage.ts
+++ b/packages/playwright-core/src/server/webkit/webview/wvPage.ts
@@ -915,7 +915,7 @@ export class WVPage implements PageDelegate {
     let quads = result as types.Quad[];
     let frame: frames.Frame | null = handle._frame;
     while (frame?.parentFrame()) {
-      const frameElement = await this.getFrameElement(frame).catch(() => null);
+      using frameElement = await this.getFrameElement(frame).catch(() => null);
       if (!frameElement)
         return null;
       const offset = await frameElement.evaluateInUtility(([injected, iframe]) => {
@@ -925,7 +925,7 @@ export class WVPage implements PageDelegate {
           return null;
         const rect = element.getBoundingClientRect();
         return { x: rect.left + style.left, y: rect.top + style.top };
-      }, {}).finally(() => frameElement.dispose());
+      }, {});
       if (!offset || typeof offset === 'string')
         return null;
       quads = quads.map(quad => quad.map(point => ({ x: point.x + offset.x, y: point.y + offset.y })) as types.Quad);
@@ -950,8 +950,8 @@ export class WVPage implements PageDelegate {
     let frame: frames.Frame = this._page.mainFrame();
     for (;;) {
       const context = await progress.race(frame.mainContext());
-      const iframe = await progress.race(context.evaluateHandle(() => (globalThis as any).__pwWebViewInput.activeIFrame())) as dom.ElementHandle;
-      const childFrame = await this._childFrameAndDispose(progress, iframe);
+      using iframe = await progress.race(context.evaluateHandle(() => (globalThis as any).__pwWebViewInput.activeIFrame())) as dom.ElementHandle;
+      const childFrame = await progress.race(this.getContentFrame(iframe));
       if (!childFrame)
         break;
       frame = childFrame;
@@ -968,27 +968,15 @@ export class WVPage implements PageDelegate {
     for (;;) {
       path.push({ frame, point });
       const context = await progress.race(frame.mainContext());
-      const position = await progress.race(context.evaluateHandle(p => (globalThis as any).__pwWebViewInput.positionInIFrame(p.x, p.y), point));
-      try {
-        const iframe = await position.getProperty(progress, 'iframe') as dom.ElementHandle;
-        const childFrame = await this._childFrameAndDispose(progress, iframe);
-        if (!childFrame)
-          break;
-        frame = childFrame;
-        point = await progress.race(position.evaluate(result => ({ x: result.x, y: result.y })));
-      } finally {
-        position.dispose();
-      }
+      using position = await progress.race(context.evaluateHandle(p => (globalThis as any).__pwWebViewInput.positionInIFrame(p.x, p.y), point));
+      using iframe = await position.getProperty(progress, 'iframe') as dom.ElementHandle;
+      const childFrame = await progress.race(this.getContentFrame(iframe));
+      if (!childFrame)
+        break;
+      frame = childFrame;
+      point = await progress.race(position.evaluate(result => ({ x: result.x, y: result.y })));
     }
     return path;
-  }
-
-  private async _childFrameAndDispose(progress: Progress, iframe: dom.ElementHandle): Promise<frames.Frame | null> {
-    try {
-      return await progress.race(this.getContentFrame(iframe));
-    } finally {
-      iframe.dispose();
-    }
   }
 
   async resetForReuse(progress: Progress): Promise<void> {
@@ -1001,9 +989,9 @@ export class WVPage implements PageDelegate {
     // Requesting the frame's own document streams its ancestor path, which
     // includes the owner element (and its siblings). Pick the one whose
     // contentDocument is this frame, then resolve it in the parent's context.
-    const documentHandle = await (await frame.mainContext()).evaluateHandle(() => document);
     let ownerNodeId: number | undefined;
-    try {
+    {
+      using documentHandle = await (await frame.mainContext()).evaluateHandle(() => document);
       if (documentHandle._objectId) {
         const { nodesById } = await this._requestNodeViaDOM(documentHandle._objectId);
         for (const node of nodesById.values()) {
@@ -1013,8 +1001,6 @@ export class WVPage implements PageDelegate {
           }
         }
       }
-    } finally {
-      documentHandle.dispose();
     }
     const resolved = ownerNodeId !== undefined ? await this._session.sendMayFail('DOM.resolveNode', { nodeId: ownerNodeId }) : null;
     if (!resolved || resolved.object.subtype === 'null')

--- a/packages/playwright-core/src/serverRegistry.ts
+++ b/packages/playwright-core/src/serverRegistry.ts
@@ -28,6 +28,7 @@ import type { FSWatcher } from 'chokidar';
 import type { LaunchOptions } from '../types/types';
 
 const packageVersion = packageJSON.version;
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
 
 export type BrowserInfo = {
   guid: string;
@@ -91,36 +92,29 @@ class ServerRegistry extends EventEmitter {
   }
 
   async list(): Promise<Map<string, BrowserDescriptor[]>> {
-    const ownWatcher = !this._watcher;
-    let dispose: (() => void) | undefined;
-    if (ownWatcher)
-      dispose = this.watch();
-    try {
-      await this._ready;
-      const statuses = await Promise.all(
-          [...this._descriptors.values()].map(async descriptor => {
-            const canConnect = await canConnectTo(descriptor);
-            return { descriptor, canConnect };
-          }),
-      );
-      const result = new Map<string, BrowserDescriptor[]>();
-      for (const { descriptor, canConnect } of statuses) {
-        if (!canConnect) {
-          await fs.promises.unlink(path.join(this._browsersDir(), descriptor.browser.guid)).catch(() => {});
-          continue;
-        }
-        const key = descriptor.workspaceDir ?? '';
-        let list = result.get(key);
-        if (!list) {
-          list = [];
-          result.set(key, list);
-        }
-        list.push(descriptor);
+    using watcher = this._watcher ? undefined : { [kDispose]: this.watch() };
+    await this._ready;
+    const statuses = await Promise.all(
+        [...this._descriptors.values()].map(async descriptor => {
+          const canConnect = await canConnectTo(descriptor);
+          return { descriptor, canConnect };
+        }),
+    );
+    const result = new Map<string, BrowserDescriptor[]>();
+    for (const { descriptor, canConnect } of statuses) {
+      if (!canConnect) {
+        await fs.promises.unlink(path.join(this._browsersDir(), descriptor.browser.guid)).catch(() => {});
+        continue;
       }
-      return result;
-    } finally {
-      dispose?.();
+      const key = descriptor.workspaceDir ?? '';
+      let list = result.get(key);
+      if (!list) {
+        list = [];
+        result.set(key, list);
+      }
+      list.push(descriptor);
     }
+    return result;
   }
 
   async create(browser: BrowserInfo, endpoint: EndpointInfo) {

--- a/packages/playwright-core/src/tools/backend/utils.ts
+++ b/packages/playwright-core/src/tools/backend/utils.ts
@@ -16,6 +16,7 @@
 
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { createTimeout } from '@isomorphic/timeoutRunner';
+import { eventsHelper } from '@utils/eventsHelper';
 
 import type * as playwright from '../../..';
 import type { Tab } from './tab';
@@ -24,18 +25,11 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
   const settleMs = tab.context.config.timeouts?.settle ?? 500;
   const requests: playwright.Request[] = [];
 
-  const requestListener = (request: playwright.Request) => requests.push(request);
-  const disposeListeners = () => {
-    tab.page.off('request', requestListener);
-  };
-  tab.page.on('request', requestListener);
-
   let result: R;
-  try {
+  {
+    using requestListener = eventsHelper.addEventListener(tab.page, 'request', (request: playwright.Request) => requests.push(request));
     result = await callback();
     await tab.waitForTimeout(settleMs);
-  } finally {
-    disposeListeners();
   }
 
   const requestedNavigation = requests.some(request => request.isNavigationRequest());
@@ -63,27 +57,15 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
 }
 
 export function eventWaiter<T>(page: playwright.Page, event: string, timeout: number): { promise: Promise<T | undefined>, abort: () => void } {
-  const disposables: (() => void)[] = [];
-
-  const eventPromise = new Promise<T | undefined>((resolve, reject) => {
-    // eslint-disable-next-line no-restricted-syntax
-    page.on(event as any, resolve as any);
-    // eslint-disable-next-line no-restricted-syntax
-    disposables.push(() => page.off(event as any, resolve as any));
-  });
-
-  let abort: () => void;
-  const abortPromise = new Promise<T | undefined>((resolve, reject) => {
-    abort = () => resolve(undefined);
-  });
-
-  const timeoutPromise = new Promise<T | undefined>(f => {
-    const timeoutId = setTimeout(() => f(undefined), timeout);
-    disposables.push(() => clearTimeout(timeoutId));
-  });
+  const result = new ManualPromise<T | undefined>();
+  async function waitForResult() {
+    using listener = eventsHelper.addEventListener(page, event, (value: T) => result.resolve(value));
+    using timer = createTimeout(() => result.resolve(undefined), timeout);
+    return await result;
+  }
 
   return {
-    promise: Promise.race([eventPromise, abortPromise, timeoutPromise]).finally(() => disposables.forEach(dispose => dispose())),
-    abort: abort!
+    promise: waitForResult(),
+    abort: () => result.resolve(undefined),
   };
 }

--- a/packages/playwright-core/src/tools/backend/utils.ts
+++ b/packages/playwright-core/src/tools/backend/utils.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { ManualPromise } from '@isomorphic/manualPromise';
+import { createTimeout } from '@isomorphic/timeoutRunner';
+
 import type * as playwright from '../../..';
 import type { Tab } from './tab';
 
@@ -48,8 +51,11 @@ export async function waitForCompletion<R>(tab: Tab, callback: () => Promise<R>)
     else
       promises.push(request.response().catch(() => {}));
   }
-  const timeout = new Promise<void>(resolve => setTimeout(resolve, 5000));
-  await Promise.race([Promise.all(promises), timeout]);
+  const timeoutPromise = new ManualPromise<void>();
+  {
+    using timeout = createTimeout(() => timeoutPromise.resolve(), 5000);
+    await Promise.race([Promise.all(promises), timeoutPromise]);
+  }
   if (requests.length)
     await tab.waitForTimeout(settleMs);
 

--- a/packages/playwright-core/src/tools/cli-client/session.ts
+++ b/packages/playwright-core/src/tools/cli-client/session.ts
@@ -230,16 +230,16 @@ class SocketConnectionClient {
   }
 
   static async sendAndClose(socket: net.Socket, method: string, params: any = {}): Promise<any> {
-    const connection = new SocketConnectionClient(socket);
-    try {
-      return await connection.send(method, params);
-    } finally {
-      connection.close();
-    }
+    using connection = new SocketConnectionClient(socket);
+    return await connection.send(method, params);
   }
 
   close() {
     this._connection.close();
+  }
+
+  [Symbol.dispose]() {
+    this.close();
   }
 
   private _onMessage(object: { id: number, error?: string, result: any }) {

--- a/packages/playwright-core/src/tools/trace/traceParser.ts
+++ b/packages/playwright-core/src/tools/trace/traceParser.ts
@@ -82,18 +82,14 @@ export class DirTraceLoaderBackend implements TraceLoaderBackend {
 }
 
 export async function extractTrace(traceFile: string, outDir: string): Promise<void> {
-  const zipFile = new ZipFile(traceFile);
-  try {
-    const entries = await zipFile.entries();
-    for (const entry of entries) {
-      const outPath = resolveWithinRoot(outDir, entry);
-      if (!outPath)
-        throw new Error(`Trace entry '${entry}' escapes output directory`);
-      await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
-      const buffer = await zipFile.read(entry);
-      await fs.promises.writeFile(outPath, buffer);
-    }
-  } finally {
-    zipFile.close();
+  using zipFile = new ZipFile(traceFile);
+  const entries = await zipFile.entries();
+  for (const entry of entries) {
+    const outPath = resolveWithinRoot(outDir, entry);
+    if (!outPath)
+      throw new Error(`Trace entry '${entry}' escapes output directory`);
+    await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+    const buffer = await zipFile.read(entry);
+    await fs.promises.writeFile(outPath, buffer);
   }
 }

--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -34,6 +34,8 @@ import { configLoader } from '../../common';
 import type { ConfigLocation } from '../../common';
 import type { BrowserMCPRequest, BrowserMCPResponse } from './browserBackend';
 
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
+
 export type SeedFile = {
   file: string;
   content: string;
@@ -78,7 +80,7 @@ ${step.code}
 type TestRunnerAndScreen = {
   testRunner: testRunner.TestRunner;
   screen: base.TerminalScreen;
-  claimStdio: () => void;
+  claimStdio: () => Disposable;
   releaseStdio: () => void;
   output: string[];
   waitForTestPaused: () => Promise<void>;
@@ -120,11 +122,10 @@ export class TestContext {
     if (!this._testRunnerAndScreen)
       return;
     await this._testRunnerAndScreen.testRunner.stopTests();
-    this._testRunnerAndScreen.claimStdio();
     try {
+      using stdio = this._testRunnerAndScreen.claimStdio();
       await this._testRunnerAndScreen.testRunner.runGlobalTeardown();
     } finally {
-      this._testRunnerAndScreen.releaseStdio();
       this._testRunnerAndScreen = undefined;
     }
   }
@@ -208,29 +209,23 @@ export class TestContext {
   private async _runTestsImpl(params: testRunner.RunTestsParams, signal?: AbortSignal): Promise<{ output: string, status: testRunner.FullResultStatus | 'paused' }> {
     const configDir = this._configLocation.configDir;
     const testRunnerAndScreen = await this.createTestRunner();
-    const { testRunner: runner, screen, claimStdio, releaseStdio } = testRunnerAndScreen;
+    const { testRunner: runner, screen, claimStdio } = testRunnerAndScreen;
 
-    claimStdio();
-    try {
+    {
+      using stdio = claimStdio();
       const setupReporter = new MCPListReporter({ configDir, screen, includeTestId: true });
       const { status } = await runner.runGlobalSetup([setupReporter]);
       if (status !== 'passed')
         return { output: testRunnerAndScreen.output.join('\n'), status };
-    } finally {
-      releaseStdio();
     }
 
     let status: testRunner.FullResultStatus | 'paused' = 'passed';
 
     const cleanup = async () => {
-      claimStdio();
-      try {
-        const result = await runner.runGlobalTeardown();
-        if (status === 'passed')
-          status = result.status;
-      } finally {
-        releaseStdio();
-      }
+      using stdio = claimStdio();
+      const result = await runner.runGlobalTeardown();
+      if (status === 'passed')
+        status = result.status;
     };
 
     {
@@ -309,7 +304,7 @@ export function createScreen() {
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
 
-  const claimStdio = () => {
+  function claimStdio(): Disposable {
     process.stdout.write = (chunk: string | Buffer) => {
       stdout.write(chunk);
       return true;
@@ -318,12 +313,21 @@ export function createScreen() {
       stderr.write(chunk);
       return true;
     };
-  };
+    let disposed = false;
+    return {
+      [kDispose]() {
+        if (disposed)
+          return;
+        disposed = true;
+        releaseStdio();
+      },
+    };
+  }
 
-  const releaseStdio = () => {
+  function releaseStdio() {
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
-  };
+  }
   /* eslint-enable no-restricted-properties */
 
   return { screen, claimStdio, releaseStdio, output };

--- a/packages/playwright/src/mcp/test/testContext.ts
+++ b/packages/playwright/src/mcp/test/testContext.ts
@@ -233,39 +233,39 @@ export class TestContext {
       }
     };
 
-    const abort = signal ? signalToPromise(signal) : undefined;
-    const abortPromise = abort
-      ? abort.promise.then(() => 'interrupted' as const)
-      : new Promise<never>(() => {});
+    {
+      using abort = signal ? signalToPromise(signal) : undefined;
+      const abortPromise = abort
+        ? abort.promise.then(() => 'interrupted' as const)
+        : new Promise<never>(() => {});
 
-    try {
-      const reporter = new MCPListReporter({ configDir, screen, includeTestId: true });
-      status = await Promise.race([
-        runner.runTests(reporter, params).then(result => result.status),
-        testRunnerAndScreen.waitForTestPaused().then(() => 'paused' as const),
-        abortPromise,
-      ]);
+      try {
+        const reporter = new MCPListReporter({ configDir, screen, includeTestId: true });
+        status = await Promise.race([
+          runner.runTests(reporter, params).then(result => result.status),
+          testRunnerAndScreen.waitForTestPaused().then(() => 'paused' as const),
+          abortPromise,
+        ]);
 
-      if (status === 'interrupted') {
-        await runner.stopTests();
+        if (status === 'interrupted') {
+          await runner.stopTests();
+          await cleanup();
+          return { output: testRunnerAndScreen.output.join('\n'), status };
+        }
+
+        if (status === 'paused') {
+          const response = await testRunnerAndScreen.sendMessageToPausedTest!({ request: { initialize: { clientInfo: this._clientInfo } } });
+          if (response.error)
+            throw new Error(response.error.message);
+          testRunnerAndScreen.output.push(response.response.initialize!.pausedMessage);
+          return { output: testRunnerAndScreen.output.join('\n'), status };
+        }
+      } catch (e) {
+        status = 'failed';
+        testRunnerAndScreen.output.push(String(e));
         await cleanup();
         return { output: testRunnerAndScreen.output.join('\n'), status };
       }
-
-      if (status === 'paused') {
-        const response = await testRunnerAndScreen.sendMessageToPausedTest!({ request: { initialize: { clientInfo: this._clientInfo } } });
-        if (response.error)
-          throw new Error(response.error.message);
-        testRunnerAndScreen.output.push(response.response.initialize!.pausedMessage);
-        return { output: testRunnerAndScreen.output.join('\n'), status };
-      }
-    } catch (e) {
-      status = 'failed';
-      testRunnerAndScreen.output.push(String(e));
-      await cleanup();
-      return { output: testRunnerAndScreen.output.join('\n'), status };
-    } finally {
-      abort?.dispose();
     }
 
     await cleanup();

--- a/packages/playwright/src/reporters/merge.ts
+++ b/packages/playwright/src/reporters/merge.ts
@@ -161,7 +161,7 @@ async function extractAndParseReports(dir: string, shardFiles: string[], interna
   for (const file of shardFiles) {
     const absolutePath = path.join(dir, file);
     printStatus(`extracting: ${relativeFilePath(absolutePath)}`);
-    const zipFile = new ZipFile(absolutePath);
+    using zipFile = new ZipFile(absolutePath);
     const entryNames = await zipFile.entries();
     for (const entryName of entryNames.sort()) {
       let reportFile = path.join(dir, entryName);
@@ -184,7 +184,6 @@ async function extractAndParseReports(dir: string, shardFiles: string[], interna
       }
       await fs.promises.writeFile(reportFile, content);
     }
-    zipFile.close();
   }
   return shardEvents;
 }

--- a/packages/playwright/src/reporters/perfetto.ts
+++ b/packages/playwright/src/reporters/perfetto.ts
@@ -273,7 +273,7 @@ class PerfettoReporter implements ReporterV2 {
 
     // Serialize event by event, the whole report does not have to fit into memory twice.
     await fs.promises.mkdir(path.dirname(this._resolvedOutputFile), { recursive: true });
-    const writer = new ChunkWriter(this._resolvedOutputFile);
+    await using writer = new ChunkWriter(this._resolvedOutputFile);
     await writer.write('{"traceEvents":[');
     let separator = '';
     for (const events of [metadataEvents, this._events]) {
@@ -283,7 +283,6 @@ class PerfettoReporter implements ReporterV2 {
       }
     }
     await writer.write(`],"displayTimeUnit":"ms","metadata":${JSON.stringify(metadata)}}`);
-    await writer.close();
   }
 }
 
@@ -317,6 +316,10 @@ class ChunkWriter {
     await this._closed;
     if (this._error)
       throw this._error;
+  }
+
+  async [Symbol.asyncDispose]() {
+    await this.close();
   }
 }
 

--- a/packages/playwright/src/runner/sigIntWatcher.ts
+++ b/packages/playwright/src/runner/sigIntWatcher.ts
@@ -40,6 +40,10 @@ export class SigIntWatcher {
   disarm() {
     FixedNodeSIGINTHandler.off(this._sigintHandler);
   }
+
+  [Symbol.dispose]() {
+    this.disarm();
+  }
 }
 
 // NPM/NPX will send us duplicate SIGINT signals, so we need to ignore them.

--- a/packages/playwright/src/runner/taskRunner.ts
+++ b/packages/playwright/src/runner/taskRunner.ts
@@ -52,8 +52,6 @@ export class TaskRunner<Context> {
   }
 
   async runDeferCleanup(context: Context, deadline: number, cancelPromise = new ManualPromise<void>()): Promise<{ status: FullResult['status'], cleanup: () => Promise<FullResult['status']> }> {
-    const sigintWatcher = new SigIntWatcher();
-    const timeoutWatcher = new TimeoutWatcher(deadline);
     const teardownRunner = new TaskRunner<Context>(this._reporter, this._globalTimeoutForError);
     teardownRunner._isTearDown = true;
 
@@ -86,15 +84,21 @@ export class TaskRunner<Context> {
       }
     };
 
-    await Promise.race([
-      taskLoop(),
-      cancelPromise,
-      sigintWatcher.promise(),
-      timeoutWatcher.promise,
-    ]);
-
-    sigintWatcher.disarm();
-    timeoutWatcher.disarm();
+    let sigintWatcher: SigIntWatcher;
+    let timeoutWatcher: TimeoutWatcher;
+    {
+      // Disarm SIGINT first, then the timeout, before calculating the status.
+      using timeout = new TimeoutWatcher(deadline);
+      using sigint = new SigIntWatcher();
+      sigintWatcher = sigint;
+      timeoutWatcher = timeout;
+      await Promise.race([
+        taskLoop(),
+        cancelPromise,
+        sigint.promise(),
+        timeout.promise,
+      ]);
+    }
 
     // Prevent subsequent tasks from running.
     this._interrupted = true;
@@ -142,5 +146,9 @@ class TimeoutWatcher {
 
   disarm() {
     clearTimeout(this._timer);
+  }
+
+  [Symbol.dispose]() {
+    this.disarm();
   }
 }

--- a/packages/playwright/src/runner/testServer.ts
+++ b/packages/playwright/src/runner/testServer.ts
@@ -323,15 +323,17 @@ async function innerRunTestServer(configLocation: ConfigLocation, configCLIOverr
   const testServer = new TestServer(configLocation, configCLIOverrides);
   const cancelPromise = new ManualPromise<void>();
   const sigintWatcher = new SigIntWatcher();
-  process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
-  void sigintWatcher.promise().then(() => cancelPromise.resolve());
-  try {
-    const server = await testServer.start(options);
-    await openUI(server, cancelPromise);
-    await cancelPromise;
-  } finally {
-    await testServer.stop();
-    sigintWatcher.disarm();
+  {
+    using watcher = sigintWatcher;
+    process.stdin.on('close', () => gracefullyProcessExitDoNotHang(0));
+    void watcher.promise().then(() => cancelPromise.resolve());
+    try {
+      const server = await testServer.start(options);
+      await openUI(server, cancelPromise);
+      await cancelPromise;
+    } finally {
+      await testServer.stop();
+    }
   }
   return sigintWatcher.hadSignal() ? 'interrupted' : 'passed';
 }

--- a/packages/playwright/src/runner/watchMode.ts
+++ b/packages/playwright/src/runner/watchMode.ts
@@ -152,13 +152,14 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
     else
       printPrompt();
 
-    const waitForCommand = readCommand();
-    const command = await Promise.race([
-      onDirtyTests,
-      waitForCommand.result,
-    ]);
-    if (command === 'changed')
-      waitForCommand.dispose();
+    let command: Command;
+    {
+      using waitForCommand = readCommand();
+      command = await Promise.race([
+        onDirtyTests,
+        waitForCommand.result,
+      ]);
+    }
     if (bufferMode && command === 'changed')
       continue;
 
@@ -274,7 +275,7 @@ export async function runWatchModeLoop(configLocation: ConfigLocation, initialOp
   return result === 'passed' ? teardown.status : result;
 }
 
-function readKeyPress<T extends string>(handler: (text: string, key: any) => T | undefined): { dispose(): void; result: Promise<T> } {
+function readKeyPress<T extends string>(handler: (text: string, key: any) => T | undefined): Disposable & { result: Promise<T> } {
   const promise = new ManualPromise<T>();
 
   const rl = readline.createInterface({ input: process.stdin, escapeCodeTimeout: 50 });
@@ -288,16 +289,20 @@ function readKeyPress<T extends string>(handler: (text: string, key: any) => T |
       promise.resolve(result);
   });
 
-  const dispose = () => {
+  let disposed = false;
+  function dispose() {
+    if (disposed)
+      return;
+    disposed = true;
     eventsHelper.removeEventListeners([listener]);
     rl.close();
     if (process.stdin.isTTY)
       process.stdin.setRawMode(false);
-  };
+  }
 
   void promise.finally(dispose);
 
-  return { result: promise, dispose };
+  return { result: promise, [Symbol.dispose]: dispose };
 }
 
 const isInterrupt = (text: string, key: any) => text === '\x03' || text === '\x1B' || (key && key.name === 'escape') || (key && key.ctrl && key.name === 'c');
@@ -308,7 +313,7 @@ async function runTests(watchOptions: WatchModeOptions, testServerConnection: Te
 }) {
   printConfiguration(watchOptions, options?.title);
 
-  const waitForDone = readKeyPress((text: string, key: any) => {
+  using waitForDone = readKeyPress((text: string, key: any) => {
     if (isInterrupt(text, key)) {
       testServerConnection.stopTestsNoReply({});
       return 'done';
@@ -324,7 +329,7 @@ async function runTests(watchOptions: WatchModeOptions, testServerConnection: Te
     reuseContext: connectWsEndpoint ? true : undefined,
     workers: connectWsEndpoint ? 1 : undefined,
     headed: connectWsEndpoint ? true : undefined,
-  }).finally(() => waitForDone.dispose());
+  });
 }
 
 function readCommand() {

--- a/packages/utils/eventsHelper.ts
+++ b/packages/utils/eventsHelper.ts
@@ -20,7 +20,9 @@ type EventEmitterLike = {
   removeListener(eventName: string | symbol, handler: (...args: any[]) => unknown): unknown;
 };
 
-export type RegisteredListener = {
+const kDispose: typeof Symbol.dispose = (Symbol.dispose || Symbol.for('Symbol.dispose')) as typeof Symbol.dispose;
+
+export type RegisteredListener = Disposable & {
   emitter: EventEmitterLike;
   eventName: (string | symbol);
   handler: (...args: any[]) => void;
@@ -33,7 +35,16 @@ class EventsHelper {
     eventName: (string | symbol),
     handler: (...args: any[]) => void): RegisteredListener {
     emitter.on(eventName, handler);
-    return { emitter, eventName, handler, dispose: async () => { emitter.removeListener(eventName, handler); } };
+    function removeListener() {
+      emitter.removeListener(eventName, handler);
+    }
+    return {
+      emitter,
+      eventName,
+      handler,
+      dispose: async () => removeListener(),
+      [kDispose]: removeListener,
+    };
   }
 
   static removeEventListeners(listeners: Array<{

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -26,6 +26,7 @@ import { SocksProxyAgent } from 'socks-proxy-agent';
 import { getProxyForUrl } from 'proxy-from-env';
 import { ManualPromise } from '@isomorphic/manualPromise';
 import { rewriteErrorMessage } from './stackTrace';
+import { eventsHelper } from './eventsHelper';
 
 export type ProxySettings = {
   server: string,
@@ -238,18 +239,11 @@ export function createHttp2Server(...args: any[]): http2.Http2SecureServer {
 
 export async function startHttpServer(server: http.Server, options: { host?: string, port?: number }) {
   const { host = 'localhost', port = 0 } = options;
-  const errorPromise = new ManualPromise();
-  const errorListener = (error: Error) => errorPromise.reject(error);
-  server.on('error', errorListener);
-  try {
-    server.listen(port, host);
-    await Promise.race([
-      new Promise(cb => server.once('listening', cb)),
-      errorPromise,
-    ]);
-  } finally {
-    server.removeListener('error', errorListener);
-  }
+  const listeningPromise = new ManualPromise<void>();
+  using errorListener = eventsHelper.addEventListener(server, 'error', (error: Error) => listeningPromise.reject(error));
+  using listeningListener = eventsHelper.addEventListener(server, 'listening', () => listeningPromise.resolve());
+  server.listen(port, host);
+  await listeningPromise;
 }
 
 export async function isURLAvailable(url: URL, ignoreHTTPSErrors: boolean, onLog?: (data: string) => void, onStdErr?: (data: string) => void) {

--- a/packages/utils/zipFile.ts
+++ b/packages/utils/zipFile.ts
@@ -72,4 +72,8 @@ export class ZipFile {
   close() {
     this._zipFile?.close();
   }
+
+  [Symbol.dispose]() {
+    this.close();
+  }
 }

--- a/utils/test-results-db/db.ts
+++ b/utils/test-results-db/db.ts
@@ -137,6 +137,10 @@ export class TestResultsDb {
     this._conn.closeSync();
     this._instance.closeSync();
   }
+
+  [Symbol.dispose]() {
+    this.close();
+  }
 }
 
 export function fileSize(path: string): number {

--- a/utils/test-results-db/truncate.ts
+++ b/utils/test-results-db/truncate.ts
@@ -19,14 +19,10 @@ import { TestResultsDb, fileSize, formatBytes } from './db.ts';
 // Keep only the newest `maxRuns` runs (a run is a `(run_id, run_attempt)` pair),
 // delete the rest, and compact to reclaim the freed disk space.
 export async function cmdTruncate(dbPath: string, maxRuns: number): Promise<void> {
-  const db = await TestResultsDb.open(dbPath);
-  try {
-    const before = await db.runCount();
-    await db.truncateToRuns(maxRuns);
-    const after = await db.runCount();
-    console.log(`Truncated ${before} -> ${after} runs (cap ${maxRuns})`);
-    console.log(`  ${await db.rowCount()} rows, size ${formatBytes(fileSize(dbPath))}`);
-  } finally {
-    db.close();
-  }
+  using db = await TestResultsDb.open(dbPath);
+  const before = await db.runCount();
+  await db.truncateToRuns(maxRuns);
+  const after = await db.runCount();
+  console.log(`Truncated ${before} -> ${after} runs (cap ${maxRuns})`);
+  console.log(`  ${await db.rowCount()} rows, size ${formatBytes(fileSize(dbPath))}`);
 }

--- a/utils/test-results-db/update.ts
+++ b/utils/test-results-db/update.ts
@@ -35,47 +35,43 @@ export type UpdateOptions = {
 // so disk usage stays bounded to one batch.
 export async function cmdUpdate(dbPath: string, token: string, options: UpdateOptions): Promise<void> {
   const github = new GitHubClient(token);
-  const db = await TestResultsDb.open(dbPath);
-  try {
-    const ingested = await db.ingestedArtifactIds();
-    console.log(`Test results database`);
-    console.log(`  ${await db.rowCount()} rows from ${ingested.size} artifacts`);
+  using db = await TestResultsDb.open(dbPath);
+  const ingested = await db.ingestedArtifactIds();
+  console.log(`Test results database`);
+  console.log(`  ${await db.rowCount()} rows from ${ingested.size} artifacts`);
 
-    const todo = await github.listArtifacts(PARQUET_ARTIFACT_PREFIX, {
-      ingested,
-      lookbackDays: options.lookbackDays,
-      stopAfterSeen: options.stopAfterSeen,
-    });
-    console.log(`\nScanning for new artifacts (last ${options.lookbackDays} days)`);
-    console.log(`  ${todo.length} new artifacts to import`);
+  const todo = await github.listArtifacts(PARQUET_ARTIFACT_PREFIX, {
+    ingested,
+    lookbackDays: options.lookbackDays,
+    stopAfterSeen: options.stopAfterSeen,
+  });
+  console.log(`\nScanning for new artifacts (last ${options.lookbackDays} days)`);
+  console.log(`  ${todo.length} new artifacts to import`);
 
-    let imported = 0;
-    for (const batch of chunk(todo, options.concurrency)) {
-      const files = await Promise.all(batch.map(async artifact => {
-        const zip = await github.downloadArtifactZip(artifact.id);
-        const file = path.join(os.tmpdir(), `trdb-${artifact.id}.parquet`);
-        await extractSingle(zip, '.parquet', file);
-        return { id: artifact.id, file };
-      }));
-      for (const { id, file } of files) {
-        try {
-          await db.ingestParquet(file, id);
-          imported++;
-        } finally {
-          fs.rmSync(file, { force: true });
-        }
+  let imported = 0;
+  for (const batch of chunk(todo, options.concurrency)) {
+    const files = await Promise.all(batch.map(async artifact => {
+      const zip = await github.downloadArtifactZip(artifact.id);
+      const file = path.join(os.tmpdir(), `trdb-${artifact.id}.parquet`);
+      await extractSingle(zip, '.parquet', file);
+      return { id: artifact.id, file };
+    }));
+    for (const { id, file } of files) {
+      try {
+        await db.ingestParquet(file, id);
+        imported++;
+      } finally {
+        fs.rmSync(file, { force: true });
       }
-      console.log(`  imported ${imported}/${todo.length}`);
     }
-
-    console.log(`\nSummary`);
-    console.log(`  imported ${imported} new artifacts`);
-    console.log(`  ${await db.rowCount()} rows from ${await db.runCount()} runs`);
-    console.log(`  size ${formatBytes(fileSize(dbPath))}`);
-
-    if (process.env.GITHUB_OUTPUT)
-      fs.appendFileSync(process.env.GITHUB_OUTPUT, `imported=${imported}\n`);
-  } finally {
-    db.close();
+    console.log(`  imported ${imported}/${todo.length}`);
   }
+
+  console.log(`\nSummary`);
+  console.log(`  imported ${imported} new artifacts`);
+  console.log(`  ${await db.rowCount()} rows from ${await db.runCount()} runs`);
+  console.log(`  size ${formatBytes(fileSize(dbPath))}`);
+
+  if (process.env.GITHUB_OUTPUT)
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `imported=${imported}\n`);
 }


### PR DESCRIPTION
in many places this avoids having repeated `foo?.dispose()` in each early `return` branch and/or allows us to drop an`try { ... } finally { ... }` entirely