### PR TITLE
fix(mcp): harden MCP server security — disable unsafe RCE tool by default & bind CDP Relay to localhost

### DIFF
--- a/packages/playwright-core/src/tools/backend/runCode.ts
+++ b/packages/playwright-core/src/tools/backend/runCode.ts
@@ -29,6 +29,7 @@ const codeSchema = z.object({
 
 const runCode = defineTabTool({
   capability: 'core',
+  skillOnly: true,
   schema: {
     name: 'browser_run_code_unsafe',
     title: 'Run Playwright code (unsafe)',

--- a/packages/playwright-core/src/tools/mcp/cdpRelay.ts
+++ b/packages/playwright-core/src/tools/mcp/cdpRelay.ts
@@ -117,7 +117,7 @@ export class CDPRelayServer {
   }
 
   async start(): Promise<void> {
-    this._wsHost = await this._wsServer.listen(0, undefined, '');
+    this._wsHost = await this._wsServer.listen(0, '127.0.0.1', '');
   }
 
   cdpEndpoint() {


### PR DESCRIPTION
## Summary

This PR addresses **two high-risk findings** from MCP security audits of the Playwright MCP Server:

### Fix 1: Disable `browser_run_code_unsafe` by default

**File**: `packages/playwright-core/src/tools/backend/runCode.ts`

**Problem**: The `browser_run_code_unsafe` tool is RCE-equivalent — it executes arbitrary JavaScript in the Playwright server process via Node.js `vm` module. The [Node.js docs explicitly state](https://nodejs.org/api/vm.html) that the `vm` module is not a security mechanism. Code executed through this tool has full access to the process, including:
- All secrets in environment variables (via `process.env`)
- The filesystem (via `fs` module accessible through `page`)
- Network access

Since this tool has `capability: 'core'`, it was **enabled by default for all MCP clients**. An AI agent that receives a prompt injection attack could directly exploit this tool to achieve full process takeover.

**Fix**: Add `skillOnly: true` to the tool definition. The `filteredTools()` function in `tools.ts` already filters out tools with `skillOnly: true`:
```typescript
.filter(tool => !tool.skillOnly)
```
This removes the tool from the default MCP tool list while keeping it available for explicit opt-in scenarios.

### Fix 2: Bind CDP Relay to localhost

**File**: `packages/playwright-core/src/tools/mcp/cdpRelay.ts`

**Problem**: The CDP Relay WebSocket server was binding to `0.0.0.0` (all network interfaces) in `--extension` mode:
```typescript
this._wsHost = await this._wsServer.listen(0, undefined, '');
```
This made the WebSocket server reachable from the local network. While UUID-based paths and Extension Token authentication provide some protection, network-level exposure is unnecessary.

**Fix**: Bind to `127.0.0.1` instead:
```typescript
this._wsHost = await this._wsServer.listen(0, '127.0.0.1', '');
```
The CDP Relay only needs to communicate with the local browser extension, so localhost binding fully satisfies the functional requirement while eliminating the network exposure risk.

## Impact

- **98.9% of tools (90/91)** are unaffected — these changes only touch the 1 high-risk tool and the CDP relay binding
- The `browser_run_code_unsafe` tool remains available for users who explicitly need it (via skill mode)
- CDP Relay functionality is unchanged for local usage; only remote network access is blocked
- No breaking changes to the public API

## Security Audit Context

These changes resolve the two high-risk items identified in MCP security audits:
1. ~~`browser_run_code_unsafe` RCE-equivalent tool enabled by default~~ → **Fixed** via `skillOnly: true`
2. ~~CDP Relay WebSocket binding to `0.0.0.0`~~ → **Fixed** via localhost binding