### PR TITLE
fix(mcp): do not close browser while tool call is running

### DIFF
--- a/packages/playwright-core/src/tools/backend/browserBackend.ts
+++ b/packages/playwright-core/src/tools/backend/browserBackend.ts
@@ -82,7 +82,15 @@ export class BrowserBackend extends EventEmitter<{ disconnected: [] }> implement
   }
 
   async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> } = {}, signal?: AbortSignal): Promise<mcpServer.CallToolResult> {
-    this._idleTimer?.poke();
+    this._idleTimer?.callStarted();
+    try {
+      return await this._callTool(name, rawArguments, signal);
+    } finally {
+      this._idleTimer?.callFinished();
+    }
+  }
+
+  private async _callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'] & { _meta?: Record<string, any> }, signal?: AbortSignal): Promise<mcpServer.CallToolResult> {
     const json = !!rawArguments._meta?.json;
     const formatError = (message: string): mcpServer.CallToolResult => ({
       content: [{ type: 'text' as const, text: json ? JSON.stringify({ isError: true, error: message }, null, 2) : `### Error\n${message}` }],

--- a/packages/playwright-core/src/tools/backend/idleTimer.ts
+++ b/packages/playwright-core/src/tools/backend/idleTimer.ts
@@ -19,6 +19,7 @@ export const defaultIdleTimeout = 60 * 60 * 1000;
 export class IdleTimer {
   private _timeout: number;
   private _onIdle: () => void;
+  private _running = 0;
   private _timer: NodeJS.Timeout | undefined;
 
   constructor(timeout: number, onIdle: () => void) {
@@ -26,9 +27,22 @@ export class IdleTimer {
     this._onIdle = onIdle;
   }
 
+  callStarted() {
+    ++this._running;
+    this.dispose();
+  }
+
+  callFinished() {
+    if (this._running > 0)
+      --this._running;
+    if (this._running === 0)
+      this._timer = setTimeout(this._onIdle, this._timeout).unref();
+  }
+
   poke() {
     this.dispose();
-    this._timer = setTimeout(this._onIdle, this._timeout);
+    if (!this._running)
+      this._timer = setTimeout(this._onIdle, this._timeout).unref();
   }
 
   dispose() {

--- a/tests/mcp/idle-timeout.spec.ts
+++ b/tests/mcp/idle-timeout.spec.ts
@@ -92,3 +92,28 @@ test('cdp endpoint only disconnects on idle and reconnects to the same pages', a
     'close browser': 1,
   });
 });
+
+test('does not close the browser while a tool call is running', async ({ startClient, server }) => {
+  const { client, stderr } = await startClient({
+    args: ['--idle-timeout=500'],
+    env: { DEBUG: 'pw:mcp:test' },
+  });
+
+  await client.callTool({
+    name: 'browser_navigate',
+    arguments: { url: server.HELLO_WORLD },
+  });
+
+  // The wait outlasts the idle timeout, which only starts once the call completes.
+  expect(await client.callTool({
+    name: 'browser_wait_for',
+    arguments: { time: 1 },
+  })).toHaveResponse({
+    code: `await new Promise(f => setTimeout(f, 1 * 1000));`,
+  });
+
+  expect(formatLog(stderr())).toEqual({
+    'create browser (persistent)': 1,
+    'create context': 1,
+  });
+});


### PR DESCRIPTION
## Summary
- Prevents the MCP idle timeout from firing and closing the browser while a tool call is actively running.
- Restores `callStarted()` and `callFinished()` on `IdleTimer` with reference counting (`_running`), ensuring the timer is cleared during tool execution and only re-armed once all active calls complete.
- Keeps `poke()` guarded so that daemon or client initialization does not arm the timer while calls are in progress, and restores `.unref()` so pending idle timeouts do not hold the Node event loop open.
- Re-adds regression test `does not close the browser while a tool call is running` in `tests/mcp/idle-timeout.spec.ts`.

Fixes https://github.com/microsoft/playwright/issues/42693